### PR TITLE
UI: Fix spacing on ANSI background escape codes

### DIFF
--- a/src/ui/React/ANSIITypography.tsx
+++ b/src/ui/React/ANSIITypography.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
 import { Theme } from "@mui/material/styles";
+import { Settings } from "../../Settings/Settings";
 
 // This particular eslint-disable is correct.
 // In this super specific weird case we in fact do want a regex on an ANSII character.
@@ -16,30 +17,35 @@ const useStyles = makeStyles((theme: Theme) =>
       overflowWrap: "anywhere",
       margin: theme.spacing(0),
       color: theme.colors.success,
+      "--padForFlushBg": (Settings.styles.lineHeight - 1) / 2 + "em",
     },
     error: {
       whiteSpace: "pre-wrap",
       overflowWrap: "anywhere",
       margin: theme.spacing(0),
       color: theme.palette.error.main,
+      "--padForFlushBg": (Settings.styles.lineHeight - 1) / 2 + "em",
     },
     primary: {
       whiteSpace: "pre-wrap",
       overflowWrap: "anywhere",
       margin: theme.spacing(0),
       color: theme.palette.primary.main,
+      "--padForFlushBg": (Settings.styles.lineHeight - 1) / 2 + "em",
     },
     info: {
       whiteSpace: "pre-wrap",
       overflowWrap: "anywhere",
       margin: theme.spacing(0),
       color: theme.palette.info.main,
+      "--padForFlushBg": (Settings.styles.lineHeight - 1) / 2 + "em",
     },
     warning: {
       whiteSpace: "pre-wrap",
       overflowWrap: "anywhere",
       margin: theme.spacing(0),
       color: theme.palette.warning.main,
+      "--padForFlushBg": (Settings.styles.lineHeight - 1) / 2 + "em",
     },
   }),
 );
@@ -220,7 +226,7 @@ function ansiCodeStyle(code: string | null): Record<string, any> {
   // If a background color is set, add slight padding to increase the background fill area.
   // This was previously display:inline-block, but that has display errors when line breaks are used.
   if (style.backgroundColor) {
-    style.padding = "0px 1px";
+    style.padding = "var(--padForFlushBg) 0px";
   }
   return style;
 }


### PR DESCRIPTION
ANSI background spacing was previously incorrect. From https://discord.com/channels/415207508303544321/415213413745164318/1044203353862844436

Old:
![image](https://user-images.githubusercontent.com/84951833/203068253-52c8f811-eda0-4a8e-994f-2895df88fca3.png)


New:
![image](https://user-images.githubusercontent.com/84951833/203068201-c8304c65-0e8b-4d0d-9e19-ea8d735f9dd1.png)