### PR TITLE
UI: Added hostname to LogBox title

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -249,7 +249,12 @@ function LogWindow(props: IProps): React.ReactElement {
 
   function title(full = false): string {
     const maxLength = 30;
-    const t = `${script.filename} ${script.args.map((x: ScriptArg): string => `${x}`).join(" ")}`;
+    const server = GetServer(script.server);
+    let hostname = "";
+    if (server !== null) {
+      hostname = `${server.hostname}: `;
+    }
+    const t = `${hostname}${script.filename} ${script.args.map((x: ScriptArg): string => `${x}`).join(" ")}`;
     if (full || t.length <= maxLength) {
       return t;
     }

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -249,12 +249,7 @@ function LogWindow(props: IProps): React.ReactElement {
 
   function title(full = false): string {
     const maxLength = 30;
-    const server = GetServer(script.server);
-    let hostname = "";
-    if (server !== null) {
-      hostname = `${server.hostname}: `;
-    }
-    const t = `${hostname}${script.filename} ${script.args.map((x: ScriptArg): string => `${x}`).join(" ")}`;
+    const t = `${script.server}: ${script.filename} ${script.args.join(" ")}`;
     if (full || t.length <= maxLength) {
       return t;
     }


### PR DESCRIPTION
I added the hostname to the title bar of the log/tail window to indicate which server the script that is being viewed is running on.

![Screenshot of log window showing the hostname "home" displayed as a prefix in the title bar.](https://i.imgur.com/ZvGbzYu.png)