### PR TITLE
BUGFIX: Prevent crash that could occur with server named runningScripts

### DIFF
--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -5,7 +5,6 @@ import { SnackbarEvents, ToastVariant } from "./ui/React/Snackbar";
 import { IReturnStatus } from "./types";
 import { GetServer } from "./Server/AllServers";
 import { ImportPlayerData, SaveData, saveObject } from "./SaveObject";
-import { Settings } from "./Settings/Settings";
 import { exportScripts } from "./Terminal/commands/download";
 import { CONSTANTS } from "./Constants";
 import { hash } from "./hash/hash";
@@ -133,7 +132,7 @@ function initSaveFunctions(): void {
     triggerScriptsExport: (): void => exportScripts("*", Player.getHomeComputer()),
     getSaveData: (): { save: string; fileName: string } => {
       return {
-        save: saveObject.getSaveString(Settings.ExcludeRunningScriptsFromSave),
+        save: saveObject.getSaveString(),
         fileName: saveObject.getSaveFileName(),
       };
     },

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -88,10 +88,15 @@ class BitburnerSaveObject {
   LastExportBonus = "";
   StaneksGiftSave = "";
 
-  getSaveString(excludeRunningScripts = false): string {
+  getSaveString(forceExcludeRunningScripts = false): string {
     this.PlayerSave = JSON.stringify(Player);
 
-    this.AllServersSave = saveAllServers(excludeRunningScripts);
+    // For the servers save, overwrite the ExcludeRunningScripts setting if forced
+    const originalExcludeSetting = Settings.ExcludeRunningScriptsFromSave;
+    if (forceExcludeRunningScripts) Settings.ExcludeRunningScriptsFromSave = true;
+    this.AllServersSave = saveAllServers();
+    Settings.ExcludeRunningScriptsFromSave = originalExcludeSetting;
+
     this.CompaniesSave = JSON.stringify(Companies);
     this.FactionsSave = JSON.stringify(Factions);
     this.AliasesSave = JSON.stringify(Aliases);
@@ -105,14 +110,13 @@ class BitburnerSaveObject {
     if (Player.gang) this.AllGangsSave = JSON.stringify(AllGangs);
 
     const saveString = btoa(unescape(encodeURIComponent(JSON.stringify(this))));
-
     return saveString;
   }
 
   saveGame(emitToastEvent = true): Promise<void> {
     const savedOn = new Date().getTime();
     Player.lastSave = savedOn;
-    const saveString = this.getSaveString(Settings.ExcludeRunningScriptsFromSave);
+    const saveString = this.getSaveString();
     return new Promise((resolve, reject) => {
       save(saveString)
         .then(() => {
@@ -146,7 +150,7 @@ class BitburnerSaveObject {
   }
 
   exportGame(): void {
-    const saveString = this.getSaveString(Settings.ExcludeRunningScriptsFromSave);
+    const saveString = this.getSaveString();
     const filename = this.getSaveFileName();
     download(filename, saveString);
   }

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -200,10 +200,7 @@ export function loadAllServers(saveString: string): void {
 }
 
 function excludeReplacer(key: string, value: any): any {
-  if (key === "runningScripts") {
-    return [];
-  }
-  return value;
+  return key === "runningScripts" && Array.isArray(key) ? [] : value;
 }
 
 export function saveAllServers(excludeRunningScripts = false): string {

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -199,10 +199,6 @@ export function loadAllServers(saveString: string): void {
   AllServers = JSON.parse(saveString, Reviver);
 }
 
-function excludeReplacer(key: string, value: any): any {
-  return key === "runningScripts" && Array.isArray(key) ? [] : value;
-}
-
-export function saveAllServers(excludeRunningScripts = false): string {
-  return JSON.stringify(AllServers, excludeRunningScripts ? excludeReplacer : undefined);
+export function saveAllServers(): string {
+  return JSON.stringify(AllServers);
 }

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -21,6 +21,7 @@ import { LiteratureName } from "src/Literature/data/LiteratureNames";
 import { CompletedProgramName } from "src/Programs/Programs";
 import { getKeyList } from "../utils/helpers/getKeyList";
 import lodash from "lodash";
+import { Settings } from "../Settings/Settings";
 
 import type { ScriptKey } from "../utils/helpers/scriptKey";
 
@@ -292,6 +293,10 @@ export abstract class BaseServer implements IServer {
     // RunningScripts are stored as a simple array, both for backward compatibility,
     // compactness, and ease of filtering them here.
     const result = Generic_toJSON(ctorName, this, keys);
+    if (Settings.ExcludeRunningScriptsFromSave) {
+      result.data.runningScripts = [];
+      return result;
+    }
 
     const rsArray: RunningScript[] = [];
     for (const byPid of this.runningScriptMap.values()) {

--- a/test/jest/Save.test.ts
+++ b/test/jest/Save.test.ts
@@ -2,6 +2,7 @@ import "../../src/Player";
 
 import { loadAllServers, saveAllServers } from "../../src/Server/AllServers";
 import { loadAllRunningScripts } from "../../src/NetscriptWorker";
+import { Settings } from "../../src/Settings/Settings";
 
 jest.useFakeTimers();
 
@@ -152,7 +153,7 @@ test("load/saveAllServers", () => {
   loadStandardServers();
 
   // Re-stringify with indenting for nicer diffs
-  const result = saveAllServers(/*excludeRunningScripts=*/ false);
+  const result = saveAllServers();
   expect(JSON.stringify(JSON.parse(result), null, 2)).toMatchSnapshot();
 });
 
@@ -163,6 +164,7 @@ test("load/saveAllServers pruning RunningScripts", () => {
   loadStandardServers();
 
   // Re-stringify with indenting for nicer diffs
-  const result = saveAllServers(/*excludeRunningScripts=*/ true);
+  Settings.ExcludeRunningScriptsFromSave = true;
+  const result = saveAllServers();
   expect(JSON.stringify(JSON.parse(result), null, 2)).toMatchSnapshot();
 });


### PR DESCRIPTION
If a purchased server was named `runningScripts` and the option to exclude running scripts from the save was enabled, the server would be replaced with an empty array, which can lead to a variety of bugs (e.g. scan command crashes)

![image](https://user-images.githubusercontent.com/84951833/236049177-8a3345e5-26e9-4e94-975d-55ab99b81ffb.png)

I included a potential fix but this does slow down the save process a bit and I still really don't like this replacer, so I am working on a better solution.