### PR TITLE
CORPORATION: prevent "Unassigned" as job in setAutoJobAssignment

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -607,6 +607,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const amount = helpers.number(ctx, "amount", _amount);
       const job = helpers.string(ctx, "job", _job);
 
+      if (job === EmployeePositions.Unassigned) return false;
       if (!checkEnum(EmployeePositions, job)) throw new Error(`'${job}' is not a valid job.`);
       if (amount < 0 || !Number.isInteger(amount))
         throw helpers.makeRuntimeErrorMsg(

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -607,8 +607,8 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const amount = helpers.number(ctx, "amount", _amount);
       const job = helpers.string(ctx, "job", _job);
 
-      if (job === EmployeePositions.Unassigned) return false;
       if (!checkEnum(EmployeePositions, job)) throw new Error(`'${job}' is not a valid job.`);
+      if (job === EmployeePositions.Unassigned) return false;
       if (amount < 0 || !Number.isInteger(amount))
         throw helpers.makeRuntimeErrorMsg(
           ctx,


### PR DESCRIPTION
setAutoJobAssignment ends early and returns false if EmployeePositions.Unassigned is the job input