### PR TITLE
CORPORATIONS: Fix performance issue with lots of employees

### DIFF
--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -383,6 +383,11 @@ export class Industry {
   }
 
   process(marketCycles = 1, state: string, corporation: Corporation): void {
+    const researchTree = IndustryResearchTrees[this.type];
+    if (researchTree) {
+      researchTree.clearHelpers();
+    }
+
     this.state = state;
 
     //At the start of a cycle, store and reset revenue/expenses

--- a/src/Corporation/ResearchTree.ts
+++ b/src/Corporation/ResearchTree.ts
@@ -89,6 +89,9 @@ export class ResearchTree {
   // Root Node
   root: Node | null = null;
 
+  // Memoized helpers, cleared each cycle
+  helpers: Map<string, number> = new Map<string, any>();
+
   // Gets an array with the 'text' values of ALL Nodes in the Research Tree
   getAllNodes(): string[] {
     const res: string[] = [];
@@ -157,6 +160,10 @@ export class ResearchTree {
 
   // Helper function for all the multiplier getter fns
   getMultiplierHelper(propName: string): number {
+    if (this.helpers.has(propName)) {
+      return this.helpers.get(propName) || 1;
+    }
+
     let res = 1;
     if (this.root == null) {
       return res;
@@ -206,6 +213,7 @@ export class ResearchTree {
       }
     }
 
+    this.helpers.set(propName, res);
     return res;
   }
 
@@ -249,5 +257,10 @@ export class ResearchTree {
   // Set the tree's Root Node
   setRoot(root: Node): void {
     this.root = root;
+  }
+
+  // Clear helpers each cycle so they recalculate on the first use
+  clearHelpers(): void {
+    this.helpers = new Map<string, any>();
   }
 }

--- a/src/Netscript/ScriptIdentifier.ts
+++ b/src/Netscript/ScriptIdentifier.ts
@@ -1,9 +1,10 @@
 import { ScriptArg } from "./ScriptArg";
 
-export type ScriptIdentifier =  //This was previously in INetscriptHelper.ts, may move to its own file or a generic types file.
-  | number
-  | {
-      scriptname: string;
-      hostname: string;
-      args: ScriptArg[];
-    };
+export type ScriptIdentifier = //This was previously in INetscriptHelper.ts, may move to its own file or a generic types file.
+
+    | number
+    | {
+        scriptname: string;
+        hostname: string;
+        args: ScriptArg[];
+      };

--- a/src/Netscript/ScriptIdentifier.ts
+++ b/src/Netscript/ScriptIdentifier.ts
@@ -1,9 +1,9 @@
 import { ScriptArg } from "./ScriptArg";
 
-export type ScriptIdentifier = //This was previously in INetscriptHelper.ts, may move to its own file or a generic types file.
-    | number
-    | {
-        scriptname: string;
-        hostname: string;
-        args: ScriptArg[];
-      };
+export type ScriptIdentifier =  //This was previously in INetscriptHelper.ts, may move to its own file or a generic types file.
+  | number
+  | {
+      scriptname: string;
+      hostname: string;
+      args: ScriptArg[];
+    };

--- a/src/Netscript/ScriptIdentifier.ts
+++ b/src/Netscript/ScriptIdentifier.ts
@@ -1,7 +1,6 @@
 import { ScriptArg } from "./ScriptArg";
 
 export type ScriptIdentifier = //This was previously in INetscriptHelper.ts, may move to its own file or a generic types file.
-
     | number
     | {
         scriptname: string;


### PR DESCRIPTION
# CORPORATIONS: Fix performance issue with lots of employees

Using chrome devtools profiling I found that it took about 4 seconds to run the process and almost all of it was in the four methods called for each employee in 'calculateProductivity' like 'industry.getEmployeeCreMultiplier' along with the same method for Cha,  Int, and Eff, about 1/4 for each.   These in turn call researchTree.getEmployeeCreMultiplier().  Each of these then processes the whole research tree looking for multipliers and creating lots of objects along the way.

This change memoizes `getMultiplierHelper(propName: string)`, and adds a call to `Industry.process()` to reset it each time process() is called.

closes #141
