### PR TITLE
DOC: Updated limitMaterialProduction() and limitProductProduction() documentation to mention removing limits.

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7364,18 +7364,18 @@ export interface WarehouseAPI {
   ): void;
   /**
    * Limit Material Production.
-   * @param divisionName - Name of the division
-   * @param cityName - Name of the city
-   * @param materialName - Name of the material
-   * @param qty - Amount to limit to
+   * @param divisionName - Name of the division.
+   * @param cityName - Name of the city.
+   * @param materialName - Name of the material.
+   * @param qty - Amount to limit to. Pass a negative value to remove the limit instead.
    */
   limitMaterialProduction(divisionName: string, cityName: string, materialName: string, qty: number): void;
   /**
    * Limit Product Production.
-   * @param divisionName - Name of the division
-   * @param cityName - Name of the city
-   * @param productName - Name of the product
-   * @param qty - Amount to limit to
+   * @param divisionName - Name of the division.
+   * @param cityName - Name of the city.
+   * @param productName - Name of the product.
+   * @param qty - Amount to limit to. Pass a negative value to remove the limit instead.
    */
   limitProductProduction(divisionName: string, cityName: string, productName: string, qty: number): void;
   /**


### PR DESCRIPTION
### DOC: Updated `limitMaterialProduction()` and `limitProductProduction()` documentation to mention removing limits.

# Documentation

- It seems like you can provide a negative value (or NaN) for `qty` arrgument to the `limitMaterialProduction()` and `limitProductProduction()` methods to remove any existing limits.
- I only realized this when someone mentioned it in Discord so I want to add it to the documentation.

