### PR TITLE
PERFORMANCE: Improve speed of saving when there are lots of scripts

### DIFF
--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -199,20 +199,20 @@ export function loadAllServers(saveString: string): void {
   AllServers = JSON.parse(saveString, Reviver);
 }
 
-export function saveAllServers(excludeRunningScripts = false): string {
-  const TempAllServers = JSON.parse(JSON.stringify(AllServers), Reviver);
-  for (const key of Object.keys(TempAllServers)) {
-    const server = TempAllServers[key];
-    if (excludeRunningScripts) {
-      server.runningScripts = [];
-      continue;
-    }
-    for (let i = 0; i < server.runningScripts.length; ++i) {
-      const runningScriptObj = server.runningScripts[i];
-      runningScriptObj.logs.length = 0;
-      runningScriptObj.logs = [];
-    }
+function excludeReplacer(key: string, value: any): any {
+  if (key === "runningScripts") {
+    return [];
   }
+  return value;
+}
 
-  return JSON.stringify(TempAllServers);
+function includeReplacer(key: string, value: any): any {
+  if (key === "logs") {
+    return [];
+  }
+  return value;
+}
+
+export function saveAllServers(excludeRunningScripts = false): string {
+  return JSON.stringify(AllServers, excludeRunningScripts ? excludeReplacer : includeReplacer);
 }


### PR DESCRIPTION
There was needless multiple-trip serialization.

Before (representative sample):
```
[home ~/]> run benchmark_save.js
Running script with 1 thread(s), pid 120013 and args: [].
Launching 10000 copies...
Launched in 2.719 seconds
Scripts started in 0.143 seconds. Saving game...
Saving took 0.697 seconds
```

After (representative sample):
```
[home ~/]> run benchmark_save.js
Running script with 1 thread(s), pid 70008 and args: [].
Launching 10000 copies...
Launched in 2.759 seconds
Scripts started in 0.127 seconds. Saving game...
Saving took 0.309 seconds
```

## Testing

Passes the golden master test in #425

The code for the benchmark script is
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.disableLog("run");
  ns.disableLog("kill");
  const orig = React.createElement;
  let resolve;
  // Pull the save function from the button on the character menu
  React.createElement = function (...args) {
    const props = args[1];
    if (props && props.save && props.killScripts) {
      React.createElement = orig;
      resolve(props.save);
    }
    return orig.call(this, ...args);
  };
  const resultP = Promise.race([
    new Promise((res) => (resolve = res)),
    ns.asleep(1000),
  ]).finally(() => {
    React.createElement = orig;
  });
  // Force a rerender
  ns.ui.setTheme(ns.ui.getTheme());
  const saveFunc = await resultP;
  if (!saveFunc) {
    ns.tprint("ERROR: Couldn't find save function!");
    return;
  }

  const COPIES = 10000;
  ns.write(
    "benchmark_save_helper.js",
    `
/** @param {NS} ns */
export function main(ns) {
  ns.writePort(ns.args[0], "");
  return ns.asleep(300000);
}`.trim(),
    "w"
  );
  ns.tprintf("Launching %d copies...", COPIES);
  const beforeLaunch = performance.now();
  ns.atExit(() => {
    const host = ns.getHostname();
    for (let i = 0; i < COPIES; ++i) {
      ns.kill("benchmark_save_helper.js", host, ns.pid, i);
    }
  });
  const promise = ns.getPortHandle(ns.pid).nextWrite();
  for (let i = 0; i < COPIES; ++i) {
    const pid = ns.run("benchmark_save_helper.js", 1, ns.pid, i);
    if (pid < 1) {
      ns.tprintf("Failed to launch copy %d, benchmark failed", i);
      return;
    }
  }
  const afterLaunch = performance.now();
  ns.tprintf("Launched in %.3f seconds", 0.001 * (afterLaunch - beforeLaunch));
  await promise;
  const afterStart = performance.now();

  ns.tprintf(
    "Scripts started in %.3f seconds. Saving game...",
    0.001 * (afterStart - afterLaunch)
  );
  await ns.asleep(0);
  const before = performance.now();
  saveFunc();
  await ns.asleep(0);
  const after = performance.now();
  ns.tprintf("Saving took %.3f seconds", 0.001 * (after - before));
}
```