### PR TITLE
MISC: Fix display for negative time

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1737,13 +1737,11 @@ const base: InternalAPI<NS> = {
 
     return numeralWrapper.format(n, format);
   },
-  tFormat:
-    (ctx) =>
-    (_milliseconds, _milliPrecision = false) => {
-      const milliseconds = helpers.number(ctx, "milliseconds", _milliseconds);
-      const milliPrecision = !!_milliPrecision;
-      return convertTimeMsToTimeElapsedString(milliseconds, milliPrecision);
-    },
+  tFormat: (ctx) => (_milliseconds, _milliPrecision) => {
+    const milliseconds = helpers.number(ctx, "milliseconds", _milliseconds);
+    const milliPrecision = !!_milliPrecision;
+    return convertTimeMsToTimeElapsedString(milliseconds, milliPrecision);
+  },
   getTimeSinceLastAug: () => () => {
     return Player.playtimeSinceLastAug;
   },

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -7,7 +7,8 @@ e.g.    10000 -> "10 seconds"
         120000 -> "2 minutes and 0 seconds"
 */
 function convertTimeMsToTimeElapsedString(time: number, showMilli = false): string {
-  time = Math.floor(time);
+  const negFlag = time < 0;
+  time = Math.abs(Math.floor(time));
   const millisecondsPerSecond = 1000;
   const secondPerMinute = 60;
   const minutesPerHours = 60;
@@ -47,7 +48,7 @@ function convertTimeMsToTimeElapsedString(time: number, showMilli = false): stri
   }
   res += `${seconds} second${!showMilli && secTruncMinutes === 1 ? "" : "s"}`;
 
-  return res;
+  return negFlag ? `-(${res})` : res;
 }
 
 // Finds the longest common starting substring in a set of strings


### PR DESCRIPTION
Previous:
![image](https://user-images.githubusercontent.com/84951833/197652649-21368206-fbda-4433-9c2e-c46db2ed18c4.png)

Now:
![image](https://user-images.githubusercontent.com/84951833/197652696-11790932-6b3b-4369-a0bd-c58728e16a6e.png)

fix #123 