### PR TITLE
TERMINAL: Prevent errors from getFilepath

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -392,22 +392,17 @@ export class Terminal {
     return null;
   }
 
-  getFilepath(filename: string): string {
+  getFilepath(filename: string): string | null {
     const path = evaluateFilePath(filename, this.cwd());
-    if (path == null) {
-      throw new Error(`Invalid file path specified: ${filename}`);
-    }
+    if (path === null || !isInRootDirectory(path)) return path;
 
-    if (isInRootDirectory(path)) {
-      return removeLeadingSlash(path);
-    }
-
-    return path;
+    return removeLeadingSlash(path);
   }
 
   getScript(filename: string): Script | null {
     const s = Player.getCurrentServer();
     const filepath = this.getFilepath(filename);
+    if (!filepath) return null;
     for (const script of s.scripts) {
       if (filepath === script.filename) {
         return script;
@@ -420,6 +415,7 @@ export class Terminal {
   getTextFile(filename: string): TextFile | null {
     const s = Player.getCurrentServer();
     const filepath = this.getFilepath(filename);
+    if (!filepath) return null;
     for (const txt of s.textFiles) {
       if (filepath === txt.fn) {
         return txt;
@@ -432,6 +428,7 @@ export class Terminal {
   getLitFile(filename: string): string | null {
     const s = Player.getCurrentServer();
     const filepath = this.getFilepath(filename);
+    if (!filepath) return null;
     for (const lit of s.messages) {
       if (typeof lit === "string" && filepath === lit) {
         return lit;

--- a/src/Terminal/commands/cat.ts
+++ b/src/Terminal/commands/cat.ts
@@ -12,6 +12,7 @@ export function cat(args: (string | number | boolean)[], server: BaseServer): vo
   }
   const relative_filename = args[0] + "";
   const filename = Terminal.getFilepath(relative_filename);
+  if (!filename) return Terminal.error(`Invalid filename: ${relative_filename}`);
   if (
     !filename.endsWith(".msg") &&
     !filename.endsWith(".lit") &&

--- a/src/Terminal/commands/check.ts
+++ b/src/Terminal/commands/check.ts
@@ -8,6 +8,8 @@ export function check(args: (string | number | boolean)[], server: BaseServer): 
     Terminal.error(`Incorrect number of arguments. Usage: check [script] [arg1] [arg2]...`);
   } else {
     const scriptName = Terminal.getFilepath(args[0] + "");
+    if (!scriptName) return Terminal.error(`Invalid filename: ${args[0]}`);
+
     // Can only tail script files
     if (!isScriptFilename(scriptName)) {
       Terminal.error(

--- a/src/Terminal/commands/common/editor.ts
+++ b/src/Terminal/commands/common/editor.ts
@@ -109,6 +109,7 @@ export function commonEditor(
 
       if (isScriptFilename(filename)) {
         const filepath = Terminal.getFilepath(filename);
+        if (!filepath) throw `Invalid filename: ${filename}`;
         const script = Terminal.getScript(filename);
         const fileIsNs2 = isNs2(filename);
         const code = script !== null ? script.code : fileIsNs2 ? newNs2Template : "";
@@ -125,6 +126,7 @@ export function commonEditor(
 
       if (filename.endsWith(".txt")) {
         const filepath = Terminal.getFilepath(filename);
+        if (!filepath) throw `Invalid filename: ${filename}`;
         const txt = Terminal.getTextFile(filename);
         return [filepath, txt === null ? "" : txt.text];
       }

--- a/src/Terminal/commands/cp.ts
+++ b/src/Terminal/commands/cp.ts
@@ -5,39 +5,26 @@ import { getDestinationFilepath, areFilesEqual } from "../DirectoryHelpers";
 
 export function cp(args: (string | number | boolean)[], server: BaseServer): void {
   try {
-    if (args.length !== 2) {
-      Terminal.error("Incorrect usage of cp command. Usage: cp [src] [dst]");
-      return;
-    }
+    if (args.length !== 2) return Terminal.error("Incorrect usage of cp command. Usage: cp [src] [dst]");
     // Convert a relative path source file to the absolute path.
     const src = Terminal.getFilepath(args[0] + "");
-    if (src === null) {
-      Terminal.error("src cannot be a directory");
-      return;
-    }
+    if (src === null) return Terminal.error(`Invalid source filename ${args[0]}`);
 
     // Get the destination based on the source file and the current directory
     const t_dst = getDestinationFilepath(args[1] + "", src, Terminal.cwd());
-    if (t_dst === null) {
-      Terminal.error("error parsing dst file");
-      return;
-    }
+    if (t_dst === null) return Terminal.error("error parsing dst file");
 
     // Convert a relative path destination file to the absolute path.
     const dst = Terminal.getFilepath(t_dst);
-    if (areFilesEqual(src, dst)) {
-      Terminal.error("src and dst cannot be the same");
-      return;
-    }
+    if (!dst) return Terminal.error(`Invalid destination filename ${t_dst}`);
+    if (areFilesEqual(src, dst)) return Terminal.error("src and dst cannot be the same");
+
     const srcExt = src.slice(src.lastIndexOf("."));
     const dstExt = dst.slice(dst.lastIndexOf("."));
-    if (srcExt !== dstExt) {
-      Terminal.error("src and dst must have the same extension.");
-      return;
-    }
+    if (srcExt !== dstExt) return Terminal.error("src and dst must have the same extension.");
+
     if (!isScriptFilename(src) && !src.endsWith(".txt")) {
-      Terminal.error("cp only works for scripts and .txt files");
-      return;
+      return Terminal.error("cp only works for scripts and .txt files");
     }
 
     // Scp for txt files

--- a/src/Terminal/commands/kill.ts
+++ b/src/Terminal/commands/kill.ts
@@ -26,6 +26,7 @@ export function kill(args: (string | number | boolean)[], server: BaseServer): v
     }
 
     const scriptName = Terminal.getFilepath(args[0]);
+    if (!scriptName) return Terminal.error(`Invalid filename: ${args[0]}`);
     const runningScript = server.getRunningScript(scriptName, args.slice(1));
     if (runningScript == null) {
       Terminal.error("No such script is running. Nothing to kill");

--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -155,6 +155,9 @@ export function ls(args: (string | number | boolean)[], server: BaseServer): voi
       const filepath = Terminal.getFilepath(`${prefix}${filename}`);
       // Terminal.getScript also calls Terminal.getFilepath and therefore also
       // needs the given parameter
+      if (!filepath) {
+        return Terminal.error(`Invalid filename (${prefix}${filename}) when clicking script link. This is a bug.`);
+      }
       const code = toString(Terminal.getScript(`${prefix}${filename}`)?.code);
       Router.toScriptEditor({ [filepath]: code });
     }
@@ -199,6 +202,9 @@ export function ls(args: (string | number | boolean)[], server: BaseServer): voi
       }
       if (filename.startsWith("/")) filename = filename.slice(1);
       const filepath = Terminal.getFilepath(`${prefix}${filename}`);
+      if (!filepath) {
+        return Terminal.error(`Invalid filename ${prefix}${filename} when clicking message link. This is a bug.`);
+      }
 
       if (filepath.endsWith(".lit")) {
         showLiterature(filepath);

--- a/src/Terminal/commands/mv.ts
+++ b/src/Terminal/commands/mv.ts
@@ -21,40 +21,28 @@ export function mv(args: (string | number | boolean)[], server: BaseServer): voi
     }
 
     const srcFile = Terminal.getFile(source);
-    if (srcFile == null) {
-      Terminal.error(`Source file ${source} does not exist`);
-      return;
-    }
+    if (srcFile == null) return Terminal.error(`Source file ${source} does not exist`);
 
     const sourcePath = Terminal.getFilepath(source);
+    if (!sourcePath) return Terminal.error(`Invalid source filename: ${source}`);
+
     // Get the destination based on the source file and the current directory
     const dest = getDestinationFilepath(t_dest, source, Terminal.cwd());
-    if (dest === null) {
-      Terminal.error("error parsing dst file");
-      return;
-    }
+    if (dest === null) return Terminal.error("error parsing dst file");
 
     const destFile = Terminal.getFile(dest);
     const destPath = Terminal.getFilepath(dest);
-    if (areFilesEqual(sourcePath, destPath)) {
-      Terminal.error(`Source and destination files are the same file`);
-      return;
-    }
+    if (!destPath) return Terminal.error(`Invalid destination filename: ${destPath}`);
+    if (areFilesEqual(sourcePath, destPath)) return Terminal.error(`Source and destination files are the same file`);
 
     // 'mv' command only works on scripts and txt files.
     // Also, you can't convert between different file types
     if (isScriptFilename(source)) {
       const script = srcFile as Script;
-      if (!isScriptFilename(destPath)) {
-        Terminal.error(`Source and destination files must have the same type`);
-        return;
-      }
+      if (!isScriptFilename(destPath)) return Terminal.error(`Source and destination files must have the same type`);
 
       // Command doesn't work if script is running
-      if (server.isRunning(sourcePath)) {
-        Terminal.error(`Cannot use 'mv' on a script that is running`);
-        return;
-      }
+      if (server.isRunning(sourcePath)) return Terminal.error(`Cannot use 'mv' on a script that is running`);
 
       if (destFile != null) {
         // Already exists, will be overwritten, so we'll delete it

--- a/src/Terminal/commands/rm.ts
+++ b/src/Terminal/commands/rm.ts
@@ -1,30 +1,10 @@
 import { Terminal } from "../../Terminal";
 import { BaseServer } from "../../Server/BaseServer";
-import { IReturnStatus } from "../../types";
 
 export function rm(args: (string | number | boolean)[], server: BaseServer): void {
-  if (args.length !== 1) {
-    Terminal.error("Incorrect number of arguments. Usage: rm [program/script]");
-    return;
-  }
-
-  // Check programs
-  let delTarget;
-  let status: IReturnStatus = {
-    res: true,
-    msg: "",
-  };
-  try {
-    delTarget = Terminal.getFilepath(args[0] + "");
-    status = server.removeFile(delTarget);
-  } catch (err) {
-    status = {
-      res: false,
-      msg: "No such file exists",
-    };
-  }
-
-  if (!status.res && status.msg) {
-    Terminal.error(status.msg);
-  }
+  if (args.length !== 1) return Terminal.error("Incorrect number of arguments. Usage: rm [program/script]");
+  const delTarget = Terminal.getFilepath(args[0] + "");
+  if (!delTarget) return Terminal.error(`Invalid filename: ${args[0]}`);
+  const status = server.removeFile(delTarget);
+  if (!status.res && status.msg) Terminal.error(status.msg);
 }

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -18,6 +18,7 @@ export function runScript(commandArgs: (string | number | boolean)[], server: Ba
   }
 
   const scriptName = Terminal.getFilepath(commandArgs[0] + "");
+  if (!scriptName) return Terminal.error(`Invalid filename: ${commandArgs[0]}`);
 
   const runArgs = { "--tail": Boolean, "-t": Number };
   const flags = libarg(runArgs, {

--- a/src/Terminal/commands/scp.ts
+++ b/src/Terminal/commands/scp.ts
@@ -10,6 +10,7 @@ export function scp(args: (string | number | boolean)[], server: BaseServer): vo
       return;
     }
     const scriptname = Terminal.getFilepath(args[0] + "");
+    if (!scriptname) return Terminal.error(`Invalid filename: ${args[0]}`);
     if (!scriptname.endsWith(".lit") && !isScriptFilename(scriptname) && !scriptname.endsWith(".txt")) {
       Terminal.error("scp only works for scripts, text files (.txt), and literature files (.lit)");
       return;

--- a/src/Terminal/commands/tail.ts
+++ b/src/Terminal/commands/tail.ts
@@ -11,6 +11,7 @@ export function tail(commandArray: (string | number | boolean)[], server: BaseSe
       Terminal.error("Incorrect number of arguments. Usage: tail [script] [arg1] [arg2]...");
     } else if (typeof commandArray[0] === "string") {
       const scriptName = Terminal.getFilepath(commandArray[0]);
+      if (!scriptName) return Terminal.error(`Invalid filename: ${commandArray[0]}`);
       if (!isScriptFilename(scriptName)) {
         Terminal.error(`tail can only be called on ${validScriptExtensions.join(", ")} files, or by PID`);
         return;

--- a/src/Terminal/commands/wget.ts
+++ b/src/Terminal/commands/wget.ts
@@ -12,7 +12,7 @@ export function wget(args: (string | number | boolean)[], server: BaseServer): v
 
   const url = args[0] + "";
   const target = Terminal.getFilepath(args[1] + "");
-  if (!isScriptFilename(target) && !target.endsWith(".txt")) {
+  if (!target || (!isScriptFilename(target) && !target.endsWith(".txt"))) {
     return Terminal.error(`wget failed: Invalid target file. Target file must be script or text file`);
   }
   $.get(


### PR DESCRIPTION
getFilepath no longer throws, it just returns null if there's no evaluated filepath.
All places that use getFilepath create their own errors based on the null value.

Also condensed some terminal stuff while making these changes.