### PR TITLE
TERMINAL: ls display is responsive

### DIFF
--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -35,10 +35,12 @@ const useStyles = makeStyles((theme: Theme) =>
       whiteSpace: "pre-wrap",
       overflowWrap: "anywhere",
       margin: theme.spacing(0),
+      width: "100%",
     },
     list: {
       padding: theme.spacing(0),
       height: "100%",
+      width: "100%",
     },
   }),
 );


### PR DESCRIPTION
Each filetype displays items in a grid. The column size of the grid depends on the longest filename (or directory) in that grid. The grid is set to auto-fill if there is space for additional columns.

Comparison images:

Full width before:
![image](https://user-images.githubusercontent.com/84951833/234678760-6fd13eba-6972-4f50-8f8d-ab60a8586ab1.png)

Full width after:
![image](https://user-images.githubusercontent.com/84951833/234678826-591f521c-59ac-46cc-8ef0-ff4c3f5035cd.png)

Half width before:
![image](https://user-images.githubusercontent.com/84951833/234678907-f54c87a2-eb83-40df-98f9-518129ed8304.png)

Half width after:
![image](https://user-images.githubusercontent.com/84951833/234678961-bd34b1a7-c4fc-4bc5-8a1a-47d5fe79677a.png)

Quarter width before:
![image](https://user-images.githubusercontent.com/84951833/234679051-a559d31e-1b4b-490c-884a-e230f706073b.png)

Quarter width after:
![image](https://user-images.githubusercontent.com/84951833/234679101-d8fb99b2-6428-4670-81a9-09aad832ee62.png)

Video (lowres) showing responsiveness:
https://user-images.githubusercontent.com/84951833/234679979-9173fec0-7dd6-4045-953b-0040bf32fc8b.mp4