### PR TITLE
CORPORATION: added Checks to setAutoJobAssignment

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -608,7 +608,18 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const job = helpers.string(ctx, "job", _job);
 
       if (!checkEnum(EmployeePositions, job)) throw new Error(`'${job}' is not a valid job.`);
+      if (amount < 0 || !Number.isInteger(amount))
+        throw helpers.makeRuntimeErrorMsg(
+          ctx,
+          `Invalid value for amount! Must be an integer and greater than or be 0". Amount:'${amount}'`,
+        );
+
       const office = getOffice(divisionName, cityName);
+      if (office.employeeJobs[EmployeePositions.Unassigned] < amount)
+        throw helpers.makeRuntimeErrorMsg(
+          ctx,
+          `Tried to assign more Employees to '${job}' than are unassigned. Amount:'${amount}'`,
+        );
       return AutoAssignJob(office, job, amount);
     },
     hireEmployee: (ctx) => (_divisionName, _cityName, _position?) => {


### PR DESCRIPTION
added two checks to setAutoJobAssignment
-> that amount is a positive Integer
-> that amount is smaller or equal to the amount of unassigned employees
the second one is already implemented in the OfficeSpace autoAssignJob but without throwing an error it just returns false 
i think the player should get alerted when the calculation of amount is wrong but if not iam fine to change it back
