### PR TITLE
UI: Fix (most) perf issues in Active Scripts

### DIFF
--- a/src/Netscript/WorkerScriptStartStopEventEmitter.ts
+++ b/src/Netscript/WorkerScriptStartStopEventEmitter.ts
@@ -1,4 +1,0 @@
-import { EventEmitter } from "../utils/EventEmitter";
-
-/** Event emitter that triggers when scripts are started/stopped */
-export const WorkerScriptStartStopEventEmitter = new EventEmitter<[]>();

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -5,7 +5,6 @@
 import { ScriptDeath } from "./ScriptDeath";
 import { WorkerScript } from "./WorkerScript";
 import { workerScripts } from "./WorkerScripts";
-import { WorkerScriptStartStopEventEmitter } from "./WorkerScriptStartStopEventEmitter";
 
 import { GetServer } from "../Server/AllServers";
 import { AddRecentScript } from "./RecentScripts";
@@ -91,5 +90,4 @@ function removeWorkerScript(workerScript: WorkerScript): void {
 
   workerScripts.delete(workerScript.pid);
   AddRecentScript(workerScript);
-  WorkerScriptStartStopEventEmitter.emit();
 }

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -6,7 +6,6 @@ import { killWorkerScript } from "./Netscript/killWorkerScript";
 import { ScriptDeath } from "./Netscript/ScriptDeath";
 import { WorkerScript } from "./Netscript/WorkerScript";
 import { workerScripts } from "./Netscript/WorkerScripts";
-import { WorkerScriptStartStopEventEmitter } from "./Netscript/WorkerScriptStartStopEventEmitter";
 import { generateNextPid } from "./Netscript/Pid";
 
 import { CONSTANTS } from "./Constants";
@@ -311,7 +310,6 @@ function createAndAddWorkerScript(runningScriptObj: RunningScript, server: BaseS
 
   // Add the WorkerScript to the global pool
   workerScripts.set(pid, workerScript);
-  WorkerScriptStartStopEventEmitter.emit();
 
   // Start the script's execution using the correct function for file type
   (workerScript.name.endsWith(".js") ? startNetscript2Script : startNetscript1Script)(workerScript)

--- a/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
+++ b/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
@@ -9,6 +9,7 @@ import Tab from "@mui/material/Tab";
 import { ActiveScriptsPage } from "./ActiveScriptsPage";
 import { RecentScriptsPage } from "./RecentScriptsPage";
 import { WorkerScript } from "../../Netscript/WorkerScript";
+import { useRerender } from "../React/hooks";
 
 interface IProps {
   workerScripts: Map<number, WorkerScript>;
@@ -16,6 +17,7 @@ interface IProps {
 
 export function ActiveScriptsRoot(props: IProps): React.ReactElement {
   const [tab, setTab] = useState<"active" | "recent">("active");
+  useRerender(400);
 
   function handleChange(event: React.SyntheticEvent, tab: "active" | "recent"): void {
     setTab(tab);

--- a/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
+++ b/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
@@ -9,7 +9,6 @@ import Tab from "@mui/material/Tab";
 import { ActiveScriptsPage } from "./ActiveScriptsPage";
 import { RecentScriptsPage } from "./RecentScriptsPage";
 import { WorkerScript } from "../../Netscript/WorkerScript";
-import { useRerender } from "../React/hooks";
 
 interface IProps {
   workerScripts: Map<number, WorkerScript>;
@@ -17,7 +16,6 @@ interface IProps {
 
 export function ActiveScriptsRoot(props: IProps): React.ReactElement {
   const [tab, setTab] = useState<"active" | "recent">("active");
-  useRerender(200);
 
   function handleChange(event: React.SyntheticEvent, tab: "active" | "recent"): void {
     setTab(tab);

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -15,7 +15,6 @@ import { BaseServer } from "../../Server/BaseServer";
 import { Settings } from "../../Settings/Settings";
 import { TablePaginationActionsAll } from "../React/TablePaginationActionsAll";
 import SearchIcon from "@mui/icons-material/Search";
-import { useRerender } from "../React/hooks";
 import { matchScriptPathUnanchored } from "../../utils/helpers/scriptKey";
 import lodash from "lodash";
 
@@ -37,7 +36,6 @@ export function ServerAccordions(props: IProps): React.ReactElement {
   const [filter, setFilter] = useState("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(Settings.ActiveScriptsServerPageSize);
-  useRerender(400);
 
   const handleChangePage = (event: unknown, newPage: number): void => {
     setPage(newPage);

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -2,7 +2,7 @@
  * React Component for rendering the Accordion elements for all servers
  * on which scripts are running
  */
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
 import { ServerAccordion } from "./ServerAccordion";
 
@@ -10,7 +10,6 @@ import TextField from "@mui/material/TextField";
 import List from "@mui/material/List";
 import TablePagination from "@mui/material/TablePagination";
 import { WorkerScript } from "../../Netscript/WorkerScript";
-import { WorkerScriptStartStopEventEmitter } from "../../Netscript/WorkerScriptStartStopEventEmitter";
 import { GetServer } from "../../Server/AllServers";
 import { BaseServer } from "../../Server/BaseServer";
 import { Settings } from "../../Settings/Settings";
@@ -38,13 +37,7 @@ export function ServerAccordions(props: IProps): React.ReactElement {
   const [filter, setFilter] = useState("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(Settings.ActiveScriptsServerPageSize);
-  const rerenderHook = useRerender();
-  let scheduledRerender = false;
-  const rerender = () => {
-    if (scheduledRerender) return;
-    scheduledRerender = true;
-    requestAnimationFrame(rerenderHook);
-  };
+  useRerender(400);
 
   const handleChangePage = (event: unknown, newPage: number): void => {
     setPage(newPage);
@@ -91,8 +84,6 @@ export function ServerAccordions(props: IProps): React.ReactElement {
     }
     return false;
   });
-
-  useEffect(() => WorkerScriptStartStopEventEmitter.subscribe(rerender));
 
   return (
     <>

--- a/test/jest/Netscript/RunScript.test.ts
+++ b/test/jest/Netscript/RunScript.test.ts
@@ -1,9 +1,9 @@
 import { startWorkerScript } from "../../../src/NetscriptWorker";
+import { workerScripts } from "../../../src/Netscript/WorkerScripts";
 import { config as EvaluatorConfig } from "../../../src/NetscriptJSEvaluator";
 import { Server } from "../../../src/Server/Server";
 import { RunningScript } from "../../../src/Script/RunningScript";
 import { AddToAllServers, DeleteServer } from "../../../src/Server/AllServers";
-import { WorkerScriptStartStopEventEmitter } from "../../../src/Netscript/WorkerScriptStartStopEventEmitter";
 import { AlertEvents } from "../../../src/ui/React/AlertManager";
 import type { Script } from "src/Script/Script";
 import { ScriptFilePath } from "src/Paths/ScriptFilePath";
@@ -97,23 +97,15 @@ test.each([
     const ramUsage = script.getRamUsage(server.scripts);
     if (!ramUsage) throw new Error(`ramUsage calculated to be ${ramUsage}`);
     const runningScript = new RunningScript(script, ramUsage as number);
-    expect(startWorkerScript(runningScript, server)).toBeGreaterThan(0);
-    // We don't care about start, so subscribe after that. Await script death.
-    const result = await Promise.race([
-      alerted,
-      new Promise((resolve) => {
-        eventDelete = WorkerScriptStartStopEventEmitter.subscribe(() => {
-          for (const byPid of server.runningScriptMap.values()) {
-            for (const rs of byPid.values()) {
-              if (rs === runningScript) return;
-            }
-          }
-          resolve(null);
-        });
-      }),
-    ]);
+    const pid = startWorkerScript(runningScript, server);
+    expect(pid).toBeGreaterThan(0);
+    // Manually attach an atExit to the now-created WorkerScript, so we can
+    // await script death.
+    const ws = workerScripts.get(pid);
+    expect(ws).toBeDefined();
+    const result = await Promise.race([alerted, new Promise((resolve) => (ws.atExit = resolve))]);
     // If an error alert was thrown, we catch it here.
-    expect(result).toBeNull();
+    expect(result).not.toBeDefined();
     expect(runningScript.logs).toEqual(expectedLog);
   } finally {
     eventDelete();


### PR DESCRIPTION
This turned out to be remarkably simple: Just delete WorkerScriptStartStopEventEmitter, and let the UI refresh at a constant cadence that is fast enough to be rapid, but slow enough to not burn excessive CPU.

I said that a rework of Active Scripts would/should wait for 2.3, and that's still true. But this is small/simple enough, and (IMO) high value enough, that it's worth considering including earlier.