### PR TITLE
MISC: reduced formatReallyBigNumber trailing 0s and updated formatSkill() to just use formatReallyBigNumber

### DIFF
--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -62,14 +62,16 @@ class NumeralFormatter {
     if (n === Infinity) return "∞";
     for (let i = 0; i < extraFormats.length; i++) {
       if (extraFormats[i] <= nAbs && nAbs < extraFormats[i] * 1000) {
-        return this.format((n as number) / extraFormats[i], "0." + "0".repeat(decimalPlaces)) + extraNotations[i];
+        return (
+          this.format((n as number) / extraFormats[i], "0." + "[" + "0".repeat(decimalPlaces) + "]") + extraNotations[i]
+        );
       }
     }
     if (nAbs < 1000) {
-      return this.format(n, "0." + "0".repeat(decimalPlaces));
+      return this.format(n, "0." + "[" + "0".repeat(decimalPlaces) + "]");
     }
-    const str = this.format(n, "0." + "0".repeat(decimalPlaces) + "a");
-    if (str === "NaNt") return this.format(n, "0." + " ".repeat(decimalPlaces) + "e+0");
+    const str = this.format(n, "0." + "[" + "0".repeat(decimalPlaces) + "]" + "a");
+    if (str === "NaNt") return this.format(n, "0." + "[" + " ".repeat(decimalPlaces) + "]" + "e+0");
     return str;
   }
 
@@ -85,9 +87,6 @@ class NumeralFormatter {
   }
 
   formatSkill(n: number): string {
-    if (n < 1e15) {
-      return this.format(n, "0,0");
-    }
     return this.formatReallyBigNumber(n);
   }
 

--- a/test/jest/ui/nFormat.test.ts
+++ b/test/jest/ui/nFormat.test.ts
@@ -134,7 +134,7 @@ describe("Numeral formatting of text", () => {
     expect(numeralWrapper.formatReallyBigNumber("987654321987654321987654321")).toEqual("987.654S");
     expect(numeralWrapper.formatReallyBigNumber("987654321987654321987654321987")).toEqual("987.654o");
     expect(numeralWrapper.formatReallyBigNumber("987654321987654321987654321987654")).toEqual("987.654n");
-    expect(numeralWrapper.formatReallyBigNumber("-987")).toEqual("-987.000");
+    expect(numeralWrapper.formatReallyBigNumber("-987")).toEqual("-987");
     expect(numeralWrapper.formatReallyBigNumber("-987654")).toEqual("-987.654k");
     expect(numeralWrapper.formatReallyBigNumber("-987654321")).toEqual("-987.654m");
     expect(numeralWrapper.formatReallyBigNumber("-987654321987")).toEqual("-987.654b");

--- a/test/jest/ui/nFormat.test.ts
+++ b/test/jest/ui/nFormat.test.ts
@@ -24,7 +24,7 @@ describe("Numeral formatting for positive numbers", () => {
     expect(numeralWrapper.formatBigNumber(987654321900000000)).toEqual("987654.322t");
   });
   test("should format really big numbers in readable format", () => {
-    expect(numeralWrapper.formatReallyBigNumber(987)).toEqual("987.000");
+    expect(numeralWrapper.formatReallyBigNumber(987)).toEqual("987");
     expect(numeralWrapper.formatReallyBigNumber(987654)).toEqual("987.654k");
     expect(numeralWrapper.formatReallyBigNumber(987654321)).toEqual("987.654m");
     expect(numeralWrapper.formatReallyBigNumber(987654321987)).toEqual("987.654b");
@@ -68,7 +68,7 @@ describe("Numeral formatting for negative numbers", () => {
     expect(numeralWrapper.formatBigNumber(-987654321900000000)).toEqual("-987654.322t");
   });
   test("should format really big numbers in readable format", () => {
-    expect(numeralWrapper.formatReallyBigNumber(-987)).toEqual("-987.000");
+    expect(numeralWrapper.formatReallyBigNumber(-987)).toEqual("-987");
     expect(numeralWrapper.formatReallyBigNumber(-987654)).toEqual("-987.654k");
     expect(numeralWrapper.formatReallyBigNumber(-987654321)).toEqual("-987.654m");
     expect(numeralWrapper.formatReallyBigNumber(-987654321987)).toEqual("-987.654b");
@@ -123,7 +123,7 @@ describe("Numeral formatting of text", () => {
     expect(numeralWrapper.formatBigNumber("-987654321900000000")).toEqual("-987654.322t");
   });
   test("should format really big numbers in readable format", () => {
-    expect(numeralWrapper.formatReallyBigNumber("987")).toEqual("987.000");
+    expect(numeralWrapper.formatReallyBigNumber("987")).toEqual("987");
     expect(numeralWrapper.formatReallyBigNumber("987654")).toEqual("987.654k");
     expect(numeralWrapper.formatReallyBigNumber("987654321")).toEqual("987.654m");
     expect(numeralWrapper.formatReallyBigNumber("987654321987")).toEqual("987.654b");


### PR DESCRIPTION
Reduced `formatReallyBigNumber()` trailing 0s and updated `formatSkill()` to just use `formatReallyBigNumber()` this helps prevent whole numbers like `1` returning as `1.000`. This change also prevents numbers like `1.040` returning when formatted with `formatReallyBigNumber()`.

Examples:
![image](https://user-images.githubusercontent.com/32428876/215044821-bc053dbd-05e0-4a57-a355-1d617e172a22.png)
![image](https://user-images.githubusercontent.com/32428876/215044847-c01aead9-5cc6-4eac-a1f5-f660543e1fd9.png)
![image](https://user-images.githubusercontent.com/32428876/215044867-7cf7c8ff-9476-4c7a-9d1e-0440b37f709a.png)
