### PR TITLE
MISC: Further BB UI number updates

### DIFF
--- a/src/Bladeburner/ui/ContractElem.tsx
+++ b/src/Bladeburner/ui/ContractElem.tsx
@@ -11,7 +11,7 @@ import { CopyableText } from "../../ui/React/CopyableText";
 import { ActionLevel } from "./ActionLevel";
 import { Autolevel } from "./Autolevel";
 import { StartButton } from "./StartButton";
-
+import { numeralWrapper } from "../../ui/numeralFormat";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 
@@ -76,11 +76,11 @@ export function ContractElem(props: IProps): React.ReactElement {
         <br />
         Time Required: {convertTimeMsToTimeElapsedString(actionTime * 1000)}
         <br />
-        Contracts remaining: {Math.floor(props.action.count)}
+        Contracts remaining: {numeralWrapper.formatReallyBigNumber(Math.floor(props.action.count), 3)}
         <br />
-        Successes: {props.action.successes}
+        Successes: {numeralWrapper.formatReallyBigNumber(props.action.successes, 3)}
         <br />
-        Failures: {props.action.failures}
+        Failures: {numeralWrapper.formatReallyBigNumber(props.action.failures, 3)}
       </Typography>
       <br />
       <Autolevel rerender={rerender} action={props.action} />

--- a/src/Bladeburner/ui/OperationElem.tsx
+++ b/src/Bladeburner/ui/OperationElem.tsx
@@ -12,7 +12,7 @@ import { Operation } from "../Operation";
 import { Operations } from "../data/Operations";
 import { Player } from "@player";
 import { CopyableText } from "../../ui/React/CopyableText";
-
+import { numeralWrapper } from "../../ui/numeralFormat";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 
@@ -79,11 +79,11 @@ export function OperationElem(props: IProps): React.ReactElement {
         <br />
         Time Required: {convertTimeMsToTimeElapsedString(actionTime * 1000)}
         <br />
-        Operations remaining: {Math.floor(props.action.count)}
+        Operations remaining: {numeralWrapper.formatReallyBigNumber(Math.floor(props.action.count), 3)}
         <br />
-        Successes: {props.action.successes}
+        Successes: {numeralWrapper.formatReallyBigNumber(props.action.successes, 3)}
         <br />
-        Failures: {props.action.failures}
+        Failures: {numeralWrapper.formatReallyBigNumber(props.action.failures, 3)}
       </Typography>
       <br />
       <Autolevel rerender={rerender} action={props.action} />

--- a/src/Bladeburner/ui/SkillElem.tsx
+++ b/src/Bladeburner/ui/SkillElem.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { CopyableText } from "../../ui/React/CopyableText";
-import { formatNumber } from "../../utils/StringHelperFunctions";
+import { numeralWrapper } from "../../ui/numeralFormat";
 import { Bladeburner } from "../Bladeburner";
-
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
 import Box from "@mui/material/Box";
@@ -49,11 +48,11 @@ export function SkillElem(props: IProps): React.ReactElement {
           </IconButton>
         )}
       </Box>
-      <Typography>Level: {currentLevel}</Typography>
+      <Typography>Level: {numeralWrapper.formatReallyBigNumber(currentLevel, 3)}</Typography>
       {maxLvl ? (
         <Typography>MAX LEVEL</Typography>
       ) : (
-        <Typography>Skill Points required: {formatNumber(pointCost, 0)}</Typography>
+        <Typography>Skill Points required: {numeralWrapper.formatReallyBigNumber(pointCost, 3)}</Typography>
       )}
       <Typography>{props.skill.desc}</Typography>
     </Paper>

--- a/src/Bladeburner/ui/SkillPage.tsx
+++ b/src/Bladeburner/ui/SkillPage.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { SkillList } from "./SkillList";
 import { BladeburnerConstants } from "../data/Constants";
-import { formatNumber } from "../../utils/StringHelperFunctions";
 import { Bladeburner } from "../Bladeburner";
+import { numeralWrapper } from "../../ui/numeralFormat";
 import Typography from "@mui/material/Typography";
 interface IProps {
   bladeburner: Bladeburner;
@@ -19,7 +19,7 @@ export function SkillPage(props: IProps): React.ReactElement {
   return (
     <>
       <Typography>
-        <strong>Skill Points: {formatNumber(props.bladeburner.skillPoints, 0)}</strong>
+        <strong>Skill Points: {numeralWrapper.formatReallyBigNumber(props.bladeburner.skillPoints, 3)}</strong>
       </Typography>
       <Typography>
         You will gain one skill point every {BladeburnerConstants.RanksPerSkillPoint} ranks.
@@ -28,34 +28,68 @@ export function SkillPage(props: IProps): React.ReactElement {
         skills with each other is multiplicative.
       </Typography>
       {valid(mults["successChanceAll"]) && (
-        <Typography>Total Success Chance: x{formatNumber(mults["successChanceAll"], 3)}</Typography>
+        <Typography>
+          Total Success Chance: x{numeralWrapper.formatReallyBigNumber(mults["successChanceAll"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceStealth"]) && (
-        <Typography>Stealth Success Chance: x{formatNumber(mults["successChanceStealth"], 3)}</Typography>
+        <Typography>
+          Stealth Success Chance: x{numeralWrapper.formatReallyBigNumber(mults["successChanceStealth"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceKill"]) && (
-        <Typography>Retirement Success Chance: x{formatNumber(mults["successChanceKill"], 3)}</Typography>
+        <Typography>
+          Retirement Success Chance: x{numeralWrapper.formatReallyBigNumber(mults["successChanceKill"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceContract"]) && (
-        <Typography>Contract Success Chance: x{formatNumber(mults["successChanceContract"], 3)}</Typography>
+        <Typography>
+          Contract Success Chance: x{numeralWrapper.formatReallyBigNumber(mults["successChanceContract"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceOperation"]) && (
-        <Typography>Operation Success Chance: x{formatNumber(mults["successChanceOperation"], 3)}</Typography>
+        <Typography>
+          Operation Success Chance: x{numeralWrapper.formatReallyBigNumber(mults["successChanceOperation"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceEstimate"]) && (
-        <Typography>Synthoid Data Estimate: x{formatNumber(mults["successChanceEstimate"], 3)}</Typography>
+        <Typography>
+          Synthoid Data Estimate: x{numeralWrapper.formatReallyBigNumber(mults["successChanceEstimate"], 3)}
+        </Typography>
       )}
-      {valid(mults["actionTime"]) && <Typography>Action Time: x{formatNumber(mults["actionTime"], 3)}</Typography>}
-      {valid(mults["effHack"]) && <Typography>Hacking Skill: x{formatNumber(mults["effHack"], 3)}</Typography>}
-      {valid(mults["effStr"]) && <Typography>Strength: x{formatNumber(mults["effStr"], 3)}</Typography>}
-      {valid(mults["effDef"]) && <Typography>Defense: x{formatNumber(mults["effDef"], 3)}</Typography>}
-      {valid(mults["effDex"]) && <Typography>Dexterity: x{formatNumber(mults["effDex"], 3)}</Typography>}
-      {valid(mults["effAgi"]) && <Typography>Agility: x{formatNumber(mults["effAgi"], 3)}</Typography>}
-      {valid(mults["effCha"]) && <Typography>Charisma: x{formatNumber(mults["effCha"], 3)}</Typography>}
-      {valid(mults["effInt"]) && <Typography>Intelligence: x{formatNumber(mults["effInt"], 3)}</Typography>}
-      {valid(mults["stamina"]) && <Typography>Stamina: x{formatNumber(mults["stamina"], 3)}</Typography>}
-      {valid(mults["money"]) && <Typography>Contract Money: x{formatNumber(mults["money"], 3)}</Typography>}
-      {valid(mults["expGain"]) && <Typography>Exp Gain: x{formatNumber(mults["expGain"], 3)}</Typography>}
+      {valid(mults["actionTime"]) && (
+        <Typography>Action Time: x{numeralWrapper.formatReallyBigNumber(mults["actionTime"], 3)}</Typography>
+      )}
+      {valid(mults["effHack"]) && (
+        <Typography>Hacking Skill: x{numeralWrapper.formatReallyBigNumber(mults["effHack"], 3)}</Typography>
+      )}
+      {valid(mults["effStr"]) && (
+        <Typography>Strength: x{numeralWrapper.formatReallyBigNumber(mults["effStr"], 3)}</Typography>
+      )}
+      {valid(mults["effDef"]) && (
+        <Typography>Defense: x{numeralWrapper.formatReallyBigNumber(mults["effDef"], 3)}</Typography>
+      )}
+      {valid(mults["effDex"]) && (
+        <Typography>Dexterity: x{numeralWrapper.formatReallyBigNumber(mults["effDex"], 3)}</Typography>
+      )}
+      {valid(mults["effAgi"]) && (
+        <Typography>Agility: x{numeralWrapper.formatReallyBigNumber(mults["effAgi"], 3)}</Typography>
+      )}
+      {valid(mults["effCha"]) && (
+        <Typography>Charisma: x{numeralWrapper.formatReallyBigNumber(mults["effCha"], 3)}</Typography>
+      )}
+      {valid(mults["effInt"]) && (
+        <Typography>Intelligence: x{numeralWrapper.formatReallyBigNumber(mults["effInt"], 3)}</Typography>
+      )}
+      {valid(mults["stamina"]) && (
+        <Typography>Stamina: x{numeralWrapper.formatReallyBigNumber(mults["stamina"], 3)}</Typography>
+      )}
+      {valid(mults["money"]) && (
+        <Typography>Contract Money: x{numeralWrapper.formatReallyBigNumber(mults["money"], 3)}</Typography>
+      )}
+      {valid(mults["expGain"]) && (
+        <Typography>Exp Gain: x{numeralWrapper.formatReallyBigNumber(mults["expGain"], 3)}</Typography>
+      )}
       <SkillList bladeburner={props.bladeburner} onUpgrade={() => setRerender((old) => !old)} />
     </>
   );


### PR DESCRIPTION
Just some further changes for BB big numbers. These include the Skills page, Skills on the skills page, Contracts and Operations as pictured below. This is achieved by applying formatReallyBigNumber() to all the values in question like was done for the rest of the BB UI number formats.

![image](https://user-images.githubusercontent.com/32428876/215027620-d41ba72d-170f-48cb-9750-2dd6707d4481.png)
![image](https://user-images.githubusercontent.com/32428876/215027638-85748445-d2cc-41af-ab40-38884ba218a6.png)
![image](https://user-images.githubusercontent.com/32428876/215027650-fb69d602-f877-48a3-85de-9970d2ec1382.png)
![image](https://user-images.githubusercontent.com/32428876/215027658-352025d4-b690-422f-b85a-0cf2f1445ea7.png)