### PR TITLE
UI: Fixed two percentage signs when creating product

### DIFF
--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -107,7 +107,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
             Designing {product.name} (req. Operations/Engineers in {product.createCity})...
           </Typography>
           <br />
-          <Typography>{formatPercent(product.prog / 100, 2)}% complete</Typography>
+          <Typography>{formatPercent(product.prog / 100, 2)} complete</Typography>
           <Button onClick={() => setCancelOpen(true)}>Cancel</Button>
           <CancelProductModal
             product={product}


### PR DESCRIPTION
fixes #394

tested in local hosted instance via chrome, using the following steps to recreate:
from the attached save:

1. Go to corpo tab
2. Go to LODLeaf tab
3. observe two percentage signs appearing after percentage progress to finish designing product

[bitburnerSave_1677263829_BN3x3.zip](https://github.com/bitburner-official/bitburner-src/files/10831143/bitburnerSave_1677263829_BN3x3.zip)

![image](https://user-images.githubusercontent.com/77801642/221357208-fd7f1be8-5498-429d-8cde-95c2b14ba03b.png)