### PR TITLE
BUGFIX: Memory Leak in NetscriptPorts

### DIFF
--- a/doc/source/netscript/netscriptmisc.rst
+++ b/doc/source/netscript/netscriptmisc.rst
@@ -15,9 +15,7 @@ the element that is read is removed from the port.
 The :js:func:`read`, :js:func:`write`, :js:func:`tryWrite`, :js:func:`clear`, and :js:func:`peek`
 Netscript functions can be used to interact with ports.
 
-Right now, there are only 20 ports for Netscript, denoted by the number 1
-through 20. When using the functions above, the ports are specified
-by passing the number as the first argument and the value as the second. 
+When using the functions above, the ports are specified by passing the number as the first argument and the value as the second. 
 The default maximum capacity of a port is 50, but this can be changed in Options > System. Setting this too high can cause the game to use a lot of memory. 
 
 .. important:: The data inside ports are not saved! This means if you close and re-open the game, or reload the page then you will lose all of the data in the ports!

--- a/markdown/bitburner.netscriptport.md
+++ b/markdown/bitburner.netscriptport.md
@@ -9,7 +9,7 @@ Object representing a port. A port is a serialized queue.
 **Signature:**
 
 ```typescript
-interface NetscriptPort 
+export interface NetscriptPort 
 ```
 
 ## Methods

--- a/markdown/bitburner.ns.getporthandle.md
+++ b/markdown/bitburner.ns.getporthandle.md
@@ -9,14 +9,14 @@ Get all data on a port.
 **Signature:**
 
 ```typescript
-getPortHandle(port: number): NetscriptPort;
+getPortHandle(portNumber: number): NetscriptPort;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  port | number | Port number. Must be an integer between 1 and 20. |
+|  portNumber | number | Port number. Must be an integer between 1 and 20. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -90,7 +90,7 @@ export async function main(ns) {
 |  [getHostname()](./bitburner.ns.gethostname.md) | Returns a string with the hostname of the server that the script is running on. |
 |  [getMoneySources()](./bitburner.ns.getmoneysources.md) | Get information about the sources of income for this run. |
 |  [getPlayer()](./bitburner.ns.getplayer.md) | Get information about the player. |
-|  [getPortHandle(port)](./bitburner.ns.getporthandle.md) | Get all data on a port. |
+|  [getPortHandle(portNumber)](./bitburner.ns.getporthandle.md) | Get all data on a port. |
 |  [getPurchasedServerCost(ram)](./bitburner.ns.getpurchasedservercost.md) | Get cost of purchasing a server. |
 |  [getPurchasedServerLimit()](./bitburner.ns.getpurchasedserverlimit.md) | Returns the maximum number of servers you can purchase. |
 |  [getPurchasedServerMaxRam()](./bitburner.ns.getpurchasedservermaxram.md) | Returns the maximum RAM that a purchased server can have. |
@@ -140,14 +140,14 @@ export async function main(ns) {
 |  [mv(host, source, destination)](./bitburner.ns.mv.md) | Move a file on the target server. |
 |  [nFormat(n, format)](./bitburner.ns.nformat.md) | Format a number using the numeral library. This function is deprecated and will be removed in 2.3. |
 |  [nuke(host)](./bitburner.ns.nuke.md) | Runs NUKE.exe on a server. |
-|  [peek(port)](./bitburner.ns.peek.md) | Get a copy of the data from a port without popping it. |
+|  [peek(portNumber)](./bitburner.ns.peek.md) | Get a copy of the data from a port without popping it. |
 |  [print(args)](./bitburner.ns.print.md) | Prints one or more values or variables to the script’s logs. |
 |  [printf(format, args)](./bitburner.ns.printf.md) | Prints a formatted string to the script’s logs. |
 |  [prompt(txt, options)](./bitburner.ns.prompt.md) | Prompt the player with an input modal. |
 |  [ps(host)](./bitburner.ns.ps.md) | List running scripts on a server. |
 |  [purchaseServer(hostname, ram)](./bitburner.ns.purchaseserver.md) | Purchase a server. |
 |  [read(filename)](./bitburner.ns.read.md) | Read content of a file. |
-|  [readPort(port)](./bitburner.ns.readport.md) | Read data from a port. |
+|  [readPort(portNumber)](./bitburner.ns.readport.md) | Read data from a port. |
 |  [relaysmtp(host)](./bitburner.ns.relaysmtp.md) | Runs relaySMTP.exe on a server. |
 |  [renamePurchasedServer(hostname, newName)](./bitburner.ns.renamepurchasedserver.md) | Rename a purchased server. |
 |  [resizeTail(width, height, pid)](./bitburner.ns.resizetail.md) | Resize a tail window. |
@@ -168,12 +168,12 @@ export async function main(ns) {
 |  [toast(msg, variant, duration)](./bitburner.ns.toast.md) | Queue a toast (bottom-right notification). |
 |  [tprint(args)](./bitburner.ns.tprint.md) | Prints one or more values or variables to the Terminal. |
 |  [tprintf(format, values)](./bitburner.ns.tprintf.md) | Prints a raw value or a variable to the Terminal. |
-|  [tryWritePort(port, data)](./bitburner.ns.trywriteport.md) | Attempt to write to a port. |
+|  [tryWritePort(portNumber, data)](./bitburner.ns.trywriteport.md) | Attempt to write to a port. |
 |  [upgradePurchasedServer(hostname, ram)](./bitburner.ns.upgradepurchasedserver.md) | Upgrade a purchased server's RAM. |
 |  [vsprintf(format, args)](./bitburner.ns.vsprintf.md) | Format a string with an array of arguments. |
 |  [weaken(host, opts)](./bitburner.ns.weaken.md) | Reduce a server's security level. |
 |  [weakenAnalyze(threads, cores)](./bitburner.ns.weakenanalyze.md) | Predict the effect of weaken. |
 |  [wget(url, target, host)](./bitburner.ns.wget.md) | Download a file from the internet. |
 |  [write(filename, data, mode)](./bitburner.ns.write.md) | Write data to a file. |
-|  [writePort(port, data)](./bitburner.ns.writeport.md) | Write data to a port. |
+|  [writePort(portNumber, data)](./bitburner.ns.writeport.md) | Write data to a port. |
 

--- a/markdown/bitburner.ns.peek.md
+++ b/markdown/bitburner.ns.peek.md
@@ -9,14 +9,14 @@ Get a copy of the data from a port without popping it.
 **Signature:**
 
 ```typescript
-peek(port: number): PortData;
+peek(portNumber: number): PortData;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  port | number | Port to peek. Must be an integer between 1 and 20. |
+|  portNumber | number | Port to peek. Must be an integer between 1 and 20. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.readport.md
+++ b/markdown/bitburner.ns.readport.md
@@ -9,14 +9,14 @@ Read data from a port.
 **Signature:**
 
 ```typescript
-readPort(port: number): PortData;
+readPort(portNumber: number): PortData;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  port | number |  |
+|  portNumber | number |  |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.trywriteport.md
+++ b/markdown/bitburner.ns.trywriteport.md
@@ -9,14 +9,14 @@ Attempt to write to a port.
 **Signature:**
 
 ```typescript
-tryWritePort(port: number, data: string | number): boolean;
+tryWritePort(portNumber: number, data: string | number): boolean;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  port | number | Port or text file that will be written to. |
+|  portNumber | number | Port or text file that will be written to. |
 |  data | string \| number | Data to write. |
 
 **Returns:**

--- a/markdown/bitburner.ns.writeport.md
+++ b/markdown/bitburner.ns.writeport.md
@@ -9,14 +9,14 @@ Write data to a port.
 **Signature:**
 
 ```typescript
-writePort(port: number, data: string | number): PortData | null;
+writePort(portNumber: number, data: string | number): PortData | null;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  port | number |  |
+|  portNumber | number |  |
 |  data | string \| number |  |
 
 **Returns:**

--- a/markdown/bitburner.tix.getposition.md
+++ b/markdown/bitburner.tix.getposition.md
@@ -28,7 +28,7 @@ Array of four elements that represents the player’s position in a stock.
 
 RAM cost: 2 GB Returns an array of four elements that represents the player’s position in a stock.
 
-The first element is the returned array is the number of shares the player owns of the stock in the Long position. The second element in the array is the average price of the player’s shares in the Long position.
+The first element in the returned array is the number of shares the player owns of the stock in the Long position. The second element in the array is the average price of the player’s shares in the Long position.
 
 The third element in the array is the number of shares the player owns of the stock in the Short position. The fourth element in the array is the average price of the player’s Short position.
 

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -19,8 +19,7 @@ import { convertTimeMsToTimeElapsedString } from "../utils/StringHelperFunctions
 import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
 import { CONSTANTS } from "../Constants";
 import { influenceStockThroughServerHack } from "../StockMarket/PlayerInfluencing";
-import { Port } from "../NetscriptPort";
-import { NetscriptPorts } from "../NetscriptWorker";
+import { PortNumber } from "../NetscriptPort";
 import { FormulaGang } from "../Gang/formulas/formulas";
 import { GangMember } from "../Gang/GangMember";
 import { GangMemberTask } from "../Gang/GangMemberTask";
@@ -52,7 +51,7 @@ export const helpers = {
   getServer,
   scriptIdentifier,
   hack,
-  getValidPort,
+  portNumber,
   person,
   server,
   gang,
@@ -538,19 +537,15 @@ function hack(
   });
 }
 
-function getValidPort(ctx: NetscriptContext, portNumber: number): Port {
-  if (portNumber < 1 || portNumber > CONSTANTS.NumNetscriptPorts || !Number.isInteger(portNumber)) {
+function portNumber(ctx: NetscriptContext, _n: unknown): PortNumber {
+  const n = positiveInteger(ctx, "portNumber", _n);
+  if (n > CONSTANTS.NumNetscriptPorts) {
     throw makeRuntimeErrorMsg(
       ctx,
-      `Trying to use an invalid port: ${portNumber}. Only integer ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
+      `Trying to use an invalid port: ${n}. Must be less or equal to ${CONSTANTS.NumNetscriptPorts}.`,
     );
   }
-  let port = NetscriptPorts.get(portNumber);
-  if (!port) {
-    port = new Port();
-    NetscriptPorts.set(portNumber, port);
-  }
-  return port;
+  return n as PortNumber;
 }
 
 function person(ctx: NetscriptContext, p: unknown): IPerson {

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -19,7 +19,7 @@ import { convertTimeMsToTimeElapsedString } from "../utils/StringHelperFunctions
 import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
 import { CONSTANTS } from "../Constants";
 import { influenceStockThroughServerHack } from "../StockMarket/PlayerInfluencing";
-import { IPort, NetscriptPort } from "../NetscriptPort";
+import { Port } from "../NetscriptPort";
 import { NetscriptPorts } from "../NetscriptWorker";
 import { FormulaGang } from "../Gang/formulas/formulas";
 import { GangMember } from "../Gang/GangMember";
@@ -539,50 +539,24 @@ function hack(
   });
 }
 
-function getValidPort(ctx: NetscriptContext, port: number): IPort {
-  if (isNaN(port)) {
+function getValidPort(ctx: NetscriptContext, portNumber: number): Port {
+  if (portNumber < 1 || portNumber > CONSTANTS.NumNetscriptPorts || !Number.isInteger(portNumber)) {
     throw makeRuntimeErrorMsg(
       ctx,
-      `Invalid argument. Must be a port number between 1 and ${CONSTANTS.NumNetscriptPorts}, is ${port}`,
+      `Trying to use an invalid port: ${portNumber}. Only integer ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
     );
   }
-  port = Math.round(port);
-  if (port < 1 || port > CONSTANTS.NumNetscriptPorts) {
-    throw makeRuntimeErrorMsg(
-      ctx,
-      `Trying to use an invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
-    );
+  let port = NetscriptPorts.get(portNumber);
+  if (!port) {
+    port = new Port();
+    NetscriptPorts.set(portNumber, port);
   }
-  let iport = NetscriptPorts.get(port);
-  if (!iport) {
-    iport = NetscriptPort();
-    NetscriptPorts.set(port, iport);
-  }
-  return iport;
+  return port;
 }
 
-function deletePortIfEmpty(ctx: NetscriptContext, port: number): void {
-  if (isNaN(port)) {
-    throw makeRuntimeErrorMsg(
-      ctx,
-      `Invalid argument. Must be a port number between 1 and ${CONSTANTS.NumNetscriptPorts}, is ${port}`,
-    );
-  }
-  port = Math.round(port);
-  if (port < 1 || port > CONSTANTS.NumNetscriptPorts) {
-    throw makeRuntimeErrorMsg(
-      ctx,
-      `Trying to use an invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
-    );
-  }
-  let iport = NetscriptPorts.get(port);
-  if (!iport) {
-    iport = NetscriptPort();
-    NetscriptPorts.set(port, iport);
-  }
-  if (iport.empty()) {
-    NetscriptPorts.delete(port);
-  }
+// Currently unused
+function deletePortIfEmpty(portNumber: number, port: Port): void {
+  if (port.empty()) NetscriptPorts.delete(portNumber);
 }
 
 function person(ctx: NetscriptContext, p: unknown): IPerson {

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -53,6 +53,7 @@ export const helpers = {
   scriptIdentifier,
   hack,
   getValidPort,
+  deletePortIfEmpty,
   person,
   server,
   gang,
@@ -558,6 +559,30 @@ function getValidPort(ctx: NetscriptContext, port: number): IPort {
     NetscriptPorts.set(port, iport);
   }
   return iport;
+}
+
+function deletePortIfEmpty(ctx: NetscriptContext, port: number): void {
+  if (isNaN(port)) {
+    throw makeRuntimeErrorMsg(
+      ctx,
+      `Invalid argument. Must be a port number between 1 and ${CONSTANTS.NumNetscriptPorts}, is ${port}`,
+    );
+  }
+  port = Math.round(port);
+  if (port < 1 || port > CONSTANTS.NumNetscriptPorts) {
+    throw makeRuntimeErrorMsg(
+      ctx,
+      `Trying to use an invalid port: ${port}. Only ports 1-${CONSTANTS.NumNetscriptPorts} are valid.`,
+    );
+  }
+  let iport = NetscriptPorts.get(port);
+  if (!iport) {
+    iport = NetscriptPort();
+    NetscriptPorts.set(port, iport);
+  }
+  if (iport.empty()) {
+    NetscriptPorts.delete(port);
+  }
 }
 
 function person(ctx: NetscriptContext, p: unknown): IPerson {

--- a/src/Netscript/NetscriptHelpers.ts
+++ b/src/Netscript/NetscriptHelpers.ts
@@ -53,7 +53,6 @@ export const helpers = {
   scriptIdentifier,
   hack,
   getValidPort,
-  deletePortIfEmpty,
   person,
   server,
   gang,
@@ -552,11 +551,6 @@ function getValidPort(ctx: NetscriptContext, portNumber: number): Port {
     NetscriptPorts.set(portNumber, port);
   }
   return port;
-}
-
-// Currently unused
-function deletePortIfEmpty(portNumber: number, port: Port): void {
-  if (port.empty()) NetscriptPorts.delete(portNumber);
 }
 
 function person(ctx: NetscriptContext, p: unknown): IPerson {

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -547,7 +547,6 @@ export const RamCosts: RamCostTree<NSFull> = {
   heart: { break: 0 },
   iKnowWhatImDoing: 0,
   printRaw: 0,
-  deletePortReference: 0,
 
   formulas: {
     mockServer: 0,

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -547,6 +547,7 @@ export const RamCosts: RamCostTree<NSFull> = {
   heart: { break: 0 },
   iKnowWhatImDoing: 0,
   printRaw: 0,
+  deletePortReference: 0,
 
   formulas: {
     mockServer: 0,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1469,6 +1469,7 @@ export const ns: InternalAPI<NSFull> = {
     // Read from port
     const iport = helpers.getValidPort(ctx, port);
     const x = iport.read();
+    helpers.deletePortIfEmpty(ctx, port);
     return x;
   },
   read: (ctx) => (_filename) => {
@@ -1498,6 +1499,7 @@ export const ns: InternalAPI<NSFull> = {
     const port = helpers.number(ctx, "port", _port);
     const iport = helpers.getValidPort(ctx, port);
     const x = iport.peek();
+    helpers.deletePortIfEmpty(ctx, port);
     return x;
   },
   clear: (ctx) => (_file) => {
@@ -1522,6 +1524,7 @@ export const ns: InternalAPI<NSFull> = {
     // Clear port
     const iport = helpers.getValidPort(ctx, port);
     iport.clear();
+    helpers.deletePortIfEmpty(ctx, port);
   },
   getPortHandle: (ctx) => (_port) => {
     const port = helpers.number(ctx, "port", _port);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1399,19 +1399,17 @@ export const ns: InternalAPI<NSFull> = {
     });
     return res;
   },
-  writePort:
-    (ctx) =>
-    (_port, data): string | number | null => {
-      const port = helpers.number(ctx, "port", _port);
-      if (typeof data !== "string" && typeof data !== "number") {
-        throw helpers.makeRuntimeErrorMsg(
-          ctx,
-          `Trying to write invalid data to a port: only strings and numbers are valid.`,
-        );
-      }
-      const iport = helpers.getValidPort(ctx, port);
-      return iport.write(data);
-    },
+  writePort: (ctx) => (_portNumber, data) => {
+    const portNumber = helpers.positiveInteger(ctx, "port", _portNumber);
+    if (typeof data !== "string" && typeof data !== "number") {
+      throw helpers.makeRuntimeErrorMsg(
+        ctx,
+        `Trying to write invalid data to a port: only strings and numbers are valid.`,
+      );
+    }
+    const port = helpers.getValidPort(ctx, portNumber);
+    return port.write(data);
+  },
   write:
     (ctx) =>
     (_filename, _data = "", _mode = "a") => {
@@ -1451,25 +1449,22 @@ export const ns: InternalAPI<NSFull> = {
       }
       return;
     },
-  tryWritePort:
-    (ctx) =>
-    (_port, data = "") => {
-      const port = helpers.number(ctx, "port", _port);
-      if (typeof data !== "string" && typeof data !== "number") {
-        throw helpers.makeRuntimeErrorMsg(
-          ctx,
-          `Trying to write invalid data to a port: only strings and numbers are valid.`,
-        );
-      }
-      const iport = helpers.getValidPort(ctx, port);
-      return iport.tryWrite(data);
-    },
-  readPort: (ctx) => (_port) => {
-    const port = helpers.number(ctx, "port", _port);
+  tryWritePort: (ctx) => (_portNumber, data) => {
+    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
+    if (typeof data !== "string" && typeof data !== "number") {
+      throw helpers.makeRuntimeErrorMsg(
+        ctx,
+        `Trying to write invalid data to a port: only strings and numbers are valid.`,
+      );
+    }
+    const port = helpers.getValidPort(ctx, portNumber);
+    return port.tryWrite(data);
+  },
+  readPort: (ctx) => (_portNumber) => {
+    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
     // Read from port
-    const iport = helpers.getValidPort(ctx, port);
-    const x = iport.read();
-    helpers.deletePortIfEmpty(ctx, port);
+    const port = helpers.getValidPort(ctx, portNumber);
+    const x = port.read();
     return x;
   },
   read: (ctx) => (_filename) => {
@@ -1495,11 +1490,10 @@ export const ns: InternalAPI<NSFull> = {
       }
     }
   },
-  peek: (ctx) => (_port) => {
-    const port = helpers.number(ctx, "port", _port);
-    const iport = helpers.getValidPort(ctx, port);
-    const x = iport.peek();
-    helpers.deletePortIfEmpty(ctx, port);
+  peek: (ctx) => (_portNumber) => {
+    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
+    const port = helpers.getValidPort(ctx, portNumber);
+    const x = port.peek();
     return x;
   },
   clear: (ctx) => (_file) => {
@@ -1519,17 +1513,15 @@ export const ns: InternalAPI<NSFull> = {
       throw helpers.makeRuntimeErrorMsg(ctx, `Invalid argument: ${file}`);
     }
   },
-  clearPort: (ctx) => (_port) => {
-    const port = helpers.number(ctx, "port", _port);
-    // Clear port
-    const iport = helpers.getValidPort(ctx, port);
-    iport.clear();
-    helpers.deletePortIfEmpty(ctx, port);
+  clearPort: (ctx) => (_portNumber) => {
+    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
+    const port = helpers.getValidPort(ctx, portNumber);
+    port.clear();
   },
-  getPortHandle: (ctx) => (_port) => {
-    const port = helpers.number(ctx, "port", _port);
-    const iport = helpers.getValidPort(ctx, port);
-    return iport;
+  getPortHandle: (ctx) => (_portNumber) => {
+    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
+    const port = helpers.getValidPort(ctx, portNumber);
+    return port;
   },
   rm:
     (ctx) =>

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -90,7 +90,7 @@ import { CityName, JobName, CrimeType, GymType, LocationName, UniversityClassTyp
 import { cloneDeep } from "lodash";
 import { FactionWorkType } from "./Enums";
 import numeral from "numeral";
-import { portHandle } from "./NetscriptPort";
+import { clearPort, peekPort, portHandle, readPort, tryWritePort, writePort } from "./NetscriptPort";
 
 export const enums: NSEnums = {
   CityName,
@@ -1401,15 +1401,14 @@ export const ns: InternalAPI<NSFull> = {
     return res;
   },
   writePort: (ctx) => (_portNumber, data) => {
-    const portNumber = helpers.positiveInteger(ctx, "port", _portNumber);
+    const portNumber = helpers.portNumber(ctx, _portNumber);
     if (typeof data !== "string" && typeof data !== "number") {
       throw helpers.makeRuntimeErrorMsg(
         ctx,
         `Trying to write invalid data to a port: only strings and numbers are valid.`,
       );
     }
-    const port = helpers.getValidPort(ctx, portNumber);
-    return port.write(data);
+    return writePort(portNumber, data);
   },
   write:
     (ctx) =>
@@ -1451,22 +1450,18 @@ export const ns: InternalAPI<NSFull> = {
       return;
     },
   tryWritePort: (ctx) => (_portNumber, data) => {
-    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
+    const portNumber = helpers.portNumber(ctx, _portNumber);
     if (typeof data !== "string" && typeof data !== "number") {
       throw helpers.makeRuntimeErrorMsg(
         ctx,
         `Trying to write invalid data to a port: only strings and numbers are valid.`,
       );
     }
-    const port = helpers.getValidPort(ctx, portNumber);
-    return port.tryWrite(data);
+    return tryWritePort(portNumber, data);
   },
   readPort: (ctx) => (_portNumber) => {
-    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
-    // Read from port
-    const port = helpers.getValidPort(ctx, portNumber);
-    const x = port.read();
-    return x;
+    const portNumber = helpers.portNumber(ctx, _portNumber);
+    return readPort(portNumber);
   },
   read: (ctx) => (_filename) => {
     const fn = helpers.string(ctx, "filename", _filename);
@@ -1492,10 +1487,8 @@ export const ns: InternalAPI<NSFull> = {
     }
   },
   peek: (ctx) => (_portNumber) => {
-    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
-    const port = helpers.getValidPort(ctx, portNumber);
-    const x = port.peek();
-    return x;
+    const portNumber = helpers.portNumber(ctx, _portNumber);
+    return peekPort(portNumber);
   },
   clear: (ctx) => (_file) => {
     const file = helpers.string(ctx, "file", _file);
@@ -1515,14 +1508,12 @@ export const ns: InternalAPI<NSFull> = {
     }
   },
   clearPort: (ctx) => (_portNumber) => {
-    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
-    const port = helpers.getValidPort(ctx, portNumber);
-    port.clear();
+    const portNumber = helpers.portNumber(ctx, _portNumber);
+    return clearPort(portNumber);
   },
   getPortHandle: (ctx) => (_portNumber) => {
-    const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
-    if (portNumber <= CONSTANTS.NumNetscriptPorts) return portHandle(portNumber);
-    throw helpers.makeRuntimeErrorMsg(ctx, `portNumber must be less than ${CONSTANTS.NumNetscriptPorts}`);
+    const portNumber = helpers.portNumber(ctx, _portNumber);
+    return portHandle(portNumber);
   },
   rm:
     (ctx) =>

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -90,6 +90,7 @@ import { CityName, JobName, CrimeType, GymType, LocationName, UniversityClassTyp
 import { cloneDeep } from "lodash";
 import { FactionWorkType } from "./Enums";
 import numeral from "numeral";
+import { portHandle } from "./NetscriptPort";
 
 export const enums: NSEnums = {
   CityName,
@@ -1520,8 +1521,8 @@ export const ns: InternalAPI<NSFull> = {
   },
   getPortHandle: (ctx) => (_portNumber) => {
     const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
-    const port = helpers.getValidPort(ctx, portNumber);
-    return port;
+    if (portNumber <= CONSTANTS.NumNetscriptPorts) return portHandle(portNumber);
+    throw helpers.makeRuntimeErrorMsg(ctx, `portNumber must be less than ${CONSTANTS.NumNetscriptPorts}`);
   },
   rm:
     (ctx) =>

--- a/src/NetscriptFunctions/Extra.ts
+++ b/src/NetscriptFunctions/Extra.ts
@@ -6,7 +6,6 @@ import { Apr1Events as devMenu } from "../ui/Apr1";
 import { InternalAPI } from "../Netscript/APIWrapper";
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { Terminal } from "../Terminal";
-import { NetscriptPorts } from "../NetscriptWorker";
 
 export type INetscriptExtra = {
   heart: {
@@ -19,7 +18,6 @@ export type INetscriptExtra = {
   rainbow(guess: string): void;
   iKnowWhatImDoing(): void;
   printRaw(value: React.ReactNode): void;
-  deletePortReference(portNumber: number): boolean;
 };
 
 export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
@@ -74,16 +72,6 @@ export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
     printRaw: (ctx) => (value) => {
       // Using this voids the warranty on your tail log
       ctx.workerScript.print(value as React.ReactNode);
-    },
-    deletePortReference: (ctx) => (_portNumber) => {
-      const portNumber = helpers.positiveInteger(ctx, "portNumber", _portNumber);
-      const port = NetscriptPorts.get(portNumber);
-      if (!port) return false;
-      // @ts-ignore deleting port data manually
-      delete port.data;
-      // @ts-ignore deleting port resolvers array manually
-      delete port.resolvers;
-      return NetscriptPorts.delete(portNumber);
     },
   };
 }

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -5,7 +5,7 @@ import { NetscriptPorts } from "./NetscriptWorker";
 type PortData = string | number;
 type Resolver = () => void;
 const emptyPortData = "NULL PORT DATA";
-// PortNumber is typechecked by helpers.portNumber. The object property is for typechecking only and is not real at runtime.
+/** The object property is for typechecking and is not present at runtime */
 export type PortNumber = number & { __PortNumber: true };
 
 /** Gets the numbered port, initializing it if it doesn't already exist.

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -1,79 +1,56 @@
 import { Settings } from "./Settings/Settings";
+import { NetscriptPort } from "@nsdefs";
 
 type PortData = string | number;
 type Resolver = () => void;
-export interface IPort {
-  write: (value: unknown) => PortData | null;
-  tryWrite: (value: unknown) => boolean;
-  read: () => PortData;
-  peek: () => PortData;
-  nextWrite: () => Promise<void>;
-  full: () => boolean;
-  empty: () => boolean;
-  clear: () => void;
-}
 
-export function NetscriptPort(): IPort {
-  const data: PortData[] = [];
-  const resolvers: Resolver[] = [];
-
-  return {
-    write: (value) => {
-      if (typeof value !== "number" && typeof value !== "string") {
-        throw new Error(
-          `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
-        );
-      }
-      data.push(value);
-      while (resolvers.length > 0) {
-        (resolvers.pop() as Resolver)();
-      }
-      if (data.length > Settings.MaxPortCapacity) {
-        return data.shift() as PortData;
-      }
-      return null;
-    },
-
-    tryWrite: (value) => {
-      if (typeof value != "number" && typeof value != "string") {
-        throw new Error(
-          `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
-        );
-      }
-      if (data.length >= Settings.MaxPortCapacity) {
-        return false;
-      }
-      data.push(value);
-      while (resolvers.length > 0) {
-        (resolvers.pop() as Resolver)();
-      }
-      return true;
-    },
-
-    read: () => {
-      if (data.length === 0) return "NULL PORT DATA";
-      return data.shift() as PortData;
-    },
-
-    peek: () => {
-      if (data.length === 0) return "NULL PORT DATA";
-      return data[0];
-    },
-
-    nextWrite: () => {
-      return new Promise((res) => resolvers.push(res));
-    },
-
-    full: () => {
-      return data.length == Settings.MaxPortCapacity;
-    },
-
-    empty: () => {
-      return data.length === 0;
-    },
-
-    clear: () => {
-      data.length = 0;
-    },
-  };
+export class Port implements NetscriptPort {
+  #data: PortData[] = [];
+  #resolvers: Resolver[] = [];
+  write(value: unknown): PortData | null {
+    if (typeof value !== "number" && typeof value !== "string") {
+      throw new Error(
+        `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
+      );
+    }
+    this.#data.push(value);
+    while (this.#resolvers.length > 0) {
+      (this.#resolvers.pop() as Resolver)();
+    }
+    if (this.#data.length > Settings.MaxPortCapacity) {
+      return this.#data.shift() as PortData;
+    }
+    return null;
+  }
+  tryWrite(value: unknown): boolean {
+    if (typeof value != "number" && typeof value != "string") {
+      throw new Error(
+        `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
+      );
+    }
+    if (this.#data.length >= Settings.MaxPortCapacity) return false;
+    this.#data.push(value);
+    while (this.#resolvers.length > 0) (this.#resolvers.pop() as Resolver)();
+    return true;
+  }
+  read(): PortData {
+    if (this.#data.length === 0) return "NULL PORT DATA";
+    return this.#data.shift() as PortData;
+  }
+  peek(): PortData {
+    if (this.#data.length === 0) return "NULL PORT DATA";
+    return this.#data[0];
+  }
+  nextWrite() {
+    return new Promise((res) => this.#resolvers.push(res as Resolver)) as Promise<void>;
+  }
+  full() {
+    return this.#data.length >= Settings.MaxPortCapacity;
+  }
+  empty() {
+    return this.#data.length === 0;
+  }
+  clear() {
+    this.#data.length = 0;
+  }
 }

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -4,8 +4,13 @@ import { NetscriptPorts } from "./NetscriptWorker";
 
 type PortData = string | number;
 type Resolver = () => void;
+const emptyPortData = "NULL PORT DATA";
+// PortNumber is typechecked by helpers.portNumber. The object property is for typechecking only and is not real at runtime.
+export type PortNumber = number & { __PortNumber: true };
 
-function getPort(n: number) {
+/** Gets the numbered port, initializing it if it doesn't already exist.
+ * Only using for functions that write data/resolvers. Use NetscriptPorts.get(n) for */
+export function getPort(n: PortNumber) {
   let port = NetscriptPorts.get(n);
   if (port) return port;
   port = new Port();
@@ -13,66 +18,83 @@ function getPort(n: number) {
   return port;
 }
 
-export function portHandle(n: number): NetscriptPort {
+export class Port {
+  data: PortData[] = [];
+  resolvers: Resolver[] = [];
+}
+export function portHandle(n: PortNumber): NetscriptPort {
   return {
-    write: (value: unknown) => getPort(n).write(value),
-    tryWrite: (value: unknown) => getPort(n).tryWrite(value),
-    read: () => getPort(n).read(),
-    peek: () => getPort(n).peek(),
-    nextWrite: () => getPort(n).nextWrite(),
-    full: () => getPort(n).full(),
-    empty: () => getPort(n).empty(),
-    clear: () => getPort(n).clear(),
+    write: (value: unknown) => writePort(n, value),
+    tryWrite: (value: unknown) => tryWritePort(n, value),
+    read: () => readPort(n),
+    peek: () => peekPort(n),
+    nextWrite: () => nextWritePort(n),
+    full: () => isFullPort(n),
+    empty: () => isEmptyPort(n),
+    clear: () => clearPort(n),
   };
 }
 
-export class Port implements NetscriptPort {
-  data: PortData[] = [];
-  resolvers: Resolver[] = [];
-  write(value: unknown): PortData | null {
-    if (typeof value !== "number" && typeof value !== "string") {
-      throw new Error(
-        `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
-      );
-    }
-    this.data.push(value);
-    while (this.resolvers.length > 0) {
-      (this.resolvers.pop() as Resolver)();
-    }
-    if (this.data.length > Settings.MaxPortCapacity) {
-      return this.data.shift() as PortData;
-    }
-    return null;
+export function writePort(n: PortNumber, value: unknown): PortData | null {
+  if (typeof value !== "number" && typeof value !== "string") {
+    throw new Error(
+      `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
+    );
   }
-  tryWrite(value: unknown): boolean {
-    if (typeof value != "number" && typeof value != "string") {
-      throw new Error(
-        `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
-      );
-    }
-    if (this.data.length >= Settings.MaxPortCapacity) return false;
-    this.data.push(value);
-    while (this.resolvers.length > 0) (this.resolvers.pop() as Resolver)();
-    return true;
+  const { data, resolvers } = getPort(n);
+  data.push(value);
+  while (resolvers.length > 0) (resolvers.pop() as Resolver)();
+  if (data.length > Settings.MaxPortCapacity) return data.shift() as PortData;
+  return null;
+}
+
+export function tryWritePort(n: PortNumber, value: unknown): boolean {
+  if (typeof value != "number" && typeof value != "string") {
+    throw new Error(
+      `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
+    );
   }
-  read(): PortData {
-    if (this.data.length === 0) return "NULL PORT DATA";
-    return this.data.shift() as PortData;
-  }
-  peek(): PortData {
-    if (this.data.length === 0) return "NULL PORT DATA";
-    return this.data[0];
-  }
-  nextWrite() {
-    return new Promise((res) => this.resolvers.push(res as Resolver)) as Promise<void>;
-  }
-  full() {
-    return this.data.length >= Settings.MaxPortCapacity;
-  }
-  empty() {
-    return this.data.length === 0;
-  }
-  clear() {
-    this.data.length = 0;
-  }
+  const { data, resolvers } = getPort(n);
+  if (data.length >= Settings.MaxPortCapacity) return false;
+  data.push(value);
+  while (resolvers.length > 0) (resolvers.pop() as Resolver)();
+  return true;
+}
+
+export function readPort(n: PortNumber): PortData {
+  const port = NetscriptPorts.get(n);
+  if (!port || !port.data.length) return emptyPortData;
+  const returnVal = port.data.shift() as PortData;
+  if (!port.data.length && !port.resolvers.length) NetscriptPorts.delete(n);
+  return returnVal;
+}
+
+export function peekPort(n: PortNumber): PortData {
+  const port = NetscriptPorts.get(n);
+  if (!port || !port.data.length) return emptyPortData;
+  return port.data[0];
+}
+
+function nextWritePort(n: PortNumber) {
+  const { resolvers } = getPort(n);
+  return new Promise<void>((res) => resolvers.push(res as Resolver));
+}
+
+function isFullPort(n: PortNumber) {
+  const port = NetscriptPorts.get(n);
+  if (!port) return false;
+  return port.data.length >= Settings.MaxPortCapacity;
+}
+
+function isEmptyPort(n: PortNumber) {
+  const port = NetscriptPorts.get(n);
+  if (!port) return true;
+  return port.data.length === 0;
+}
+
+export function clearPort(n: PortNumber) {
+  const port = NetscriptPorts.get(n);
+  if (!port) return;
+  if (!port.resolvers.length) NetscriptPorts.delete(n);
+  port.data.length = 0;
 }

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -1,24 +1,46 @@
 import { Settings } from "./Settings/Settings";
 import { NetscriptPort } from "@nsdefs";
+import { NetscriptPorts } from "./NetscriptWorker";
 
 type PortData = string | number;
 type Resolver = () => void;
 
+function getPort(n: number) {
+  let port = NetscriptPorts.get(n);
+  if (port) return port;
+  port = new Port();
+  NetscriptPorts.set(n, port);
+  return port;
+}
+
+export function portHandle(n: number): NetscriptPort {
+  return {
+    write: (value: unknown) => getPort(n).write(value),
+    tryWrite: (value: unknown) => getPort(n).tryWrite(value),
+    read: () => getPort(n).read(),
+    peek: () => getPort(n).peek(),
+    nextWrite: () => getPort(n).nextWrite(),
+    full: () => getPort(n).full(),
+    empty: () => getPort(n).empty(),
+    clear: () => getPort(n).clear(),
+  };
+}
+
 export class Port implements NetscriptPort {
-  #data: PortData[] = [];
-  #resolvers: Resolver[] = [];
+  data: PortData[] = [];
+  resolvers: Resolver[] = [];
   write(value: unknown): PortData | null {
     if (typeof value !== "number" && typeof value !== "string") {
       throw new Error(
         `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
       );
     }
-    this.#data.push(value);
-    while (this.#resolvers.length > 0) {
-      (this.#resolvers.pop() as Resolver)();
+    this.data.push(value);
+    while (this.resolvers.length > 0) {
+      (this.resolvers.pop() as Resolver)();
     }
-    if (this.#data.length > Settings.MaxPortCapacity) {
-      return this.#data.shift() as PortData;
+    if (this.data.length > Settings.MaxPortCapacity) {
+      return this.data.shift() as PortData;
     }
     return null;
   }
@@ -28,29 +50,29 @@ export class Port implements NetscriptPort {
         `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
       );
     }
-    if (this.#data.length >= Settings.MaxPortCapacity) return false;
-    this.#data.push(value);
-    while (this.#resolvers.length > 0) (this.#resolvers.pop() as Resolver)();
+    if (this.data.length >= Settings.MaxPortCapacity) return false;
+    this.data.push(value);
+    while (this.resolvers.length > 0) (this.resolvers.pop() as Resolver)();
     return true;
   }
   read(): PortData {
-    if (this.#data.length === 0) return "NULL PORT DATA";
-    return this.#data.shift() as PortData;
+    if (this.data.length === 0) return "NULL PORT DATA";
+    return this.data.shift() as PortData;
   }
   peek(): PortData {
-    if (this.#data.length === 0) return "NULL PORT DATA";
-    return this.#data[0];
+    if (this.data.length === 0) return "NULL PORT DATA";
+    return this.data[0];
   }
   nextWrite() {
-    return new Promise((res) => this.#resolvers.push(res as Resolver)) as Promise<void>;
+    return new Promise((res) => this.resolvers.push(res as Resolver)) as Promise<void>;
   }
   full() {
-    return this.#data.length >= Settings.MaxPortCapacity;
+    return this.data.length >= Settings.MaxPortCapacity;
   }
   empty() {
-    return this.#data.length === 0;
+    return this.data.length === 0;
   }
   clear() {
-    this.#data.length = 0;
+    this.data.length = 0;
   }
 }

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -13,7 +13,7 @@ import { CONSTANTS } from "./Constants";
 import { Interpreter } from "./ThirdParty/JSInterpreter";
 import { NetscriptFunctions } from "./NetscriptFunctions";
 import { compile, Node } from "./NetscriptJSEvaluator";
-import { Port } from "./NetscriptPort";
+import { Port, PortNumber } from "./NetscriptPort";
 import { RunningScript } from "./Script/RunningScript";
 import { getRamUsageFromRunningScript } from "./Script/RunningScriptHelpers";
 import { scriptCalculateOfflineProduction } from "./Script/ScriptHelpers";
@@ -35,7 +35,7 @@ import { Terminal } from "./Terminal";
 import { ScriptArg } from "./Netscript/ScriptArg";
 import { handleUnknownError } from "./Netscript/NetscriptHelpers";
 
-export const NetscriptPorts: Map<number, Port> = new Map();
+export const NetscriptPorts: Map<PortNumber, Port> = new Map();
 
 export function prestigeWorkerScripts(): void {
   for (const ws of workerScripts.values()) {

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -13,7 +13,7 @@ import { CONSTANTS } from "./Constants";
 import { Interpreter } from "./ThirdParty/JSInterpreter";
 import { NetscriptFunctions } from "./NetscriptFunctions";
 import { compile, Node } from "./NetscriptJSEvaluator";
-import { IPort } from "./NetscriptPort";
+import { Port } from "./NetscriptPort";
 import { RunningScript } from "./Script/RunningScript";
 import { getRamUsageFromRunningScript } from "./Script/RunningScriptHelpers";
 import { scriptCalculateOfflineProduction } from "./Script/ScriptHelpers";
@@ -35,7 +35,7 @@ import { Terminal } from "./Terminal";
 import { ScriptArg } from "./Netscript/ScriptArg";
 import { handleUnknownError } from "./Netscript/NetscriptHelpers";
 
-export const NetscriptPorts: Map<number, IPort> = new Map();
+export const NetscriptPorts: Map<number, Port> = new Map();
 
 export function prestigeWorkerScripts(): void {
   for (const ws of workerScripts.values()) {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -927,7 +927,7 @@ export type SleeveTask =
 
 /** Object representing a port. A port is a serialized queue.
  * @public */
-interface NetscriptPort {
+export interface NetscriptPort {
   /** Write data to a port.
    * @remarks
    * RAM cost: 0 GB
@@ -6117,11 +6117,11 @@ export interface NS {
    * If the port is full, the data will not be written.
    * Otherwise, the data will be written normally.
    *
-   * @param port - Port or text file that will be written to.
+   * @param portNumber - Port or text file that will be written to.
    * @param data - Data to write.
    * @returns True if the data is successfully written to the port, and false otherwise.
    */
-  tryWritePort(port: number, data: string | number): boolean;
+  tryWritePort(portNumber: number, data: string | number): boolean;
 
   /**
    * Read content of a file.
@@ -6147,10 +6147,10 @@ export interface NS {
    * first element in the specified port without removing that element. If
    * the port is empty, the string “NULL PORT DATA” will be returned.
    *
-   * @param port - Port to peek. Must be an integer between 1 and 20.
+   * @param portNumber - Port to peek. Must be an integer between 1 and 20.
    * @returns Data in the specified port.
    */
-  peek(port: number): PortData;
+  peek(portNumber: number): PortData;
 
   /**
    * Clear data from a file.
@@ -6182,7 +6182,7 @@ export interface NS {
    * Write data to the given Netscript port.
    * @returns The data popped off the queue if it was full, or null if it was not full.
    */
-  writePort(port: number, data: string | number): PortData | null;
+  writePort(portNumber: number, data: string | number): PortData | null;
   /**
    * Read data from a port.
    * @remarks
@@ -6193,7 +6193,7 @@ export interface NS {
    * If the queue is empty, then the string “NULL PORT DATA” will be returned.
    * @returns The data read.
    */
-  readPort(port: number): PortData;
+  readPort(portNumber: number): PortData;
 
   /**
    * Get all data on a port.
@@ -6205,9 +6205,9 @@ export interface NS {
    * WARNING: Port Handles only work in NetscriptJS (Netscript 2.0). They will not work in Netscript 1.0.
    *
    * @see https://bitburner-official.readthedocs.io/en/latest/netscript/netscriptmisc.html#netscript-ports
-   * @param port - Port number. Must be an integer between 1 and 20.
+   * @param portNumber - Port number. Must be an integer between 1 and 20.
    */
-  getPortHandle(port: number): NetscriptPort;
+  getPortHandle(portNumber: number): NetscriptPort;
 
   /**
    * Delete a file.


### PR DESCRIPTION
Prior to making this change, a script that uses a non-trivial amount of Netscript Ports once each and then never uses them again would cause the empty ports to hang around, taking up a growing amount of memory. This patch deallocates empty ports from the NetscriptPorts map.

Tested by running my script that uses a non-trivial number of ports once each and watching the Memory tab in the debug console. Prior to the patch, it would grow until game crashed, at a rate of about 2MB/s. After the patch, memory usage grew to about 300MB and stayed there.