### PR TITLE
UI: Make tooltips for CoffeeParty better reflect reality

### DIFF
--- a/src/Corporation/ui/IndustryOffice.tsx
+++ b/src/Corporation/ui/IndustryOffice.tsx
@@ -314,7 +314,12 @@ export function IndustryOffice(props: IProps): React.ReactElement {
           {!division.hasResearch("AutoBrew") && (
             <>
               <Tooltip
-                title={<Typography>Provide your employees with coffee, increasing their energy by 5%</Typography>}
+                title={
+                  <Typography>
+                    Provide your employees with coffee, increasing their energy by half the difference to 100%, plus
+                    1.5%
+                  </Typography>
+                }
               >
                 <span>
                   <Button

--- a/src/Corporation/ui/modals/ThrowPartyModal.tsx
+++ b/src/Corporation/ui/modals/ThrowPartyModal.tsx
@@ -38,11 +38,15 @@ export function ThrowPartyModal(props: IProps): React.ReactElement {
       dialogBoxCreate("You don't have enough company funds to throw a party!");
     } else {
       const mult = ThrowParty(corp, props.office, cost);
+      // Each 5% multiplier gives an extra flat +1 to morale and happiness to make recovering from low morale easier.
+      const increase = mult > 1 ? (mult - 1) * 0.2 : 0;
 
       if (mult > 0) {
         dialogBoxCreate(
           "You threw a party for the office! The morale and happiness of each employee increased by " +
-            numeralWrapper.formatPercentage(mult - 1),
+            numeralWrapper.formatPercentage(increase) +
+            " and was multiplied by " +
+            numeralWrapper.formatMultiplier(mult),
         );
       }
 


### PR DESCRIPTION
You won't find +1.5% in the code for Coffee, it's written as 3%, but the order its applied in makes it effectively 1.5%.

![image](https://user-images.githubusercontent.com/459704/209877035-4362f096-6677-4f84-a290-225a3ae6b31d.png)

![image](https://user-images.githubusercontent.com/459704/209877068-a2e11a1a-d244-492d-8f82-b07bbc0d4cf4.png)
