### PR TITLE
CORP: Move Sale after Export in Corp States

### DIFF
--- a/src/Corporation/data/Constants.ts
+++ b/src/Corporation/data/Constants.ts
@@ -15,7 +15,7 @@ import { IndustryType, EmployeePositions } from "./Enums";
 // This structure + import * as corpConstants allows easier type definitions for individual properties.
 
 /** Names of all corporation game states */
-export const stateNames: CorpStateName[] = ["START", "PURCHASE", "PRODUCTION", "SALE", "EXPORT"],
+export const stateNames: CorpStateName[] = ["START", "PURCHASE", "PRODUCTION", "EXPORT", "SALE"],
   // TODO: remove IndustryType and EmployeePositions enums and just use the typed strings.
   /** Names of all corporation employee positions */
   employeePositions: CorpEmployeePosition[] = Object.values(EmployeePositions),

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7604,7 +7604,7 @@ interface CorporationInfo {
   dividendTax: number;
   /** Your earnings as a shareholder per second this cycle */
   dividendEarnings: number;
-  /** State of the corporation. Possible states are START, PURCHASE, PRODUCTION, SALE, EXPORT. */
+  /** State of the corporation. Possible states are START, PURCHASE, PRODUCTION, EXPORT, SALE. */
   state: string;
   /** Array of all division names */
   divisions: string[];
@@ -7662,7 +7662,7 @@ interface CorpConstants {
   minEmployeeDecay: number;
 }
 /** @public */
-type CorpStateName = "START" | "PURCHASE" | "PRODUCTION" | "SALE" | "EXPORT";
+type CorpStateName = "START" | "PURCHASE" | "PRODUCTION" | "EXPORT" | "SALE";
 
 /** @public */
 type CorpMaterialName =


### PR DESCRIPTION
Move Sale to after Export in the Corp states lists, as this will allow exports to happen before a possible sale of all remaining product via the "MAX" argument.