### PR TITLE
TEST: Add a NS2 test (finally)

### DIFF
--- a/FixJSDOMEnvironment.ts
+++ b/FixJSDOMEnvironment.ts
@@ -1,0 +1,15 @@
+import JSDOMEnvironment from "jest-environment-jsdom";
+
+// https://github.com/facebook/jest/blob/v29.4.3/website/versioned_docs/version-29.4/Configuration.md#testenvironment-string
+export default class FixJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+
+    // FIXME https://github.com/nodejs/node/issues/35889
+    // Add missing importActual() function to mirror requireActual(),
+    // which lets us work around the ESM bug.
+    // Wrap the construction of the function in eval, so that transpilers
+    // don't touch the import() call.
+    this.global.importActual = eval("url => import(url)");
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,11 @@
 module.exports = {
+  roots: ["<rootDir>/src/", "<rootDir>/test/"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   transform: {
     "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
   },
   testPathIgnorePatterns: [".cypress", "node_modules", "dist"],
-  testEnvironment: "jsdom",
+  testEnvironment: "./FixJSDOMEnvironment.ts",
   moduleNameMapper: {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/test/__mocks__/fileMock.js",


### PR DESCRIPTION
This was much harder than it should have been, since it required working around https://github.com/nodejs/node/issues/35889 : Node.js has a bug open for 1.5 years (and it's been present for longer) where it just segfaults if you dynamic import() in certain circumstances. These circumstances are hit by basically all test runners, and certainly by Jest.

Also sped up tests by reducing the number of traversed directories (the "roots" option).

# Testing

Scripts still run (sanity check of the very small amount of game code touched)