### PR TITLE
DOC: CORP: typo fixes in hire AdVert functions

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7176,19 +7176,17 @@ export interface OfficeAPI {
    */
   getOffice(divisionName: string, cityName: string): Office;
   /**
-   * Get data about an employee
-   * @param divisionName - Name of the division
-   * @param cityName - Name of the city
-   * @param employeeName - Name of the employee
-   * @returns Employee data
+   * Get the cost to hire AdVert.
+   * @param divisionName - Name of the division.
+   * @returns The cost to hire AdVert.
    */
   getHireAdVertCost(divisionName: string): number;
   /**
-   * Get the number of times you have Hired AdVert
-   * @param divisionName - Name of the division
-   * @returns Number of times you have Hired AdVert
+   * Get the number of times you have hired AdVert.
+   * @param divisionName - Name of the division.
+   * @returns Number of times you have hired AdVert.
    */
-  getHireAdVertCount(adivisionName: string): number;
+  getHireAdVertCount(divisionName: string): number;
   /**
    * Get the cost to unlock research
    * @param divisionName - Name of the division


### PR DESCRIPTION
* The documentation of `getHireAdVertCost()` talks about getting data of an employee, whereas it should be about the cost to hire AdVert.  Fix this and remove irrelevant parameter documentation.
* Fix some typographical errors in the documentation of `getHireAdVertCount()`.  The parameter signature `adivisionName: string` is wrong and prevents the documentation of the parameter from being generated.  The parameter signature should be `divisionName: string`.