### PR TITLE
UI: Fixed spacing of text in Trade for reputation button after Infiltration

### DIFF
--- a/src/Infiltration/ui/Victory.tsx
+++ b/src/Infiltration/ui/Victory.tsx
@@ -89,7 +89,9 @@ export function Victory(props: IProps): React.ReactElement {
               ))}
           </Select>
           <Button onClick={trade}>
-            Trade for <Reputation reputation={repGain} /> reputation
+            Trade for&nbsp;
+            <Reputation reputation={repGain} />
+            &nbsp;reputation
           </Button>
         </Box>
         <Button onClick={sell} sx={{ width: "100%" }}>


### PR DESCRIPTION
### UI: Fixed spacing of text in `Trade for reputation` button after Infiltration

# Bug fix

- I fixed it the same way it's done for the 'Sell for _' button

### Before
![image](https://user-images.githubusercontent.com/17806916/203159844-fe0b6651-527a-41bc-8856-60031650052c.png)

### After
![image](https://user-images.githubusercontent.com/17806916/203159878-0d4bbddf-c86a-4e89-988c-2d3541492aa5.png)
