### PR TITLE
 BUGFIX: Fixed issue where duplicate programs could be created

### DIFF
--- a/src/Programs/ui/ProgramsRoot.tsx
+++ b/src/Programs/ui/ProgramsRoot.tsx
@@ -10,7 +10,7 @@ import { Player } from "@player";
 import { Settings } from "../../Settings/Settings";
 
 import { Programs } from "../Programs";
-import { CreateProgramWork } from "../../Work/CreateProgramWork";
+import { CreateProgramWork, isCreateProgramWork } from "../../Work/CreateProgramWork";
 import { useRerender } from "../../ui/React/hooks";
 
 export const ProgramsSeen: string[] = [];
@@ -91,6 +91,9 @@ export function ProgramsRoot(): React.ReactElement {
                     sx={{ my: 1, width: "100%" }}
                     onClick={(event) => {
                       if (!event.isTrusted) return;
+                      if (isCreateProgramWork(Player.currentWork)) {
+                        Player.finishWork(true);
+                      }
                       Player.startWork(new CreateProgramWork({ singularity: false, programName: program.name }));
                       Player.startFocusing();
                       Router.toPage(Page.Work);


### PR DESCRIPTION
# Linked issues

fixes #346

# Bug fix

- The issue was that clicking "doing something else" after starting, and then "create program" would not add the program to the Player.getHomeComputer().programs array, before the new CreateProgramWork Instance would check the array. The fix was to check if the current work was still on a program, and if so, call finishWork before creating a new instance when clicking the create program button. 