### PR TITLE
MULTS: Make BitNodeMultipliers.ServerMaxMoney more sensible

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -527,7 +527,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         HackingLevelMultiplier: 0.8,
 
         ServerGrowthRate: 0.8,
-        ServerMaxMoney: 0.2,
+        ServerMaxMoney: 0.08,
         ServerStartingMoney: 0.4,
 
         PurchasedServerSoftcap: 1.3,
@@ -550,7 +550,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         HackingLevelMultiplier: 0.8,
 
         ServerGrowthRate: 0.2,
-        ServerMaxMoney: 0.2,
+        ServerMaxMoney: 0.04,
         ServerStartingMoney: 0.2,
 
         HomeComputerRamCost: 1.5,
@@ -579,7 +579,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
     }
     case 4: {
       return Object.assign(mults, {
-        ServerMaxMoney: 0.15,
+        ServerMaxMoney: 0.1125,
         ServerStartingMoney: 0.75,
 
         PurchasedServerSoftcap: 1.2,
@@ -607,7 +607,6 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
     }
     case 5: {
       return Object.assign(mults, {
-        ServerMaxMoney: 2,
         ServerStartingSecurity: 2,
         ServerStartingMoney: 0.5,
 
@@ -638,7 +637,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
       return Object.assign(mults, {
         HackingLevelMultiplier: 0.35,
 
-        ServerMaxMoney: 0.4,
+        ServerMaxMoney: 0.2,
         ServerStartingMoney: 0.5,
         ServerStartingSecurity: 1.5,
 
@@ -671,7 +670,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
       return Object.assign(mults, {
         HackingLevelMultiplier: 0.35,
 
-        ServerMaxMoney: 0.4,
+        ServerMaxMoney: 0.2,
         ServerStartingMoney: 0.5,
         ServerStartingSecurity: 1.5,
 
@@ -744,7 +743,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         AgilityLevelMultiplier: 0.45,
         CharismaLevelMultiplier: 0.45,
 
-        ServerMaxMoney: 0.1,
+        ServerMaxMoney: 0.01,
         ServerStartingMoney: 0.1,
         ServerStartingSecurity: 2.5,
 
@@ -822,7 +821,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         HackingLevelMultiplier: 0.6,
 
         ServerGrowthRate: 0.2,
-        ServerMaxMoney: 0.1,
+        ServerMaxMoney: 0.01,
         ServerStartingMoney: 0.1,
         ServerWeakenRate: 2,
 
@@ -866,7 +865,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         CharismaLevelMultiplier: dec,
 
         ServerGrowthRate: dec,
-        ServerMaxMoney: dec,
+        ServerMaxMoney: dec * dec,
         ServerStartingMoney: dec,
         ServerWeakenRate: dec,
 
@@ -931,7 +930,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
 
         PurchasedServerSoftcap: 1.6,
 
-        ServerMaxMoney: 0.45,
+        ServerMaxMoney: 0.3375,
         ServerStartingMoney: 0.75,
         ServerStartingSecurity: 3,
 

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -70,9 +70,9 @@ export class Server extends BaseServer {
 
     /* Hacking information (only valid for "foreign" aka non-purchased servers) */
     this.requiredHackingSkill = params.requiredHackingSkill != null ? params.requiredHackingSkill : 1;
-    this.moneyAvailable =
-      params.moneyAvailable != null ? params.moneyAvailable * BitNodeMultipliers.ServerStartingMoney : 0;
-    this.moneyMax = 25 * this.moneyAvailable * BitNodeMultipliers.ServerMaxMoney;
+    const baseMoney = params.moneyAvailable ?? 0;
+    this.moneyAvailable = baseMoney * BitNodeMultipliers.ServerStartingMoney;
+    this.moneyMax = 25 * baseMoney * BitNodeMultipliers.ServerMaxMoney;
 
     //Hack Difficulty is synonymous with server security. Base Difficulty = Starting difficulty
     const realDifficulty =


### PR DESCRIPTION
Before, a server's max money was effectively multiplied by both ServerMaxMoney *and* ServerStartingMoney. This changes it so they both act independently, while updating the values so that all servers will continue to have the same amounts as before.

Players will see the new values in both the stats screen and through code (getBitnodeMultipliers()), but the actual effect remains the same.

This leads to some surprising results (that are now more apparent), such as ServerMaxMoney decreasing with a 2x exponent compared to starting money in BN12. The values can be rebalanced later if desired.