### PR TITLE
UI: Add memoization to character overview

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -432,11 +432,17 @@ export function GameRoot(): React.ReactElement {
         <BypassWrapper content={bypassGame ? mainPage : null}>
           <SnackbarProvider>
             <Overview mode={ITutorial.isRunning ? "tutorial" : "overview"}>
-              {!ITutorial.isRunning ? (
-                <CharacterOverview save={() => saveObject.saveGame()} killScripts={killAllScripts} />
-              ) : (
-                <InteractiveTutorialRoot />
-              )}
+              {(parentOpen) =>
+                !ITutorial.isRunning ? (
+                  <CharacterOverview
+                    parentOpen={parentOpen}
+                    save={() => saveObject.saveGame()}
+                    killScripts={killAllScripts}
+                  />
+                ) : (
+                  <InteractiveTutorialRoot />
+                )
+              }
             </Overview>
             {withSidebar ? (
               <Box display="flex" flexDirection="row" width="100%">

--- a/src/ui/React/Overview.tsx
+++ b/src/ui/React/Overview.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles({
 });
 
 interface IProps {
-  children: JSX.Element[] | JSX.Element | React.ReactElement[] | React.ReactElement;
+  children: (parentOpen: boolean) => JSX.Element[] | JSX.Element | React.ReactElement[] | React.ReactElement;
   mode: "tutorial" | "overview";
 }
 
@@ -141,7 +141,7 @@ export function Overview({ children, mode }: IProps): React.ReactElement {
           </Box>
         </Box>
         <Collapse in={open} className={classes.collapse}>
-          {children}
+          {children(open)}
         </Collapse>
       </Paper>
     </Draggable>


### PR DESCRIPTION
Remove the final periodic slow task by optimizing CharacterOverview. It now runs in around the same time as the Sidebar if you are working a hacking job, and less if you are doing nothing. Also, the overhead can be eliminated completely by minimizing the panel.

The panel still works (this is lineheight 1):
![image](https://user-images.githubusercontent.com/459704/205636851-b4a9f72b-086e-47d0-847f-e865adc0f5e3.png)

Only renders what's changing (the hack stats and work stuff, in this case)
![image](https://user-images.githubusercontent.com/459704/205637095-bc1d1670-aadf-44ce-bc4b-c3e029c42460.png)

Stuff like toggling progressbars in the settings still works.