### PR TITLE
CORP: Better fix for MP validation

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -103,7 +103,7 @@ export function SellMaterial(mat: Material, amt: string, price: string): void {
     throw new Error("Invalid value or expression for sell price field: " + e);
   }
 
-  if (temp == null || isNaN(parseFloat(temp)) || parseFloat(temp) < 0) {
+  if (temp == null || isNaN(parseFloat(temp))) {
     throw new Error("Invalid value or expression for sell price field");
   }
 
@@ -163,7 +163,7 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
     } catch (e) {
       throw new Error("Invalid value or expression for sell price field: " + e);
     }
-    if (temp == null || isNaN(parseFloat(temp)) || parseFloat(temp) < 0) {
+    if (temp == null || isNaN(parseFloat(temp))) {
       throw new Error("Invalid value or expression for sell price field.");
     }
     product.sCost = price; //Use sanitized price

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -95,7 +95,7 @@ export function SellMaterial(mat: Material, amt: string, price: string): void {
   if (amt === "") amt = "0";
   let cost = price.replace(/\s+/g, "");
   cost = cost.replace(/[^-()\d/*+.MPe]/g, ""); //Sanitize cost
-  let temp = cost.replace(/MP/, mat.bCost + "");
+  let temp = cost.replace(/MP/, "1.234e5");
   try {
     if (temp.includes("MP")) throw "Only one reference to MP is allowed in sell price.";
     temp = eval(temp);
@@ -156,7 +156,7 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
     //Sanitize input, then replace dynamic variables with arbitrary numbers
     price = price.replace(/\s+/g, "");
     price = price.replace(/[^-()\d/*+.MPe]/g, "");
-    let temp = price.replace(/MP/, product.pCost + "");
+    let temp = price.replace(/MP/, "1.234e5");
     try {
       if (temp.includes("MP")) throw "Only one reference to MP is allowed in sell price.";
       temp = eval(temp);

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -900,7 +900,7 @@ export class Industry {
                 product.mku = 1;
               }
               sCost = sCostString.replace(/MP/g, product.pCost + product.rat / product.mku + "");
-              sCost = eval(sCost);
+              sCost = Math.max(product.pCost, eval(sCost));
             } else {
               sCost = product.sCost;
             }


### PR DESCRIPTION
Improve the fix for #121.

* Minimum product sell price bound to product cost.
* Validation strings for MP-based sell price formula updated to provide better validation no matter the product or material's actual cost / market price. Should not be possible to get syntax errors for any MP on a string that was accepted as the formula.
* Validation string evaluation no longer required to be >0.