### PR TITLE
CORP: Revert mandatory coffeeparty

### DIFF
--- a/src/Corporation/OfficeSpace.ts
+++ b/src/Corporation/OfficeSpace.ts
@@ -112,10 +112,14 @@ export class OfficeSpace {
     if (this.totalEmployees > 0) {
       /** Multiplier for employee morale/happiness/energy based on company performance */
       const perfMult = Math.pow(
-        0.999 - (corporation.funds < 0 ? 0.002 : 0) - (industry.lastCycleRevenue < 0 ? 0.002 : 0),
+        1.002 -
+          (corporation.funds < 0 ? 0.002 : 0) -
+          (industry.lastCycleRevenue < industry.lastCycleExpenses ? 0.002 : 0),
         marketCycles,
       );
-      /** Flat reduction per cycle */
+      // Flat reduction per cycle.
+      // This does not cause a noticable decrease (it's only -.001% per cycle), it only serves
+      // to make the numbers slightly different between Happiness and Morale.
       const reduction = 0.001 * marketCycles;
 
       if (this.autoCoffee) {


### PR DESCRIPTION
Steady-state Morale/Happiness/Energy drain is not a good gameplay mechanic. It forces the player to do a tedious task for no real reason. Worse, it disproportionally punishes new players, who already have an uphill battle dealing with corp and trying to play it manually.

This goes back to the 2.1 model of steady-state morale increase. The multiplier is much lower than it was then; for best results, coffeeparty should still be used, but it no longer is required on a recurring basis.

This also fixes a bug where only revenue was being checked; now the multiplier will properly decrease when profits are negative.