### PR TITLE
BUGFIX: Fix npm audit for webpack 5.75.0 by upgrading to 5.77.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15130,9 +15130,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -27061,9 +27061,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",


### PR DESCRIPTION
There is a  high severity vulnerability when running npm audit, run `npm audit fix` to upgrade webpack from 5.75.0 to 5.77.0