### PR TITLE
ENGINE: Use setTimeout() instead of requestAnimationFrame()

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -407,7 +407,7 @@ const Engine: {
       Player.lastUpdate = _thisUpdate - offset;
       Engine.updateGame(diff);
     }
-    window.requestAnimationFrame(Engine.start);
+    window.setTimeout(Engine.start, CONSTANTS.MilliPerCycle - offset);
   },
 };
 


### PR DESCRIPTION
This changes the main loop to use setTimeout() instead of requestAnimationFrame(): This is both appropriate (we are updating game logic, not painting the screen), and also necessary for any kind of background processing: requestAnimationFrame is always *completely* descheduled when the tab loses focus.