### PR TITLE
NETSCRIPT: added portHandle.nextWrite()

### DIFF
--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -1,11 +1,13 @@
 import { Settings } from "./Settings/Settings";
 
 type PortData = string | number;
+type Resolver = () => void;
 export interface IPort {
   write: (value: unknown) => PortData | null;
   tryWrite: (value: unknown) => boolean;
   read: () => PortData;
   peek: () => PortData;
+  nextWrite: () => Promise<void>;
   full: () => boolean;
   empty: () => boolean;
   clear: () => void;
@@ -13,6 +15,7 @@ export interface IPort {
 
 export function NetscriptPort(): IPort {
   const data: PortData[] = [];
+  const resolvers: Resolver[] = [];
 
   return {
     write: (value) => {
@@ -22,6 +25,9 @@ export function NetscriptPort(): IPort {
         );
       }
       data.push(value);
+      while (resolvers.length > 0) {
+        (resolvers.pop() as Resolver)();
+      }
       if (data.length > Settings.MaxPortCapacity) {
         return data.shift() as PortData;
       }
@@ -38,6 +44,9 @@ export function NetscriptPort(): IPort {
         return false;
       }
       data.push(value);
+      while (resolvers.length > 0) {
+        (resolvers.pop() as Resolver)();
+      }
       return true;
     },
 
@@ -49,6 +58,10 @@ export function NetscriptPort(): IPort {
     peek: () => {
       if (data.length === 0) return "NULL PORT DATA";
       return data[0];
+    },
+
+    nextWrite: () => {
+      return new Promise(res => resolvers.push(res));
     },
 
     full: () => {

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -61,7 +61,7 @@ export function NetscriptPort(): IPort {
     },
 
     nextWrite: () => {
-      return new Promise(res => resolvers.push(res));
+      return new Promise((res) => resolvers.push(res));
     },
 
     full: () => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -999,6 +999,13 @@ export interface NetscriptPort {
   tryWrite(value: string | number): boolean;
 
   /**
+   * Sleeps until the port is written to.
+   * @remarks
+   * RAM cost: 0 GB
+   */
+  nextWrite(): Promise<void>;
+
+  /**
    * Shift an element out of the port.
    * @remarks
    * RAM cost: 0 GB


### PR DESCRIPTION
As discussed on Discord this PR adds a new function, `portHandle.nextWrite()`, that sleeps until the next write to the port. This adds a push model alternative to the existing functions which utilize the pull model. This allows for quicker execution of code, without incurring the additional polling delay of a pull model. Example usage and a basic test is below:
```ts
// a.js
export function main(ns) {
  ns.writePort(1, ns.args[0]);
}
```
```ts
// b.js
export async function main(ns) {
  const handle = ns.getPortHandle(1);
  while(true) {
    await handle.nextWrite();
    ns.tprint(handle.read());
  }
}
```
![image](https://user-images.githubusercontent.com/23249107/199663304-2055c7b2-dd13-43a5-95b7-a5e0dfc63a7d.png)
