### PR TITLE
GANG: Fix some weirdness in respect calculations

### DIFF
--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -111,7 +111,7 @@ export class Gang {
     let wantedLevelGains = 0;
     let justice = 0;
     for (let i = 0; i < this.members.length; ++i) {
-      respectGains += this.members[i].calculateRespectGain(this);
+      respectGains += this.members[i].earnRespect(numCycles, this);
       moneyGains += this.members[i].calculateMoneyGain(this);
       const wantedLevelGain = this.members[i].calculateWantedLevelGain(this);
       wantedLevelGains += wantedLevelGain;
@@ -134,10 +134,6 @@ export class Gang {
 
     fac.playerReputation += (Player.mults.faction_rep * gain * favorMult) / GangConstants.GangRespectToReputationRatio;
 
-    // Keep track of respect gained per member
-    for (let i = 0; i < this.members.length; ++i) {
-      this.members[i].recordEarnedRespect(numCycles, this);
-    }
     if (!(this.wanted === 1 && wantedLevelGains < 0)) {
       const oldWanted = this.wanted;
       let newWanted = oldWanted + wantedLevelGains * numCycles;
@@ -335,7 +331,7 @@ export class Gang {
     // Player loses a percentage of total respect, plus whatever respect that member has earned
     const totalRespect = this.respect;
     const lostRespect = 0.05 * totalRespect + member.earnedRespect;
-    this.respect = Math.max(0, totalRespect - lostRespect);
+    this.respect = Math.max(1, totalRespect - lostRespect);
 
     for (let i = 0; i < this.members.length; ++i) {
       if (member.name === this.members[i].name) {

--- a/src/Gang/GangMember.ts
+++ b/src/Gang/GangMember.ts
@@ -191,8 +191,10 @@ export class GangMember {
       this.calculateAscensionMult(this.cha_asc_points);
   }
 
-  recordEarnedRespect(numCycles = 1, gang: Gang): void {
-    this.earnedRespect += this.calculateRespectGain(gang) * numCycles;
+  earnRespect(numCycles = 1, gang: Gang): number {
+    const earnedRespect = this.calculateRespectGain(gang) * numCycles;
+    this.earnedRespect += earnedRespect;
+    return earnedRespect;
   }
 
   getGainedAscensionPoints(): IMults {

--- a/src/Gang/formulas/formulas.ts
+++ b/src/Gang/formulas/formulas.ts
@@ -9,7 +9,7 @@ export interface FormulaGang {
 }
 
 export function calculateWantedPenalty(gang: FormulaGang): number {
-  return Math.max(gang.respect + 0.0001) / (gang.respect + gang.wantedLevel);
+  return gang.respect / (gang.respect + gang.wantedLevel);
 }
 
 export function calculateRespectGain(gang: FormulaGang, member: GangMember, task: GangMemberTask): number {


### PR DESCRIPTION
Fixes this problem which leads to member earnedRespect appearing higher than their actual contributions to the gang:
![image](https://user-images.githubusercontent.com/84951833/228955848-683e941a-9407-4454-9811-1e6c7f926f53.png)

Also make formulas calculateWantedPenalty match the actual gang getWantedPenalty function.

Also changed member deaths to clamp respect to 1 (just like ascension), instead of allowing respect to drop all the way to 0.