### PR TITLE
STATS: Fix logic for increasing HP based on defense skill levels

### DIFF
--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -51,10 +51,8 @@ export function gainDefenseExp(this: Person, exp: number): void {
     this.mults.defense * BitNodeMultipliers.DefenseLevelMultiplier,
   );
   const ratio = this.hp.current / this.hp.max;
-  this.hp = {
-    max: Math.floor(10 + this.skills.defense / 10),
-    current: Math.round(this.hp.max * ratio),
-  };
+  this.hp.max = Math.floor(10 + this.skills.defense / 10);
+  this.hp.current = Math.round(this.hp.max * ratio);
 }
 
 export function gainDexterityExp(this: Person, exp: number): void {


### PR DESCRIPTION
Should fix #131 

Method was using an old value for hp.max in the hp.current calculation. hp.max needs to be set before hp.current, since hp.max is used in the calculation of hp.current


old (commented) code block was neglecting the fact that the value for current depended on the value for max being updated first.
(commented code was removed before PR)

![image](https://user-images.githubusercontent.com/2829855/200980470-5e78b279-c200-462e-a9b3-4da8093ed0d3.png)
