### PR TITLE
STOCK:Adds function to return the organization for a stock symbol

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -124,6 +124,7 @@ const stock = {
   has4SDataTIXAPI: 0.05,
   getSymbols: RamCostConstants.ScriptGetStockRamCost,
   getPrice: RamCostConstants.ScriptGetStockRamCost,
+  getOrganization: RamCostConstants.ScriptGetStockRamCost,
   getAskPrice: RamCostConstants.ScriptGetStockRamCost,
   getBidPrice: RamCostConstants.ScriptGetStockRamCost,
   getPosition: RamCostConstants.ScriptGetStockRamCost,

--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -403,5 +403,12 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
       helpers.log(ctx, () => "Purchased TIX API");
       return true;
     },
+    getOrganization: (ctx) => (_symbol) => {
+      const symbol = helpers.string(ctx, "symbol", _symbol);
+      checkTixApiAccess(ctx);
+      const stock = getStockFromSymbol(ctx, symbol);
+
+      return stock.name;
+    },
   };
 }

--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -60,6 +60,13 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
 
       return stock.price;
     },
+    getOrganization: (ctx) => (_symbol) => {
+      const symbol = helpers.string(ctx, "symbol", _symbol);
+      checkTixApiAccess(ctx);
+      const stock = getStockFromSymbol(ctx, symbol);
+
+      return stock.name;
+    },
     getAskPrice: (ctx) => (_symbol) => {
       const symbol = helpers.string(ctx, "symbol", _symbol);
       checkTixApiAccess(ctx);
@@ -402,13 +409,6 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
       player.loseMoney(getStockMarketTixApiCost(), "stock");
       helpers.log(ctx, () => "Purchased TIX API");
       return true;
-    },
-    getOrganization: (ctx) => (_symbol) => {
-      const symbol = helpers.string(ctx, "symbol", _symbol);
-      checkTixApiAccess(ctx);
-      const stock = getStockFromSymbol(ctx, symbol);
-
-      return stock.name;
     },
   };
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1121,6 +1121,46 @@ export interface TIX {
   getPrice(sym: string): number;
 
   /**
+   * Returns the organization associated with a stock symbol.
+   *
+   * @remarks
+   * RAM cost: 2 GB
+   *
+   * The organization associated with the corresponding stock symbol. This function
+   * requires that you have the following:
+   *
+   * 1. WSE Account
+   *
+   * 1. TIX API Access
+   *
+   * @example
+   * ```ts
+   * // NS1
+   * stock.getOrganization("FSIG");
+   *
+   * // Choose the first stock symbol from the array of stock symbols. Get the
+   * // organization associated with the corresponding stock symbol
+   * var sym = stock.getSymbols()[0];
+   * tprint("Stock symbol: " + sym);
+   * tprint("Stock price: " + stock.getOrganization(sym));
+   * ```
+   * @example
+   * ```ts
+   * // NS2
+   * ns.stock.getOrganization("FSIG");
+   *
+   * // Choose the first stock symbol from the array of stock symbols. Get the
+   * // organization associated with the corresponding stock symbol.
+   * const sym = ns.stock.getSymbols()[0];
+   * ns.tprint("Stock symbol: " + sym);
+   * ns.tprint("Stock organization: " + ns.stock.getOrganization(sym));
+   * ```
+   * @param sym - Stock symbol.
+   * @returns The organization assicated with the stock symbol.
+   */
+  getOrganization(sym: string): string;
+
+  /**
    * Returns the ask price of that stock.
    * @remarks RAM cost: 2 GB
    *


### PR DESCRIPTION
Currently there is no way to map stock symbols to the organization. This fixes that.

# Linked issues
closes #181

# Bug fix
Tested NS1 and NS2, requires WSE and TIX.

NS1
tprint(stock.getOrganization('SLRS'))

NS2
ns.tprint(ns.stock.getOrganization('ECP'))