### PR TITLE
BUGFIX: Fix order-of-ops issue with SCRIPT_32GB achievement

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -341,7 +341,7 @@ export const achievements: Record<string, Achievement> = {
   SCRIPT_32GB: {
     ...achievementData["SCRIPT_32GB"],
     Icon: "bigcost",
-    Condition: () => Player.getHomeComputer().scripts.some((s) => s.ramUsage ?? 0 >= 32),
+    Condition: () => Player.getHomeComputer().scripts.some((s) => (s.ramUsage ?? 0) >= 32),
   },
   FIRST_HACKNET_NODE: {
     ...achievementData["FIRST_HACKNET_NODE"],


### PR DESCRIPTION
It was awarding as soon as you had a valid script.