### PR TITLE
BUGFIX: Corrected error in formatReallyBigNumber and updated BB UI to be more large number friendly

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1288,12 +1288,14 @@ export class Bladeburner {
               this.changeRank(person, gain);
               if (isOperation && this.logging.ops) {
                 this.log(
-                  `${person.whoAmI()}: ${action.name} successfully completed! Gained ${formatNumber(gain, 3)} rank`,
+                  `${person.whoAmI()}: ${
+                    action.name
+                  } successfully completed! Gained ${numeralWrapper.formatReallyBigNumber(gain)} rank`,
                 );
               } else if (!isOperation && this.logging.contracts) {
                 this.log(
                   `${person.whoAmI()}: ${action.name} contract successfully completed! Gained ` +
-                    `${formatNumber(gain, 3)} rank and ${numeralWrapper.formatMoney(moneyGain)}`,
+                    `${numeralWrapper.formatReallyBigNumber(gain)} rank and ${numeralWrapper.formatMoney(moneyGain)}`,
                 );
               }
             }
@@ -1450,15 +1452,15 @@ export class Bladeburner {
           this.log(
             `${person.whoAmI()}: ` +
               "Training completed. Gained: " +
-              formatNumber(strExpGain, 1) +
+              numeralWrapper.formatExp(strExpGain) +
               " str exp, " +
-              formatNumber(defExpGain, 1) +
+              numeralWrapper.formatExp(defExpGain) +
               " def exp, " +
-              formatNumber(dexExpGain, 1) +
+              numeralWrapper.formatExp(dexExpGain) +
               " dex exp, " +
-              formatNumber(agiExpGain, 1) +
+              numeralWrapper.formatExp(agiExpGain) +
               " agi exp, " +
-              formatNumber(staminaGain, 3) +
+              numeralWrapper.formatReallyBigNumber(staminaGain) +
               " max stamina",
           );
         }
@@ -1486,9 +1488,9 @@ export class Bladeburner {
         if (this.logging.general) {
           this.log(
             `${person.whoAmI()}: ` +
-              `Field analysis completed. Gained ${formatNumber(rankGain, 2)} rank, ` +
-              `${formatNumber(hackingExpGain, 1)} hacking exp, and ` +
-              `${formatNumber(charismaExpGain, 1)} charisma exp`,
+              `Field analysis completed. Gained ${numeralWrapper.formatReallyBigNumber(rankGain)} rank, ` +
+              `${numeralWrapper.formatExp(hackingExpGain)} hacking exp, and ` +
+              `${numeralWrapper.formatExp(charismaExpGain)} charisma exp`,
           );
         }
         break;
@@ -1504,7 +1506,7 @@ export class Bladeburner {
             this.log(
               `${person.whoAmI()}: ` +
                 "Successfully recruited a team member! Gained " +
-                formatNumber(expGain, 1) +
+                numeralWrapper.formatExp(expGain) +
                 " charisma exp",
             );
           }
@@ -1515,7 +1517,7 @@ export class Bladeburner {
             this.log(
               `${person.whoAmI()}: ` +
                 "Failed to recruit a team member. Gained " +
-                formatNumber(expGain, 1) +
+                numeralWrapper.formatExp(expGain) +
                 " charisma exp",
             );
           }

--- a/src/Bladeburner/ui/Stats.tsx
+++ b/src/Bladeburner/ui/Stats.tsx
@@ -59,7 +59,7 @@ export function Stats(props: IProps): React.ReactElement {
         </Box>
         <Box display="flex">
           <Tooltip title={<Typography>Your rank within the Bladeburner division.</Typography>}>
-            <Typography>Rank: {formatNumber(props.bladeburner.rank, 2)}</Typography>
+            <Typography>Rank: {numeralWrapper.formatReallyBigNumber(props.bladeburner.rank)}</Typography>
           </Tooltip>
         </Box>
         <br />
@@ -88,7 +88,8 @@ export function Stats(props: IProps): React.ReactElement {
             }
           >
             <Typography>
-              Stamina: {formatNumber(props.bladeburner.stamina, 3)} / {formatNumber(props.bladeburner.maxStamina, 3)}
+              Stamina: {numeralWrapper.formatReallyBigNumber(props.bladeburner.stamina)} /{" "}
+              {numeralWrapper.formatReallyBigNumber(props.bladeburner.maxStamina)}
             </Typography>
           </Tooltip>
         </Box>
@@ -140,7 +141,9 @@ export function Stats(props: IProps): React.ReactElement {
               </Typography>
             }
           >
-            <Typography>City Chaos: {formatNumber(props.bladeburner.getCurrentCity().chaos)}</Typography>
+            <Typography>
+              City Chaos: {numeralWrapper.formatReallyBigNumber(props.bladeburner.getCurrentCity().chaos)}
+            </Typography>
           </Tooltip>
         </Box>
         <br />
@@ -166,7 +169,7 @@ export function Stats(props: IProps): React.ReactElement {
             <br />
           </>
         )}
-        <Typography>Skill Points: {formatNumber(props.bladeburner.skillPoints, 0)}</Typography>
+        <Typography>Skill Points: {numeralWrapper.formatReallyBigNumber(props.bladeburner.skillPoints)}</Typography>
         <br />
         <Typography>
           Aug. Success Chance mult: {formatNumber(Player.mults.bladeburner_success_chance * 100, 1)}%

--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -61,7 +61,7 @@ class NumeralFormatter {
     const nAbs = Math.abs(n as number);
     if (n === Infinity) return "∞";
     for (let i = 0; i < extraFormats.length; i++) {
-      if (extraFormats[i] < nAbs && nAbs <= extraFormats[i] * 1000) {
+      if (extraFormats[i] <= nAbs && nAbs < extraFormats[i] * 1000) {
         return this.format((n as number) / extraFormats[i], "0." + "0".repeat(decimalPlaces)) + extraNotations[i];
       }
     }
@@ -119,7 +119,7 @@ class NumeralFormatter {
   }
 
   formatPercentage(n: number | string, decimalPlaces = 2): string {
-    const formatter: string = "0." + "0".repeat(decimalPlaces) + "%";
+    const formatter: string = "0,0." + "0".repeat(decimalPlaces) + "%";
     return this.format(n, formatter);
   }
 
@@ -152,11 +152,11 @@ class NumeralFormatter {
   }
 
   formatPopulation(n: number): string {
-    return this.format(n, "0.000a");
+    return this.formatReallyBigNumber(n);
   }
 
   formatStamina(n: number): string {
-    return this.format(n, "0.0");
+    return this.formatReallyBigNumber(n);
   }
 
   formatShares(n: number): string {

--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -119,7 +119,7 @@ class NumeralFormatter {
   }
 
   formatPercentage(n: number | string, decimalPlaces = 2): string {
-    const formatter: string = "0,0." + "0".repeat(decimalPlaces) + "%";
+    const formatter: string = "0." + "0".repeat(decimalPlaces) + "%";
     return this.format(n, formatter);
   }
 


### PR DESCRIPTION
L64 of numeralFormat.ts used to allow 1000t, 1000q etc. Flipping where the `=` is in `<=` fixed this.
Image for a quick reference:
![image](https://user-images.githubusercontent.com/32428876/213344762-f6e04405-b473-4ffd-a2f5-9be33a93fae9.png)

Also added several updates to BB's UI numbers to look more compact.

Before:
![image](https://user-images.githubusercontent.com/32428876/213343406-9a4b6a31-f066-4580-8c3e-96a4c13549f3.png)

After:
![image](https://user-images.githubusercontent.com/32428876/213347755-9ad20939-7e77-423a-9e43-d7d830dd3f46.png)
