### PR TITLE
STANEK: Improve performance when not charging, rework bonus time

### DIFF
--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -44,7 +44,9 @@ export function NetscriptStanek(): InternalAPI<IStanek> {
         );
       }
       //Charge the fragment
-      const time = staneksGift.inBonus() ? 200 : 1000;
+      const inBonus = staneksGift.inBonus();
+      const time = inBonus ? 200 : 1000;
+      if (inBonus) staneksGift.isBonusCharging = true;
       return helpers.netscriptDelay(ctx, time).then(function () {
         staneksGift.charge(fragment, ctx.workerScript.scriptRef.threads);
         helpers.log(ctx, () => `Charged fragment with ${ctx.workerScript.scriptRef.threads} threads.`);


### PR DESCRIPTION
* Player multipliers are only recalculated by stanek if charging a fragment was done during last cycle. (Performance boost)
* Bonus time accrued is saved until used (via ns.stanek.chargeFragment). (Buff)
* Cycles were previously used at a 10x rate to provide a 5x boost to stanek. Now they are used at 5x rate. (Buff)