### PR TITLE
MISC: added formatBBNumber() and applied to BB UI

### DIFF
--- a/src/Bladeburner/ui/ContractElem.tsx
+++ b/src/Bladeburner/ui/ContractElem.tsx
@@ -11,7 +11,7 @@ import { CopyableText } from "../../ui/React/CopyableText";
 import { ActionLevel } from "./ActionLevel";
 import { Autolevel } from "./Autolevel";
 import { StartButton } from "./StartButton";
-
+import { numeralWrapper } from "../../ui/numeralFormat";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 
@@ -76,11 +76,11 @@ export function ContractElem(props: IProps): React.ReactElement {
         <br />
         Time Required: {convertTimeMsToTimeElapsedString(actionTime * 1000)}
         <br />
-        Contracts remaining: {Math.floor(props.action.count)}
+        Contracts remaining: {numeralWrapper.formatBBNumber(Math.floor(props.action.count))}
         <br />
-        Successes: {props.action.successes}
+        Successes: {numeralWrapper.formatBBNumber(props.action.successes)}
         <br />
-        Failures: {props.action.failures}
+        Failures: {numeralWrapper.formatBBNumber(props.action.failures)}
       </Typography>
       <br />
       <Autolevel rerender={rerender} action={props.action} />

--- a/src/Bladeburner/ui/OperationElem.tsx
+++ b/src/Bladeburner/ui/OperationElem.tsx
@@ -12,7 +12,7 @@ import { Operation } from "../Operation";
 import { Operations } from "../data/Operations";
 import { Player } from "@player";
 import { CopyableText } from "../../ui/React/CopyableText";
-
+import { numeralWrapper } from "../../ui/numeralFormat";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 
@@ -79,11 +79,11 @@ export function OperationElem(props: IProps): React.ReactElement {
         <br />
         Time Required: {convertTimeMsToTimeElapsedString(actionTime * 1000)}
         <br />
-        Operations remaining: {Math.floor(props.action.count)}
+        Operations remaining: {numeralWrapper.formatBBNumber(Math.floor(props.action.count))}
         <br />
-        Successes: {props.action.successes}
+        Successes: {numeralWrapper.formatBBNumber(props.action.successes)}
         <br />
-        Failures: {props.action.failures}
+        Failures: {numeralWrapper.formatBBNumber(props.action.failures)}
       </Typography>
       <br />
       <Autolevel rerender={rerender} action={props.action} />

--- a/src/Bladeburner/ui/SkillElem.tsx
+++ b/src/Bladeburner/ui/SkillElem.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { CopyableText } from "../../ui/React/CopyableText";
-import { formatNumber } from "../../utils/StringHelperFunctions";
 import { Bladeburner } from "../Bladeburner";
-
+import { numeralWrapper } from "../../ui/numeralFormat";
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
 import Box from "@mui/material/Box";
@@ -49,11 +48,11 @@ export function SkillElem(props: IProps): React.ReactElement {
           </IconButton>
         )}
       </Box>
-      <Typography>Level: {currentLevel}</Typography>
+      <Typography>Level: {numeralWrapper.formatBBNumber(currentLevel)}</Typography>
       {maxLvl ? (
         <Typography>MAX LEVEL</Typography>
       ) : (
-        <Typography>Skill Points required: {formatNumber(pointCost, 0)}</Typography>
+        <Typography>Skill Points required: {numeralWrapper.formatBBNumber(pointCost, 0)}</Typography>
       )}
       <Typography>{props.skill.desc}</Typography>
     </Paper>

--- a/src/Bladeburner/ui/SkillPage.tsx
+++ b/src/Bladeburner/ui/SkillPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { SkillList } from "./SkillList";
 import { BladeburnerConstants } from "../data/Constants";
-import { formatNumber } from "../../utils/StringHelperFunctions";
+import { numeralWrapper } from "../../ui/numeralFormat";
 import { Bladeburner } from "../Bladeburner";
 import Typography from "@mui/material/Typography";
 interface IProps {
@@ -19,7 +19,7 @@ export function SkillPage(props: IProps): React.ReactElement {
   return (
     <>
       <Typography>
-        <strong>Skill Points: {formatNumber(props.bladeburner.skillPoints, 0)}</strong>
+        <strong>Skill Points: {numeralWrapper.formatBBNumber(props.bladeburner.skillPoints, 0)}</strong>
       </Typography>
       <Typography>
         You will gain one skill point every {BladeburnerConstants.RanksPerSkillPoint} ranks.
@@ -28,34 +28,62 @@ export function SkillPage(props: IProps): React.ReactElement {
         skills with each other is multiplicative.
       </Typography>
       {valid(mults["successChanceAll"]) && (
-        <Typography>Total Success Chance: x{formatNumber(mults["successChanceAll"], 3)}</Typography>
+        <Typography>Total Success Chance: x{numeralWrapper.formatBBNumber(mults["successChanceAll"], 3)}</Typography>
       )}
       {valid(mults["successChanceStealth"]) && (
-        <Typography>Stealth Success Chance: x{formatNumber(mults["successChanceStealth"], 3)}</Typography>
+        <Typography>
+          Stealth Success Chance: x{numeralWrapper.formatBBNumber(mults["successChanceStealth"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceKill"]) && (
-        <Typography>Retirement Success Chance: x{formatNumber(mults["successChanceKill"], 3)}</Typography>
+        <Typography>
+          Retirement Success Chance: x{numeralWrapper.formatBBNumber(mults["successChanceKill"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceContract"]) && (
-        <Typography>Contract Success Chance: x{formatNumber(mults["successChanceContract"], 3)}</Typography>
+        <Typography>
+          Contract Success Chance: x{numeralWrapper.formatBBNumber(mults["successChanceContract"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceOperation"]) && (
-        <Typography>Operation Success Chance: x{formatNumber(mults["successChanceOperation"], 3)}</Typography>
+        <Typography>
+          Operation Success Chance: x{numeralWrapper.formatBBNumber(mults["successChanceOperation"], 3)}
+        </Typography>
       )}
       {valid(mults["successChanceEstimate"]) && (
-        <Typography>Synthoid Data Estimate: x{formatNumber(mults["successChanceEstimate"], 3)}</Typography>
+        <Typography>
+          Synthoid Data Estimate: x{numeralWrapper.formatBBNumber(mults["successChanceEstimate"], 3)}
+        </Typography>
       )}
-      {valid(mults["actionTime"]) && <Typography>Action Time: x{formatNumber(mults["actionTime"], 3)}</Typography>}
-      {valid(mults["effHack"]) && <Typography>Hacking Skill: x{formatNumber(mults["effHack"], 3)}</Typography>}
-      {valid(mults["effStr"]) && <Typography>Strength: x{formatNumber(mults["effStr"], 3)}</Typography>}
-      {valid(mults["effDef"]) && <Typography>Defense: x{formatNumber(mults["effDef"], 3)}</Typography>}
-      {valid(mults["effDex"]) && <Typography>Dexterity: x{formatNumber(mults["effDex"], 3)}</Typography>}
-      {valid(mults["effAgi"]) && <Typography>Agility: x{formatNumber(mults["effAgi"], 3)}</Typography>}
-      {valid(mults["effCha"]) && <Typography>Charisma: x{formatNumber(mults["effCha"], 3)}</Typography>}
-      {valid(mults["effInt"]) && <Typography>Intelligence: x{formatNumber(mults["effInt"], 3)}</Typography>}
-      {valid(mults["stamina"]) && <Typography>Stamina: x{formatNumber(mults["stamina"], 3)}</Typography>}
-      {valid(mults["money"]) && <Typography>Contract Money: x{formatNumber(mults["money"], 3)}</Typography>}
-      {valid(mults["expGain"]) && <Typography>Exp Gain: x{formatNumber(mults["expGain"], 3)}</Typography>}
+      {valid(mults["actionTime"]) && (
+        <Typography>Action Time: x{numeralWrapper.formatBBNumber(mults["actionTime"], 3)}</Typography>
+      )}
+      {valid(mults["effHack"]) && (
+        <Typography>Hacking Skill: x{numeralWrapper.formatBBNumber(mults["effHack"], 3)}</Typography>
+      )}
+      {valid(mults["effStr"]) && (
+        <Typography>Strength: x{numeralWrapper.formatBBNumber(mults["effStr"], 3)}</Typography>
+      )}
+      {valid(mults["effDef"]) && <Typography>Defense: x{numeralWrapper.formatBBNumber(mults["effDef"], 3)}</Typography>}
+      {valid(mults["effDex"]) && (
+        <Typography>Dexterity: x{numeralWrapper.formatBBNumber(mults["effDex"], 3)}</Typography>
+      )}
+      {valid(mults["effAgi"]) && <Typography>Agility: x{numeralWrapper.formatBBNumber(mults["effAgi"], 3)}</Typography>}
+      {valid(mults["effCha"]) && (
+        <Typography>Charisma: x{numeralWrapper.formatBBNumber(mults["effCha"], 3)}</Typography>
+      )}
+      {valid(mults["effInt"]) && (
+        <Typography>Intelligence: x{numeralWrapper.formatBBNumber(mults["effInt"], 3)}</Typography>
+      )}
+      {valid(mults["stamina"]) && (
+        <Typography>Stamina: x{numeralWrapper.formatBBNumber(mults["stamina"], 3)}</Typography>
+      )}
+      {valid(mults["money"]) && (
+        <Typography>Contract Money: x{numeralWrapper.formatBBNumber(mults["money"], 3)}</Typography>
+      )}
+      {valid(mults["expGain"]) && (
+        <Typography>Exp Gain: x{numeralWrapper.formatBBNumber(mults["expGain"], 3)}</Typography>
+      )}
       <SkillList bladeburner={props.bladeburner} onUpgrade={() => setRerender((old) => !old)} />
     </>
   );

--- a/src/Bladeburner/ui/Stats.tsx
+++ b/src/Bladeburner/ui/Stats.tsx
@@ -8,7 +8,6 @@ import { Factions } from "../../Faction/Factions";
 import { Router } from "../../ui/GameRoot";
 import { joinFaction } from "../../Faction/FactionHelpers";
 import { Bladeburner } from "../Bladeburner";
-
 import { TravelModal } from "./TravelModal";
 import Typography from "@mui/material/Typography";
 import Tooltip from "@mui/material/Tooltip";
@@ -59,7 +58,7 @@ export function Stats(props: IProps): React.ReactElement {
         </Box>
         <Box display="flex">
           <Tooltip title={<Typography>Your rank within the Bladeburner division.</Typography>}>
-            <Typography>Rank: {numeralWrapper.formatReallyBigNumber(props.bladeburner.rank)}</Typography>
+            <Typography>Rank: {numeralWrapper.formatBBNumber(props.bladeburner.rank)}</Typography>
           </Tooltip>
         </Box>
         <br />
@@ -88,8 +87,8 @@ export function Stats(props: IProps): React.ReactElement {
             }
           >
             <Typography>
-              Stamina: {numeralWrapper.formatReallyBigNumber(props.bladeburner.stamina)} /{" "}
-              {numeralWrapper.formatReallyBigNumber(props.bladeburner.maxStamina)}
+              Stamina: {numeralWrapper.formatBBNumber(props.bladeburner.stamina)} /{" "}
+              {numeralWrapper.formatBBNumber(props.bladeburner.maxStamina)}
             </Typography>
           </Tooltip>
         </Box>
@@ -142,7 +141,7 @@ export function Stats(props: IProps): React.ReactElement {
             }
           >
             <Typography>
-              City Chaos: {numeralWrapper.formatReallyBigNumber(props.bladeburner.getCurrentCity().chaos)}
+              City Chaos: {numeralWrapper.formatBBNumber(props.bladeburner.getCurrentCity().chaos)}
             </Typography>
           </Tooltip>
         </Box>
@@ -169,7 +168,7 @@ export function Stats(props: IProps): React.ReactElement {
             <br />
           </>
         )}
-        <Typography>Skill Points: {numeralWrapper.formatReallyBigNumber(props.bladeburner.skillPoints)}</Typography>
+        <Typography>Skill Points: {numeralWrapper.formatBBNumber(props.bladeburner.skillPoints)}</Typography>
         <br />
         <Typography>
           Aug. Success Chance mult: {formatNumber(Player.mults.bladeburner_success_chance * 100, 1)}%

--- a/src/ui/numeralFormat.ts
+++ b/src/ui/numeralFormat.ts
@@ -73,6 +73,24 @@ class NumeralFormatter {
     return str;
   }
 
+  formatBBNumber(n: number | string, decimalPlaces = 3): string {
+    const nAbs = Math.abs(n as number);
+    if (n === Infinity) return "∞";
+    for (let i = 0; i < extraFormats.length; i++) {
+      if (extraFormats[i] <= nAbs && nAbs < extraFormats[i] * 1000) {
+        return (
+          this.format((n as number) / extraFormats[i], "0." + "[" + "0".repeat(decimalPlaces) + "]") + extraNotations[i]
+        );
+      }
+    }
+    if (nAbs < 1000) {
+      return this.format(n, "0." + "[" + "0".repeat(decimalPlaces) + "]");
+    }
+    const str = this.format(n, "0." + "[" + "0".repeat(decimalPlaces) + "]" + "a");
+    if (str === "NaNt") return this.format(n, "0." + "[" + " ".repeat(decimalPlaces) + "]" + "e+0");
+    return str;
+  }
+
   formatHp(n: number): string {
     if (n < 1e6) {
       return this.format(n, "0,0");


### PR DESCRIPTION
added formatBBNumber() and applied to BB UI elements to properly display digits without unnecessary trailing 0s and as to not effect formatReallyBigNumber() in the process.

Images below to show effect:
![image](https://user-images.githubusercontent.com/32428876/215774325-74499691-5be3-456d-a59e-f6d9f464be06.png)
![image](https://user-images.githubusercontent.com/32428876/215774357-4f450301-3a95-41e2-b8eb-bcc6b30d1451.png)
![image](https://user-images.githubusercontent.com/32428876/215774536-ec559914-78b8-42a4-9a9f-6e8eaf14667e.png)
Before with old PR:
![image](https://user-images.githubusercontent.com/32428876/215774383-c5f25a5b-fb94-4a4a-9a69-03f5df21b05e.png)
After this PR:
![image](https://user-images.githubusercontent.com/32428876/215774479-227a5902-91ee-4433-88dd-2195e3de41d3.png)
