### PR TITLE
API: Align hostname validation in port hack programs

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -576,6 +576,9 @@ const base: InternalAPI<NS> = {
   },
   brutessh: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
+    if (hostname === undefined) {
+      throw helpers.makeRuntimeErrorMsg(ctx, "Takes 1 argument.");
+    }
     const server = helpers.getServer(ctx, hostname);
     if (!(server instanceof Server)) {
       helpers.log(ctx, () => "Cannot be executed on this server.");
@@ -640,7 +643,7 @@ const base: InternalAPI<NS> = {
   httpworm: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
     if (hostname === undefined) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "Takes 1 argument");
+      throw helpers.makeRuntimeErrorMsg(ctx, "Takes 1 argument.");
     }
     const server = helpers.getServer(ctx, hostname);
     if (!(server instanceof Server)) {


### PR DESCRIPTION
`ns.brutessh` is missing the `hostname === undefined` validation.

(Also a full stop was missed in `ns.httpworm` validation fail message.)