### PR TITLE
REFACTOR: Break the import cycle of Player

### DIFF
--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -1,4 +1,3 @@
-import { PlayerObject } from "../PersonObjects/Player/PlayerObject";
 import { AugmentationNames } from "../Augmentation/data/AugmentationNames";
 import { SkillNames } from "../Bladeburner/data/SkillNames";
 import { Skills } from "../Bladeburner/Skills";
@@ -25,6 +24,8 @@ import { FactionNames } from "../Faction/data/FactionNames";
 import { BlackOperationNames } from "../Bladeburner/data/BlackOperationNames";
 import { isClassWork } from "../Work/ClassWork";
 import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
+
+import type { PlayerObject } from "../PersonObjects/Player/PlayerObject";
 
 // Unable to correctly cast the JSON data into AchievementDataJson type otherwise...
 const achievementData = (<AchievementDataJson>(<unknown>data)).achievements;

--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -6,6 +6,7 @@ import * as generalMethods from "./PlayerObjectGeneralMethods";
 import * as serverMethods from "./PlayerObjectServerMethods";
 import * as workMethods from "./PlayerObjectWorkMethods";
 
+import { setPlayer } from "../../Player";
 import { Sleeve } from "../Sleeve/Sleeve";
 import { PlayerOwnedSourceFile } from "../../SourceFile/PlayerOwnedSourceFile";
 import { Exploit } from "../../Exploits/Exploit";
@@ -171,5 +172,7 @@ export class PlayerObject extends Person implements IPlayer {
     return player;
   }
 }
+
+setPlayer(new PlayerObject());
 
 Reviver.constructors.PlayerObject = PlayerObject;

--- a/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
@@ -1,6 +1,7 @@
 /** Augmentation-related methods for the Player class (PlayerObject) */
-import { PlayerObject } from "./PlayerObject";
 import { calculateEntropy } from "../Grafting/EntropyAccumulation";
+
+import type { PlayerObject } from "./PlayerObject";
 
 export function applyEntropy(this: PlayerObject, stacks = 1): void {
   // Re-apply all multipliers

--- a/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
@@ -1,5 +1,6 @@
 import { Bladeburner } from "../../Bladeburner/Bladeburner";
-import { PlayerObject } from "./PlayerObject";
+
+import type { PlayerObject } from "./PlayerObject";
 
 export function canAccessBladeburner(this: PlayerObject): boolean {
   return this.bitNodeN === 6 || this.bitNodeN === 7 || this.sourceFileLvl(6) > 0 || this.sourceFileLvl(7) > 0;

--- a/src/PersonObjects/Player/PlayerObjectCorporationMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectCorporationMethods.ts
@@ -3,8 +3,9 @@ import {
   CorporationUnlockUpgradeIndex,
   CorporationUnlockUpgrades,
 } from "../../Corporation/data/CorporationUnlockUpgrades";
-import { PlayerObject } from "./PlayerObject";
 import { resetIndustryResearchTrees } from "../../Corporation/IndustryData";
+
+import type { PlayerObject } from "./PlayerObject";
 
 export function canAccessCorporation(this: PlayerObject): boolean {
   return this.bitNodeN === 3 || this.sourceFileLvl(3) > 0;

--- a/src/PersonObjects/Player/PlayerObjectGangMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGangMethods.ts
@@ -1,9 +1,10 @@
 import { Factions } from "../../Faction/Factions";
 import { Faction } from "../../Faction/Faction";
 import { Gang } from "../../Gang/Gang";
-import { PlayerObject } from "./PlayerObject";
 import { GangConstants } from "../../Gang/data/Constants";
 import { isFactionWork } from "../../Work/FactionWork";
+
+import type { PlayerObject } from "./PlayerObject";
 
 export function canAccessGang(this: PlayerObject): boolean {
   if (this.bitNodeN === 2) {

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -1,4 +1,3 @@
-import { PlayerObject } from "./PlayerObject";
 import { applyAugmentation } from "../../Augmentation/AugmentationHelpers";
 import { PlayerOwnedAugmentation } from "../../Augmentation/PlayerOwnedAugmentation";
 import { AugmentationNames } from "../../Augmentation/data/AugmentationNames";
@@ -44,6 +43,8 @@ import { FactionNames } from "../../Faction/data/FactionNames";
 
 import { isCompanyWork } from "../../Work/CompanyWork";
 import { serverMetadata } from "../../Server/data/servers";
+
+import type { PlayerObject } from "./PlayerObject";
 
 export function init(this: PlayerObject): void {
   /* Initialize Player's home computer */

--- a/src/PersonObjects/Player/PlayerObjectServerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectServerMethods.ts
@@ -1,6 +1,4 @@
 // Server and HacknetServer-related methods for the Player class (PlayerObject)
-import { PlayerObject } from "./PlayerObject";
-
 import { CONSTANTS } from "../../Constants";
 
 import { BitNodeMultipliers } from "../../BitNode/BitNodeMultipliers";
@@ -10,6 +8,8 @@ import { HacknetServer } from "../../Hacknet/HacknetServer";
 import { GetServer, AddToAllServers, createUniqueRandomIp } from "../../Server/AllServers";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 import { hasHacknetServers } from "../../Hacknet/HacknetHelpers";
+
+import type { PlayerObject } from "./PlayerObject";
 
 export function hasTorRouter(this: PlayerObject): boolean {
   return this.getHomeComputer().serversOnNetwork.includes(SpecialServers.DarkWeb);

--- a/src/PersonObjects/Player/PlayerObjectWorkMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectWorkMethods.ts
@@ -1,5 +1,6 @@
 import { Work } from "../../Work/Work";
-import { PlayerObject } from "./PlayerObject";
+
+import type { PlayerObject } from "./PlayerObject";
 
 export function startWork(this: PlayerObject, w: Work): void {
   if (this.currentWork !== null) {

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1,9 +1,14 @@
-import { PlayerObject } from "./PersonObjects/Player/PlayerObject";
 import { sanitizeExploits } from "./Exploits/Exploit";
 
 import { Reviver } from "./utils/JSONReviver";
 
-export let Player = new PlayerObject();
+import type { PlayerObject } from "./PersonObjects/Player/PlayerObject";
+
+export let Player: PlayerObject;
+
+export function setPlayer(playerObj: PlayerObject): void {
+  Player = playerObj;
+}
 
 export function loadPlayer(saveString: string): void {
   Player = JSON.parse(saveString, Reviver);

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -11,6 +11,7 @@ import { Reviver } from "../utils/JSONReviver";
 import { isValidIPAddress } from "../utils/helpers/isValidIPAddress";
 import { SpecialServers } from "./data/SpecialServers";
 import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
+import "../Script/RunningScript"; // For reviver side-effect
 
 import type { RunningScript } from "../Script/RunningScript";
 

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -12,6 +12,7 @@ import { processPassiveFactionRepGain, inviteToFaction } from "./Faction/Faction
 import { Router } from "./ui/GameRoot";
 import { Page } from "./ui/Router";
 import { SetupTextEditor } from "./ScriptEditor/ui/ScriptEditorRoot";
+import "./PersonObjects/Player/PlayerObject"; // For side-effect of creating Player
 
 import {
   getHackingWorkRepGain,

--- a/test/jest/Imports/Hacknet.test.ts
+++ b/test/jest/Imports/Hacknet.test.ts
@@ -1,0 +1,5 @@
+import { HacknetServer } from "../../../src/Hacknet/HacknetServer";
+
+test("Can import only HacknetServer", () => {
+  new HacknetServer();
+});

--- a/test/jest/Imports/Server.test.ts
+++ b/test/jest/Imports/Server.test.ts
@@ -1,0 +1,5 @@
+import { Server } from "../../../src/Server/Server";
+
+test("Can import only Server", () => {
+  new Server();
+});

--- a/test/jest/Imports/WorkerScript.test.ts
+++ b/test/jest/Imports/WorkerScript.test.ts
@@ -1,0 +1,5 @@
+import { WorkerScript } from "../../../src/Netscript/WorkerScript";
+
+test("Can import only WorkerScript", () => {
+  WorkerScript;
+});


### PR DESCRIPTION
This reorders the dependency between `Player` (the global object) and `PersonObjects/Player/PlayerObject` (the implementation) so that instead of going `Player` -> `PlayerObject`, it now goes `PlayerObject` -> `Player`.

Since `PlayerObject` is a massive class, it depends on most things throughout the game, and at the same time most things depend on `Player`. This massive dependency cycle permeated most things, and prevented a lot of classes from being imported standalone without ordering issues.

Added 3 tests on important mid-level classes that used to fail to import.

----
## Testing

This change exposed a latent bug in `AllServers.ts`: It is importing `RunningScript.ts` for the type `RunningScript`, but also depending on execution of `RunningScript` for the side-effect of setting the property on the Reviver so that it loads correctly.
Since it is using `import type`, that side-effect doesn't happen since the import doesn't exist at run-time. Interestingly, changing to `import` doesn't change things: Both TypeScript and Babel prune imports if it can identify that you are using them to import types only, and this saves *tons* of circular import headaches.

Before, the large circular import caused by `Player` caused the side-effect to happen due to an import of `RunningScript` through another path. Now, that doesn't happen. In the full game, `RunningScript` will also be imported through another path, but it is not good to depend on this.

What's especially of note is that this was caught *only* by the new Save test, so it is already showing its worth...