### PR TITLE
NETSCRIPT: Fix a typo in scp

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -883,7 +883,7 @@ export const ns: InternalAPI<NSFull> = {
             continue;
           }
           destScript.code = sourceScript.code;
-          destScript.ramUsage = destScript.ramUsage;
+          destScript.ramUsage = sourceScript.ramUsage;
           destScript.markUpdated();
           helpers.log(ctx, () => `WARNING: File '${file}' overwritten on '${destServer?.hostname}'`);
           continue;


### PR DESCRIPTION
Although I don't think anyone ever noticed in practice, it was possible to cheat RAM usage with this.

See https://github.com/bitburner-official/bitburner-src/pull/252 for history.