### PR TITLE
DOCS: De-uglify ns.print examples

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4898,12 +4898,9 @@ export interface NS {
    * var green = "\u001b[32m";
    * var red = "\u001b[31m";
    * var reset = "\u001b[0m";
-   * var msgError = red + "Ugh! What a mess." + reset;
-   * var msgSuccess = green + "Well done!" + reset;
-   * var msgMixed = cyan + "ERROR Should this be in red?" + reset;
-   * print(msgError);
-   * print(msgSuccess);
-   * print(msgMixed);
+   * print(red + "Ugh! What a mess." + reset);
+   * print(green + "Well done!" + reset);
+   * print(cyan + "ERROR Should this be in red?" + reset);
    * tail();
    * ```
    * @example
@@ -4922,12 +4919,9 @@ export interface NS {
    * const green = "\u001b[32m";
    * const red = "\u001b[31m";
    * const reset = "\u001b[0m";
-   * const msgError = "Ugh! What a mess.";
-   * const msgSuccess = "Well done!";
-   * const msgMixed = "ERROR Should this be in red?";
-   * ns.print(`${red + msgError + reset}`);
-   * ns.print(`${green + msgSuccess + reset}`);
-   * ns.print(`${cyan + msgMixed + reset}`);
+   * ns.print(`${red}Ugh! What a mess.${reset}`);
+   * ns.print(`${green}Well done!${reset}`);
+   * ns.print(`${cyan}ERROR Should this be in red?${reset}`);
    * ns.tail();
    * ```
    *


### PR DESCRIPTION
I saw this example and it seems to completely misuse template strings, there's no need to concat within a template string.
I also noticed that the first example use an unnecessary amount amount of variables and so I fixed it to what the former second example seemed to be trying to do.