### PR TITLE
GENERAL: Renaming a purchased server while connected to it no longer leads to a crash

### DIFF
--- a/src/Server/ServerPurchases.ts
+++ b/src/Server/ServerPurchases.ts
@@ -68,6 +68,7 @@ export const renamePurchasedServer = (hostname: string, newName: string): void =
     return arr.map((v) => (v === old ? next : v));
   };
   Player.purchasedServers = replace(Player.purchasedServers, hostname, newName);
+  if (Player.currentServer === hostname) Player.currentServer = newName;
   const home = Player.getHomeComputer();
   home.serversOnNetwork = replace(home.serversOnNetwork, hostname, newName);
   server.serversOnNetwork = replace(server.serversOnNetwork, hostname, newName);


### PR DESCRIPTION
Fixes #426 

Test script:
```js
/** @param {NS} ns */
export async function main(ns) {
  const currentName = ns.getHostname();
  const newName = {Test1: "Test2", Test2: "Test1"}[currentName] ?? "Test1";
  ns.tprint(`Attempting to rename this server from ${currentName} to ${newName}`);
  ns.renamePurchasedServer(currentName, newName);
  await ns.asleep(10000);
}
```
Image showing no crash (same script crashes pre-PR):
![image](https://user-images.githubusercontent.com/84951833/226776962-64e1d903-3b0c-47f3-9083-2ecff84a809e.png)
