### PR TITLE
EDITOR: Add more script editor options

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -5,8 +5,6 @@ import { useEffect, useRef } from "react";
 export type Monaco = typeof monaco;
 
 type EditorProps = {
-  /** css height of editor */
-  height: string;
   /** Editor options */
   options: monaco.editor.IEditorOptions;
   /** Function to be ran prior to mounting editor */
@@ -17,7 +15,7 @@ type EditorProps = {
   onChange: (newCode?: string) => void;
 };
 
-export function Editor({ height, options, beforeMount, onMount, onChange }: EditorProps) {
+export function Editor({ options, beforeMount, onMount, onChange }: EditorProps) {
   const containerDiv = useRef<HTMLDivElement | null>(null);
   const editor = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const subscription = useRef<monaco.IDisposable | null>(null);
@@ -44,11 +42,10 @@ export function Editor({ height, options, beforeMount, onMount, onChange }: Edit
     // Unmounting
     return () => {
       editor.current?.dispose();
-      const model = editor.current?.getModel();
-      model?.dispose();
+      editor.current?.getModel()?.dispose();
       subscription.current?.dispose();
     };
   }, []);
 
-  return <div ref={containerDiv} style={{ height: height, width: "100%" }} />;
+  return <div ref={containerDiv} style={{ height: "1px", width: "100%", flexGrow: 1 }} />;
 }

--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -41,9 +41,9 @@ export function Editor({ options, beforeMount, onMount, onChange }: EditorProps)
 
     // Unmounting
     return () => {
-      editor.current?.dispose();
-      editor.current?.getModel()?.dispose();
       subscription.current?.dispose();
+      editor.current?.getModel()?.dispose();
+      editor.current?.dispose();
     };
   }, []);
 

--- a/src/ScriptEditor/ui/Options.ts
+++ b/src/ScriptEditor/ui/Options.ts
@@ -1,8 +1,12 @@
 export type WordWrapOptions = "on" | "off" | "bounded" | "wordWrapColumn";
-export interface Options {
+export type Options = {
   theme: string;
   insertSpaces: boolean;
+  tabSize: number;
+  detectIndentation: boolean;
+  fontFamily: string;
   fontSize: number;
+  fontLigatures: boolean;
   wordWrap: WordWrapOptions;
   vim: boolean;
-}
+};

--- a/src/ScriptEditor/ui/OptionsModal.tsx
+++ b/src/ScriptEditor/ui/OptionsModal.tsx
@@ -3,7 +3,6 @@ import { Options, WordWrapOptions } from "./Options";
 import { Modal } from "../../ui/React/Modal";
 
 import Button from "@mui/material/Button";
-import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Select from "@mui/material/Select";
 import Switch from "@mui/material/Switch";
@@ -24,7 +23,11 @@ interface IProps {
 export function OptionsModal(props: IProps): React.ReactElement {
   const [theme, setTheme] = useState(props.options.theme);
   const [insertSpaces, setInsertSpaces] = useState(props.options.insertSpaces);
+  const [tabSize, setTabSize] = useState(props.options.tabSize);
+  const [detectIndentation, setDetectIndentation] = useState(props.options.detectIndentation);
+  const [fontFamily, setFontFamily] = useState(props.options.fontFamily);
   const [fontSize, setFontSize] = useState(props.options.fontSize);
+  const [fontLigatures, setFontLigatures] = useState(props.options.fontLigatures);
   const [wordWrap, setWordWrap] = useState(props.options.wordWrap);
   const [vim, setVim] = useState(props.options.vim);
   const [themeEditorOpen, setThemeEditorOpen] = useState(false);
@@ -33,23 +36,33 @@ export function OptionsModal(props: IProps): React.ReactElement {
     props.save({
       theme,
       insertSpaces,
+      tabSize,
+      detectIndentation,
+      fontFamily,
       fontSize,
+      fontLigatures,
       wordWrap,
       vim,
     });
     props.onClose();
   }
 
-  function onFontChange(event: React.ChangeEvent<HTMLInputElement>): void {
-    const f = parseFloat(event.target.value);
-    if (isNaN(f)) return;
-    setFontSize(f);
+  function onFontSizeChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    const n = parseInt(event.target.value);
+    if (!Number.isFinite(n) || n < 1) return;
+    setFontSize(n);
+  }
+
+  function onTabSizeChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    const n = parseInt(event.target.value);
+    if (!Number.isFinite(n) || n < 1) return;
+    setTabSize(n);
   }
 
   return (
     <Modal open={props.open} onClose={props.onClose}>
       <ThemeEditorModal open={themeEditorOpen} onClose={() => setThemeEditorOpen(false)} />
-      <Box display="flex" flexDirection="row" alignItems="center">
+      <div style={{ display: "flex", alignItems: "center" }}>
         <Typography>Theme: </Typography>
         <Select onChange={(event) => setTheme(event.target.value)} value={theme}>
           <MenuItem value="monokai">monokai</MenuItem>
@@ -61,34 +74,56 @@ export function OptionsModal(props: IProps): React.ReactElement {
           <MenuItem value="one-dark">one-dark</MenuItem>
           <MenuItem value="customTheme">Custom theme</MenuItem>
         </Select>
-        <Button onClick={() => setThemeEditorOpen(true)} sx={{ mx: 1 }} startIcon={<EditIcon />}>
+        <Button onClick={() => setThemeEditorOpen(true)} sx={{ ml: 1 }} startIcon={<EditIcon />}>
           Edit custom theme
         </Button>
-      </Box>
+      </div>
 
-      <Box display="flex" flexDirection="row" alignItems="center">
-        <Typography>Use whitespace over tabs: </Typography>
-        <Switch onChange={(event) => setInsertSpaces(event.target.checked)} checked={insertSpaces} />
-      </Box>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Indent using tabs: </Typography>
+        <Switch onChange={(e) => setInsertSpaces(e.target.checked)} checked={insertSpaces} />
+      </div>
 
-      <Box display="flex" flexDirection="row" alignItems="center">
-        <Typography>Word Wrap: </Typography>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Tab size: </Typography>
+        <TextField type="number" value={tabSize} onChange={onTabSizeChange} />
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Auto-detect indentation: </Typography>
+        <Switch onChange={(e) => setDetectIndentation(e.target.checked)} checked={detectIndentation} />
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Word wrap: </Typography>
         <Select onChange={(event) => setWordWrap(event.target.value as WordWrapOptions)} value={wordWrap}>
           <MenuItem value={"off"}>Off</MenuItem>
           <MenuItem value={"on"}>On</MenuItem>
           <MenuItem value={"bounded"}>Bounded</MenuItem>
           <MenuItem value={"wordWrapColumn"}>Word Wrap Column</MenuItem>
         </Select>
-      </Box>
+      </div>
 
-      <Box display="flex" flexDirection="row" alignItems="center">
-        <Typography>Enable vim mode: </Typography>
-        <Switch onChange={(event) => setVim(event.target.checked)} checked={vim} />
-      </Box>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Enable vim mode: </Typography>
+        <Switch onChange={(e) => setVim(e.target.checked)} checked={vim} />
+      </div>
 
-      <Box display="flex" flexDirection="row" alignItems="center">
-        <TextField type="number" label="Font size" value={fontSize} onChange={onFontChange} />
-      </Box>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Font family: </Typography>
+        <TextField type="text" value={fontFamily} onChange={(e) => setFontFamily(e.target.value)} />
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Font size: </Typography>
+        <TextField type="number" value={fontSize} onChange={onFontSizeChange} />
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Enable font ligatures: </Typography>
+        <Switch onChange={(e) => setFontLigatures(e.target.checked)} checked={fontLigatures} />
+      </div>
+
       <br />
       <Button onClick={save} startIcon={<SaveIcon />}>
         Save

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -115,7 +115,11 @@ export function Root(props: IProps): React.ReactElement {
   const [options, setOptions] = useState<Options>({
     theme: Settings.MonacoTheme,
     insertSpaces: Settings.MonacoInsertSpaces,
+    tabSize: Settings.MonacoTabSize,
+    detectIndentation: Settings.MonacoDetectIndentation,
+    fontFamily: Settings.MonacoFontFamily,
     fontSize: Settings.MonacoFontSize,
+    fontLigatures: Settings.MonacoFontLigatures,
     wordWrap: Settings.MonacoWordWrap,
     vim: props.vim || Settings.MonacoVim,
   });
@@ -896,13 +900,7 @@ export function Root(props: IProps): React.ReactElement {
             monaco.editor.defineTheme("customTheme", makeTheme(Settings.EditorTheme));
             setOptionsOpen(false);
           }}
-          options={{
-            theme: Settings.MonacoTheme,
-            insertSpaces: Settings.MonacoInsertSpaces,
-            fontSize: Settings.MonacoFontSize,
-            wordWrap: Settings.MonacoWordWrap,
-            vim: Settings.MonacoVim,
-          }}
+          options={{ ...options }}
           save={(options: Options) => {
             sanitizeTheme(Settings.EditorTheme);
             monaco.editor.defineTheme("customTheme", makeTheme(Settings.EditorTheme));
@@ -910,7 +908,11 @@ export function Root(props: IProps): React.ReactElement {
             setOptions(options);
             Settings.MonacoTheme = options.theme;
             Settings.MonacoInsertSpaces = options.insertSpaces;
+            Settings.MonacoTabSize = options.tabSize;
+            Settings.MonacoDetectIndentation = options.detectIndentation;
+            Settings.MonacoFontFamily = options.fontFamily;
             Settings.MonacoFontSize = options.fontSize;
+            Settings.MonacoFontLigatures = options.fontLigatures;
             Settings.MonacoWordWrap = options.wordWrap;
             Settings.MonacoVim = options.vim;
           }}

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -705,13 +705,21 @@ export function Root(props: IProps): React.ReactElement {
   const tabTextWidth = tabMaxWidth - tabIconWidth * 2;
   return (
     <>
-      <div style={{ display: currentScript !== null ? "block" : "none", height: "100%", width: "100%" }}>
+      <div
+        style={{
+          display: currentScript !== null ? "flex" : "none",
+          height: "100%",
+          width: "100%",
+          flexDirection: "column",
+        }}
+      >
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable droppableId="tabs" direction="horizontal">
             {(provided, snapshot) => (
               <Box
                 maxWidth={`${tabsMaxWidth}px`}
                 display="flex"
+                flexGrow="0"
                 flexDirection="row"
                 alignItems="center"
                 whiteSpace="nowrap"
@@ -830,19 +838,19 @@ export function Root(props: IProps): React.ReactElement {
             )}
           </Droppable>
         </DragDropContext>
-        <div style={{ paddingBottom: "5px" }} />
+        <div style={{ flex: "0 0 5px" }} />
         <Editor
           beforeMount={beforeMount}
           onMount={onMount}
-          height={`calc(100vh - ${130 + (options.vim ? 34 : 0)}px)`}
           onChange={updateCode}
           options={{ ...options, glyphMargin: true }}
         />
 
         <Box
           ref={vimStatusRef}
-          className="monaco-editor"
+          className="vim-display"
           display="flex"
+          flexGrow="0"
           flexDirection="row"
           sx={{ p: 1 }}
           alignItems="center"

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -898,6 +898,7 @@ export function Root(props: IProps): React.ReactElement {
           save={(options: Options) => {
             sanitizeTheme(Settings.EditorTheme);
             monaco.editor.defineTheme("customTheme", makeTheme(Settings.EditorTheme));
+            editor?.updateOptions(options);
             setOptions(options);
             Settings.MonacoTheme = options.theme;
             Settings.MonacoInsertSpaces = options.insertSpaces;

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -78,9 +78,18 @@ export const Settings = {
   PurchaseAugmentationsOrder: PurchaseAugmentationsOrderSetting.Default,
   /** Script editor theme. */
   MonacoTheme: "monokai",
-  MonacoInsertSpaces: false,
+  /** Whether to use spaces instead of tabs for indentation */
+  MonacoInsertSpaces: true,
+  /** Size of indentation */
+  MonacoTabSize: 2,
+  /** Whether to auto detect indentation settings per-file based on contents */
+  MonacoDetectIndentation: false,
+  /** Font Family for script editor. */
+  MonacoFontFamily: "Lucida Console",
   /** Text size for script editor. */
   MonacoFontSize: 20,
+  /** Whether to use font ligatures */
+  MonacoFontLigatures: false,
   /** Whether to use Vim mod by default in the script editor */
   MonacoVim: false,
   /** Word wrap setting for Script Editor. */


### PR DESCRIPTION
Saving options will update the editor options immediately (previous change broke this).

Options added:
* Tab size (Size of tabs or number of spaces)
* Detect indentation: Whether to autodetect existing indentation and use that on a per-file basis
* Font family: The font used by the script editor
* Font ligatures: Whether to enable font ligatures (special combination characters included in some fonts)

Also redid a little of the styles on the options modal, the alignment was wonky before:
Before:
![image](https://user-images.githubusercontent.com/84951833/221180226-cac297ce-a4e6-4b5d-b475-75e6c74023fc.png)

After:
![image](https://user-images.githubusercontent.com/84951833/221180284-4fc903ce-6097-4a3d-8499-71ccb3bd50b7.png)
