### PR TITLE
DOC: Sleeve: link the Sleeve API in the list of APIs

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -55,7 +55,7 @@ interface Player extends Person {
 }
 
 /** @public */
-interface Sleeve extends Person {
+interface SleeveObject extends Person {
   shock: number;
   sync: number;
   memory: number;
@@ -260,7 +260,7 @@ interface CodingAttemptOptions {
 }
 
 /**
- * Return value of {@link sleeve.getSleevePurchasableAugs | getSleevePurchasableAugs}
+ * Return value of {@link Sleeve.getSleevePurchasableAugs | getSleevePurchasableAugs}
  * @public
  */
 interface AugmentPair {
@@ -3515,7 +3515,7 @@ export interface Gang {
  * If you are not in BitNode-10, then you must have Source-File 10 in order to use this API.
  * @public
  */
-export interface sleeve {
+export interface Sleeve {
   /**
    * Get the number of sleeves you own.
    * @remarks
@@ -3537,7 +3537,7 @@ export interface sleeve {
    * @param sleeveNumber - Index of the sleeve to retrieve information.
    * @returns Object containing information about this sleeve.
    */
-  getSleeve(sleeveNumber: number): Sleeve;
+  getSleeve(sleeveNumber: number): SleeveObject;
 
   /**
    * Get task of a sleeve.
@@ -4479,7 +4479,7 @@ export interface NS {
    * Namespace for sleeve functions.
    * @remarks RAM cost: 0 GB
    */
-  readonly sleeve: sleeve;
+  readonly sleeve: Sleeve;
 
   /**
    * Namespace for stock functions.


### PR DESCRIPTION
From Venusaur (`후시기바나#0028`) on the Bitburner server of Discord:

> In head branch, it seems that there is type named sleeve (can get by ns.sleeve), and there is type named Sleeve (can get by ns.sleeve.getSleeve(0)).
The markdown document doesn't have former, only latter. i.e. I can't see markdown document of list of function of ns.sleeve.
https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.sleeve.md

The URL

https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.sleeve.md

currently points to this page:

![sleeve](https://user-images.githubusercontent.com/66396308/203749022-4e5253e2-d1bf-498b-a04b-4e506c52a0ec.png)

The expected page is something like this:

https://github.com/danielyxie/bitburner/blob/dev/markdown/bitburner.sleeve.md

The interface that defines the Sleeve object clashes with the interface that defines the Sleeve API.  The former is named `Sleeve` (uppercase), whereas the latter is named `sleeve` (lowercase).  API Extractor does not like this and inserts a link to the Sleeve object in place of where the Sleeve API should be.  A fix is to rename the interface for the Sleeve object as `SleeveObject`.  Or something other than using lowercase and uppercase to differentiate the Sleeve object interface from the Sleeve API interface.
