### PR TITLE
SETTINGS: Add infinite loop detection setting

### DIFF
--- a/src/GameOptions/ui/SystemPage.tsx
+++ b/src/GameOptions/ui/SystemPage.tsx
@@ -141,6 +141,17 @@ export const SystemPage = (): React.ReactElement => {
         />
       </>
       <OptionSwitch
+        checked={Settings.infiniteLoopDetection}
+        onChange={(newValue) => (Settings.infiniteLoopDetection = newValue)}
+        text="Infinite loop detection"
+        tooltip={
+          <>
+            If this is set, scripts can generate an execution timeout error when an ns function is called and the script
+            has been running synchronous operations for at least 7s.
+          </>
+        }
+      />
+      <OptionSwitch
         checked={Settings.SuppressSavedGameToast}
         onChange={(newValue) => (Settings.SuppressSavedGameToast = newValue)}
         text="Suppress Auto-Save Game Toast"

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -102,6 +102,8 @@ export const Settings = {
   useEngineeringNotation: false,
   /** Whether to disable suffixes and always use exponential form (scientific or engineering). */
   disableSuffixes: false,
+  /** Whether to check for execution timeout errors */
+  infiniteLoopDetection: true,
 
   load(saveString: string) {
     const save = JSON.parse(saveString);


### PR DESCRIPTION
An interval runs every 1s to update a time tracking parameter. If an ns function runs and this timer hasn't been updated in the last 8s, an error is thrown. There's a setting to disable this behavior, if you have code that actually runs synchronously for long enough to trigger this.

Changing the visibility of the window provides some additional handling that is intended to prevent false positives from e.g. switching tabs. In my own testing I couldn't get the error to display when it wasn't an actual infinite loop / long synchronous code. Merging this early so it gets more test time to identify issues before 2.3 release.