### PR TITLE
NETSCRIPT: Change error return of hackAnalyzeThreads

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -173,7 +173,7 @@ export const ns: InternalAPI<NSFull> = {
     const percentHacked = calculatePercentMoneyHacked(server, Player);
 
     if (percentHacked === 0 || server.moneyAvailable === 0) {
-      return 0; // To prevent returning infinity below
+      return -1; // To prevent returning infinity below
     }
 
     return hackAmount / (server.moneyAvailable * percentHacked);


### PR DESCRIPTION
Fixes #102

If we don't do this, we should probably close that issue as WontFix.