### PR TITLE
MISC: remove trailing whitespaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  
+
 concurrency:
   group: "pages"
   cancel-in-progress: true
@@ -35,16 +35,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          
+
       - name: Use Node.js 16.13.1
         uses: actions/setup-node@v2
         with:
           node-version: 16.13.1
           cache: "npm"
-          
+
       - name: Install NPM dependencies
         run: npm ci
-        
+
       - name: Build Production App
         if: ${{ github.event.inputs.buildApp == 'true' }}
         run: npm run build
@@ -59,7 +59,7 @@ jobs:
             dist/vendor.bundle.js.map
             index.html
           expire-on: never
-        
+
       - name: Build Documentation
         if: ${{ github.event.inputs.buildDoc == 'true' }}
         run: npm run doc


### PR DESCRIPTION
The command `npm run format` reports some trailing whitespaces.  Remove those whitespaces.