### PR TITLE
MISC: Various bugfix and cleanup

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1792,8 +1792,11 @@ function createDeprecatedProperty(
         Terminal.warn(`Deprecated property ${propName} accessed from ns.${ctx.functionPath} return value.`);
         Terminal.warn(`This is no longer supported usage and will be removed in a later version.`);
         Terminal.warn(message);
+        Terminal.info(`Note that this message can also appear if you iterate through the object's values.`);
+        Terminal.info(`This message will only be shown once per game session for each deprecated property accessed.`);
       }
       return value;
     },
+    enumerable: true,
   });
 }

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -669,8 +669,13 @@ function evaluateVersionCompatibility(ver: string | number): void {
     if (anyPlayer.hashManager?.upgrades) {
       anyPlayer.hashManager.upgrades["Company Favor"] ??= 0;
     }
-    anyPlayer.lastAugReset ??= anyPlayer.lastUpdate - anyPlayer.playtimeSinceLastAug;
-    anyPlayer.lastNodeReset ??= anyPlayer.lastUpdate - anyPlayer.playtimeSinceLastBitnode;
+    if (!anyPlayer.lastAugReset || anyPlayer.lastAugReset === -1) {
+      anyPlayer.lastAugReset = anyPlayer.lastUpdate - anyPlayer.playtimeSinceLastAug;
+    }
+    if (!anyPlayer.lastNodeRest || anyPlayer.lastNodeReset === -1) {
+      anyPlayer.lastNodeReset = anyPlayer.lastUpdate - anyPlayer.playtimeSinceLastBitnode;
+    }
+
     const newDirectory = resolveDirectory("v2.3FileChanges/") as Directory;
     for (const server of GetAllServers()) {
       let invalidScriptCount = 0;

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -131,12 +131,13 @@ export function Root(props: IProps): React.ReactElement {
     GetServer(openScripts[i].hostname) === null && openScripts.splice(i, 1);
   }
   if (currentScript && GetServer(currentScript.hostname) === null) {
-    currentScript = openScripts[0];
-    if (currentScript === undefined) currentScript = null;
+    currentScript = openScripts[0] ?? null;
   }
 
   useEffect(() => {
     if (currentScript !== null) {
+      const tabIndex = currentTabIndex();
+      if (typeof tabIndex === "number") onTabClick(tabIndex);
       updateRAM(currentScript.code);
     }
   }, []);
@@ -481,13 +482,7 @@ export function Root(props: IProps): React.ReactElement {
   }
 
   function currentTabIndex(): number | undefined {
-    if (currentScript !== null) {
-      return openScripts.findIndex(
-        (script) =>
-          currentScript !== null && script.path === currentScript.path && script.hostname === currentScript.hostname,
-      );
-    }
-
+    if (currentScript) return openScripts.findIndex((openScript) => currentScript === openScript);
     return undefined;
   }
 

--- a/src/Terminal/Parser.ts
+++ b/src/Terminal/Parser.ts
@@ -12,25 +12,27 @@ function parseArg(arg: string): string | number | boolean {
   return arg;
 }
 
-/** Split a commands string (what is typed into the terminal) into multiple commands */
-export function splitCommands(commandString: string): string[] {
-  const commandArray = commandString.match(/(?:'[^']*'|"[^"]*"|[^;"])*/g);
-  if (!commandArray) return [];
-  return commandArray.map((command) => command.trim());
+/** split a commands string into a commands array */
+export function splitCommands(commandsText: string): string[] {
+  // regex to match each entire command separately, without the semicolon included.
+  const commandRegex = /(?:'[^']*'|"[^"]*"|[^;])*/g;
+  const commands = commandsText.match(commandRegex);
+  if (!commands) return [];
+  return commands.map((command) => command.trim());
 }
 
-/** Split commands string while also applying aliases */
-export function parseCommands(commands: string): string[] {
-  // Remove any unquoted whitespace longer than length 1
-  commands = commands.replace(/(?:"[^"]*"|'[^']*'|\s{2,})+?/g, (match) => (match.startsWith(" ") ? " " : match));
-  // Split the commands, apply aliases once, then split again and filter out empty strings.
-  const commandsArr = splitCommands(commands).map(substituteAliases).flatMap(splitCommands).filter(Boolean);
-  return commandsArr;
+/** parse a commands string, including alias substitution, into a commands array */
+export function parseCommands(commandsText: string): string[] {
+  // Split the commands, apply aliases once, then split again and filter out empty commands.
+  const commands = splitCommands(commandsText).map(substituteAliases).flatMap(splitCommands).filter(Boolean);
+  return commands;
 }
 
+/** get a commandArgs array from a single command string */
 export function parseCommand(command: string): (string | number | boolean)[] {
-  const commandArgs = command.match(/(?:("[^"]*"|'[^']*'|[^\s]+))+?/g);
+  // Match every command arg in a given command string
+  const argDetection = /(?:("[^"]*"|'[^']*'|[^\s]+))/g;
+  const commandArgs = command.match(argDetection);
   if (!commandArgs) return [];
-  const argsToReturn = commandArgs.map(parseArg);
-  return argsToReturn;
+  return commandArgs.map(parseArg);
 }


### PR DESCRIPTION
* parseCommands no longer removes excess whitespace (it was unneeded and also had a bug in it relating to commands that ended in a quote mark)
* more documentation and some variable renaming for terminal parsing functions
* Fix script editor focus bug on navigating to the editor from sidebar
* Fix initialization for lastNodeReset and lastAugReset