### PR TITLE
HASHNET: Company Favor

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -88,7 +88,7 @@ export const CONSTANTS: {
   LatestUpdate: string;
 } = {
   VersionString: "2.3.0",
-  VersionNumber: 30,
+  VersionNumber: 31,
 
   /** Max level for any skill, assuming no multipliers. Determined by max numerical value in javascript for experience
    * and the skill level formula in Player.js. Note that all this means it that when experience hits MAX_INT, then

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -88,7 +88,7 @@ export const CONSTANTS: {
   LatestUpdate: string;
 } = {
   VersionString: "2.3.0",
-  VersionNumber: 31,
+  VersionNumber: 30,
 
   /** Max level for any skill, assuming no multipliers. Determined by max numerical value in javascript for experience
    * and the skill level formula in Player.js. Note that all this means it that when experience hits MAX_INT, then

--- a/src/Hacknet/HacknetHelpers.tsx
+++ b/src/Hacknet/HacknetHelpers.tsx
@@ -21,6 +21,7 @@ import { iTutorialSteps, iTutorialNextStep, ITutorial } from "../InteractiveTuto
 import { Player } from "@player";
 import { GetServer } from "../Server/AllServers";
 import { Server } from "../Server/Server";
+import { Companies } from "../Company/Companies";
 
 // Returns a boolean indicating whether the player has Hacknet Servers
 // (the upgraded form of Hacknet Nodes)
@@ -560,6 +561,14 @@ export function purchaseHashUpgrade(upgName: string, upgTarget: string, count = 
         for (let i = 0; i < count; i++) {
           generateRandomContract();
         }
+        break;
+      }
+      case "Company Favor": {
+        if (!(upgTarget in Companies)) {
+          console.error(`Invalid target specified in purchaseHashUpgrade(): ${upgTarget}`);
+          throw new Error(`'${upgTarget}' is not a company.`);
+        }
+        Companies[upgTarget].favor += 5;
         break;
       }
       default:

--- a/src/Hacknet/HashUpgrade.ts
+++ b/src/Hacknet/HashUpgrade.ts
@@ -33,7 +33,7 @@ export class HashUpgrade {
    * the "target" server
    */
   hasTargetServer = false;
-  
+
   /**
    * Boolean indicating that this upgrade's effect affects a single company,
    * the "target" company

--- a/src/Hacknet/HashUpgrade.ts
+++ b/src/Hacknet/HashUpgrade.ts
@@ -4,6 +4,7 @@ export interface IConstructorParams {
   costPerLevel: number;
   desc: string;
   hasTargetServer?: boolean;
+  hasTargetCompany?: boolean;
   name: string;
   value: number;
   effectText?: (level: number) => JSX.Element | null;
@@ -32,6 +33,12 @@ export class HashUpgrade {
    * the "target" server
    */
   hasTargetServer = false;
+  
+  /**
+   * Boolean indicating that this upgrade's effect affects a single company,
+   * the "target" company
+   */
+  hasTargetCompany = false;
 
   /** Name of upgrade */
   name = "";
@@ -51,6 +58,7 @@ export class HashUpgrade {
     this.costPerLevel = p.costPerLevel;
     this.desc = p.desc;
     this.hasTargetServer = p.hasTargetServer ? p.hasTargetServer : false;
+    this.hasTargetCompany = p.hasTargetCompany ? p.hasTargetCompany : false;
     this.name = p.name;
     this.value = p.value;
   }

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -103,9 +103,7 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
   },
   {
     costPerLevel: 200,
-    desc:
-      "Use hashes to increase the favor with a company by 5. " +
-      "This effect is permanent.",
+    desc: "Use hashes to increase the favor with a company by 5. " + "This effect is permanent.",
     hasTargetCompany: true,
     name: "Company Favor",
     value: 5,

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -101,4 +101,13 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
     effectText: (level: number): JSX.Element | null => <>Generated {level} contracts.</>,
     value: 1,
   },
+  {
+    costPerLevel: 200,
+    desc:
+      "Use hashes to increase the favor with a company by 5. " +
+      "This effect is permanent.",
+    hasTargetCompany: true,
+    name: "Company Favor",
+    value: 5,
+  },
 ];

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -103,7 +103,7 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
   },
   {
     costPerLevel: 200,
-    desc: "Use hashes to increase the favor with a company by 5. " + "This effect is permanent.",
+    desc: "Use hashes to increase the favor with a company by 5. This effect is permanent.",
     hasTargetCompany: true,
     name: "Company Favor",
     value: 5,

--- a/src/Hacknet/ui/HacknetUpgradeElem.tsx
+++ b/src/Hacknet/ui/HacknetUpgradeElem.tsx
@@ -5,6 +5,7 @@ import { HashManager } from "../HashManager";
 import { HashUpgrade } from "../HashUpgrade";
 
 import { ServerDropdown, ServerType } from "../../ui/React/ServerDropdown";
+import { CompanyDropdown } from "../../ui/React/CompanyDropdown";
 
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import { CopyableText } from "../../ui/React/CopyableText";
@@ -15,6 +16,7 @@ import Paper from "@mui/material/Paper";
 import Button from "@mui/material/Button";
 import { SelectChangeEvent } from "@mui/material/Select";
 import { FactionNames } from "../../Faction/data/FactionNames";
+import { companiesMetadata } from "../../Company/data/CompaniesMetadata";
 
 interface IProps {
   hashManager: HashManager;
@@ -23,6 +25,7 @@ interface IProps {
 }
 
 const serversMap: { [key: string]: string } = {};
+const companiesMap: { [key: string]: string } = {};
 
 export function HacknetUpgradeElem(props: IProps): React.ReactElement {
   const [selectedServer, setSelectedServer] = useState(
@@ -32,11 +35,17 @@ export function HacknetUpgradeElem(props: IProps): React.ReactElement {
     setSelectedServer(event.target.value);
     serversMap[props.upg.name] = event.target.value;
   }
-
+  const [selectedCompany, setSelectedCompany] = useState(
+    companiesMap[props.upg.name] ? companiesMap[props.upg.name] : companiesMetadata[0].name,
+  );
+  function changeTargetCompany(event: SelectChangeEvent<string>): void {
+    setSelectedCompany(event.target.value);
+    companiesMap[props.upg.name] = event.target.value;
+  }
   function purchase(): void {
     const canPurchase = props.hashManager.hashes >= props.hashManager.getUpgradeCost(props.upg.name);
     if (canPurchase) {
-      const res = purchaseHashUpgrade(props.upg.name, selectedServer);
+      const res = purchaseHashUpgrade(props.upg.name, props.upg.name === "Company Favor" ? selectedCompany : selectedServer);
       if (!res) {
         dialogBoxCreate(
           "Failed to purchase upgrade. This may be because you do not have enough hashes, " +
@@ -67,7 +76,7 @@ export function HacknetUpgradeElem(props: IProps): React.ReactElement {
       </Typography>
 
       <Typography>{upg.desc}</Typography>
-      {!upg.hasTargetServer && (
+      {!upg.hasTargetServer && !upg.hasTargetCompany && (
         <Button onClick={purchase} disabled={!canPurchase}>
           Buy
         </Button>
@@ -79,6 +88,14 @@ export function HacknetUpgradeElem(props: IProps): React.ReactElement {
           value={selectedServer}
           serverType={ServerType.Foreign}
           onChange={changeTargetServer}
+        />
+      )}
+      {upg.hasTargetCompany && (
+        <CompanyDropdown
+          purchase={purchase}
+          canPurchase={canPurchase}
+          value={selectedCompany}
+          onChange={changeTargetCompany}
         />
       )}
       {level > 0 && effect && <Typography>{effect}</Typography>}

--- a/src/Hacknet/ui/HacknetUpgradeElem.tsx
+++ b/src/Hacknet/ui/HacknetUpgradeElem.tsx
@@ -45,7 +45,10 @@ export function HacknetUpgradeElem(props: IProps): React.ReactElement {
   function purchase(): void {
     const canPurchase = props.hashManager.hashes >= props.hashManager.getUpgradeCost(props.upg.name);
     if (canPurchase) {
-      const res = purchaseHashUpgrade(props.upg.name, props.upg.name === "Company Favor" ? selectedCompany : selectedServer);
+      const res = purchaseHashUpgrade(
+        props.upg.name,
+        props.upg.name === "Company Favor" ? selectedCompany : selectedServer,
+      );
       if (!res) {
         dialogBoxCreate(
           "Failed to purchase upgrade. This may be because you do not have enough hashes, " +

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -657,6 +657,9 @@ function evaluateVersionCompatibility(ver: string | number): void {
     // Prior to v2.2.0, sleeve shock was 0 to 100 internally but displayed as 100 to 0. This unifies them as 100 to 0.
     for (const sleeve of Player.sleeves) sleeve.shock = 100 - sleeve.shock;
   }
+  if (ver < 31) {
+    anyPlayer.hashManager.upgrades["Company Favor"] = anyPlayer.hashManager.upgrades["Company Favor"] ?? 0;
+  }
 }
 
 function loadGame(saveString: string): boolean {

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -658,7 +658,9 @@ function evaluateVersionCompatibility(ver: string | number): void {
     for (const sleeve of Player.sleeves) sleeve.shock = 100 - sleeve.shock;
   }
   if (ver < 31) {
-    anyPlayer.hashManager.upgrades["Company Favor"] = anyPlayer.hashManager.upgrades["Company Favor"] ?? 0;
+    if (anyPlayer.hashManager !== undefined) {
+      anyPlayer.hashManager.upgrades["Company Favor"] = anyPlayer.hashManager.upgrades["Company Favor"] ?? 0;
+    }
   }
 }
 

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -657,10 +657,8 @@ function evaluateVersionCompatibility(ver: string | number): void {
     // Prior to v2.2.0, sleeve shock was 0 to 100 internally but displayed as 100 to 0. This unifies them as 100 to 0.
     for (const sleeve of Player.sleeves) sleeve.shock = 100 - sleeve.shock;
   }
-  if (ver < 31) {
-    if (anyPlayer.hashManager !== undefined) {
-      anyPlayer.hashManager.upgrades["Company Favor"] = anyPlayer.hashManager.upgrades["Company Favor"] ?? 0;
-    }
+  if (anyPlayer.hashManager !== undefined) {
+    anyPlayer.hashManager.upgrades["Company Favor"] ??= 0;
   }
 }
 

--- a/src/ui/React/CompanyDropdown.tsx
+++ b/src/ui/React/CompanyDropdown.tsx
@@ -15,9 +15,11 @@ interface IProps {
   value: string;
 }
 
+const sortedCompanies = companiesMetadata.sort((a, b) => a.name.localeCompare(b.name));
+
 export function CompanyDropdown(props: IProps): React.ReactElement {
   const companies = [];
-  for (const company of companiesMetadata.sort((a, b) => a.name.localeCompare(b.name))) {
+  for (const company of sortedCompanies) {
     companies.push(
       <MenuItem key={company.name} value={company.name}>
         {company.name}

--- a/src/ui/React/CompanyDropdown.tsx
+++ b/src/ui/React/CompanyDropdown.tsx
@@ -16,7 +16,6 @@ interface IProps {
 }
 
 export function CompanyDropdown(props: IProps): React.ReactElement {
-
   const companies = [];
   for (const company of companiesMetadata.sort((a, b) => a.name.localeCompare(b.name))) {
     companies.push(

--- a/src/ui/React/CompanyDropdown.tsx
+++ b/src/ui/React/CompanyDropdown.tsx
@@ -1,0 +1,43 @@
+/**
+ * Creates a dropdown (select HTML element) with company names as options
+ */
+import React from "react";
+import { companiesMetadata } from "../../Company/data/CompaniesMetadata";
+
+import Select, { SelectChangeEvent } from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import Button from "@mui/material/Button";
+
+interface IProps {
+  purchase: () => void;
+  canPurchase: boolean;
+  onChange: (event: SelectChangeEvent<string>) => void;
+  value: string;
+}
+
+export function CompanyDropdown(props: IProps): React.ReactElement {
+
+  const companies = [];
+  for (const company of companiesMetadata.sort((a, b) => a.name.localeCompare(b.name))) {
+    companies.push(
+      <MenuItem key={company.name} value={company.name}>
+        {company.name}
+      </MenuItem>,
+    );
+  }
+
+  return (
+    <Select
+      startAdornment={
+        <Button onClick={props.purchase} disabled={!props.canPurchase}>
+          Buy
+        </Button>
+      }
+      sx={{ mx: 1 }}
+      value={props.value}
+      onChange={props.onChange}
+    >
+      {companies}
+    </Select>
+  );
+}


### PR DESCRIPTION
HASHNET: Company Favor

Adds a new option to HashNet to spend hashes 5 Company Favor at a time.