### PR TITLE
UI: Added F12 keyboard shortcut for accessing DevTools

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -369,6 +369,7 @@ function getMenu(window) {
       submenu: [
         {
           label: "Activate",
+          accelerator: "f12",
           click: () => window.webContents.openDevTools(),
         },
         {


### PR DESCRIPTION
Added the F12 accelerator for Debug->Activate (DevTools) for faster access. Matches the shortcut for Chrome browsers.

- Tested locally using electron build
- ran `npm run format`
- ran `npm run lint`
