### PR TITLE
UI: Changed skill formatting from numeral to localeString

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -44,7 +44,7 @@ import { workerScripts } from "./Netscript/WorkerScripts";
 import { WorkerScript } from "./Netscript/WorkerScript";
 import { helpers, assertObjectType } from "./Netscript/NetscriptHelpers";
 import { numeralWrapper } from "./ui/numeralFormat";
-import { convertTimeMsToTimeElapsedString } from "./utils/StringHelperFunctions";
+import { convertTimeMsToTimeElapsedString, formatNumber } from "./utils/StringHelperFunctions";
 import { LogBoxEvents, LogBoxCloserEvents, LogBoxPositionEvents, LogBoxSizeEvents } from "./ui/React/LogBoxManager";
 import { arrayToString } from "./utils/helpers/arrayToString";
 import { isString } from "./utils/helpers/isString";
@@ -1134,10 +1134,7 @@ const base: InternalAPI<NS> = {
     if (helpers.failOnHacknetServer(ctx, server)) {
       return 1;
     }
-    helpers.log(
-      ctx,
-      () => `returned ${numeralWrapper.formatSkill(server.requiredHackingSkill)} for '${server.hostname}'`,
-    );
+    helpers.log(ctx, () => `returned ${formatNumber(server.requiredHackingSkill, 0)} for '${server.hostname}'`);
     return server.requiredHackingSkill;
   },
   getServerMaxMoney: (ctx) => (_hostname) => {

--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -7,7 +7,7 @@ import createStyles from "@mui/styles/createStyles";
 import { numeralWrapper } from "../numeralFormat";
 import { Reputation } from "./Reputation";
 import { KillScriptsModal } from "./KillScriptsModal";
-import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFunctions";
+import { convertTimeMsToTimeElapsedString, formatNumber } from "../../utils/StringHelperFunctions";
 
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -54,9 +54,7 @@ function Intelligence(): React.ReactElement {
           <Typography classes={{ root: classes.int }}>Int&nbsp;</Typography>
         </TableCell>
         <TableCell align="right" classes={{ root: classes.cell }}>
-          <Typography classes={{ root: classes.int }}>
-            {numeralWrapper.formatSkill(Player.skills.intelligence)}
-          </Typography>
+          <Typography classes={{ root: classes.int }}>{formatNumber(Player.skills.intelligence, 0)}</Typography>
         </TableCell>
         <TableCell align="right" classes={{ root: classes.cell }}>
           <Typography id="overview-int-hook" classes={{ root: classes.int }}>
@@ -350,9 +348,7 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
               <Typography classes={{ root: classes.hack }}>Hack&nbsp;</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.hack }}>
-                {numeralWrapper.formatSkill(Player.skills.hacking)}
-              </Typography>
+              <Typography classes={{ root: classes.hack }}>{formatNumber(Player.skills.hacking, 0)}</Typography>
             </TableCell>
           </TableRow>
           <TableRow>
@@ -376,9 +372,7 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
               <Typography classes={{ root: classes.combat }}>Str&nbsp;</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>
-                {numeralWrapper.formatSkill(Player.skills.strength)}
-              </Typography>
+              <Typography classes={{ root: classes.combat }}>{formatNumber(Player.skills.strength, 0)}</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography id="overview-str-hook" classes={{ root: classes.combat }}>
@@ -397,9 +391,7 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
               <Typography classes={{ root: classes.combat }}>Def&nbsp;</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>
-                {numeralWrapper.formatSkill(Player.skills.defense)}
-              </Typography>
+              <Typography classes={{ root: classes.combat }}>{formatNumber(Player.skills.defense, 0)}</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography id="overview-def-hook" classes={{ root: classes.combat }}>
@@ -418,9 +410,7 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
               <Typography classes={{ root: classes.combat }}>Dex&nbsp;</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.combat }}>
-                {numeralWrapper.formatSkill(Player.skills.dexterity)}
-              </Typography>
+              <Typography classes={{ root: classes.combat }}>{formatNumber(Player.skills.dexterity, 0)}</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography id="overview-dex-hook" classes={{ root: classes.combat }}>
@@ -439,9 +429,7 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
               <Typography classes={{ root: classes.combat }}>Agi&nbsp;</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cell }}>
-              <Typography classes={{ root: classes.combat }}>
-                {numeralWrapper.formatSkill(Player.skills.agility)}
-              </Typography>
+              <Typography classes={{ root: classes.combat }}>{formatNumber(Player.skills.agility, 0)}</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cell }}>
               <Typography id="overview-agi-hook" classes={{ root: classes.combat }}>
@@ -460,9 +448,7 @@ export function CharacterOverview({ save, killScripts }: IProps): React.ReactEle
               <Typography classes={{ root: classes.cha }}>Cha&nbsp;</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography classes={{ root: classes.cha }}>
-                {numeralWrapper.formatSkill(Player.skills.charisma)}
-              </Typography>
+              <Typography classes={{ root: classes.cha }}>{formatNumber(Player.skills.charisma, 0)}</Typography>
             </TableCell>
             <TableCell align="right" classes={{ root: classes.cellNone }}>
               <Typography id="overview-cha-hook" classes={{ root: classes.cha }}>

--- a/src/ui/React/ImportSaveRoot.tsx
+++ b/src/ui/React/ImportSaveRoot.tsx
@@ -27,7 +27,7 @@ import WarningIcon from "@mui/icons-material/Warning";
 
 import { ImportData, saveObject } from "../../SaveObject";
 import { Settings } from "../../Settings/Settings";
-import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFunctions";
+import { convertTimeMsToTimeElapsedString, formatNumber } from "../../utils/StringHelperFunctions";
 import { numeralWrapper } from "../numeralFormat";
 import { ConfirmationModal } from "./ConfirmationModal";
 import { pushImportResult } from "../../Electron";
@@ -243,8 +243,8 @@ export function ImportSaveRoot(props: IProps): JSX.Element {
 
             <TableRow>
               <TableCell>Hacking</TableCell>
-              <TableCell>{numeralWrapper.formatSkill(currentData.playerData?.hacking ?? 0)}</TableCell>
-              <TableCell>{numeralWrapper.formatSkill(importData.playerData?.hacking ?? 0)}</TableCell>
+              <TableCell>{formatNumber(currentData.playerData?.hacking ?? 0, 0)}</TableCell>
+              <TableCell>{formatNumber(importData.playerData?.hacking ?? 0, 0)}</TableCell>
               <TableCell>
                 {importData.playerData?.hacking !== currentData.playerData?.hacking && (
                   <ComparisonIcon


### PR DESCRIPTION
# UI: Changed skill formatting from numeral to localeString

The code now uses `formatNumber` instead of `numeralWrapper.formatSkill`.

This might be *bad*, though the numeralWrapper library is deprecated...
Please share your opinion about this. From my point of view, using the numeralWrapper
less is a good thing. And with a bad formatting past 1e35 (IIRC) we might as well switch.
Though that would probably be a nightmare...

### Linked issues

Closes #4 

### Formatting
- [X] lint
- [X] format
