### PR TITLE
ELECTRON: Fix link handling

### DIFF
--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { app, BrowserWindow } = require("electron");
+const { app, shell, BrowserWindow } = require("electron");
 const log = require("electron-log");
 const utils = require("./utils");
 const achievements = require("./achievements");
 const menu = require("./menu");
 const api = require("./api-server");
-const cp = require("child_process");
 const path = require("path");
 const { windowTracker } = require("./windowTracker");
 
@@ -48,39 +47,15 @@ async function createWindow(killall) {
   window.show();
   if (debug) window.webContents.openDevTools();
 
-  window.webContents.on("new-window", async function (e, url) {
-    // Let's make sure sure we have a proper url
-    let parsedUrl;
-    try {
-      parsedUrl = new URL(url);
-    } catch (_) {
-      // This is an invalid url, let's just do nothing
-      log.warn(`Invalid url found: ${url}`);
-      e.preventDefault();
-      return;
-    }
-
-    // Just use the default handling for file requests, they should be intercepted in main.js file protocol intercept.
-    if (url.startswith("file://")) return;
-
-    if (process.platform === "win32") {
-      // If we have parameters in the URL, explorer.exe won't register the URL and will open the file explorer instead.
-      let urlToOpen = parsedUrl.toString();
-      if (parsedUrl.search) {
-        log.log(`Cannot open a path with parameters: ${parsedUrl.search}`);
-        urlToOpen = urlToOpen.replace(parsedUrl.search, "");
-        // It would be possible to launch an URL with parameter using this, but it would mess up the process again...
-        // const escapedUri = parsedUrl.href.replace('&', '^&');
-        // cp.spawn("cmd.exe", ["/c", "start", escapedUri], { detached: true, stdio: "ignore" });
-      }
-
-      cp.spawn("explorer", [urlToOpen], { detached: true, stdio: "ignore" });
-    } else {
-      // and open every other protocols on the browser
-      utils.openExternal(url);
-    }
-    e.preventDefault();
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    // File protocol is allowed because it will use the file protocol intercept from main.js
+    if (url.startsWith("file://")) return { action: "allow" };
+    // Only http and https requests will be forwarded to browser.
+    // By using shell.openExternal and returning action: "deny"
+    if (url.startsWith("http://") || url.startsWith("https://")) shell.openExternal(url);
+    return { action: "deny" };
   });
+
   window.webContents.backgroundThrottling = false;
 
   achievements.enableAchievementsInterval(window);

--- a/electron/main.js
+++ b/electron/main.js
@@ -72,6 +72,9 @@ function setStopProcessHandler(app, window) {
       log.error(error);
     }
 
+    // This may no longer be needed due to the return of action: deny in gameWindow.js setWindowOpenHandler.
+    // Nothing currently sets the app_playerOpenedExternalLink flag. See utils.js openExternal comment for more info.
+    // -------
     // Because of a steam limitation, if the player has launched an external browser,
     // steam will keep displaying the game as "Running" in their UI as long as the browser is up.
     // So we'll alert the player to close their browser.

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -310,7 +310,7 @@ function getMenu(window) {
               })
               .then(({ response }) => {
                 if (response === 1) {
-                  utils.openExternal("https://github.com/bitburner-official/bitburner-vscode");
+                  shell.openExternal("https://github.com/bitburner-official/bitburner-vscode");
                 }
               });
           },

--- a/electron/utils.js
+++ b/electron/utils.js
@@ -87,6 +87,9 @@ async function writeToast(window, message, type = "info", duration = 2000) {
   await window.webContents.executeJavaScript(`window.appNotifier.toast("${message}", "${type}", ${duration});`, true);
 }
 
+// This may no longer be needed due to the return of { action: "deny" } in gameWindow.js setWindowOpenHandler.
+// Currently this is unused so that this can be tested. If the issue no longer exists, this util will be removed.
+// Otherwise, its use will be reimplemented.
 function openExternal(url) {
   shell.openExternal(url);
   global.app_playerOpenedExternalLink = true;


### PR DESCRIPTION
`http` and `https` links are opened by the system
`file` links are opened using electron (following the limitations of the file protocol intercept).

Potentially this implementation also prevents the steam process from thinking it's still running if a URL has been opened (e.g. tutorial / docs). Will need to test once this is up on steam.