### PR TITLE
DOC: CCT: typo fixes in examples for "Sanitize Parentheses in Expression"

### DIFF
--- a/doc/source/basicgameplay/codingcontracts.rst
+++ b/doc/source/basicgameplay/codingcontracts.rst
@@ -249,9 +249,9 @@ The list contains the name of (i.e. the value returned by
 |                                         | | the string, the result should be an array with only an empty string.                   |
 |                                         | |                                                                                        |
 |                                         | | Examples:                                                                              |
-|                                         | |  ()())() -> [()()(), (())()]                                                           |
-|                                         | |  (a)())() -> [(a)()(), (a())()]                                                        |
-|                                         | |  )( -> [""]                                                                            |
+|                                         | |  "()())()" -> ["()()()", "(())()"]                                                     |
+|                                         | |  "(a)())()" -> ["(a)()()", "(a())()"]                                                  |
+|                                         | |  ")(" -> [""]                                                                          |
 +-----------------------------------------+------------------------------------------------------------------------------------------+
 | Find All Valid Math Expressions         | | You are given a string which contains only digits between 0 and 9 as well as a target  |
 |                                         | | number. Return all possible ways you can add the +, -, and * operators to the string   |

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -1073,8 +1073,8 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
         "the result should be an array with only an empty string.\n\n",
         "IMPORTANT: The string may contain letters, not just parentheses.",
         `Examples:\n`,
-        `"()())()" -> [()()(), (())()]\n`,
-        `"(a)())()" -> [(a)()(), (a())()]\n`,
+        `"()())()" -> ["()()()", "(())()"]\n`,
+        `"(a)())()" -> ["(a)()()", "(a())()"]\n`,
         `")(" -> [""]`,
       ].join(" ");
     },


### PR DESCRIPTION
Each example for "Sanitize Parentheses in Expression" should be an array of strings. Fixes #323. The contract should be like this now:
![paren-answer](https://user-images.githubusercontent.com/66396308/221270485-49acabd4-7550-4d53-a78c-63b02fbf7ccf.png)
