### PR TITLE
DOC: Grammar & language fixes for v2.0.0 migration

### DIFF
--- a/doc/source/v2.0.0_migration.rst
+++ b/doc/source/v2.0.0_migration.rst
@@ -100,7 +100,7 @@ Singularity
 stock.buy, stock.sell, stock.short
 ----------------------------------
     
-    These functions were renamed to stock.buyStock, stock.sellStock, and stock.buyShort because 'buy', 'sell', and 'short',
+    These functions were renamed to stock.buyStock, stock.sellStock, and stock.buyShort because 'buy', 'sell', and 'short'
     are very common tokens that would trick the ram calculation.
 
 corporation.bribe

--- a/doc/source/v2.0.0_migration.rst
+++ b/doc/source/v2.0.0_migration.rst
@@ -1,32 +1,32 @@
 v2.0.0 Migration Guide
 ======================
 
-In v2.0.0 a few more API have been broken.
+In v2.0.0 a few more APIs have been broken.
 
 Working
 -------
 
-    Working has been rebuilt from the grounds up. The motivation for that change is that all
+    Working has been rebuilt from the ground up. The motivation for this change is that all
     different types of work all required different cached variables on the main Player object.
     This caused a lot of bugs and crashes. It's been reworked in such a way as to prevent bugs
     and make it nearly trivial to add new kinds of work.
-    All work type give their reward immediately. No need to stop work to bank rewards like reputation.
+    All work types give their reward immediately. No need to stop work to bank rewards like reputation.
     Faction and Company work no longer have a time limit.
     Company work no longer reduces rep gain by half for quitting early.
-    Company faction require 400k rep to join (from 200k)
-    Backdooring company server reduces faction requirement to 300k.
+    Company factions now require 400k rep to join (up from 200k).
+    Backdooring a company server reduces faction requirement to 300k.
     All types of work generally no longer keep track of cumulative gains like exp and reputation since it's applied instantly.
 
 commitCrime
 -----------
 
-    crime now loops, meaning after finishing one shoplift you start the next one with no input. While the signature
-    has not changed its behavior has. It also has a new 'focus' parameters.
+    Crime now loops, meaning after finishing one shoplift you start the next one with no input. While the signature
+    has not changed, its behavior has. It also has a new 'focus' parameter.
 
 getPlayer
 ---------
 
-    The following work-related fields are not longer included: 
+    The following work-related fields are no longer included: 
 
     * workChaExpGained
     * currentWorkFactionName
@@ -55,55 +55,55 @@ getPlayer
     * workAgiExpGained
     * className
 
-    The reason for that is that these fields are all, in one way or another, included in the new work field 'currentWork'.
+    The reason for this, is that these fields are all, in one way or another, included in the new work field 'currentWork'.
     Some of these values are also irrelevant.
-    Take a look at the new singularity.getCurrentWork function.
+    Take a look at the new singularity.getCurrentWork function:
 
     All fields ending in _mult have been moved to the 'mults' struct.
     For example: getPlayer().hacking_skill_mult => getPlayer().mults.hacking_skill
 
-    skills have been moved to the skills struct
+    skills has been moved to the skills struct
     For example: getPlayer().hacking => getPlayer().skills.hacking
 
-    exp have been moved to the exp struct
+    exp has been moved to the exp struct
     For example: getPlayer().hacking_exp => getPlayer().exp.hacking
 
-    hp have been moved to the hp struct
+    hp has been moved to the hp struct
     For example: getPlayer().max_hp => getPlayer().hp.max or hp.current
 
-    hasWseAccount, hasTixApiAccess, has4SData, has4SDataTixApi have been removed and replaced with similar stock functions
+    hasWseAccount, hasTixApiAccess, has4SData, has4SDataTixApi have been removed and replaced with similar stock functions.
 
 workForCompany
 --------------
 
-    The argument 'companyName' is now not-optional.
+    The argument 'companyName' is now required.
 
 
 getScriptIncome & getScriptExpGain
 ----------------------------------
 
-    Those 2 functions used to have a call where no arguments would return the total for all scripts. This caused weird signature.
-    If you want to get the total income/exp for all scripts used the new getTotalScriptIncome / getTotalScriptExpGain instead.
+    These two functions used to have a call where, if no arguments were provided, it would return the total for all scripts. This caused weird signature.
+    If you want to get the total income/exp for all scripts, use the new getTotalScriptIncome / getTotalScriptExpGain instead.
 
 scp
 ---
 
-    scp has it's 2 last argument reversed, the signature is now scp(files, destination, optional_source)
+    The last two arguments of spc have been reversed. The signature is now scp(files, destination, optional_source)
 
 Singularity
 -----------
 
-    A while ago top level singularity function were deprecated in favor of the singularity namespace.
+    The top level singularity functions were deprecated a while ago in favor of the singularity namespace.
     This means calls like 'ns.connect' need to be changed to 'ns.singularity.connect'
 
 
 stock.buy, stock.sell, stock.short
 ----------------------------------
     
-    These functions were renamed to stock.buyStock, stock.sellStock, and stock.buyShort because 'buy', 'sell', and 'short'
+    These functions were renamed to stock.buyStock, stock.sellStock, and stock.buyShort because 'buy', 'sell', and 'short',
     are very common tokens that would trick the ram calculation.
 
 corporation.bribe
 -----------------
 
-    The ability to give shares as bribe has been removed. The signature is now bribe(faction, money)
+    The ability to give shares as a bribe has been removed. The signature is now bribe(faction, money)


### PR DESCRIPTION
# Documentation

Small changes were made to improve the grammar and punctuation with minimal changes made to the content.

Line 79 changed a term from `not-optional`, to `required`.