### PR TITLE
CORPORATION: getCorporation() returns division names not division objects

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -860,7 +860,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
         dividendTax: corporation.dividendTax,
         dividendEarnings: corporation.getCycleDividends() / CorporationConstants.SecsPerMarketCycle,
         state: corporation.state.getState(),
-        divisions: corporation.divisions.map((division): NSDivision => getSafeDivision(division)),
+        divisions: corporation.divisions.map((division): string => division.name),
       };
     },
     createCorporation:

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7598,8 +7598,8 @@ interface CorporationInfo {
   dividendEarnings: number;
   /** State of the corporation. Possible states are START, PURCHASE, PRODUCTION, SALE, EXPORT. */
   state: string;
-  /** Array of all divisions */
-  divisions: Division[];
+  /** Array of all division names */
+  divisions: string[];
 }
 
 /**


### PR DESCRIPTION
getCorporation() is the only way to get the names of current divisions via script
but it returns the whole division Object this makes getDivision() redundant

with this change getCorporation().divisions is an array of strings of division names without the extra information 
this will makes it easier for the player to handle the data (string[] instead of object[]) and gives getDivision() the purpose it should have