### PR TITLE
NETSCRIPT: Allow concurrent calls to instant functions

### DIFF
--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -301,7 +301,12 @@ function checkEnvFlags(ctx: NetscriptContext): void {
     log(ctx, () => "Failed to run due to script being killed.");
     throw new ScriptDeath(ws);
   }
-  if (ws.env.runningFn && ctx.function !== "asleep") {
+}
+
+/** Set a timeout for performing a task, mark the script as busy in the meantime. */
+function netscriptDelay(ctx: NetscriptContext, time: number): Promise<void> {
+  const ws = ctx.workerScript;
+  if (ws.delay) {
     ws.delayReject?.(new ScriptDeath(ws));
     ws.env.stopFlag = true;
     log(ctx, () => "Failed to run due to failed concurrency check.");
@@ -314,11 +319,6 @@ function checkEnvFlags(ctx: NetscriptContext): void {
       "CONCURRENCY",
     );
   }
-}
-
-/** Set a timeout for performing a task, mark the script as busy in the meantime. */
-function netscriptDelay(ctx: NetscriptContext, time: number): Promise<void> {
-  const ws = ctx.workerScript;
   return new Promise(function (resolve, reject) {
     ws.delay = window.setTimeout(() => {
       ws.delay = null;


### PR DESCRIPTION
This allows delay free calls like `getPlayer()` during time consuming functions like `hack()` or `installBackdoor()`.

Note that this **does NOT** allow multiple calls at the same time to the latter category of functions (you still can only call `hack()` once at a time from a script), so it should not affect balance or anything, just make the API much less cumbersome to work with.
