### PR TITLE
CORP: Industry descriptions shows what each division uses and makes

### DIFF
--- a/src/Corporation/IndustryData.tsx
+++ b/src/Corporation/IndustryData.tsx
@@ -287,6 +287,13 @@ export const IndustryDescriptions = (industry: IndustryType, corp: Corporation) 
       {data.description}
       <br />
       <br />
+      Required Materials: {Object.keys(data.requiredMaterials).toString().replace(/,/gi, ", ")}
+      <br />
+      Produces Materials: {data.producedMaterials ? data.producedMaterials.toString().replace(/,/gi, ", ") : "NONE"}
+      <br />
+      Produces products: {data.product ? "YES" : "NO"}
+      <br />
+      <br />
       Starting cost: <MoneyCost money={data.startingCost} corp={corp} />
       <br />
       Recommended starting Industry: {data.recommendStarting ? "YES" : "NO"}

--- a/src/Corporation/IndustryData.tsx
+++ b/src/Corporation/IndustryData.tsx
@@ -284,7 +284,7 @@ export const IndustryDescriptions = (industry: IndustryType, corp: Corporation) 
   const data = IndustriesData[industry];
   return (
     <>
-      ${data.description}
+      {data.description}
       <br />
       <br />
       Starting cost: <MoneyCost money={data.startingCost} corp={corp} />


### PR DESCRIPTION
Instead of just short description and cost, industry description in "Expand to industry" screen shows which materials are required, which materials, if any, are produced and whether the division makes products.