### PR TITLE
LOGS: Add ctrl-a support for selecting logs

### DIFF
--- a/src/ui/React/ANSIITypography.tsx
+++ b/src/ui/React/ANSIITypography.tsx
@@ -97,7 +97,7 @@ export const ANSIITypography = React.memo((props: IProps): React.ReactElement =>
     parts.push({ code: null, text: text });
   }
   return (
-    <Typography classes={{ root: lineClass(classes, props.color) }} paragraph={false}>
+    <Typography component={"div"} classes={{ root: lineClass(classes, props.color) }} paragraph={false}>
       {parts.map((part, i) => (
         <span key={i} style={ansiCodeStyle(part.code)}>
           {part.text}

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -139,12 +139,26 @@ function LogWindow(props: IProps): React.ReactElement {
   const [script, setScript] = useState(props.script);
   const classes = useStyles();
   const container = useRef<HTMLDivElement>(null);
+  const textArea = useRef<HTMLDivElement>(null);
   const setRerender = useState(false)[1];
   const [size, setSize] = useState<[number, number]>([500, 500]);
   const [minimized, setMinimized] = useState(false);
   function rerender(): void {
     setRerender((old) => !old);
   }
+
+  const textAreaKeyDown = (e: React.KeyboardEvent) => {
+    if (e.ctrlKey && e.key === "a") {
+      if (!textArea.current) return; //Should never happen
+      const r = new Range();
+      r.setStartBefore(textArea.current);
+      r.setEndAfter(textArea.current);
+      document.getSelection()?.removeAllRanges();
+      document.getSelection()?.addRange(r);
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
 
   const onResize = (e: React.SyntheticEvent, { size }: ResizeCallbackData) => {
     setSize([size.width, size.height]);
@@ -364,15 +378,18 @@ function LogWindow(props: IProps): React.ReactElement {
 
             <Paper
               className={classes.logs}
-              sx={{ height: `calc(100% - ${minConstraints[1]}px)`, display: minimized ? "none" : "flex" }}
+              style={{ height: `calc(100% - ${minConstraints[1]}px)`, display: minimized ? "none" : "flex" }}
+              tabIndex={-1}
+              ref={textArea}
+              onKeyDown={textAreaKeyDown}
             >
-              <span style={{ display: "flex", flexDirection: "column" }}>
+              <div style={{ display: "flex", flexDirection: "column" }}>
                 {script.logs.map(
                   (line: string, i: number): JSX.Element => (
                     <ANSIITypography key={i} text={line} color={lineColor(line)} />
                   ),
                 )}
-              </span>
+              </div>
             </Paper>
           </>
         </ResizableBox>


### PR DESCRIPTION
Also prevents double line returns when copying logs

https://user-images.githubusercontent.com/84951833/203827620-cb691181-09a9-4aa8-b828-93e835a53348.mp4

Fix #204 