### PR TITLE
CORP: Major changes to material quality/product rating calculations, products' prices can be set separately in each city

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitburner",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitburner",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -525,62 +525,84 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
     case 2: {
       return Object.assign(mults, {
         HackingLevelMultiplier: 0.8,
+
         ServerGrowthRate: 0.8,
         ServerMaxMoney: 0.2,
         ServerStartingMoney: 0.4,
+
+        PurchasedServerSoftcap: 1.3,
+
         CrimeMoney: 3,
-        InfiltrationMoney: 3,
-        FactionWorkRepGain: 0.5,
+
         FactionPassiveRepGain: 0,
+        FactionWorkRepGain: 0.5,
+
+        CorporationSoftcap: 0.9,
+        
+        InfiltrationMoney: 3,
         StaneksGiftPowerMultiplier: 2,
         StaneksGiftExtraSize: -6,
-        PurchasedServerSoftcap: 1.3,
-        CorporationSoftcap: 0.9,
         WorldDaemonDifficulty: 5,
       });
     }
     case 3: {
       return Object.assign(mults, {
         HackingLevelMultiplier: 0.8,
-        RepToDonateToFaction: 0.5,
-        AugmentationRepCost: 3,
-        AugmentationMoneyCost: 3,
+
+        ServerGrowthRate: 0.2,
         ServerMaxMoney: 0.2,
         ServerStartingMoney: 0.2,
-        ServerGrowthRate: 0.2,
-        ScriptHackMoney: 0.2,
+
+        HomeComputerRamCost: 1.5,
+
+        PurchasedServerCost: 2,
+        PurchasedServerSoftcap: 1.3,
+
         CompanyWorkMoney: 0.25,
         CrimeMoney: 0.25,
         HacknetNodeMoney: 0.25,
-        HomeComputerRamCost: 1.5,
-        PurchasedServerCost: 2,
+        ScriptHackMoney: 0.2,
+
+        RepToDonateToFaction: 0.5,
+
+        AugmentationMoneyCost: 3,
+        AugmentationRepCost: 3,
+
+        GangSoftcap: 0.9,
+        GangUniqueAugs: 0.5,
+
         StaneksGiftPowerMultiplier: 0.75,
         StaneksGiftExtraSize: -2,
-        PurchasedServerSoftcap: 1.3,
-        GangSoftcap: 0.9,
+
         WorldDaemonDifficulty: 2,
-        GangUniqueAugs: 0.5,
       });
     }
     case 4: {
       return Object.assign(mults, {
         ServerMaxMoney: 0.15,
         ServerStartingMoney: 0.75,
-        ScriptHackMoney: 0.2,
+
+        PurchasedServerSoftcap: 1.2,
+
         CompanyWorkMoney: 0.1,
         CrimeMoney: 0.2,
         HacknetNodeMoney: 0.05,
-        CompanyWorkExpGain: 0.5,
+        ScriptHackMoney: 0.2,
+
         ClassGymExpGain: 0.5,
+        CompanyWorkExpGain: 0.5,
+        CrimeExpGain: 0.5,
         FactionWorkExpGain: 0.5,
         HackExpGain: 0.4,
-        CrimeExpGain: 0.5,
+
         FactionWorkRepGain: 0.75,
+
+        GangUniqueAugs: 0.5,
+
         StaneksGiftPowerMultiplier: 1.5,
         StaneksGiftExtraSize: 0,
-        PurchasedServerSoftcap: 1.2,
+
         WorldDaemonDifficulty: 3,
-        GangUniqueAugs: 0.5,
       });
     }
     case 5: {
@@ -588,90 +610,129 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         ServerMaxMoney: 2,
         ServerStartingSecurity: 2,
         ServerStartingMoney: 0.5,
-        ScriptHackMoney: 0.15,
-        HacknetNodeMoney: 0.2,
+
+        PurchasedServerSoftcap: 1.2,
+
         CrimeMoney: 0.5,
-        InfiltrationRep: 1.5,
-        InfiltrationMoney: 1.5,
-        AugmentationMoneyCost: 2,
+        HacknetNodeMoney: 0.2,
+        ScriptHackMoney: 0.15,
+
         HackExpGain: 0.5,
+
+        AugmentationMoneyCost: 2,
+
+        InfiltrationMoney: 1.5,
+        InfiltrationRep: 1.5,
+
         CorporationValuation: 0.5,
+
+        GangUniqueAugs: 0.5,
+
         StaneksGiftPowerMultiplier: 1.3,
         StaneksGiftExtraSize: 0,
-        PurchasedServerSoftcap: 1.2,
+
         WorldDaemonDifficulty: 1.5,
-        GangUniqueAugs: 0.5,
       });
     }
     case 6: {
       return Object.assign(mults, {
         HackingLevelMultiplier: 0.35,
+
         ServerMaxMoney: 0.4,
         ServerStartingMoney: 0.5,
         ServerStartingSecurity: 1.5,
-        ScriptHackMoney: 0.75,
+
+        PurchasedServerSoftcap: 2,
+
         CompanyWorkMoney: 0.5,
         CrimeMoney: 0.75,
-        InfiltrationMoney: 0.75,
-        CorporationValuation: 0.2,
         HacknetNodeMoney: 0.2,
+        ScriptHackMoney: 0.75,
+
         HackExpGain: 0.25,
+
+        InfiltrationMoney: 0.75,
+
+        CorporationValuation: 0.2,
+        CorporationSoftcap: 0.9,
+
+        GangSoftcap: 0.7,
+        GangUniqueAugs: 0.2,
+
         DaedalusAugsRequirement: 35,
-        PurchasedServerSoftcap: 2,
+
         StaneksGiftPowerMultiplier: 0.5,
         StaneksGiftExtraSize: 2,
-        GangSoftcap: 0.7,
-        CorporationSoftcap: 0.9,
+
         WorldDaemonDifficulty: 2,
-        GangUniqueAugs: 0.2,
       });
     }
     case 7: {
       return Object.assign(mults, {
-        BladeburnerRank: 0.6,
-        BladeburnerSkillCost: 2,
-        AugmentationMoneyCost: 3,
         HackingLevelMultiplier: 0.35,
+
         ServerMaxMoney: 0.4,
         ServerStartingMoney: 0.5,
         ServerStartingSecurity: 1.5,
-        ScriptHackMoney: 0.5,
+
+        PurchasedServerSoftcap: 2,
+
         CompanyWorkMoney: 0.5,
         CrimeMoney: 0.75,
-        InfiltrationMoney: 0.75,
-        CorporationValuation: 0.2,
         HacknetNodeMoney: 0.2,
+        ScriptHackMoney: 0.5,
+
         HackExpGain: 0.25,
+
+        AugmentationMoneyCost: 3,
+
+        InfiltrationMoney: 0.75,
+
         FourSigmaMarketDataCost: 2,
         FourSigmaMarketDataApiCost: 2,
+
+        CorporationValuation: 0.2,
+        CorporationSoftcap: 0.9,
+
+        BladeburnerRank: 0.6,
+        BladeburnerSkillCost: 2,
+
+        GangSoftcap: 0.7,
+        GangUniqueAugs: 0.2,
+
         DaedalusAugsRequirement: 35,
-        PurchasedServerSoftcap: 2,
+
         StaneksGiftPowerMultiplier: 0.9,
         StaneksGiftExtraSize: -1,
-        GangSoftcap: 0.7,
-        CorporationSoftcap: 0.9,
+
         WorldDaemonDifficulty: 2,
-        GangUniqueAugs: 0.2,
       });
     }
     case 8: {
       return Object.assign(mults, {
-        BladeburnerRank: 0,
-        ScriptHackMoney: 0.3,
-        ScriptHackMoneyGain: 0,
-        ManualHackMoney: 0,
+        PurchasedServerSoftcap: 4,
+
         CompanyWorkMoney: 0,
         CrimeMoney: 0,
         HacknetNodeMoney: 0,
-        InfiltrationMoney: 0,
-        RepToDonateToFaction: 0,
-        CorporationValuation: 0,
+        ManualHackMoney: 0,
+        ScriptHackMoney: 0.3,
+        ScriptHackMoneyGain: 0,
         CodingContractMoney: 0,
-        StaneksGiftExtraSize: -99,
-        PurchasedServerSoftcap: 4,
-        GangSoftcap: 0,
+
+        RepToDonateToFaction: 0,
+
+        InfiltrationMoney: 0,
+
+        CorporationValuation: 0,
         CorporationSoftcap: 0,
+
+        BladeburnerRank: 0,
+
+        GangSoftcap: 0,
         GangUniqueAugs: 0,
+
+        StaneksGiftExtraSize: -99,
       });
     }
     case 9: {
@@ -682,25 +743,36 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         DexterityLevelMultiplier: 0.45,
         AgilityLevelMultiplier: 0.45,
         CharismaLevelMultiplier: 0.45,
-        PurchasedServerLimit: 0,
+
+        ServerMaxMoney: 0.1,
+        ServerStartingMoney: 0.1,
+        ServerStartingSecurity: 2.5,
+
         HomeComputerRamCost: 5,
+
+        PurchasedServerLimit: 0,
+
         CrimeMoney: 0.5,
         ScriptHackMoney: 0.1,
+
         HackExpGain: 0.05,
-        ServerStartingMoney: 0.1,
-        ServerMaxMoney: 0.1,
-        ServerStartingSecurity: 2.5,
-        CorporationValuation: 0.5,
+
         FourSigmaMarketDataCost: 5,
         FourSigmaMarketDataApiCost: 4,
+
+        CorporationValuation: 0.5,
+        CorporationSoftcap: 0.7,
+
         BladeburnerRank: 0.9,
         BladeburnerSkillCost: 1.2,
+
+        GangSoftcap: 0.8,
+        GangUniqueAugs: 0.25,
+
         StaneksGiftPowerMultiplier: 0.5,
         StaneksGiftExtraSize: 2,
-        GangSoftcap: 0.8,
-        CorporationSoftcap: 0.7,
+
         WorldDaemonDifficulty: 2,
-        GangUniqueAugs: 0.25,
       });
     }
     case 10: {
@@ -711,52 +783,72 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         DexterityLevelMultiplier: 0.4,
         AgilityLevelMultiplier: 0.4,
         CharismaLevelMultiplier: 0.4,
+
+        HomeComputerRamCost: 1.5,
+
+        PurchasedServerCost: 5,
+        PurchasedServerSoftcap: 1.1,
+        PurchasedServerLimit: 0.6,
+        PurchasedServerMaxRam: 0.5,
+
         CompanyWorkMoney: 0.5,
         CrimeMoney: 0.5,
         HacknetNodeMoney: 0.5,
         ManualHackMoney: 0.5,
         ScriptHackMoney: 0.5,
         CodingContractMoney: 0.5,
-        InfiltrationMoney: 0.5,
-        CorporationValuation: 0.5,
+
         AugmentationMoneyCost: 5,
         AugmentationRepCost: 2,
-        HomeComputerRamCost: 1.5,
-        PurchasedServerCost: 5,
-        PurchasedServerLimit: 0.6,
-        PurchasedServerMaxRam: 0.5,
+
+        InfiltrationMoney: 0.5,
+
+        CorporationValuation: 0.5,
+        CorporationSoftcap: 0.9,
+
         BladeburnerRank: 0.8,
+        
+        GangSoftcap: 0.9,
+        GangUniqueAugs: 0.25,
+
         StaneksGiftPowerMultiplier: 0.75,
         StaneksGiftExtraSize: -3,
-        PurchasedServerSoftcap: 1.1,
-        GangSoftcap: 0.9,
-        CorporationSoftcap: 0.9,
+
         WorldDaemonDifficulty: 2,
-        GangUniqueAugs: 0.25,
       });
     }
     case 11: {
       return Object.assign(mults, {
         HackingLevelMultiplier: 0.6,
-        HackExpGain: 0.5,
+
+        ServerGrowthRate: 0.2,
         ServerMaxMoney: 0.1,
         ServerStartingMoney: 0.1,
-        ServerGrowthRate: 0.2,
         ServerWeakenRate: 2,
-        CrimeMoney: 3,
+
+        PurchasedServerSoftcap: 2,
+
         CompanyWorkMoney: 0.5,
+        CrimeMoney: 3,
         HacknetNodeMoney: 0.1,
+        CodingContractMoney: 0.25,
+
+        HackExpGain: 0.5,
+
         AugmentationMoneyCost: 2,
+
         InfiltrationMoney: 2.5,
         InfiltrationRep: 2.5,
-        CorporationValuation: 0.1,
-        CodingContractMoney: 0.25,
+
         FourSigmaMarketDataCost: 4,
         FourSigmaMarketDataApiCost: 4,
-        PurchasedServerSoftcap: 2,
+
+        CorporationValuation: 0.1,
         CorporationSoftcap: 0.9,
-        WorldDaemonDifficulty: 1.5,
+
         GangUniqueAugs: 0.75,
+        
+        WorldDaemonDifficulty: 1.5,
       });
     }
     case 12: {
@@ -773,9 +865,9 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         AgilityLevelMultiplier: dec,
         CharismaLevelMultiplier: dec,
 
+        ServerGrowthRate: dec,
         ServerMaxMoney: dec,
         ServerStartingMoney: dec,
-        ServerGrowthRate: dec,
         ServerWeakenRate: dec,
 
         //Does not scale, otherwise security might start at 300+
@@ -784,29 +876,29 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         HomeComputerRamCost: inc,
 
         PurchasedServerCost: inc,
+        PurchasedServerSoftcap: inc,
         PurchasedServerLimit: dec,
         PurchasedServerMaxRam: dec,
-        PurchasedServerSoftcap: inc,
 
-        ManualHackMoney: dec,
-        ScriptHackMoney: dec,
         CompanyWorkMoney: dec,
         CrimeMoney: dec,
         HacknetNodeMoney: dec,
+        ManualHackMoney: dec,
+        ScriptHackMoney: dec,
         CodingContractMoney: dec,
 
-        CompanyWorkExpGain: dec,
         ClassGymExpGain: dec,
+        CompanyWorkExpGain: dec,
+        CrimeExpGain: dec,
         FactionWorkExpGain: dec,
         HackExpGain: dec,
-        CrimeExpGain: dec,
 
-        FactionWorkRepGain: dec,
         FactionPassiveRepGain: dec,
+        FactionWorkRepGain: dec,
         RepToDonateToFaction: inc,
 
-        AugmentationRepCost: inc,
         AugmentationMoneyCost: inc,
+        AugmentationRepCost: inc,
 
         InfiltrationMoney: dec,
         InfiltrationRep: dec,
@@ -815,45 +907,45 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         FourSigmaMarketDataApiCost: inc,
 
         CorporationValuation: dec,
+        CorporationSoftcap: 0.8,
 
         BladeburnerRank: dec,
         BladeburnerSkillCost: inc,
 
+        GangSoftcap: 0.8,
+        GangUniqueAugs: dec,
+
         StaneksGiftPowerMultiplier: inc,
         StaneksGiftExtraSize: inc,
-        GangSoftcap: 0.8,
-        CorporationSoftcap: 0.8,
-        WorldDaemonDifficulty: inc,
 
-        GangUniqueAugs: dec,
+        WorldDaemonDifficulty: inc,
       });
     }
     case 13: {
       return Object.assign(mults, {
-        PurchasedServerSoftcap: 1.6,
-
         HackingLevelMultiplier: 0.25,
         StrengthLevelMultiplier: 0.7,
         DefenseLevelMultiplier: 0.7,
         DexterityLevelMultiplier: 0.7,
         AgilityLevelMultiplier: 0.7,
+        
+        PurchasedServerSoftcap: 1.6,
 
         ServerMaxMoney: 0.45,
         ServerStartingMoney: 0.75,
-
         ServerStartingSecurity: 3,
 
-        ScriptHackMoney: 0.2,
         CompanyWorkMoney: 0.4,
         CrimeMoney: 0.4,
         HacknetNodeMoney: 0.4,
+        ScriptHackMoney: 0.2,
         CodingContractMoney: 0.4,
 
-        CompanyWorkExpGain: 0.5,
         ClassGymExpGain: 0.5,
+        CompanyWorkExpGain: 0.5,
+        CrimeExpGain: 0.5,
         FactionWorkExpGain: 0.5,
         HackExpGain: 0.1,
-        CrimeExpGain: 0.5,
 
         FactionWorkRepGain: 0.6,
 
@@ -861,15 +953,18 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         FourSigmaMarketDataApiCost: 10,
 
         CorporationValuation: 0.001,
+        CorporationSoftcap: 0.3,
 
         BladeburnerRank: 0.45,
         BladeburnerSkillCost: 2,
+
+        GangSoftcap: 0.3,
+        GangUniqueAugs: 0.1,
+
         StaneksGiftPowerMultiplier: 2,
         StaneksGiftExtraSize: 1,
-        GangSoftcap: 0.3,
-        CorporationSoftcap: 0.3,
+
         WorldDaemonDifficulty: 3,
-        GangUniqueAugs: 0.1,
       });
     }
     default: {

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -538,7 +538,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         FactionWorkRepGain: 0.5,
 
         CorporationSoftcap: 0.9,
-        
+
         InfiltrationMoney: 3,
         StaneksGiftPowerMultiplier: 2,
         StaneksGiftExtraSize: -6,
@@ -807,7 +807,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         CorporationSoftcap: 0.9,
 
         BladeburnerRank: 0.8,
-        
+
         GangSoftcap: 0.9,
         GangUniqueAugs: 0.25,
 
@@ -847,7 +847,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         CorporationSoftcap: 0.9,
 
         GangUniqueAugs: 0.75,
-        
+
         WorldDaemonDifficulty: 1.5,
       });
     }
@@ -928,7 +928,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         DefenseLevelMultiplier: 0.7,
         DexterityLevelMultiplier: 0.7,
         AgilityLevelMultiplier: 0.7,
-        
+
         PurchasedServerSoftcap: 1.6,
 
         ServerMaxMoney: 0.45,

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -166,13 +166,13 @@ export function SellProduct(product: Product, city: string, amt: string, price: 
     if (temp == null || isNaN(parseFloat(temp))) {
       throw new Error("Invalid value or expression for sell price field.");
     }
-    product.sCost = price; //Use sanitized price
+    product.sCost[city] = price; //Use sanitized price
   } else {
     const cost = parseFloat(price);
     if (isNaN(cost)) {
       throw new Error("Invalid value for sell price field");
     }
-    product.sCost = cost;
+    product.sCost[city] = cost;
   }
 
   // Array of all cities. Used later

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -490,7 +490,7 @@ export class Industry {
                     office.employeeProd[EmployeePositions.Engineer] / 90 +
                     Math.pow(this.sciResearch.qty, this.sciFac) +
                     Math.pow(warehouse.materials["AICores"].qty, this.aiFac) / 10e3;
-                  tempQlt = Math.min(tempQlt, avgQlt * Math.log10(tempQlt));
+                  tempQlt = Math.min(tempQlt, Math.max(avgQlt, 1) * Math.log10(tempQlt));
                   warehouse.materials[this.prodMats[j]].qlt =
                     (warehouse.materials[this.prodMats[j]].qlt * warehouse.materials[this.prodMats[j]].qty +
                       tempQlt * prod * producableFrac) /
@@ -881,7 +881,7 @@ export class Industry {
             const marketFactor = this.getMarketFactor(product); //Competition + demand
 
             // Calculate Sale Cost (sCost), which could be dynamically evaluated
-            const markupLimit = Math.max(product.data[city][3], 0.1) / product.mku;
+            const markupLimit = Math.max(product.data[city][3], 0.001) / product.mku;
             let sCost;
             if (product.marketTa2) {
               const prod = product.data[city][1];
@@ -918,8 +918,8 @@ export class Industry {
               sCost = optimalPrice;
             } else if (product.marketTa1) {
               sCost = product.pCost + markupLimit;
-            } else if (isString(product.sCost)) {
-              const sCostString = product.sCost as string;
+            } else if (isString(product.sCost[city])) {
+              const sCostString = product.sCost[city] as string;
               if (product.mku === 0) {
                 console.error(`mku is zero, reverting to 1 to avoid Infinity`);
                 product.mku = 1;
@@ -927,7 +927,7 @@ export class Industry {
               sCost = sCostString.replace(/MP/g, product.pCost + product.rat / product.mku + "");
               sCost = Math.max(product.pCost, eval(sCost));
             } else {
-              sCost = product.sCost;
+              sCost = product.sCost[city];
             }
 
             let markup = 1;

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -328,6 +328,7 @@ export class Industry {
 
               buyAmt = Math.min(buyAmt, maxAmt);
               if (buyAmt > 0) {
+                mat.qlt = (mat.qlt * mat.qty + 0 * buyAmt) / (mat.qty + buyAmt);
                 mat.qty += buyAmt;
                 expenses += buyAmt * mat.bCost;
               }
@@ -401,6 +402,7 @@ export class Industry {
             for (const [matName, buyAmt] of Object.entries(smartBuy)) {
               const mat = warehouse.materials[matName];
               if (buyAmt === undefined) throw new Error(`Somehow smartbuy matname is undefined`);
+              mat.qlt = (mat.qlt * mat.qty + 0 * buyAmt) / (mat.qty + buyAmt);
               mat.qty += buyAmt;
               expenses += buyAmt * mat.bCost;
             }
@@ -471,6 +473,7 @@ export class Industry {
 
               // Make our materials if they are producable
               if (producableFrac > 0 && prod > 0) {
+                let avgQlt = 0;
                 for (const reqMatName of Object.keys(this.reqMats)) {
                   const reqMat = this.reqMats[reqMatName];
                   if (reqMat === undefined) continue;
@@ -479,13 +482,17 @@ export class Industry {
                   warehouse.materials[reqMatName].prd = 0;
                   warehouse.materials[reqMatName].prd -=
                     reqMatQtyNeeded / (CorporationConstants.SecsPerMarketCycle * marketCycles);
+                  avgQlt += warehouse.materials[reqMatName].qlt;
                 }
+                avgQlt /= Object.keys(this.reqMats).length;
                 for (let j = 0; j < this.prodMats.length; ++j) {
                   warehouse.materials[this.prodMats[j]].qty += prod * producableFrac;
-                  warehouse.materials[this.prodMats[j]].qlt =
+                  warehouse.materials[this.prodMats[j]].qlt = Math.min(
+                    avgQlt,
                     office.employeeProd[EmployeePositions.Engineer] / 90 +
-                    Math.pow(this.sciResearch.qty, this.sciFac) +
-                    Math.pow(warehouse.materials["AICores"].qty, this.aiFac) / 10e3;
+                      Math.pow(this.sciResearch.qty, this.sciFac) +
+                      Math.pow(warehouse.materials["AICores"].qty, this.aiFac) / 10e3,
+                  );
                 }
               } else {
                 for (const reqMatName of Object.keys(this.reqMats)) {
@@ -689,8 +696,14 @@ export class Industry {
                       }
                       expWarehouse.materials[matName].imp +=
                         amt / (CorporationConstants.SecsPerMarketCycle * marketCycles);
+
+                      //Pretty sure this can cause some issues if there are multiple sources importing same material to same warehouse
+                      //but this will do for now
+                      expWarehouse.materials[matName].qlt =
+                        (expWarehouse.materials[matName].qlt * expWarehouse.materials[matName].qty + amt * mat.qlt) /
+                        (expWarehouse.materials[matName].qty + amt);
+
                       expWarehouse.materials[matName].qty += amt;
-                      expWarehouse.materials[matName].qlt = mat.qlt;
                       mat.qty -= amt;
                       mat.totalExp += amt;
                       expIndustry.updateWarehouseSizeUsed(expWarehouse);
@@ -822,14 +835,22 @@ export class Industry {
 
             //Make our Products if they are producable
             if (producableFrac > 0 && prod > 0) {
+              let avgQlt = 0;
               for (const reqMatName of Object.keys(product.reqMats)) {
                 if (product.reqMats.hasOwnProperty(reqMatName)) {
                   const reqMatQtyNeeded = product.reqMats[reqMatName] * prod * producableFrac;
                   warehouse.materials[reqMatName].qty -= reqMatQtyNeeded;
                   warehouse.materials[reqMatName].prd -=
                     reqMatQtyNeeded / (CorporationConstants.SecsPerMarketCycle * marketCycles);
+                  avgQlt += warehouse.materials[reqMatName].qlt;
                 }
               }
+              avgQlt /= Object.keys(product.reqMats).length;
+              const tempEffRat = Math.min(product.qlt, avgQlt * Math.log10(product.qlt));
+              //Effective Rating
+              product.data[city][3] =
+                (product.data[city][3] * product.data[city][0] + tempEffRat * prod * producableFrac) /
+                (product.data[city][0] + prod * producableFrac);
               //Quantity
               product.data[city][0] += prod * producableFrac;
             }
@@ -856,7 +877,7 @@ export class Industry {
             const marketFactor = this.getMarketFactor(product); //Competition + demand
 
             // Calculate Sale Cost (sCost), which could be dynamically evaluated
-            const markupLimit = product.rat / product.mku;
+            const markupLimit = Math.max(product.data[city][3], 0.1) / product.mku;
             let sCost;
             if (product.marketTa2) {
               const prod = product.data[city][1];

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -486,13 +486,17 @@ export class Industry {
                 }
                 avgQlt /= Object.keys(this.reqMats).length;
                 for (let j = 0; j < this.prodMats.length; ++j) {
-                  warehouse.materials[this.prodMats[j]].qty += prod * producableFrac;
-                  warehouse.materials[this.prodMats[j]].qlt = Math.min(
-                    avgQlt,
+                  let tempQlt =
                     office.employeeProd[EmployeePositions.Engineer] / 90 +
-                      Math.pow(this.sciResearch.qty, this.sciFac) +
-                      Math.pow(warehouse.materials["AICores"].qty, this.aiFac) / 10e3,
-                  );
+                    Math.pow(this.sciResearch.qty, this.sciFac) +
+                    Math.pow(warehouse.materials["AICores"].qty, this.aiFac) / 10e3;
+                  warehouse.materials[this.prodMats[j]].qlt = Math.min(tempQlt, avgQlt * Math.log10(tempQlt));
+                  warehouse.materials[this.prodMats[j]].qlt =
+                    (warehouse.materials[this.prodMats[j]].qlt * warehouse.materials[this.prodMats[j]].qty +
+                      tempQlt * prod * producableFrac) /
+                    (warehouse.materials[this.prodMats[j]].qty + prod * producableFrac);
+
+                  warehouse.materials[this.prodMats[j]].qty += prod * producableFrac;
                 }
               } else {
                 for (const reqMatName of Object.keys(this.reqMats)) {

--- a/src/Corporation/Industry.ts
+++ b/src/Corporation/Industry.ts
@@ -490,7 +490,7 @@ export class Industry {
                     office.employeeProd[EmployeePositions.Engineer] / 90 +
                     Math.pow(this.sciResearch.qty, this.sciFac) +
                     Math.pow(warehouse.materials["AICores"].qty, this.aiFac) / 10e3;
-                  warehouse.materials[this.prodMats[j]].qlt = Math.min(tempQlt, avgQlt * Math.log10(tempQlt));
+                  tempQlt = Math.min(tempQlt, avgQlt * Math.log10(tempQlt));
                   warehouse.materials[this.prodMats[j]].qlt =
                     (warehouse.materials[this.prodMats[j]].qlt * warehouse.materials[this.prodMats[j]].qty +
                       tempQlt * prod * producableFrac) /

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -45,8 +45,8 @@ export class Product {
   // Production cost - estimation of how much money it costs to make this Product
   pCost = 0;
 
-  // Sell cost
-  sCost: string | number = 0;
+  // Sell costs
+  sCost: Record<string, any> = createCityMap<any>(0);
 
   // Variables for handling the creation process of this Product
   fin = false; // Whether this Product has finished being created

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -80,8 +80,8 @@ export class Product {
 
   // Data refers to the production, sale, and quantity of the products
   // These values are specific to a city
-  // For each city, the data is [qty, prod, sell]
-  data: Record<string, number[]> = createCityMap<number[]>([0, 0, 0]);
+  // For each city, the data is [qty, prod, sell, effRat]
+  data: Record<string, number[]> = createCityMap<number[]>([0, 0, 0, 0]);
 
   // Location of this Product
   // Only applies for location-based products like restaurants/hospitals

--- a/src/Corporation/data/CorporationUpgrades.ts
+++ b/src/Corporation/data/CorporationUpgrades.ts
@@ -59,7 +59,7 @@ export const CorporationUpgrades: Record<CorporationUpgradeIndex, CorporationUpg
       "to consumers through their dreams. Each level of this upgrade provides a passive " +
       "increase in awareness of all of your companies (divisions) by 0.004 / market cycle," +
       "and in popularity by 0.001 / market cycle. A market cycle is approximately " +
-      "15 seconds.",
+      "10 seconds.",
   },
 
   //Makes advertising more effective

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -81,9 +81,9 @@ export function ProductElem(props: IProductProps): React.ReactElement {
         {sellButtonText} @ <Money money={product.pCost + markupLimit} />
       </>
     );
-  } else if (product.sCost) {
-    if (isString(product.sCost)) {
-      const sCost = (product.sCost as string).replace(/MP/g, product.pCost + product.rat / product.mku + "");
+  } else if (product.sCost[city]) {
+    if (isString(product.sCost[city])) {
+      const sCost = (product.sCost[city] as string).replace(/MP/g, product.pCost + product.rat / product.mku + "");
       sellButtonText = (
         <>
           {sellButtonText} @ <Money money={eval(sCost)} />
@@ -92,7 +92,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
     } else {
       sellButtonText = (
         <>
-          {sellButtonText} @ <Money money={product.sCost} />
+          {sellButtonText} @ <Money money={product.sCost[city]} />
         </>
       );
     }

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -144,6 +144,8 @@ export function ProductElem(props: IProductProps): React.ReactElement {
             <Tooltip
               title={
                 <Typography>
+                  Effective rating is calculated from product rating and the quality of materials used <br />
+                  Rating: {numeralWrapper.format(product.rat, nf)} <br /> <br />
                   Quality: {numeralWrapper.format(product.qlt, nf)} <br />
                   Performance: {numeralWrapper.format(product.per, nf)} <br />
                   Durability: {numeralWrapper.format(product.dur, nf)} <br />
@@ -157,7 +159,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
                 </Typography>
               }
             >
-              <Typography>Rating: {numeralWrapper.format(product.rat, nf)}</Typography>
+              <Typography>Effective rating: {numeralWrapper.format(product.data[city][3], nf)}</Typography>
             </Tooltip>
           </Box>
           <Box display="flex">

--- a/src/Corporation/ui/modals/IssueNewSharesModal.tsx
+++ b/src/Corporation/ui/modals/IssueNewSharesModal.tsx
@@ -56,7 +56,7 @@ export function IssueNewSharesModal(props: IProps): React.ReactElement {
   const corp = useCorporation();
   const [shares, setShares] = useState<number>(NaN);
   const maxNewSharesUnrounded = Math.round(corp.totalShares * 0.2);
-  const maxNewShares = maxNewSharesUnrounded - (maxNewSharesUnrounded % 1e6);
+  const maxNewShares = maxNewSharesUnrounded - (maxNewSharesUnrounded % 10e6);
 
   const newShares = Math.round((shares || 0) / 10e6) * 10e6;
   const disabled = isNaN(shares) || isNaN(newShares) || newShares < 10e6 || newShares > maxNewShares;
@@ -79,7 +79,7 @@ export function IssueNewSharesModal(props: IProps): React.ReactElement {
     // Round # of private shares to the nearest million
     const privateOwnedRatio = 1 - (corp.numShares + corp.issuedShares) / corp.totalShares;
     const maxPrivateShares = Math.round((newShares / 2) * privateOwnedRatio);
-    const privateShares = Math.round(getRandomInt(0, maxPrivateShares) / 1e6) * 1e6;
+    const privateShares = Math.round(getRandomInt(0, maxPrivateShares) / 10e6) * 10e6;
 
     corp.issuedShares += newShares - privateShares;
     corp.totalShares += newShares;

--- a/src/Corporation/ui/modals/IssueNewSharesModal.tsx
+++ b/src/Corporation/ui/modals/IssueNewSharesModal.tsx
@@ -19,7 +19,7 @@ function EffectText(props: IEffectTextProps): React.ReactElement {
   if (props.shares === null) return <></>;
   const newSharePrice = Math.round(corp.sharePrice * 0.9);
   const maxNewSharesUnrounded = Math.round(corp.totalShares * 0.2);
-  const maxNewShares = maxNewSharesUnrounded - (maxNewSharesUnrounded % 1e6);
+  const maxNewShares = maxNewSharesUnrounded - (maxNewSharesUnrounded % 10e6);
   let newShares = props.shares;
   if (isNaN(newShares)) {
     return <Typography>Invalid input</Typography>;

--- a/src/Corporation/ui/modals/SellProductModal.tsx
+++ b/src/Corporation/ui/modals/SellProductModal.tsx
@@ -11,8 +11,8 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import { KEY } from "../../../utils/helpers/keyCodes";
 
-function initialPrice(product: Product): string {
-  let val = product.sCost ? product.sCost + "" : "";
+function initialPrice(product: Product, city: string): string {
+  let val = product.sCost[city] ? product.sCost[city] + "" : "";
   if (product.marketTa2) {
     val += " (Market-TA.II)";
   } else if (product.marketTa1) {
@@ -34,7 +34,7 @@ export function SellProductModal(props: IProps): React.ReactElement {
   const [iQty, setQty] = useState<string>(
     props.product.sllman[props.city][1] ? props.product.sllman[props.city][1] : "",
   );
-  const [px, setPx] = useState<string>(initialPrice(props.product));
+  const [px, setPx] = useState<string>(initialPrice(props.product, props.city));
 
   function onCheckedChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setChecked(event.target.checked);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7627,7 +7627,7 @@ interface Product {
   /** Production cost */
   pCost: number;
   /** Sell cost, can be "MP+5" */
-  sCost: string | number;
+  sCost: { [key: string]: any };
   /** Data refers to the production, sale, and quantity of the products
    * These values are specific to a city
    * For each city, the data is [qty, prod, sell, effRat] */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7630,7 +7630,7 @@ interface Product {
   sCost: string | number;
   /** Data refers to the production, sale, and quantity of the products
    * These values are specific to a city
-   * For each city, the data is [qty, prod, sell] */
+   * For each city, the data is [qty, prod, sell, effRat] */
   cityData: { [key: string]: number[] };
   /** Creation progress - A number between 0-100 representing percentage */
   developmentProgress: number;


### PR DESCRIPTION
> Reorganize and regroup bitnode multipliers

The node multiplier lists had no internal consistency, grouped them like the default node multiplier list.

> Change quality calculation of produced materials and products to take used materials' quality into account

Previously produced materials' and products' quality/rating didn't take the materials used into account at all. changed it so that Quality = MIN(quality, avg used material quality * log_10(quality))
Effective rating = MIN(rating, avg used materials * log_10(quality))

and previously stored materials/products and bought/imported materials effect the quality/effRating:
Quality = (old quality * old stored amount + new quality * produced amount + import quality * import amount + 0 * bought amount) / (old + produced + imported + bought amounts) (tho since purchasing, producing and importing are all done in different corp states, each of them change the quality sequentially instead of at once)
Rating = (old effective rating * old amount + produced rating * produced amount) / (old + produced amounts)

material production uses small (1) base value for quality of materials used to prevent a catch-22 situation (to get >0 quality materials, you'd need other >0 quality materials, but you can't get >0 quality materials without >0 quality materials)

> products' prices can be set separately in each city

Changed the product sCost from a single value per product to an array so that each city has it's own value.
issues: The sell product modal doesn't show the right things for some reason :/ and any pre-change products will keep their old single value sCost. somebody else has to figure out how to fix that.