### PR TITLE
BN9: QoL improvements.

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -754,8 +754,6 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         CrimeMoney: 0.5,
         ScriptHackMoney: 0.1,
 
-        HacknetNodeMoney: 1,
-
         HackExpGain: 0.05,
 
         FourSigmaMarketDataCost: 5,

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -754,7 +754,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         CrimeMoney: 0.5,
         ScriptHackMoney: 0.1,
 
-        HacknetNodeMoney: Math.PI,
+        HacknetNodeMoney: 1,
 
         HackExpGain: 0.05,
 
@@ -773,7 +773,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: 0.5,
         StaneksGiftExtraSize: 2,
 
-        WorldDaemonDifficulty: Math.PI,
+        WorldDaemonDifficulty: 2,
       });
     }
     case 10: {

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -754,6 +754,8 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         CrimeMoney: 0.5,
         ScriptHackMoney: 0.1,
 
+        HacknetNodeMoney: Math.PI,
+
         HackExpGain: 0.05,
 
         FourSigmaMarketDataCost: 5,
@@ -771,7 +773,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         StaneksGiftPowerMultiplier: 0.5,
         StaneksGiftExtraSize: 2,
 
-        WorldDaemonDifficulty: 2,
+        WorldDaemonDifficulty: Math.PI,
       });
     }
     case 10: {

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -284,7 +284,8 @@ export function prestigeSourceFile(flume: boolean): void {
 
   resetIndustryResearchTrees();
 
-  // Source-File 9 (level 3) effect also now applies when in bn9
+  // Source-File 9 (level 3) effect
+  // also now applies when entering bn9 until install
   if (Player.sourceFileLvl(9) >= 3 || Player.bitNodeN === 9) {
     const hserver = Player.createHacknetServer();
 

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -284,8 +284,8 @@ export function prestigeSourceFile(flume: boolean): void {
 
   resetIndustryResearchTrees();
 
-  // Source-File 9 (level 3) effect
-  if (Player.sourceFileLvl(9) >= 3) {
+  // Source-File 9 (level 3) effect also now applies when in bn9
+  if (Player.sourceFileLvl(9) >= 3 || Player.bitNodeN === 9) {
     const hserver = Player.createHacknetServer();
 
     hserver.level = 100;


### PR DESCRIPTION
`Bn9` now starts with the same node that `bn9.3` rewards (the idea here is, it helps showcase the BNs new feature and just speeds up a lot of what made it so slow early on).
