### PR TITLE
STOCKMARKET: Fix broken initializer when manually buying WSE access

### DIFF
--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -1,6 +1,6 @@
 import { Player as player } from "../Player";
 import { buyStock, sellStock, shortStock, sellShort } from "../StockMarket/BuyingAndSelling";
-import { StockMarket, SymbolToStockMap, placeOrder, cancelOrder, initStockMarketFn } from "../StockMarket/StockMarket";
+import { StockMarket, SymbolToStockMap, placeOrder, cancelOrder, initStockMarket } from "../StockMarket/StockMarket";
 import { getBuyTransactionCost, getSellTransactionGain } from "../StockMarket/StockMarketHelpers";
 import { OrderTypes } from "../StockMarket/data/OrderTypes";
 import { PositionTypes } from "../StockMarket/data/PositionTypes";
@@ -382,7 +382,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
       }
 
       player.hasWseAccount = true;
-      initStockMarketFn();
+      initStockMarket();
       player.loseMoney(getStockMarketWseCost(), "stock");
       helpers.log(ctx, () => "Purchased WSE Account Access");
       return true;

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -19,7 +19,7 @@ import { LiteratureNames } from "./Literature/data/LiteratureNames";
 import { GetServer, AddToAllServers, initForeignServers, prestigeAllServers } from "./Server/AllServers";
 import { prestigeHomeComputer } from "./Server/ServerHelpers";
 import { SpecialServers } from "./Server/data/SpecialServers";
-import { deleteStockMarket, initStockMarket, initSymbolToStockMap } from "./StockMarket/StockMarket";
+import { deleteStockMarket, initStockMarket } from "./StockMarket/StockMarket";
 import { Terminal } from "./Terminal";
 
 import { dialogBoxCreate } from "./ui/React/DialogBox";
@@ -142,7 +142,6 @@ export function prestigeAugmentation(): void {
   // Reset Stock market
   if (Player.hasWseAccount) {
     initStockMarket();
-    initSymbolToStockMap();
   }
 
   // Red Pill
@@ -278,7 +277,6 @@ export function prestigeSourceFile(flume: boolean): void {
   // Reset Stock market, gang, and corporation
   if (Player.hasWseAccount) {
     initStockMarket();
-    initSymbolToStockMap();
   } else {
     deleteStockMarket();
   }

--- a/src/StockMarket/StockMarket.tsx
+++ b/src/StockMarket/StockMarket.tsx
@@ -167,6 +167,7 @@ export function initStockMarket(): void {
   StockMarket.storedCycles = 0;
   StockMarket.lastUpdate = 0;
   StockMarket.ticksUntilCycle = TicksPerCycle;
+  initSymbolToStockMap();
 }
 
 export function initSymbolToStockMap(): void {
@@ -279,9 +280,4 @@ export function processStockPrices(numCycles = 1): void {
     // Shares required for price movement gradually approaches max over time
     stock.shareTxUntilMovement = Math.min(stock.shareTxUntilMovement + 10, stock.shareTxForMovement);
   }
-}
-
-export function initStockMarketFn(): void {
-  initStockMarket();
-  initSymbolToStockMap();
 }


### PR DESCRIPTION
Fix #122 

Previously, there were 3 stock market initializer functions of interest:

1. initStockMarket - initializes the stock market, but not the stock symbols
2. initSymbolToStockMap - initializes stock symbols
3. initStockMarketFn - does both, by just calling both of the above

The issue came about because manually buying a wse account was using function 1 when it was supposed to use function 3, due to confusing similarity in name.

changes:
* Removed initStockMarketFn.
* Added a call to initSymbolToStockMap to the end of initStockMarket. Previously, every existing call to initStockMarket was calling initSymbolToStockMap directly afterwards anyway. Now they just call initStockMarket and it does both.