### PR TITLE
HACKNET: make hacknet servers be called servers instead of nodes

### DIFF
--- a/src/Hacknet/HacknetHelpers.tsx
+++ b/src/Hacknet/HacknetHelpers.tsx
@@ -65,7 +65,7 @@ export function purchaseHacknet(): number {
     }
 
     // Auto generate a name for the Node
-    const name = "hacknet-node-" + numOwned;
+    const name = hasHacknetServers() ? `hacknet-server-${numOwned}` : `hacknet-node-${numOwned}`;
     const node = new HacknetNode(name, Player.mults.hacknet_node_money);
 
     Player.loseMoney(cost, "hacknet_expenses");

--- a/src/PersonObjects/Player/PlayerObjectServerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectServerMethods.ts
@@ -9,6 +9,7 @@ import { BaseServer } from "../../Server/BaseServer";
 import { HacknetServer } from "../../Hacknet/HacknetServer";
 import { GetServer, AddToAllServers, createUniqueRandomIp } from "../../Server/AllServers";
 import { SpecialServers } from "../../Server/data/SpecialServers";
+import { hasHacknetServers } from "../../Hacknet/HacknetHelpers";
 
 export function hasTorRouter(this: PlayerObject): boolean {
   return this.getHomeComputer().serversOnNetwork.includes(SpecialServers.DarkWeb);
@@ -44,7 +45,7 @@ export function getUpgradeHomeCoresCost(this: PlayerObject): number {
 
 export function createHacknetServer(this: PlayerObject): HacknetServer {
   const numOwned = this.hacknetNodes.length;
-  const name = `hacknet-node-${numOwned}`;
+  const name = hasHacknetServers() ? `hacknet-server-${numOwned}` : `hacknet-node-${numOwned}`;
   const server = new HacknetServer({
     adminRights: true,
     hostname: name,

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -59,7 +59,7 @@ export class Server extends BaseServer {
     super(params);
 
     // "hacknet-node-X" hostnames are reserved for Hacknet Servers
-    if (this.hostname.startsWith("hacknet-node-")) {
+    if (this.hostname.startsWith("hacknet-node-" || "hacknet-server-")) {
       this.hostname = createRandomString(10);
     }
 


### PR DESCRIPTION


Formatted as such:
SECTION: PLAYER DESCRIPTION

SECTION"UI"
hacknet-node-X are now named hacknet-server-x with the corresponding sourcefile.

![image](https://user-images.githubusercontent.com/122596795/212742614-f3b0bdf9-72fa-4472-b4ea-7ab8495d834e.png)
A soft reset will fix the issue of pre existing hacknet-node-X(if it should be server)
![image](https://user-images.githubusercontent.com/122596795/212742741-000ce947-d678-4bb6-a127-88715173afe1.png)




