### PR TITLE
UI: Fix keyboard shortcuts for other keyboard layouts

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -4,6 +4,7 @@ import * as monaco from "monaco-editor";
 
 type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 type ITextModel = monaco.editor.ITextModel;
+import { KEY } from "../../utils/helpers/keyCodes";
 import { OptionsModal } from "./OptionsModal";
 import { Options } from "./Options";
 import { isValidFilePath } from "../../Terminal/DirectoryHelpers";
@@ -152,13 +153,13 @@ export function Root(props: IProps): React.ReactElement {
     function keydown(event: KeyboardEvent): void {
       if (Settings.DisableHotkeys) return;
       //Ctrl + b
-      if (event.code == "KeyB" && (event.ctrlKey || event.metaKey)) {
+      if (event.key == KEY.B && (event.ctrlKey || event.metaKey)) {
         event.preventDefault();
         Router.toTerminal();
       }
 
       // CTRL/CMD + S
-      if (event.code == "KeyS" && (event.ctrlKey || event.metaKey)) {
+      if (event.key == KEY.S && (event.ctrlKey || event.metaKey)) {
         event.preventDefault();
         event.stopPropagation();
         save();

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { KEYCODE } from "../../utils/helpers/keyCodes";
+import { KEY } from "../../utils/helpers/keyCodes";
 import clsx from "clsx";
 import { styled, Theme, CSSObject } from "@mui/material/styles";
 import createStyles from "@mui/styles/createStyles";
@@ -275,53 +275,53 @@ export function SidebarRoot(props: IProps): React.ReactElement {
     function handleShortcuts(this: Document, event: KeyboardEvent): void {
       if (Settings.DisableHotkeys) return;
       if ((Player.currentWork && Player.focus) || Router.page() === Page.BitVerse) return;
-      if (event.code === KEYCODE.T && event.altKey) {
+      if (event.key === KEY.T && event.altKey) {
         event.preventDefault();
         clickTerminal();
-      } else if (event.code === KEYCODE.C && event.altKey) {
+      } else if (event.key === KEY.C && event.altKey) {
         event.preventDefault();
         clickStats();
-      } else if (event.code === KEYCODE.E && event.altKey) {
+      } else if (event.key === KEY.E && event.altKey) {
         event.preventDefault();
         clickScriptEditor();
-      } else if (event.code === KEYCODE.S && event.altKey) {
+      } else if (event.key === KEY.S && event.altKey) {
         event.preventDefault();
         clickActiveScripts();
-      } else if (event.code === KEYCODE.H && event.altKey) {
+      } else if (event.key === KEY.H && event.altKey) {
         event.preventDefault();
         clickHacknet();
-      } else if (event.code === KEYCODE.W && event.altKey) {
+      } else if (event.key === KEY.W && event.altKey) {
         event.preventDefault();
         clickCity();
-      } else if (event.code === KEYCODE.J && event.altKey && !event.ctrlKey && !event.metaKey && canJob) {
+      } else if (event.key === KEY.J && event.altKey && !event.ctrlKey && !event.metaKey && canJob) {
         // ctrl/cmd + alt + j is shortcut to open Chrome dev tools
         event.preventDefault();
         clickJob();
-      } else if (event.code === KEYCODE.R && event.altKey) {
+      } else if (event.key === KEY.R && event.altKey) {
         event.preventDefault();
         clickTravel();
-      } else if (event.code === KEYCODE.P && event.altKey) {
+      } else if (event.key === KEY.P && event.altKey) {
         event.preventDefault();
         clickCreateProgram();
-      } else if (event.code === KEYCODE.F && event.altKey) {
+      } else if (event.key === KEY.F && event.altKey) {
         if (props.page == Page.Terminal && Settings.EnableBashHotkeys) {
           return;
         }
         event.preventDefault();
         clickFactions();
-      } else if (event.code === KEYCODE.A && event.altKey) {
+      } else if (event.key === KEY.A && event.altKey) {
         event.preventDefault();
         clickAugmentations();
-      } else if (event.code === KEYCODE.U && event.altKey) {
+      } else if (event.key === KEY.U && event.altKey) {
         event.preventDefault();
         clickTutorial();
-      } else if (event.code === KEYCODE.O && event.altKey) {
+      } else if (event.key === KEY.O && event.altKey) {
         event.preventDefault();
         clickOptions();
-      } else if (event.code === KEYCODE.B && event.altKey && Player.bladeburner) {
+      } else if (event.key === KEY.B && event.altKey && Player.bladeburner) {
         event.preventDefault();
         clickBladeburner();
-      } else if (event.code === KEYCODE.G && event.altKey && Player.gang) {
+      } else if (event.key === KEY.G && event.altKey && Player.gang) {
         event.preventDefault();
         clickGang();
       }

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -7,7 +7,7 @@ import Paper from "@mui/material/Paper";
 import Popper from "@mui/material/Popper";
 import TextField from "@mui/material/TextField";
 
-import { KEY, KEYCODE } from "../../utils/helpers/keyCodes";
+import { KEY } from "../../utils/helpers/keyCodes";
 import { Terminal } from "../../Terminal";
 import { Player } from "@player";
 import { determineAllPossibilitiesForTabCompletion } from "../determineAllPossibilitiesForTabCompletion";
@@ -316,63 +316,63 @@ export function TerminalInput(): React.ReactElement {
 
     // Extra Bash Emulation Hotkeys, must be enabled through options
     if (Settings.EnableBashHotkeys) {
-      if (event.code === KEYCODE.C && event.ctrlKey && ref && ref.selectionStart === ref.selectionEnd) {
+      if (event.key === KEY.C && event.ctrlKey && ref && ref.selectionStart === ref.selectionEnd) {
         event.preventDefault();
         Terminal.print(`[${Player.getCurrentServer().hostname} ~${Terminal.cwd()}]> ${value}`);
         modifyInput("clearall");
       }
 
-      if (event.code === KEYCODE.A && event.ctrlKey) {
+      if (event.key === KEY.A && event.ctrlKey) {
         event.preventDefault();
         moveTextCursor("home");
       }
 
-      if (event.code === KEYCODE.E && event.ctrlKey) {
+      if (event.key === KEY.E && event.ctrlKey) {
         event.preventDefault();
         moveTextCursor("end");
       }
 
-      if (event.code === KEYCODE.B && event.ctrlKey) {
+      if (event.key === KEY.B && event.ctrlKey) {
         event.preventDefault();
         moveTextCursor("prevchar");
       }
 
-      if (event.code === KEYCODE.B && event.altKey) {
+      if (event.key === KEY.B && event.altKey) {
         event.preventDefault();
         moveTextCursor("prevword");
       }
 
-      if (event.code === KEYCODE.F && event.ctrlKey) {
+      if (event.key === KEY.F && event.ctrlKey) {
         event.preventDefault();
         moveTextCursor("nextchar");
       }
 
-      if (event.code === KEYCODE.F && event.altKey) {
+      if (event.key === KEY.F && event.altKey) {
         event.preventDefault();
         moveTextCursor("nextword");
       }
 
-      if ((event.code === KEYCODE.H || event.code === KEYCODE.D) && event.ctrlKey) {
+      if ((event.key === KEY.H || event.key === KEY.D) && event.ctrlKey) {
         modifyInput("backspace");
         event.preventDefault();
       }
 
-      if (event.code === KEYCODE.W && event.ctrlKey) {
+      if (event.key === KEY.W && event.ctrlKey) {
         event.preventDefault();
         modifyInput("deletewordbefore");
       }
 
-      if (event.code === KEYCODE.D && event.altKey) {
+      if (event.key === KEY.D && event.altKey) {
         event.preventDefault();
         modifyInput("deletewordafter");
       }
 
-      if (event.code === KEYCODE.U && event.ctrlKey) {
+      if (event.key === KEY.U && event.ctrlKey) {
         event.preventDefault();
         modifyInput("clearbefore");
       }
 
-      if (event.code === KEYCODE.K && event.ctrlKey) {
+      if (event.key === KEY.K && event.ctrlKey) {
         event.preventDefault();
         modifyInput("clearafter");
       }

--- a/src/utils/helpers/keyCodes.ts
+++ b/src/utils/helpers/keyCodes.ts
@@ -1,4 +1,4 @@
-/** Keyboard key codes as returned by event.key */
+/** Keyboard key codes */
 export enum KEY {
   //SHIFT: 16, // Check by `&& event.shiftKey`
   //CTRL: 17, // Check by `&& event.ctrlKey`
@@ -68,68 +68,4 @@ export enum KEY {
   X = "x",
   Y = "y",
   Z = "z",
-}
-
-/** Keyboard key codes as returned by event.code */
-export enum KEYCODE {
-  //SHIFT: 16, // Check by `&& event.shiftKey`
-  //CTRL: 17, // Check by `&& event.ctrlKey`
-  //ALT: 18, // Check by `&& event.altKey`
-  ENTER = "Enter",
-  ESC = "Escape",
-  TAB = "Tab",
-  SPACE = "Space",
-  BACKSPACE = "Backspace",
-  UP_ARROW = "ArrowUp",
-  DOWN_ARROW = "ArrowDown",
-  LEFT_ARROW = "ArrowLeft",
-  RIGHT_ARROW = "ArrowRight",
-
-  BACKWARD_SLASH = "Backslash",
-  BACKQUOTE = "Backquote",
-  COMMA = "Comma",
-  DOT = "Period",
-  EQUAL = "Equal",
-  FORWARD_SLASH = "Slash",
-  HYPHEN = "Minus",
-  SEMICOLON = "Semicolon",
-  QUOTE = "Quote",
-
-  k0 = "Digit0",
-  k1 = "Digit1",
-  k2 = "Digit2",
-  k3 = "Digit3",
-  k4 = "Digit4",
-  k5 = "Digit5",
-  k6 = "Digit6",
-  k7 = "Digit7",
-  k8 = "Digit8",
-  k9 = "Digit9",
-
-  A = "KeyA",
-  B = "KeyB",
-  C = "KeyC",
-  D = "KeyD",
-  E = "KeyE",
-  F = "KeyF",
-  G = "KeyG",
-  H = "KeyH",
-  I = "KeyI",
-  J = "KeyJ",
-  K = "KeyK",
-  L = "KeyL",
-  M = "KeyM",
-  N = "KeyN",
-  O = "KeyO",
-  P = "KeyP",
-  Q = "KeyQ",
-  R = "KeyR",
-  S = "KeyS",
-  T = "KeyT",
-  U = "KeyU",
-  V = "KeyV",
-  W = "KeyW",
-  X = "KeyX",
-  Y = "KeyY",
-  Z = "KeyZ",
 }


### PR DESCRIPTION
A prior change changed from event.key to event.code. I'm not sure why this commit was made, since there's no further explanation in the commit message. But using event.code breaks non-QWERTY keyboard layouts, so reverting improves my (Dvorak) experience greatly.
Also, it's strongly warned against at MDN:
https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event#event_properties

This also fixes ScriptEditorRoot.tsx, where some code snuck in that wasn't using *any* of the constants.

This reverts commit 016a9a873fba71388bdbaa1423134fd1f2335a15.

## Testing

Tried the various hotkeys, they work correctly for Dvorak now. In particular, Ctrl-X (which is physically Ctrl-B) now cuts text instead of exiting to the terminal in the script editor.

Switching to Qwerty, the hotkeys match their "usual" behavior. I didn't detect any weird cases, and I tried a bunch in both layouts.