### PR TITLE
TERMINAL: Connect command will connect to player owned servers from anywhere.

### DIFF
--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -93,6 +93,9 @@ export abstract class BaseServer {
   // Flag indicating whether this is a purchased server
   purchasedByPlayer = false;
 
+  // Variables that exist only on some types of servers can just be optional.
+  backdoorInstalled?: boolean;
+
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {
     this.ip = params.ip ? params.ip : createRandomIp();
 

--- a/src/Terminal/commands/connect.ts
+++ b/src/Terminal/commands/connect.ts
@@ -2,7 +2,6 @@ import { Terminal } from "../../Terminal";
 import { BaseServer } from "../../Server/BaseServer";
 import { getServerOnNetwork } from "../../Server/ServerHelpers";
 import { GetServer } from "../../Server/AllServers";
-import { Server } from "../../Server/Server";
 
 export function connect(args: (string | number | boolean)[], server: BaseServer): void {
   // Disconnect from current server in Terminal and connect to new one
@@ -24,7 +23,7 @@ export function connect(args: (string | number | boolean)[], server: BaseServer)
 
   const other = GetServer(hostname);
   if (other !== null) {
-    if (other instanceof Server && other.backdoorInstalled) {
+    if (other.backdoorInstalled || other.purchasedByPlayer) {
       Terminal.connectToServer(hostname);
       return;
     }


### PR DESCRIPTION
* purchasedByPlayer allows connect-from-anywhere as if the server was backdoored.
* Also added optional backdoorInstalled variable to type for BaseServer. This has no runtime effect, but it allows accessing that variable without TS needing us to verify whether it's instanceof Server first.

Fixes #69 

Previous:
![image](https://user-images.githubusercontent.com/84951833/197887252-3d2cf198-df0c-4ee4-a21f-98b24151540d.png)

Now:
![image](https://user-images.githubusercontent.com/84951833/197887286-5726932a-d1be-401b-87bf-ef56d904f026.png)
