### PR TITLE
UI: use newline to separate sentences in popup message

### DIFF
--- a/src/Work/CreateProgramWork.ts
+++ b/src/Work/CreateProgramWork.ts
@@ -85,7 +85,7 @@ export class CreateProgramWork extends Work {
           `You've finished creating ${programName}!`,
           "The new program can be found on your home computer.",
         ];
-        dialogBoxCreate(lines.join("<br>"));
+        dialogBoxCreate(lines.join("\n"));
       }
 
       if (!Player.getHomeComputer().programs.includes(programName)) {


### PR DESCRIPTION
From Venusaur (`후시기바나#0028`) on the Bitburner server of Discord:

> One more presentation layer issue
>
> Bitburner v2.1.0 (6ac04717) 
![break](https://user-images.githubusercontent.com/66396308/199869723-a0fe510d-f603-4f30-a8fd-5e26166e7c66.png)

After the player has completed the creation of a program, a popup message appears to inform that the program is completed.  ~We should use whitespace to separate the sentences in the popup message, as done in these files:~

1. ~[src/DarkWeb/DarkWeb.tsx](https://github.com/bitburner-official/bitburner-src/blob/6ac04717fe363b2054bb8b7b28211f9e6f2294e9/src/DarkWeb/DarkWeb.tsx#L83)~
2. ~[src/NetscriptFunctions/Singularity.ts](https://github.com/bitburner-official/bitburner-src/blob/6ac04717fe363b2054bb8b7b28211f9e6f2294e9/src/NetscriptFunctions/Singularity.ts#L546)~

Before:
![break-before](https://user-images.githubusercontent.com/66396308/199870554-6bbeb544-6be4-47ef-bc91-7f0e65f3a6ba.png)

~After:~
![break-after](https://user-images.githubusercontent.com/66396308/199870567-2838782f-b357-4dc0-83ef-22622ef81cbb.png)
