### PR TITLE
SCRIPTS: Fixed bug where zombie scripts could be created after a soft reset

### DIFF
--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -107,14 +107,8 @@ function removeWorkerScript(workerScript: WorkerScript): void {
   server.updateRamUsed(0);
   for (const rs of server.runningScripts) server.updateRamUsed(server.ramUsed + rs.ramUsage * rs.threads);
 
-  // Delete script from global pool (workerScripts)
-  workerScripts.delete(workerScript.pid);
-  // const res = workerScripts.delete(workerScript.pid);
-  // if (!res) {
-  //   console.warn(`removeWorkerScript() called with WorkerScript that wasn't in the global map:`);
-  //   console.warn(workerScript);
-  // }
+  // Delete script from global pool (workerScripts) after verifying it's the right script (PIDs reset on aug install)
+  if (workerScripts.get(workerScript.pid) === workerScript) workerScripts.delete(workerScript.pid);
   AddRecentScript(workerScript);
-
   WorkerScriptStartStopEventEmitter.emit();
 }

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -5,7 +5,6 @@ import { Augmentation } from "../Augmentation/Augmentation";
 import { StaticAugmentations } from "../Augmentation/StaticAugmentations";
 import { augmentationExists, installAugmentations } from "../Augmentation/AugmentationHelpers";
 import { AugmentationNames } from "../Augmentation/data/AugmentationNames";
-import { killWorkerScript } from "../Netscript/killWorkerScript";
 import { CONSTANTS } from "../Constants";
 import { isString } from "../utils/helpers/isString";
 import { RunningScript } from "../Script/RunningScript";
@@ -213,12 +212,8 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       const cbScript = _cbScript ? helpers.string(ctx, "cbScript", _cbScript) : "";
 
       helpers.log(ctx, () => "Soft resetting. This will cause this script to be killed");
-      setTimeout(() => {
-        installAugmentations(true);
-        runAfterReset(cbScript);
-      }, 0);
-
-      killWorkerScript(ctx.workerScript);
+      installAugmentations(true);
+      if (cbScript) setTimeout(() => runAfterReset(cbScript), 500);
     },
     installAugmentations: (ctx) => (_cbScript) => {
       helpers.checkSingularityAccess(ctx);
@@ -230,13 +225,8 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       }
       Player.gainIntelligenceExp(CONSTANTS.IntelligenceSingFnBaseExpGain * 10);
       helpers.log(ctx, () => "Installing Augmentations. This will cause this script to be killed");
-      setTimeout(() => {
-        installAugmentations();
-        runAfterReset(cbScript);
-      }, 0);
-
-      killWorkerScript(ctx.workerScript);
-      return true;
+      installAugmentations();
+      if (cbScript) setTimeout(() => runAfterReset(cbScript), 500);
     },
 
     goToLocation: (ctx) => (_locationName) => {


### PR DESCRIPTION
Also added a 500ms delay for launching the callback script when soft resetting via singularity, and there is no more timeout before performing the reset.

See https://discord.com/channels/415207508303544321/459097632896188436/1039584845342453791 and https://discord.com/channels/415207508303544321/415213413745164318/1032018573331284099 for more information about the issue.