### PR TITLE
NETSCRIPT: reduce RAM cost for renamePurchasedServer to 0

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -494,7 +494,7 @@ export const RamCosts: RamCostTree<NSFull> = {
   getPurchasedServerCost: RamCostConstants.GetPurchaseServer,
   getPurchasedServerUpgradeCost: 0.1,
   upgradePurchasedServer: 0.25,
-  renamePurchasedServer: 2,
+  renamePurchasedServer: 0,
   purchaseServer: RamCostConstants.PurchaseServer,
   deleteServer: RamCostConstants.PurchaseServer,
   getPurchasedServers: RamCostConstants.PurchaseServer,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1254,6 +1254,7 @@ export const ns: InternalAPI<NSFull> = {
       return -1;
     }
   },
+
   upgradePurchasedServer: (ctx) => (_hostname, _ram) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
     const ram = helpers.number(ctx, "ram", _ram);
@@ -1265,17 +1266,11 @@ export const ns: InternalAPI<NSFull> = {
       return false;
     }
   },
+
   renamePurchasedServer: (ctx) => (_hostname, _newName) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
     const newName = helpers.string(ctx, "newName", _newName);
-    try {
-      renamePurchasedServer(hostname, newName);
-      return true;
-    } catch (err) {
-      helpers.log(ctx, () => String(err));
-      return false;
-    }
-    return false;
+    renamePurchasedServer(hostname, newName);
   },
 
   deleteServer: (ctx) => (_name) => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6086,9 +6086,8 @@ export interface NS {
    *
    * @param hostname - Current server hostname.
    * @param newName - New server hostname.
-   * @returns True if the upgrade succeeded, and false otherwise.
    */
-  renamePurchasedServer(hostname: string, newName: string): boolean;
+  renamePurchasedServer(hostname: string, newName: string): void;
 
   /**
    * Delete a purchased server.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6082,7 +6082,7 @@ export interface NS {
   /**
    * Rename a purchased server.
    * @remarks
-   * RAM cost: 2.00 GB
+   * RAM cost: 0 GB
    *
    * @param hostname - Current server hostname.
    * @param newName - New server hostname.


### PR DESCRIPTION
I personally feel this cosmetic of a function at 2gb of ram makes it pretty much unusable. I personally see no harm in making it cost 0 RAM or if it must cost something 1 or less RAM. Just a suggestion, feel free to shoot it down if it doesn't align with your personal vision for the game.

![image](https://user-images.githubusercontent.com/32428876/227793845-40f33e35-d790-4ce4-b9c2-a6f949ffacd4.png)

![image](https://user-images.githubusercontent.com/32428876/227793885-4205060f-f4f4-4582-9b89-3a2c1501b6a4.png)


Post Update:
![image](https://user-images.githubusercontent.com/32428876/228344537-7e9ae6e8-173a-432b-b24e-13eccd0a0140.png)
