### PR TITLE
MISC: Significantly improve the speed of script creation

### DIFF
--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -43,36 +43,46 @@ export type NetscriptContext = {
   functionPath: string;
 };
 
-export function wrapAPI(ws: WorkerScript, internalAPI: InternalAPI<NSFull>, args: ScriptArg[]): ExternalAPI<NSFull> {
-  function wrapAPILayer<API>(eLayer: ExternalAPI<API>, iLayer: InternalAPI<API>, tree: string[]): ExternalAPI<API> {
-    for (const [key, value] of Object.entries(iLayer) as [Key<API>, InternalValues][]) {
-      if (key === "enums") {
-        (eLayer[key] as Enums) = cloneDeep(value as Enums);
-      } else if (key === "args") continue;
-      // Args are added in wrapAPI function and should only exist at top level
-      else if (typeof value === "function") {
-        wrapFunction(eLayer, value as InternalFn<APIFn>, tree, key);
-      } else if (typeof value === "object") {
-        wrapAPILayer((eLayer[key] = {} as ExternalAPI<API>[Key<API>]), value, [...tree, key as string]);
-      } else {
-        console.warn(`Unexpected data while wrapping API.`, "tree:", tree, "key:", key, "value:", value);
-        throw new Error("Error while wrapping netscript API. See console.");
-      }
-    }
-    return eLayer;
-  }
-  function wrapFunction<API>(eLayer: ExternalAPI<API>, func: InternalFn<APIFn>, tree: string[], key: Key<API>) {
-    const arrayPath = [...tree, key];
-    const functionPath = arrayPath.join(".");
-    const ctx = { workerScript: ws, function: key, functionPath };
-    function wrappedFunction(...args: unknown[]): unknown {
-      helpers.checkEnvFlags(ctx);
-      helpers.updateDynamicRam(ctx, getRamCost(...tree, key));
-      return func(ctx)(...args);
-    }
-    (eLayer[key] as WrappedFn) = wrappedFunction;
-  }
+export function wrapAPI(ns: InternalAPI<NSFull>) {
+  class WrappedAPI {
+    #workerScript: WorkerScript;
+    args: ScriptArg[];
 
-  const wrappedAPI = wrapAPILayer({ args } as ExternalAPI<NSFull>, internalAPI, []);
-  return wrappedAPI;
+    constructor(ws: WorkerScript) {
+      this.#workerScript = ws;
+      this.args = ws.args.slice();
+    }
+
+    static wrapAPILayer<API>(eLayer: ExternalAPI<API>, iLayer: InternalAPI<API>, tree: string[]): object {
+      for (const [key, value] of Object.entries(iLayer) as [Key<API>, InternalValues][]) {
+        if (key === "enums") {
+          (eLayer[key] as Enums) = cloneDeep(value as Enums);
+        } else if (key === "args") continue;
+        // Args are added in the constructor and should only exist at top level
+        else if (typeof value === "function") {
+          this.wrapFunction(eLayer, value as InternalFn<APIFn>, tree, key);
+        } else if (typeof value === "object") {
+          this.wrapAPILayer((eLayer[key] = {} as ExternalAPI<API>[Key<API>]), value, [...tree, key as string]);
+        } else {
+          console.warn(`Unexpected data while wrapping API.`, "tree:", tree, "key:", key, "value:", value);
+          throw new Error("Error while wrapping netscript API. See console.");
+        }
+      }
+      return eLayer;
+    }
+
+    static wrapFunction<API>(eLayer: ExternalAPI<API>, func: InternalFn<APIFn>, tree: string[], key: Key<API>) {
+      const arrayPath = [...tree, key];
+      const functionPath = arrayPath.join(".");
+      function wrappedFunction(this: WrappedAPI, ...args: unknown[]): unknown {
+        const ctx = { workerScript: this.#workerScript, function: key, functionPath };
+        helpers.checkEnvFlags(ctx);
+        helpers.updateDynamicRam(ctx, getRamCost(...tree, key));
+        return func(ctx)(...args);
+      }
+      (eLayer[key] as WrappedFn) = wrappedFunction;
+    }
+  }
+  Object.assign(WrappedAPI.prototype, WrappedAPI.wrapAPILayer({} as ExternalAPI<NSFull>, ns, []));
+  return (ws: WorkerScript) => new WrappedAPI(ws) as unknown as ExternalAPI<NSFull>;
 }

--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -83,6 +83,11 @@ export function wrapAPI(ns: InternalAPI<NSFull>) {
       (eLayer[key] as WrappedFn) = wrappedFunction;
     }
   }
+  Object.defineProperty(WrappedAPI.prototype, "constructor", {
+    value: function () {
+      throw new Error("Can't create a new ns object. Sorry.");
+    },
+  });
   Object.assign(WrappedAPI.prototype, WrappedAPI.wrapAPILayer({} as ExternalAPI<NSFull>, ns, []));
   return (ws: WorkerScript) => new WrappedAPI(ws) as unknown as ExternalAPI<NSFull>;
 }

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -41,7 +41,6 @@ import { TextFile, getTextFile, createTextFile } from "./TextFile";
 import { runScriptFromScript } from "./NetscriptWorker";
 import { killWorkerScript } from "./Netscript/killWorkerScript";
 import { workerScripts } from "./Netscript/WorkerScripts";
-import { WorkerScript } from "./Netscript/WorkerScript";
 import { helpers, assertObjectType } from "./Netscript/NetscriptHelpers";
 import { numeralWrapper } from "./ui/numeralFormat";
 import { convertTimeMsToTimeElapsedString } from "./utils/StringHelperFunctions";
@@ -72,7 +71,7 @@ import { Flags } from "./NetscriptFunctions/Flags";
 import { calculateIntelligenceBonus } from "./PersonObjects/formulas/intelligence";
 import { CalculateShareMult, StartSharing } from "./NetworkShare/Share";
 import { recentScripts } from "./Netscript/RecentScripts";
-import { ExternalAPI, InternalAPI, wrapAPI } from "./Netscript/APIWrapper";
+import { InternalAPI, wrapAPI } from "./Netscript/APIWrapper";
 import { INetscriptExtra } from "./NetscriptFunctions/Extra";
 import { ScriptDeath } from "./Netscript/ScriptDeath";
 import { getBitNodeMultipliers } from "./BitNode/BitNode";
@@ -92,10 +91,6 @@ export const enums: NSEnums = {
 };
 
 export type NSFull = Readonly<NS & INetscriptExtra>;
-
-export function NetscriptFunctions(workerScript: WorkerScript): ExternalAPI<NSFull> {
-  return wrapAPI(workerScript, ns, workerScript.args.slice());
-}
 
 const base: InternalAPI<NS> = {
   args: [],
@@ -1912,6 +1907,7 @@ export const ns = {
   ...base,
   ...NetscriptExtra(),
 };
+export const NetscriptFunctions = wrapAPI(ns);
 
 const possibleLogs = Object.fromEntries([...getFunctionNames(ns, "")].map((a) => [a, true]));
 /** Provides an array of all function names on a nested object */

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -134,7 +134,7 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
     const singObjects = singFunctions.map(([key, val]) => {
       return {
         name: key,
-        fn: val,
+        fn: val.bind(ns),
         baseRam: grabCost(RamCosts.singularity, ["singularity", key]),
       };
     });


### PR DESCRIPTION
In my browser (Chrome 107.0.5304.107 Windows 10) this improves noop script execution from 8281.063/sec to 13942.606/sec - a 68% speedup!

The 'ns' API has to be wrapped, so that functions can access the context (primarily the WorkerScript) without leaking it to the player. Before, this happened by walking the whole API tree and creating new wrapping functions for every script, which is understandably expensive.

Now we take advantage of class #private fields to securely hold the context, allowing the wrapping functions to exist on the prototype and only need to be created once. These are widely available (>93% according to caniuse) and work with Electron.

# Benchmarks
benchmark.js
```js
/** @param {NS} ns */
export async function main(ns) {
    const resolved = Promise.resolve();
    const perf = globalThis.performance;
    let speedMax = 0;
    for (let i = 0; i < Number(ns.args[0]); ++i) {
        const start = perf.now();
        let end, cycles;
        for (cycles = 0; (end = perf.now()) - start < 1000; cycles++) {
            ns.exec("/lib/noop.js", "home");
            await resolved;
        }
        const speed = (cycles * 1000) / (end - start);
        speedMax = speed > speedMax ? speed : speedMax;
        ns.tprintf("Iter %2d: %.3f/sec", i, speed);
        await new Promise(resolve => setTimeout(resolve));
    }
    ns.tprintf("Best: %.3f/sec", speedMax);
}
```
/lib/noop.js
```js
/** @param {NS} ns */
export function main(ns) {}
```
## Output
### Before
```
[home ~/]> run benchmark.js 30
Running script with 1 thread(s), pid 128630 and args: [30].
Iter  0: 7246.000/sec
Iter  1: 7737.905/sec
Iter  2: 6598.361/sec
Iter  3: 6433.427/sec
Iter  4: 7428.571/sec
Iter  5: 7370.000/sec
Iter  6: 7113.155/sec
Iter  7: 7682.927/sec
Iter  8: 8137.167/sec
Iter  9: 7428.029/sec
Iter 10: 7266.000/sec
Iter 11: 7976.000/sec
Iter 12: 7094.581/sec
Iter 13: 7966.000/sec
Iter 14: 7235.018/sec
Iter 15: 7076.754/sec
Iter 16: 7199.560/sec
Iter 17: 7373.051/sec
Iter 18: 7654.469/sec
Iter 19: 7538.738/sec
Iter 20: 8281.063/sec
Iter 21: 7820.218/sec
Iter 22: 7871.554/sec
Iter 23: 6979.604/sec
Iter 24: 6813.956/sec
Iter 25: 7170.283/sec
Iter 26: 7546.000/sec
Iter 27: 7093.872/sec
Iter 28: 7173.848/sec
Iter 29: 7616.099/sec
Best: 8281.063/sec
```
### After
```
[home ~/]> run benchmark.js 30
Running script with 1 thread(s), pid 65008 and args: [30].
Iter  0: 13535.525/sec
Iter  1: 11431.000/sec
Iter  2: 12362.346/sec
Iter  3: 10344.966/sec
Iter  4: 12774.723/sec
Iter  5: 11089.891/sec
Iter  6: 12011.000/sec
Iter  7: 9351.324/sec
Iter  8: 10857.314/sec
Iter  9: 10649.000/sec
Iter 10: 12542.000/sec
Iter 11: 10861.000/sec
Iter 12: 12526.000/sec
Iter 13: 11858.000/sec
Iter 14: 12429.757/sec
Iter 15: 13491.000/sec
Iter 16: 12009.000/sec
Iter 17: 10983.803/sec
Iter 18: 11814.819/sec
Iter 19: 13811.000/sec
Iter 20: 12753.073/sec
Iter 21: 12450.000/sec
Iter 22: 11474.525/sec
Iter 23: 12557.744/sec
Iter 24: 13942.606/sec
Iter 25: 13336.000/sec
Iter 26: 11866.000/sec
Iter 27: 12286.000/sec
Iter 28: 10080.000/sec
Iter 29: 10176.000/sec
Best: 13942.606/sec
```