### PR TITLE
BUG: fixed a bug caused by previous fix

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -421,9 +421,6 @@ export function runScriptFromScript(
     return 0;
   }
 
-  //prevent leading / from causing a bug
-  if (scriptname.startsWith("/")) scriptname = scriptname.slice(1);
-
   if (typeof scriptname !== "string" || !Array.isArray(args)) {
     workerScript.log(caller, () => `Invalid arguments: scriptname='${scriptname} args='${args}'`);
     console.error(`runScriptFromScript() failed due to invalid arguments`);

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -129,7 +129,12 @@ export abstract class BaseServer {
    */
   getRunningScript(scriptName: string, scriptArgs: ScriptArg[]): RunningScript | null {
     for (const rs of this.runningScripts) {
-      if (rs.filename === scriptName && compareArrays(rs.args, scriptArgs)) {
+      //compare file names without leading '/' to prevent running multiple script with the same name
+      if (
+        (rs.filename.charAt(0) == "/" ? rs.filename.slice(1) : rs.filename) ===
+          (scriptName.charAt(0) == "/" ? scriptName.slice(1) : scriptName) &&
+        compareArrays(rs.args, scriptArgs)
+      ) {
         return rs;
       }
     }


### PR DESCRIPTION
Closes #299

Previous fix fixed the game allowing scripts to be run multiple times with same arguments if you put a leading '/' in the filename ("file.js" -> "/file.js"), the game allows running both but the filename that is saved is the version without the leading '/', whether it was there or not. Then when a new script is ran comparison is made between the names with and without '/', which didn't catch that they are the same file.

Previous fix caused files in subfolders to be able to be run multiple times with same arguments because of the opposite reason. The filenames are saved with '/' but the checker removes the leading '/' from the new script, causing the check to fail.

This fix removes the old fix and makes the actual comparison compare the filenames without any possible leading '/' on either filename.