### PR TITLE
API: Update Corporation setAutoAssignJob unassigned employee checks to account for employees currently in role.

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -616,10 +616,13 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
         );
 
       const office = getOffice(divisionName, cityName);
-      if (office.employeeJobs[EmployeePositions.Unassigned] < amount)
+
+      const totalNewEmployees = amount - office.employeeNextJobs[job];
+
+      if (office.employeeNextJobs[EmployeePositions.Unassigned] < totalNewEmployees)
         throw helpers.makeRuntimeErrorMsg(
           ctx,
-          `Tried to assign more Employees to '${job}' than are unassigned. Amount:'${amount}'`,
+          `Unable to bring '${job} employees to ${amount}. Requires ${totalNewEmployees} unassigned employees`,
         );
       return AutoAssignJob(office, job, amount);
     },


### PR DESCRIPTION
Current check assumes we need to assign `amount` employees to the role. In actuality we only need to assign the difference between `amount` and the employees that role is currently scheduled to have after the next job assignment tick.

Tested by:
Created a corporation with no unassigned employees and 2 managers in Sector-12.

Ran a test script with `ns.corporation.setAutoJobAssignment("AG", "Sector-12", "Management", 2);`. Script throws an exception on dev branch, does not throw an exception on fix branch and corporation endstate is 2 managers in Sector-12

Manually updated corporation to have 1 manager and 1 unassigned employees. 
Ran script again: Script throws an exception on dev branch. Script does not throw exception on fix branch, corporation endstate is 2 managers in Sector-12

Manually updated corporation to have 1 manager and 0 unassigned employees.
Ran script again: Script throws an exception on dev branch. Script also throws an exception on fix branch.
