### PR TITLE
UI: scaled next gang equipment unlock money required

### DIFF
--- a/src/Gang/ui/EquipmentsSubpage.tsx
+++ b/src/Gang/ui/EquipmentsSubpage.tsx
@@ -41,7 +41,7 @@ function NextReveal(props: INextRevealProps): React.ReactElement {
   if (upgrades.length === 0) return <></>;
   return (
     <Typography>
-      Next at <Money money={upgrades[0].cost} />
+      Next at <Money money={gang.getUpgradeCost(upgrades[0])} />
     </Typography>
   );
 }


### PR DESCRIPTION
fixes #415

tested on localhosted instance with browser (chrome)

First screenshot demonstrates visible correction:

![image](https://user-images.githubusercontent.com/77801642/224294614-80c57f02-7c93-472b-a94f-04993e6be649.png)

Used dev menu to check that shown amount is indeed the threshold used (not the original $10b), demonstrated in second screenshot:

![image](https://user-images.githubusercontent.com/77801642/224295283-73f160a9-9084-4429-97e3-f27e6036e5fa.png)

