### PR TITLE
NETSCRIPT: Added cyclesWorked to certain sleeve.getTask returns, and added bladeburner.getActionSuccesses

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -249,6 +249,7 @@ const bladeburner = {
   getActionMaxLevel: RamCostConstants.BladeburnerApiBase,
   getActionCurrentLevel: RamCostConstants.BladeburnerApiBase,
   getActionAutolevel: RamCostConstants.BladeburnerApiBase,
+  getActionSuccesses: RamCostConstants.BladeburnerApiBase,
   setActionAutolevel: RamCostConstants.BladeburnerApiBase,
   setActionLevel: RamCostConstants.BladeburnerApiBase,
   getRank: RamCostConstants.BladeburnerApiBase,

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -172,6 +172,13 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
       const action = getBladeburnerActionObject(ctx, type, name);
       return action.autoLevel;
     },
+    getActionSuccesses: (ctx) => (_type, _name) => {
+      const type = helpers.string(ctx, "type", _type);
+      const name = helpers.string(ctx, "name", _name);
+      checkBladeburnerAccess(ctx);
+      const action = getBladeburnerActionObject(ctx, type, name);
+      return action.successes;
+    },
     setActionAutolevel:
       (ctx) =>
       (_type, _name, _autoLevel = true) => {

--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -67,6 +67,7 @@ export class SleeveBladeburnerWork extends Work {
       type: WorkType.BLADEBURNER as "BLADEBURNER",
       actionType: this.actionType,
       actionName: this.actionName,
+      cyclesWorked: this.cyclesWorked,
     };
   }
 

--- a/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
@@ -51,6 +51,7 @@ export class SleeveCrimeWork extends Work {
     return {
       type: WorkType.CRIME as "CRIME",
       crimeType: this.crimeType,
+      cyclesWorked: this.cyclesWorked,
     };
   }
 

--- a/src/PersonObjects/Sleeve/Work/SleeveInfiltrateWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveInfiltrateWork.ts
@@ -32,6 +32,7 @@ export class SleeveInfiltrateWork extends Work {
   APICopy() {
     return {
       type: WorkType.INFILTRATE as "INFILTRATE",
+      cyclesWorked: this.cyclesWorked,
     };
   }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -874,6 +874,7 @@ type SleeveBladeburnerTask = {
   type: "BLADEBURNER";
   actionType: "General" | "Contracts";
   actionName: string;
+  cyclesWorked: number;
 };
 
 /** @public */
@@ -887,7 +888,7 @@ type SleeveClassTask = {
 type SleeveCompanyTask = { type: "COMPANY"; companyName: string };
 
 /** @public */
-type SleeveCrimeTask = { type: "CRIME"; crimeType: CrimeType | `${CrimeType}` };
+type SleeveCrimeTask = { type: "CRIME"; crimeType: CrimeType | `${CrimeType}`; cyclesWorked: number; };
 
 /** @public */
 type SleeveFactionTask = {
@@ -897,7 +898,7 @@ type SleeveFactionTask = {
 };
 
 /** @public */
-type SleeveInfiltrateTask = { type: "INFILTRATE" };
+type SleeveInfiltrateTask = { type: "INFILTRATE"; cyclesWorked: number; };
 
 /** @public */
 type SleeveRecoveryTask = { type: "RECOVERY" };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -888,7 +888,7 @@ type SleeveClassTask = {
 type SleeveCompanyTask = { type: "COMPANY"; companyName: string };
 
 /** @public */
-type SleeveCrimeTask = { type: "CRIME"; crimeType: CrimeType | `${CrimeType}`; cyclesWorked: number; };
+type SleeveCrimeTask = { type: "CRIME"; crimeType: CrimeType | `${CrimeType}`; cyclesWorked: number };
 
 /** @public */
 type SleeveFactionTask = {
@@ -898,7 +898,7 @@ type SleeveFactionTask = {
 };
 
 /** @public */
-type SleeveInfiltrateTask = { type: "INFILTRATE"; cyclesWorked: number; };
+type SleeveInfiltrateTask = { type: "INFILTRATE"; cyclesWorked: number };
 
 /** @public */
 type SleeveRecoveryTask = { type: "RECOVERY" };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2871,6 +2871,19 @@ export type Bladeburner = {
   getActionAutolevel(type: string, name: string): boolean;
 
   /**
+   * Get action successes.
+   * @remarks
+   * RAM cost: 4 GB
+   *
+   * Return a number with how many successes you have with action.
+   *
+   * @param type - Type of action.
+   * @param name - Name of action. Must be an exact match.
+   * @returns a number with how many successes you have with action.
+   */
+  getActionSuccesses(type: string, name: string): number;
+
+  /**
    * Set an action autolevel.
    * @remarks
    * RAM cost: 4 GB


### PR DESCRIPTION
Add access to some values not originally available via API.
 -Sleeve crime cycles worked
 -Sleeve bladeburner work cycles worked
 -Sleeve infiltration cycles worked
 -Bladeburner action successes

The above mentioned applicable sleeve tasks could be found with ns.sleeve.getTask(sleeveNum).cyclesWorked and if the task is crime, BBwork, or Infiltration it will return how many cycles have passed since it started. If it is not doing one of those actions it will return null.

ns.bladeburner.getActionSuccesses(type,name) returns the current amount of successes you have with that action.

closes: https://github.com/bitburner-official/bitburner-src/issues/318

Here is getActionSuccesses in action:
![image](https://user-images.githubusercontent.com/32428876/212596967-de292d0f-6a9b-4e7d-b489-57b610014567.png)