### PR TITLE
MESSAGE: reduce level of jumper3 to 325

### DIFF
--- a/src/Message/MessageHelpers.tsx
+++ b/src/Message/MessageHelpers.tsx
@@ -101,7 +101,7 @@ function checkForMessagesToSend(): void {
     sendMessage(jumper2);
   } else if (!recvd(nitesecTest) && Player.skills.hacking >= 200) {
     sendMessage(nitesecTest);
-  } else if (!recvd(jumper3) && Player.skills.hacking >= 350) {
+  } else if (!recvd(jumper3) && Player.skills.hacking >= 325) {
     sendMessage(jumper3);
   } else if (!recvd(jumper4) && Player.skills.hacking >= 490) {
     sendMessage(jumper4);


### PR DESCRIPTION
This PR adjusts the hacking level for the Jumper3 message to 325 so that the message pops up 15 levels before the player is able to hack `I.I.I.I`. This aligns Jumper3 with the rest of the messages which are also sent before the player is able to hack the respective server.