### PR TITLE
BUGFIX: Fix the return of weaken() to account for BN mult

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -383,7 +383,8 @@ export const ns: InternalAPI<NSFull> = {
           return Promise.resolve(0);
         }
         const coreBonus = 1 + (host.cpuCores - 1) / 16;
-        server.weaken(CONSTANTS.ServerWeakenAmount * threads * coreBonus);
+        const weakenAmt = CONSTANTS.ServerWeakenAmount * threads * coreBonus;
+        server.weaken(weakenAmt);
         ctx.workerScript.scriptRef.recordWeaken(server.hostname, threads);
         const expGain = calculateHackingExpGain(server, Player) * threads;
         helpers.log(
@@ -395,7 +396,8 @@ export const ns: InternalAPI<NSFull> = {
         );
         ctx.workerScript.scriptRef.onlineExpGained += expGain;
         Player.gainHackingExp(expGain);
-        return Promise.resolve(CONSTANTS.ServerWeakenAmount * threads * coreBonus);
+        // Account for hidden multiplier in Server.weaken()
+        return Promise.resolve(weakenAmt * BitNodeMultipliers.ServerWeakenRate);
       });
     },
   weakenAnalyze:


### PR DESCRIPTION
Fun fact: This has been broken since the multiplier was first added in 7a05d3585aad55881b753e9513ea15eab1e68a2a 6 years ago in 0.28.0.