### PR TITLE
TERMINAL: Fixed speechmarks not making numeric terminal arguments into strings

### DIFF
--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -1,8 +1,9 @@
 import { KEY } from "../utils/helpers/keyCodes";
 import { substituteAliases } from "../Alias";
 // Helper function to parse individual arguments into number/boolean/string as appropriate
-function parseArg(arg: string): string | number | boolean {
+function parseArg(arg: string, stringOverride: boolean): string | number | boolean {
   // Handles all numbers including hexadecimal, octal, and binary representations, returning NaN on an unparsable string
+  if (stringOverride) return arg;
   const asNumber = Number(arg);
   if (!isNaN(asNumber)) {
     return asNumber;
@@ -47,14 +48,15 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
   let lastQuote = "";
 
   let arg = "";
+  let stringOverride = false;
   while (idx < command.length) {
     const c = command.charAt(idx);
-
     // If the current character is a backslash, add the next character verbatim to the argument
     if (c === "\\") {
       arg += command.charAt(++idx);
       // If the current character is a single- or double-quote mark, add it to the current argument.
     } else if (c === KEY.DOUBLE_QUOTE || c === KEY.QUOTE) {
+      stringOverride = true;
       // If we're currently in a quoted string argument and this quote mark is the same as the beginning,
       // the string is done
       if (lastQuote !== "" && c === lastQuote) {
@@ -69,8 +71,8 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
       // If the current character is a space and we are not inside a string, parse the current argument
       // and start a new one
     } else if (c === KEY.SPACE && lastQuote === "") {
-      args.push(parseArg(arg));
-
+      args.push(parseArg(arg, stringOverride));
+      stringOverride = false;
       arg = "";
     } else {
       // Add the current character to the current argument
@@ -82,8 +84,7 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
 
   // Add the last arg (if any)
   if (arg !== "") {
-    args.push(parseArg(arg));
+    args.push(parseArg(arg, stringOverride));
   }
-
   return args;
 }

--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -49,12 +49,13 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
 
   let arg = "";
   let stringOverride = false;
-  
+
   while (idx < command.length) {
     const c = command.charAt(idx);
     // If the current character is a backslash, add the next character verbatim to the argument
     if (c === "\\") {
       arg += command.charAt(++idx);
+      
       // If the current character is a single- or double-quote mark, add it to the current argument.
     } else if (c === KEY.DOUBLE_QUOTE || c === KEY.QUOTE) {
       stringOverride = true;
@@ -73,6 +74,7 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
       // and start a new one
     } else if (c === KEY.SPACE && lastQuote === "") {
       args.push(parseArg(arg, stringOverride));
+
       stringOverride = false;
       arg = "";
     } else {
@@ -87,5 +89,6 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
   if (arg !== "") {
     args.push(parseArg(arg, stringOverride));
   }
+  
   return args;
 }

--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -49,6 +49,7 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
 
   let arg = "";
   let stringOverride = false;
+  
   while (idx < command.length) {
     const c = command.charAt(idx);
     // If the current character is a backslash, add the next character verbatim to the argument

--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -55,7 +55,7 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
     // If the current character is a backslash, add the next character verbatim to the argument
     if (c === "\\") {
       arg += command.charAt(++idx);
-      
+
       // If the current character is a single- or double-quote mark, add it to the current argument.
     } else if (c === KEY.DOUBLE_QUOTE || c === KEY.QUOTE) {
       stringOverride = true;
@@ -89,6 +89,6 @@ export function ParseCommand(command: string): (string | number | boolean)[] {
   if (arg !== "") {
     args.push(parseArg(arg, stringOverride));
   }
-  
+
   return args;
 }


### PR DESCRIPTION
fixes #349

tested in local hosted instance via chrome:

```/** @param {NS} ns */
export async function main(ns) {
  for (let arg of ns.args){
		ns.tprint(typeof arg);
  }
}
```
![image](https://user-images.githubusercontent.com/77801642/221304797-e0dd671f-4eda-409a-9011-7db324bdb086.png)

![image](https://user-images.githubusercontent.com/77801642/221304765-b93aee38-67a9-4b92-9fc8-099d93306c9c.png)
