### PR TITLE
INFILTRATION: Fix SlashGame scaling

### DIFF
--- a/src/Infiltration/ui/SlashGame.tsx
+++ b/src/Infiltration/ui/SlashGame.tsx
@@ -40,18 +40,18 @@ export function SlashGame(props: IMinigameProps): React.ReactElement {
     }
   }
   const hasAugment = Player.hasAugmentation(AugmentationNames.MightOfAres, true);
-  const phaseZeroTime = Math.random() * 3250 + 1500 - (250 + difficulty.window);
-  const phaseOneTime = 250;
-  const timeUntilAttacking = phaseZeroTime;
+  const guardingTime = Math.random() * 3250 + 1500 - (250 + difficulty.window);
+  const preparingTime = difficulty.window;
+  const attackingTime = 250;
 
   useEffect(() => {
     let id = window.setTimeout(() => {
       setPhase(1);
       id = window.setTimeout(() => {
         setPhase(2);
-        id = window.setTimeout(() => setPhase(0), difficulty.window);
-      }, phaseOneTime);
-    }, phaseZeroTime);
+        id = window.setTimeout(() => props.onFailure(), attackingTime);
+      }, preparingTime);
+    }, guardingTime);
     return () => {
       clearInterval(id);
     };
@@ -66,7 +66,7 @@ export function SlashGame(props: IMinigameProps): React.ReactElement {
         {hasAugment ? (
           <Box sx={{ my: 1 }}>
             <Typography variant="h5">Guard will drop in...</Typography>
-            <GameTimer millis={timeUntilAttacking} onExpire={() => null} ignoreAugment_WKSharmonizer noPaper />
+            <GameTimer millis={guardingTime} onExpire={() => null} ignoreAugment_WKSharmonizer noPaper />
           </Box>
         ) : (
           <></>


### PR DESCRIPTION
Address / Fix #124

Slash game was previously changed so that the guard is vulnerable during "Preparing?" instead of "ATTACKING!" phase, but the time scaling was not changed to use the difficulty setting for the preparing phase, it was still using a hardcoded 250ms.

* Difficulty now scales time for correct phase
* Player loses game immediately after guard attacks (attack lasts for 250ms)