### PR TITLE
SOURCEFILE: Fix calculation of decMult

### DIFF
--- a/doc/source/guidesandtips/recommendedbitnodeorder.rst
+++ b/doc/source/guidesandtips/recommendedbitnodeorder.rst
@@ -308,9 +308,9 @@ Source-File
 
     This Source-File also increases your hacknet multipliers by:
 
-    * Level 1: 8%
-    * Level 2: 12%
-    * Level 3: 14%
+    * Level 1: 16%
+    * Level 2: 24%
+    * Level 3: 28%
 
 Difficulty
     Hard

--- a/doc/source/guidesandtips/recommendedbitnodeorder.rst
+++ b/doc/source/guidesandtips/recommendedbitnodeorder.rst
@@ -308,9 +308,9 @@ Source-File
 
     This Source-File also increases hacknet production and reduces hacknet costs by:
 
-    * Level 1: 16%
-    * Level 2: 24%
-    * Level 3: 28%
+    * Level 1: 12%
+    * Level 2: 18%
+    * Level 3: 21%
 
 Difficulty
     Hard

--- a/doc/source/guidesandtips/recommendedbitnodeorder.rst
+++ b/doc/source/guidesandtips/recommendedbitnodeorder.rst
@@ -306,7 +306,7 @@ Source-File
     (Note that the Level 3 effect of this Source-File only applies when entering a new BitNode, NOT
     when installing Augmentations.)
 
-    This Source-File also increases your hacknet multipliers by:
+    This Source-File also increases hacknet production and reduces hacknet costs by:
 
     * Level 1: 16%
     * Level 2: 24%

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -322,7 +322,7 @@ export function initBitNodes() {
         Augmentations)
         <br />
         <br />
-        This Source-File also increases your hacknet multipliers by:
+        This Source-File also increases hacknet production and reduces hacknet costs by:
         <br />
         Level 1: 16%
         <br />

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -119,11 +119,11 @@ export function initBitNodes() {
         BitNodes will disable this mechanic) and level 3 permanently unlocks the full API. This Source-File also
         increases your charisma and company salary multipliers by:
         <br />
-        Level 1: 16%
+        Level 1: 8%
         <br />
-        Level 2: 24%
+        Level 2: 12%
         <br />
-        Level 3: 28%
+        Level 3: 14%
       </>
     ),
   );
@@ -324,11 +324,11 @@ export function initBitNodes() {
         <br />
         This Source-File also increases your hacknet multipliers by:
         <br />
-        Level 1: 8%
+        Level 1: 16%
         <br />
-        Level 2: 12%
+        Level 2: 24%
         <br />
-        Level 3: 14%
+        Level 3: 28%
       </>
     ),
   );

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -119,11 +119,11 @@ export function initBitNodes() {
         BitNodes will disable this mechanic) and level 3 permanently unlocks the full API. This Source-File also
         increases your charisma and company salary multipliers by:
         <br />
-        Level 1: 8%
+        Level 1: 16%
         <br />
-        Level 2: 12%
+        Level 2: 24%
         <br />
-        Level 3: 14%
+        Level 3: 28%
       </>
     ),
   );

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -324,11 +324,11 @@ export function initBitNodes() {
         <br />
         This Source-File also increases hacknet production and reduces hacknet costs by:
         <br />
-        Level 1: 16%
+        Level 1: 12%
         <br />
-        Level 2: 24%
+        Level 2: 18%
         <br />
-        Level 3: 28%
+        Level 3: 21%
       </>
     ),
   );

--- a/src/SourceFile/SourceFiles.tsx
+++ b/src/SourceFile/SourceFiles.tsx
@@ -175,11 +175,11 @@ export function initSourceFiles() {
         <br />
         This Source-File also increases hacknet production and reduces hacknet costs by:
         <br />
-        Level 1: 16%
+        Level 1: 12%
         <br />
-        Level 2: 24%
+        Level 2: 18%
         <br />
-        Level 3: 28%
+        Level 3: 21%
       </>
     ),
   );

--- a/src/SourceFile/SourceFiles.tsx
+++ b/src/SourceFile/SourceFiles.tsx
@@ -175,11 +175,11 @@ export function initSourceFiles() {
         <br />
         This Source-File also increases your hacknet multipliers by:
         <br />
-        Level 1: 8%
+        Level 1: 16%
         <br />
-        Level 2: 12%
+        Level 2: 24%
         <br />
-        Level 3: 14%
+        Level 3: 28%
       </>
     ),
   );

--- a/src/SourceFile/SourceFiles.tsx
+++ b/src/SourceFile/SourceFiles.tsx
@@ -173,7 +173,7 @@ export function initSourceFiles() {
         Augmentations)
         <br />
         <br />
-        This Source-File also increases your hacknet multipliers by:
+        This Source-File also increases hacknet production and reduces hacknet costs by:
         <br />
         Level 1: 16%
         <br />

--- a/src/SourceFile/applySourceFile.ts
+++ b/src/SourceFile/applySourceFile.ts
@@ -135,10 +135,10 @@ export function applySourceFile(srcFile: PlayerOwnedSourceFile): void {
       // Hacktocracy
       let mult = 0;
       for (let i = 0; i < srcFile.lvl; ++i) {
-        mult += 16 / Math.pow(2, i);
+        mult += 12 / Math.pow(2, i);
       }
       const incMult = 1 + mult / 100;
-      const decMult = 1 / incMult;
+      const decMult = 1 - mult / 100;
       Player.mults.hacknet_node_core_cost *= decMult;
       Player.mults.hacknet_node_level_cost *= decMult;
       Player.mults.hacknet_node_money *= incMult;

--- a/src/SourceFile/applySourceFile.ts
+++ b/src/SourceFile/applySourceFile.ts
@@ -19,7 +19,7 @@ export function applySourceFile(srcFile: PlayerOwnedSourceFile): void {
         mult += 16 / Math.pow(2, i);
       }
       const incMult = 1 + mult / 100;
-      const decMult = 1 - mult / 100;
+      const decMult = 1 / incMult;
       Player.mults.hacking_chance *= incMult;
       Player.mults.hacking_speed *= incMult;
       Player.mults.hacking_money *= incMult;
@@ -135,10 +135,10 @@ export function applySourceFile(srcFile: PlayerOwnedSourceFile): void {
       // Hacktocracy
       let mult = 0;
       for (let i = 0; i < srcFile.lvl; ++i) {
-        mult += 8 / Math.pow(2, i);
+        mult += 16 / Math.pow(2, i);
       }
       const incMult = 1 + mult / 100;
-      const decMult = 1 - mult / 100;
+      const decMult = 1 / incMult;
       Player.mults.hacknet_node_core_cost *= decMult;
       Player.mults.hacknet_node_level_cost *= decMult;
       Player.mults.hacknet_node_money *= incMult;


### PR DESCRIPTION
This change was prompted because someone was confused by the discrepancy on Discord.

----

The decrease was being calculated via subtraction instead of reciprocal. This was an artifical buff to things that improved through decrease, since they decreased "more" than they should.

Since this only affected hacknet server-related costs, and those are rather weak anyway, I buffed the bonus from BN9 to compensate. The overall effect on decrease is now rougly the same if you have BN1.3 + BN9.3: (1 - .28) * (1 - .14) = .6192 ~= .6104 ~= 1 / (1.28 * 1.28)

The overall effect is a buff for BN9 hacknet server production, and more rational formulas.

## Testing

Dev menu (after much fiddling) agreed with the expected numbers