### PR TITLE
NETSCRIPT: Improve error message when unexpected type is thrown

### DIFF
--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -751,8 +751,10 @@ export function handleUnknownError(e: unknown, ws: WorkerScript | ScriptDeath | 
     e = ws ? makeBasicErrorMsg(ws, msg) : `RUNTIME ERROR:\n\n${msg}`;
   }
   if (typeof e !== "string") {
-    console.error("Unexpected error type:", e);
-    e = "Unexpected type of error thrown. See console output.";
+    console.error("Unexpected error:", e);
+    const msg = `Unexpected type of error thrown. This error was likely thrown manually within a script.
+      Error has been logged to the console.\n\nType of error: ${typeof e}\nValue of error: ${e}`;
+    e = ws ? makeBasicErrorMsg(ws, msg, "UNKNOWN") : msg;
   }
   dialogBoxCreate(initialText + e);
 }


### PR DESCRIPTION
Fix #23
Previous error message for an unexpected error type (e.g. non-string, also not a ScriptDeath or Error) gave little info. Here is the old message:
![image](https://user-images.githubusercontent.com/84951833/196797165-1bab3ba8-5890-4b2d-9fbc-1006ffb2d952.png)

Here are some examples of what the new error message looks like with the following error generating lines inside a script:

`Promise.reject(400);`
![image](https://user-images.githubusercontent.com/84951833/196795463-e27b9517-3234-4f89-9594-99710c259514.png)

`await Promise.reject([1,2,3,4,5]);`
![image](https://user-images.githubusercontent.com/84951833/196795738-c71006b0-aba5-472f-a81b-462014bf274a.png)

`throw ns;`
![image](https://user-images.githubusercontent.com/84951833/196795857-732e20bd-33ff-49ad-845d-772371df11eb.png)