### PR TITLE
BUGFIX: Allow (attempting) importing the same save twice in a row

### DIFF
--- a/src/GameOptions/ui/GameOptionsSidebar.tsx
+++ b/src/GameOptions/ui/GameOptionsSidebar.tsx
@@ -73,6 +73,9 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
     } catch (e: unknown) {
       console.error(e);
       SnackbarEvents.emit(String(e), ToastVariant.ERROR, 5000);
+    } finally {
+      // Re-trigger if we import the same save
+      event.target.value = "";
     }
   }
 


### PR DESCRIPTION
Because it was the same filename, it wouldn't trigger onChange after the first time.