### PR TITLE
NETSCRIPT: New ns implementation using Proxy

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -11,7 +11,7 @@ import { generateNextPid } from "./Netscript/Pid";
 
 import { CONSTANTS } from "./Constants";
 import { Interpreter } from "./ThirdParty/JSInterpreter";
-import { NetscriptFunctions, wrappedNS } from "./NetscriptFunctions";
+import { NetscriptFunctions } from "./NetscriptFunctions";
 import { compile, Node } from "./NetscriptJSEvaluator";
 import { IPort } from "./NetscriptPort";
 import { RunningScript } from "./Script/RunningScript";
@@ -81,15 +81,15 @@ async function startNetscript1Script(workerScript: WorkerScript): Promise<void> 
 
   //TODO unplanned: Make NS1 wrapping type safe instead of using BasicObject.
   type BasicObject = Record<string, any>;
+  const wrappedNS = NetscriptFunctions(workerScript);
   function wrapNS1Layer(int: Interpreter, intLayer: unknown, nsLayer = wrappedNS as BasicObject) {
-    if (nsLayer === wrappedNS) int.setProperty(intLayer, "args", int.nativeToPseudo(workerScript.args));
     for (const [name, entry] of Object.entries(nsLayer)) {
       if (typeof entry === "function") {
         const wrapper = async (...args: unknown[]) => {
           try {
             // Sent a resolver function as an extra arg. See createAsyncFunction JSInterpreter.js:3209
             const callback = args.pop() as (value: unknown) => void;
-            const result = await entry.bind(workerScript.env.vars)(...args.map((arg) => int.pseudoToNative(arg)));
+            const result = await entry(...args.map((arg) => int.pseudoToNative(arg)));
             return callback(int.nativeToPseudo(result));
           } catch (e: unknown) {
             errorToThrow = e;

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -1,5 +1,5 @@
 import { Player } from "../../../src/Player";
-import { NetscriptFunctions, wrappedNS } from "../../../src/NetscriptFunctions";
+import { NetscriptFunctions } from "../../../src/NetscriptFunctions";
 import { RamCosts, getRamCost, RamCostConstants } from "../../../src/Netscript/RamCostGenerator";
 import { Environment } from "../../../src/Netscript/Environment";
 import { RunningScript } from "../../../src/Script/RunningScript";
@@ -108,7 +108,7 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
   }
 
   describe("ns", () => {
-    Object.entries(wrappedNS as unknown as NSLayer).forEach(([key, val]) => {
+    Object.entries(NetscriptFunctions(workerScript) as unknown as NSLayer).forEach(([key, val]) => {
       if (key === "args" || key === "enums") return;
       if (typeof val === "function") {
         // Removed functions have no ram cost and should be skipped.
@@ -145,7 +145,9 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
 
   describe("Singularity multiplier checks", () => {
     sf4.lvl = 3;
-    const singFunctions = Object.entries(wrappedNS.singularity).filter(([__, val]) => typeof val === "function");
+    const singFunctions = Object.entries(NetscriptFunctions(workerScript).singularity).filter(
+      ([__, val]) => typeof val === "function",
+    );
     const singObjects = singFunctions
       .filter((fn) => !isRemovedFunction(fn))
       .map(([key, val]) => {


### PR DESCRIPTION
Potential candidate for (late) inclusion to 2.2, since it fixes an API-break/frustration that several people have had.

This should be at least as fast as the previous method, since very few objects are being created at script startup. Instead, we pay the cost of wrapping incrementally, as functions are called. (But the wrapped version is memoized.)

NS1 will be slow, since it traverses the entire tree and re-wraps everything.