### PR TITLE
NETSCRIPT: Uncaught promises no longer spam console

### DIFF
--- a/src/UncaughtPromiseHandler.ts
+++ b/src/UncaughtPromiseHandler.ts
@@ -2,6 +2,7 @@ import { handleUnknownError } from "./Netscript/NetscriptHelpers";
 
 export function setupUncaughtPromiseHandler(): void {
   window.addEventListener("unhandledrejection", (e) => {
+    e.preventDefault();
     handleUnknownError(
       e.reason,
       null,


### PR DESCRIPTION
Fix #21 (Well, it was already fixed, just removing the one last related issue).

Depending on player scripts (use of asleep, custom sleep functions, setTimeout, etc), there may be a lot of uncaught promise errors when the player uses killall, which would previously flood the console with errors about all the uncaught promises. Console logging has been removed, because the error is already handled by the uncaughtPromiseHandler.
 