### PR TITLE
NETSCRIPT: Add ns.pid variable for accessing the current script's PID

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Resolving deltas: 100% (43708/43708), done.
 Updating files: 100% (2561/2561), done.
 
 # Change to the directory that contains your local copy.
-$ cd bitburner
+$ cd bitburner-src
 
 # The upstream is the repository that contains the game's source code. The
 # upstream is also the place where proposed changes are merged into the game.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitburner",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitburner",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1931,6 +1931,7 @@ export function NetscriptFunctions(ws: WorkerScript): ExternalAPI<NSFull> {
     obj[key] = new StampedLayer(ws, obj[key]);
   }
   instance.args = ws.args.slice();
+  instance.pid = ws.pid;
   return instance;
 }
 


### PR DESCRIPTION
API: Add "ns.pid" to allow scripts to fetch their own pid without contributing to the script's RAM size.