### PR TITLE
DOC: `ns.args`: improve documentation and examples

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4574,11 +4574,52 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * Arguments passed into a script can be accessed using a normal
-   * array using the [] operator (args[0], args[1], etc…).
+   * Arguments passed into a script can be accessed as a normal
+   * array by using the `[]` operator (`args[0]`, `args[1]`, etc...). If your
+   * script expects a certain number of arguments, you should provide that
+   * number of arguments. Any additional arguments provided will be ignored. For
+   * example, suppose your script expects 3 arguments. If you provide only 2
+   * arguments, then the value of the third argument will be undefined.
+   * Providing 4 arguments will result in the fourth argument being ignored. Use
+   * `args.length` to get the number of arguments that was passed into a script.
    *
-   * It is also possible to get the number of arguments that was passed into a script using: 'args.length'
-   * WARNING: Do not try to modify the args array. This will break the game.
+   * WARNING: Do not try to modify the `args` array. This will break the game.
+   *
+   * @example
+   * ```ts
+   * // NS1
+   * // Save the code below in a script named "argue.script".
+   * var name = args[0];
+   * var howLong = args[1];
+   * tprint("Hello, " + name + ".");
+   * tprint("Welcome to the Argument Clinic.");
+   * tprint("You will argue for " + howLong + " minute(s).");
+   * tprint("Expected 2 arguments.");
+   * tprint("Received " + args.length + " argument(s).");
+   *
+   * // From the Terminal, run the command below. The script expects 2 arguments,
+   * // but the command provides 3.
+   * run argue.script Bruce 5 30
+   * ```
+   *
+   * @example
+   * ```ts
+   * // NS2
+   * // Save the code below in a script named "argue.js".
+   * export async function main(ns) {
+   *     const name = ns.args[0];
+   *     const howLong = ns.args[1];
+   *     ns.tprint(`Hello, ${name}.`);
+   *     ns.tprint("Welcome to the Argument Clinic.");
+   *     ns.tprint(`You will argue for ${howLong} minute(s).`);
+   *     ns.tprint("Expected 2 arguments.");
+   *     ns.tprint(`Received ${ns.args.length} argument(s).`);
+   * }
+   *
+   * // From the Terminal, run the command below. The script expects 2 arguments,
+   * // but the command provides 3.
+   * run argue.js Bruce 5 30
+   * ```
    */
   readonly args: (string | number | boolean)[];
 


### PR DESCRIPTION
Elaborate on the documentation of the arguments array `ns.args`.  Provide examples to illustrate how to pass arguments from the Terminal and extract the provided arguments within a script.