### PR TITLE
NETSCRIPT: Faster API wrapping on script launch.

### DIFF
--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -2,7 +2,6 @@ import { getRamCost } from "./RamCostGenerator";
 import type { WorkerScript } from "./WorkerScript";
 import { helpers } from "./NetscriptHelpers";
 import { ScriptArg } from "./ScriptArg";
-import { ns, NSFull } from "../NetscriptFunctions";
 import { cloneDeep } from "lodash";
 
 /** Generic type for an enums object */

--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -2,7 +2,7 @@ import { getRamCost } from "./RamCostGenerator";
 import type { WorkerScript } from "./WorkerScript";
 import { helpers } from "./NetscriptHelpers";
 import { ScriptArg } from "./ScriptArg";
-import { NSFull } from "src/NetscriptFunctions";
+import { ns, NSFull } from "../NetscriptFunctions";
 import { cloneDeep } from "lodash";
 
 /** Generic type for an enums object */
@@ -37,42 +37,56 @@ export type InternalAPI<API> = {
 /** Any of the possible values on a internal API layer */
 type InternalValues = Enums | ScriptArg[] | InternalFn<APIFn> | InternalAPI<unknown>;
 
+export class StampedLayer {
+  #workerScript: WorkerScript;
+  constructor(ws: WorkerScript, obj: any) {
+    this.#workerScript = ws;
+    Object.assign(this, obj);
+  }
+  static wrapFunction<API>(eLayer: ExternalAPI<API>, func: InternalFn<APIFn>, tree: string[], key: Key<API>) {
+    const arrayPath = [...tree, key];
+    const functionPath = arrayPath.join(".");
+    function wrappedFunction(this: StampedLayer, ...args: unknown[]): unknown {
+      const ctx = { workerScript: this.#workerScript, function: key, functionPath };
+      helpers.checkEnvFlags(ctx);
+      helpers.updateDynamicRam(ctx, getRamCost(...tree, key));
+      return func(ctx)(...args);
+    }
+    Object.defineProperty(eLayer, key, { value: wrappedFunction, enumerable: true, writable: false });
+  }
+}
+Object.defineProperty(StampedLayer.prototype, "constructor", {
+  value: Object,
+  enumerable: false,
+  writable: false,
+  configurable: false,
+});
+
 export type NetscriptContext = {
   workerScript: WorkerScript;
   function: string;
   functionPath: string;
 };
 
-export function wrapAPI(ws: WorkerScript, internalAPI: InternalAPI<NSFull>, args: ScriptArg[]): ExternalAPI<NSFull> {
-  function wrapAPILayer<API>(eLayer: ExternalAPI<API>, iLayer: InternalAPI<API>, tree: string[]): ExternalAPI<API> {
-    for (const [key, value] of Object.entries(iLayer) as [Key<API>, InternalValues][]) {
-      if (key === "enums") {
-        (eLayer[key] as Enums) = cloneDeep(value as Enums);
-      } else if (key === "args") continue;
-      // Args are added in wrapAPI function and should only exist at top level
-      else if (typeof value === "function") {
-        wrapFunction(eLayer, value as InternalFn<APIFn>, tree, key);
-      } else if (typeof value === "object") {
-        wrapAPILayer((eLayer[key] = {} as ExternalAPI<API>[Key<API>]), value, [...tree, key as string]);
-      } else {
-        console.warn(`Unexpected data while wrapping API.`, "tree:", tree, "key:", key, "value:", value);
-        throw new Error("Error while wrapping netscript API. See console.");
-      }
+export function wrapAPILayer<API>(
+  eLayer: ExternalAPI<API>,
+  iLayer: InternalAPI<API>,
+  tree: string[],
+): ExternalAPI<API> {
+  for (const [key, value] of Object.entries(iLayer) as [Key<API>, InternalValues][]) {
+    if (key === "enums") {
+      (eLayer[key] as Enums) = cloneDeep(value as Enums);
+    } else if (key === "args") continue;
+    // Args only added on individual instances.
+    else if (typeof value === "function") {
+      StampedLayer.wrapFunction(eLayer, value as InternalFn<APIFn>, tree, key);
+    } else if (typeof value === "object") {
+      wrapAPILayer((eLayer[key] = {} as ExternalAPI<API>[Key<API>]), value, [...tree, key as string]);
+    } else {
+      console.warn(`Unexpected data while wrapping API.`, "tree:", tree, "key:", key, "value:", value);
+      throw new Error("Error while wrapping netscript API. See console.");
     }
-    return eLayer;
   }
-  function wrapFunction<API>(eLayer: ExternalAPI<API>, func: InternalFn<APIFn>, tree: string[], key: Key<API>) {
-    const arrayPath = [...tree, key];
-    const functionPath = arrayPath.join(".");
-    const ctx = { workerScript: ws, function: key, functionPath };
-    function wrappedFunction(...args: unknown[]): unknown {
-      helpers.checkEnvFlags(ctx);
-      helpers.updateDynamicRam(ctx, getRamCost(...tree, key));
-      return func(ctx)(...args);
-    }
-    (eLayer[key] as WrappedFn) = wrappedFunction;
-  }
-
-  const wrappedAPI = wrapAPILayer({ args } as ExternalAPI<NSFull>, internalAPI, []);
-  return wrappedAPI;
+  return eLayer;
 }
+// single wrapped version of NS.

--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -38,9 +38,9 @@ type InternalValues = Enums | ScriptArg[] | InternalFn<APIFn> | InternalAPI<unkn
 
 export class StampedLayer {
   #workerScript: WorkerScript;
-  constructor(ws: WorkerScript, obj: any) {
+  constructor(ws: WorkerScript, obj: ExternalAPI<unknown>) {
     this.#workerScript = ws;
-    Object.assign(this, obj);
+    Object.setPrototypeOf(this, obj);
   }
   static wrapFunction<API>(eLayer: ExternalAPI<API>, func: InternalFn<APIFn>, tree: string[], key: Key<API>) {
     const arrayPath = [...tree, key];
@@ -90,4 +90,3 @@ export function wrapAPILayer<API>(
   }
   return eLayer;
 }
-// single wrapped version of NS.

--- a/src/Netscript/APIWrapper.ts
+++ b/src/Netscript/APIWrapper.ts
@@ -74,7 +74,9 @@ export function wrapAPILayer<API>(
 ): ExternalAPI<API> {
   for (const [key, value] of Object.entries(iLayer) as [Key<API>, InternalValues][]) {
     if (key === "enums") {
-      (eLayer[key] as Enums) = cloneDeep(value as Enums);
+      const enumObj = Object.freeze(cloneDeep(value as Enums));
+      for (const member of Object.values(enumObj)) Object.freeze(member);
+      (eLayer[key] as Enums) = enumObj;
     } else if (key === "args") continue;
     // Args only added on individual instances.
     else if (typeof value === "function") {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1910,16 +1910,6 @@ export const ns = {
 };
 
 const wrappedNS = wrapAPILayer({} as ExternalAPI<NSFull>, ns, []);
-function freezeEnums(obj: object, isEnums = false) {
-  if (isEnums) Object.freeze(obj);
-  for (const [k, v] of Object.entries(obj)) {
-    if (isEnums) Object.freeze(v);
-    else if (typeof obj === "object") {
-      freezeEnums(v, k === "enums");
-    }
-  }
-}
-freezeEnums(wrappedNS);
 
 export function NetscriptFunctions(ws: WorkerScript): ExternalAPI<NSFull> {
   const instance = new StampedLayer(ws, wrappedNS) as any;
@@ -1932,7 +1922,7 @@ function stampLayers(ws: WorkerScript, stamped: any, unstamped: any) {
   for (const [k, v] of Object.entries(unstamped)) {
     if (typeof v === "object" && k !== "enums") {
       stamped[k] = new StampedLayer(ws, v);
-      stampLayers(ws, stamped[k], unstamped[k]);
+      stampLayers(ws, stamped[k], v);
     }
   }
 }

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -88,7 +88,7 @@ async function startNetscript1Script(workerScript: WorkerScript): Promise<void> 
           try {
             // Sent a resolver function as an extra arg. See createAsyncFunction JSInterpreter.js:3209
             const callback = args.pop() as (value: unknown) => void;
-            const result = await entry(...args.map((arg) => int.pseudoToNative(arg)));
+            const result = await entry.bind(workerScript.env.vars)(...args.map((arg) => int.pseudoToNative(arg)));
             return callback(int.nativeToPseudo(result));
           } catch (e: unknown) {
             errorToThrow = e;

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -11,7 +11,7 @@ import { generateNextPid } from "./Netscript/Pid";
 
 import { CONSTANTS } from "./Constants";
 import { Interpreter } from "./ThirdParty/JSInterpreter";
-import { NetscriptFunctions } from "./NetscriptFunctions";
+import { NetscriptFunctions, wrappedNS } from "./NetscriptFunctions";
 import { compile, Node } from "./NetscriptJSEvaluator";
 import { IPort } from "./NetscriptPort";
 import { RunningScript } from "./Script/RunningScript";
@@ -81,7 +81,7 @@ async function startNetscript1Script(workerScript: WorkerScript): Promise<void> 
 
   //TODO: Make NS1 wrapping type safe instead of using BasicObject
   type BasicObject = Record<string, any>;
-  function wrapNS1Layer(int: Interpreter, intLayer: unknown, nsLayer = workerScript.env.vars as BasicObject) {
+  function wrapNS1Layer(int: Interpreter, intLayer: unknown, nsLayer = wrappedNS as BasicObject) {
     for (const [name, entry] of Object.entries(nsLayer)) {
       if (typeof entry === "function") {
         const wrapper = async (...args: unknown[]) => {

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -134,7 +134,7 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
     const singObjects = singFunctions.map(([key, val]) => {
       return {
         name: key,
-        fn: val,
+        fn: val.bind(ns),
         baseRam: grabCost(RamCosts.singularity, ["singularity", key]),
       };
     });

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -1,5 +1,5 @@
 import { Player } from "../../../src/Player";
-import { NetscriptFunctions } from "../../../src/NetscriptFunctions";
+import { NetscriptFunctions, wrappedNS } from "../../../src/NetscriptFunctions";
 import { RamCosts, getRamCost, RamCostConstants } from "../../../src/Netscript/RamCostGenerator";
 import { Environment } from "../../../src/Netscript/Environment";
 import { RunningScript } from "../../../src/Script/RunningScript";
@@ -62,7 +62,6 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
     expectedRamCost: number,
     extraLayerCost = 0,
   ) {
-    fn = fn.bind(ns);
     const code = `${fnPath.join(".")}();\n`.repeat(3);
     const fnName = fnPath[fnPath.length - 1];
 
@@ -100,11 +99,11 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
   }
 
   describe("ns", () => {
-    Object.entries(ns as unknown as NSLayer).forEach(([key, val]) => {
+    Object.entries(wrappedNS as unknown as NSLayer).forEach(([key, val]) => {
       if (key === "args" || key === "enums") return;
       if (typeof val === "function") {
         const expectedRam = grabCost(RamCosts, [key]);
-        it(`${key}()`, () => combinedRamCheck(val, [key], expectedRam));
+        it(`${key}()`, () => combinedRamCheck(val.bind(ns), [key], expectedRam));
       }
       //The only other option should be an NSLayer
       const extraLayerCost = { corporation: 1022.4, hacknet: 4 }[key] ?? 0;
@@ -113,13 +112,15 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
   });
 
   function testLayer(nsLayer: NSLayer, ramLayer: RamLayer, path: string[], extraLayerCost: number) {
+    // nsLayer is the layer on the main, unstamped wrappedNS object. The actualLayer is needed to check correct stamping.
+    const actualLayer = path.reduce((prev, curr) => prev[curr], ns as any); //todo: do this typesafely?
     describe(path[path.length - 1], () => {
       Object.entries(nsLayer).forEach(([key, val]) => {
         const newPath = [...path, key];
         if (typeof val === "function") {
           const fnName = newPath.join(".");
           const expectedRam = grabCost(ramLayer, newPath);
-          it(`${fnName}()`, () => combinedRamCheck(val, newPath, expectedRam, extraLayerCost));
+          it(`${fnName}()`, () => combinedRamCheck(val.bind(actualLayer), newPath, expectedRam, extraLayerCost));
         }
         //Skip enums layers
         else if (key === "enums") return;
@@ -131,11 +132,11 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
 
   describe("Singularity multiplier checks", () => {
     sf4.lvl = 3;
-    const singFunctions = Object.entries(ns.singularity).filter(([__, val]) => typeof val === "function");
+    const singFunctions = Object.entries(wrappedNS.singularity).filter(([__, val]) => typeof val === "function");
     const singObjects = singFunctions.map(([key, val]) => {
       return {
         name: key,
-        fn: val,
+        fn: val.bind(ns.singularity),
         baseRam: grabCost(RamCosts.singularity, ["singularity", key]),
       };
     });

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -62,6 +62,7 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
     expectedRamCost: number,
     extraLayerCost = 0,
   ) {
+    fn = fn.bind(ns);
     const code = `${fnPath.join(".")}();\n`.repeat(3);
     const fnName = fnPath[fnPath.length - 1];
 
@@ -134,7 +135,7 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
     const singObjects = singFunctions.map(([key, val]) => {
       return {
         name: key,
-        fn: val.bind(ns),
+        fn: val,
         baseRam: grabCost(RamCosts.singularity, ["singularity", key]),
       };
     });


### PR DESCRIPTION
Credit to @d0sboots , this is basically his work from #223 just refactored a bit.

* ns API is wrapped once
* reference to workerscript is kept in a private class field, and this is all that needs to be updated when running a new script. All layers of ns are stamped with this private class field.
* Significantly increases maximum number of scripts before out-of-memory crash (for performance reasons it is still not recommended to run more than a few thousand scripts at once).
* Significantly speeds up the time needed to generate a new WorkerScript.

**_BREAKING CHANGE:_** if you take an ns function and put it into another variable off of ns, you will need to bind the function to ns (or to its parent layer) for it to continue to work. e.g. 
```js
// No longer works
let myTprint1 = ns.tprint

// Still works
let myTprint2 = ns.tprint.bind(ns);

myTprint2("Hello world"); // Works
myTprint1("Goodbye world"); // Error due to function not having an ns layer as a this value
```

There are still types that should be improved, todos have been added in those locations.

### Benchmark1:
10k script executions, both one-at-a-time and all-at-once. Over 6x faster in one-at-a-time execution and almost 2x as fast for all-at-once.
![image](https://user-images.githubusercontent.com/84951833/204100666-395ece42-0a23-452a-a16d-5a224354b53d.png)

### Benchmark2:
Running as many scripts as possible before browser crashes due to out-of-memory error. Also include how long it took to launch each of the first 60 sets of 1000 scripts.
**Dev**: browser crashed at 63000
![image](https://user-images.githubusercontent.com/84951833/204100762-3b2947fc-1731-4ccb-9ae7-f2da8b1d5dd6.png)

**This PR**: At least 344k scripts at once. Test had ran for a very long time at this point. so I just closed it.

https://user-images.githubusercontent.com/84951833/204103009-7071bf49-7f6b-4b89-a014-b4e5960291a1.mp4

![PR60kScriptTimes](https://user-images.githubusercontent.com/84951833/204103019-7817b7e5-0002-4b89-9a89-6743a7f816af.png)
