### PR TITLE
NETSCRIPT: Add undocumented function printRaw()

### DIFF
--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -703,7 +703,7 @@ function createPublicRunningScript(runningScript: RunningScript): IRunningScript
   return {
     args: runningScript.args.slice(),
     filename: runningScript.filename,
-    logs: runningScript.logs.slice(),
+    logs: runningScript.logs.map((x) => "" + x),
     offlineExpGained: runningScript.offlineExpGained,
     offlineMoneyMade: runningScript.offlineMoneyMade,
     offlineRunningTime: runningScript.offlineRunningTime,

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -546,6 +546,7 @@ export const RamCosts: RamCostTree<NSFull> = {
   rainbow: 0,
   heart: { break: 0 },
   iKnowWhatImDoing: 0,
+  printRaw: 0,
 
   formulas: {
     mockServer: 0,

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -6,6 +6,7 @@
  * Instead, whenever the game is opened, WorkerScripts are re-created from
  * RunningScript objects
  */
+import type React from "react";
 import { Environment } from "./Environment";
 import { RamCostConstants } from "./RamCostGenerator";
 
@@ -180,7 +181,7 @@ export class WorkerScript {
     }
   }
 
-  print(txt: string): void {
+  print(txt: React.ReactNode): void {
     this.scriptRef.log(txt);
   }
 }

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -516,7 +516,7 @@ export const ns: InternalAPI<NSFull> = {
         return [] as string[];
       }
 
-      return runningScriptObj.logs.slice();
+      return runningScriptObj.logs.map((x) => "" + x);
     },
   tail:
     (ctx) =>

--- a/src/NetscriptFunctions/Extra.ts
+++ b/src/NetscriptFunctions/Extra.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import { Player } from "../Player";
 import { Exploit } from "../Exploits/Exploit";
 import * as bcrypt from "bcryptjs";
@@ -16,6 +17,7 @@ export interface INetscriptExtra {
   alterReality(): void;
   rainbow(guess: string): void;
   iKnowWhatImDoing(): void;
+  printRaw(value: React.ReactNode): void;
 }
 
 export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
@@ -81,6 +83,10 @@ export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
       helpers.log(ctx, () => "Unlocking unsupported feature: window.tprintRaw");
       // @ts-ignore window has no tprintRaw property defined
       window.tprintRaw = Terminal.printRaw.bind(Terminal);
+    },
+    printRaw: (ctx) => (value) => {
+      // Using this voids the warranty on your tail log
+      ctx.workerScript.print(value as React.ReactNode);
     },
   };
 }

--- a/src/Script/RunningScript.ts
+++ b/src/Script/RunningScript.ts
@@ -2,6 +2,7 @@
  * Class representing a Script instance that is actively running.
  * A Script can have multiple active instances
  */
+import type React from "react";
 import { Script } from "./Script";
 import { ScriptUrl } from "./ScriptUrl";
 import { Settings } from "../Settings/Settings";
@@ -23,7 +24,7 @@ export class RunningScript {
   filename = "";
 
   // This script's logs. An array of log entries
-  logs: string[] = [];
+  logs: React.ReactNode[] = [];
 
   // Flag indicating whether the logs have been updated since
   // the last time the UI was updated
@@ -73,13 +74,13 @@ export class RunningScript {
     this.dependencies = script.dependencies;
   }
 
-  log(txt: string): void {
+  log(txt: React.ReactNode): void {
     if (this.logs.length > Settings.MaxLogCapacity) {
       this.logs.shift();
     }
 
     let logEntry = txt;
-    if (Settings.TimestampsFormat) {
+    if (Settings.TimestampsFormat && typeof txt === "string") {
       logEntry = "[" + formatTime(Settings.TimestampsFormat) + "] " + logEntry;
     }
 
@@ -88,8 +89,12 @@ export class RunningScript {
   }
 
   displayLog(): void {
-    for (let i = 0; i < this.logs.length; ++i) {
-      Terminal.print(this.logs[i]);
+    for (const log of this.logs) {
+      if (typeof log === "string") {
+        Terminal.print(log);
+      } else {
+        Terminal.printRaw(log);
+      }
     }
   }
 

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -385,9 +385,8 @@ function LogWindow(props: IProps): React.ReactElement {
             >
               <div style={{ display: "flex", flexDirection: "column" }}>
                 {script.logs.map(
-                  (line: string, i: number): JSX.Element => (
-                    <ANSIITypography key={i} text={line} color={lineColor(line)} />
-                  ),
+                  (line: React.ReactNode, i: number): React.ReactNode =>
+                    typeof line !== "string" ? line : <ANSIITypography key={i} text={line} color={lineColor(line)} />,
                 )}
               </div>
             </Paper>


### PR DESCRIPTION
This is analagous to tprintRaw (enabled by ns.iKnowWhatImDoing()), but for logs instead of the terminal. This provides a supported* method of creating complicated UIs for scripts.

*No actual support, expressed or implied, is provided for use of this function.

### Example usage
```js
/** @param {NS} ns */
export async function main(ns) {
	ns.disableLog("ALL");
	ns.tail();
	let numAdded = 0;
	const addStyled = () => {
		numAdded++;
		ns.printRaw(React.createElement(
			"span",
			{style: {fontSize: 25, color: "yellow"}},
			"Styled span #" + numAdded));
	};
	ns.printRaw(React.createElement("div", {style: {textAlign: "center"}}, [
		React.createElement("span"),
		React.createElement("button", {type: "button", onClick: addStyled}, "Click me!"),
		React.createElement("span"),
	]));
	ns.printf("A normal log line");
	await ns.asleep(10000);
}
```
![image](https://user-images.githubusercontent.com/459704/210159774-1debc7ba-8501-42c1-9e94-79a73615e753.png)
![image](https://user-images.githubusercontent.com/459704/210159829-940c5937-2eee-4a57-9748-0d5fd865a4b4.png)
The button is live (in both the log and the terminal) for as long as the script runs, once the script exits the `ns` instance goes dead and the button stops functioning (without throwing visible errors, although you'll get uncaught `ScriptDeath` in the console).