### PR TITLE
MISC: Fix inconsistent magic number in skill/exp calculation

### DIFF
--- a/src/PersonObjects/formulas/skill.ts
+++ b/src/PersonObjects/formulas/skill.ts
@@ -3,7 +3,7 @@
  * stat level. Stat-agnostic (same formula for every stat)
  */
 export function calculateSkill(exp: number, mult = 1): number {
-  return Math.max(Math.floor(mult * (32 * Math.log(exp + 534.5) - 200)), 1);
+  return Math.max(Math.floor(mult * (32 * Math.log(exp + 534.6) - 200)), 1);
 }
 
 export function calculateExp(skill: number, mult = 1): number {


### PR DESCRIPTION
https://www.reddit.com/r/Bitburner/comments/11vq17h/there_is_a_bug_in_the_current_version_v222_with_a/

See `src/PersonObjects/formulas/skill.ts` `calculateSkill` vs `calculateExp`