### PR TITLE
DOCUMENTATION: UPDATE TO EXPLAIN ARGS USAGE IN NS2

### DIFF
--- a/doc/source/netscript/netscriptscriptarguments.rst
+++ b/doc/source/netscript/netscriptscriptarguments.rst
@@ -34,3 +34,16 @@ ns2 script:
 const args_obj = arguments[0]
 const argument1 = (args_obj.server.args[0])
 const argument2 = (args_obj.server.args[1])
+
+When using ns2, the main function takes as input the game's ns object
+containing the argument array you are trying to pass into the script,
+so the arguments can be referenced from it like this::
+
+    export async function main(ns) {
+	    if (ns.args[0]){ 
+		    while (true){
+			    await ns.hack(ns.args[0]);
+		    }
+	    }
+	    else{ns.print("No target given")}
+    }


### PR DESCRIPTION
First, this repo does not seem to be where the site I'm reading is generated from; thus, this is not the documentation I saw.

Second, unless the tail function does something odd I have yet to see, when I attempt to run the NS2 code shown in this file it does not work. This PR does not remove said code.

The [documentation](https://bitburner.readthedocs.io/en/latest/netscript/netscriptscriptarguments.html) does not explain how NS2 scopes the game arguments, I wasted 30 minutes trying to figure out why I couldn't get args to work as this file stated. It's explained in other files, but this one looks like it missed the updating.

Simple fix, I suspect this is just a minor oversight, code now includes an example of how to use it with ns2.