### PR TITLE
UI: `cat`: proper line breaks when showing .js, .script, or .txt files

### DIFF
--- a/src/Terminal/commands/cat.ts
+++ b/src/Terminal/commands/cat.ts
@@ -49,7 +49,7 @@ export function cat(args: (string | number | boolean)[], server: BaseServer): vo
   } else if (filename.endsWith(".script") || filename.endsWith(".js")) {
     const script = Terminal.getScript(relative_filename);
     if (script != null) {
-      dialogBoxCreate(`${script.filename}<br /><br />${script.code}`);
+      dialogBoxCreate(`${script.filename}\n\n${script.code}`);
       return;
     }
   }

--- a/src/TextFile.ts
+++ b/src/TextFile.ts
@@ -54,7 +54,7 @@ export class TextFile {
 
   /** Shows the content to the user via the game's dialog box. */
   show(): void {
-    dialogBoxCreate(`${this.fn}<br /><br />${this.text}`);
+    dialogBoxCreate(`${this.fn}\n\n${this.text}`);
   }
 
   /** Serialize the current file to a JSON save state. */


### PR DESCRIPTION
From Venusaur (`후시기바나#0028`) on the Bitburner server of Discord:

> I just found another instance of similar issue.
> Maybe it is time to check every usage of `<br>`.
>
> How to reproduce: type cat <any_js_file> on terminal 
![dialog](https://user-images.githubusercontent.com/66396308/199956277-741fe481-ca57-4d2d-9cff-81a65c1d11b6.png)

Currently, the HTML line break sequence `<br /><br />` is hardcoded into the dialog box message when showing the content of these file types: ".js", ".script", and ".txt".  By default, the function `dialogBoxCreate()` currently assumes that its first parameter is not HTML, but a text string, so whatever is in the string will appear in the dialog box.  

### Before patch

Here are the current dialog boxes.

**cat [.js file]**
![cat-js-before](https://user-images.githubusercontent.com/66396308/199955084-5919b206-1b85-49c8-891e-4201aa9672f8.png)

**cat [.script file]**
![cat-script-before](https://user-images.githubusercontent.com/66396308/199955173-2e567382-994b-4105-9919-667415f6c4ed.png)

**cat [.txt file]**
![cat-txt-before](https://user-images.githubusercontent.com/66396308/199955250-b46535f4-901a-43de-8277-67fdca88317f.png)

### How to fix

Use the newline character instead for line break.  If we still want HTML, then the following code also works:

**src/Terminal/commands/cat.ts**
```js
const isHtml = true;
dialogBoxCreate(`${script.filename}<br /><br />${script.code}`, isHtml);
```

**src/TextFile.ts**
```js
const isHtml = true;
dialogBoxCreate(`${this.fn}<br /><br />${this.text}`, isHtml);
```

### After patch

Here are dialog boxes after the patch.

**cat [.js file]**
![cat-js-after](https://user-images.githubusercontent.com/66396308/199955510-8e17920f-bc06-463c-b518-f47cb426bd4b.png)

**cat [.script file]**
![cat-script-after](https://user-images.githubusercontent.com/66396308/199955601-c9b17c98-452c-4549-83a2-aaf660b5fe6b.png)

**cat [.txt file]**
![cat-txt-after](https://user-images.githubusercontent.com/66396308/199955668-b504f492-fc24-4504-8a92-cda7ae9be106.png)
