### PR TITLE
NETSCRIPT: Make ns.writePort synchronous

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1449,7 +1449,7 @@ const base: InternalAPI<NS> = {
   },
   writePort:
     (ctx) =>
-    (_port, data = ""): Promise<any> => {
+    (_port, data): string | number | null => {
       const port = helpers.number(ctx, "port", _port);
       if (typeof data !== "string" && typeof data !== "number") {
         throw helpers.makeRuntimeErrorMsg(
@@ -1458,7 +1458,7 @@ const base: InternalAPI<NS> = {
         );
       }
       const iport = helpers.getValidPort(ctx, port);
-      return Promise.resolve(iport.write(data));
+      return iport.write(data);
     },
   write:
     (ctx) =>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6291,9 +6291,9 @@ export interface NS {
    * RAM cost: 0 GB
    *
    * Write data to the given Netscript port.
-   * @returns The data popped off the queue if it was full.
+   * @returns The data popped off the queue if it was full, or null if it was not full.
    */
-  writePort(port: number, data: string | number): Promise<PortData>;
+  writePort(port: number, data: string | number): PortData | null;
   /**
    * Read data from a port.
    * @remarks


### PR DESCRIPTION
There was no reason for this function to still be asynchronous.