### PR TITLE
HASHNET: Little boost for the extreme late game.

### DIFF
--- a/src/Hacknet/data/Constants.ts
+++ b/src/Hacknet/data/Constants.ts
@@ -43,10 +43,10 @@ export const HacknetServerConstants = {
   UpgradeCoreMult: 1.55,
   UpgradeCacheMult: 1.85,
 
-  MaxServers: 20,
+  MaxServers: 21,
 
   MaxLevel: 300,
   MaxRam: 8192,
   MaxCores: 128,
-  MaxCache: 15,
+  MaxCache: 18,
 };


### PR DESCRIPTION
+1 MaxServers fills out the max servers page evenly. 
+3 MaxCache is nice for extreme late game.

Save file info:
-Brand new with just SF 1.1
-Currently in BN9.1
-Dev tools to get max money and purchase all servers and max out all their upgrades. This should be the rate with no external modifers.

![image](https://user-images.githubusercontent.com/32428876/220759430-f8485d79-bb3c-406b-83d3-7a0d08ac9448.png)
