### PR TITLE
UI: Better support for custom player React content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@types/numeral": "^2.0.2",
         "@types/react": "^17.0.52",
         "@types/react-beautiful-dnd": "^13.1.3",
-        "@types/react-dom": "^17.0.18",
+        "@types/react-dom": "^17.0.20",
         "@types/react-resizable": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "@typescript-eslint/parser": "^5.48.0",
@@ -4472,9 +4472,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.18.tgz",
-      "integrity": "sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.20.tgz",
+      "integrity": "sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==",
       "dev": true,
       "dependencies": {
         "@types/react": "^17"
@@ -18963,9 +18963,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.18.tgz",
-      "integrity": "sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.20.tgz",
+      "integrity": "sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==",
       "dev": true,
       "requires": {
         "@types/react": "^17"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/numeral": "^2.0.2",
     "@types/react": "^17.0.52",
     "@types/react-beautiful-dnd": "^13.1.3",
-    "@types/react-dom": "^17.0.18",
+    "@types/react-dom": "^17.0.20",
     "@types/react-resizable": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -548,7 +548,7 @@ export const RamCosts: RamCostTree<NSFull> = {
   alterReality: 0,
   rainbow: 0,
   heart: { break: 0 },
-  iKnowWhatImDoing: 0,
+  tprintRaw: 0,
   printRaw: 0,
 
   formulas: {

--- a/src/NetscriptFunctions/Extra.tsx
+++ b/src/NetscriptFunctions/Extra.tsx
@@ -21,7 +21,7 @@ export interface INetscriptExtra {
   bypass(doc: Document): void;
   alterReality(): void;
   rainbow(guess: string): void;
-  iKnowWhatImDoing(): void;
+  tprintRaw(value: React.ReactNode): void;
   printRaw(value: React.ReactNode): void;
 }
 
@@ -71,12 +71,10 @@ export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
       Player.giveExploit(Exploit.INeedARainbow);
       return true;
     },
-    iKnowWhatImDoing: (ctx) => () => {
-      helpers.log(ctx, () => "Unlocking unsupported feature: window.tprintRaw");
-      // @ts-expect-error window has no tprintRaw property defined
-      window.tprintRaw = (value: React.ReactNode) => {
-        Terminal.printRaw(<CustomBoundary key={`PlayerContent${customElementKey++}`} children={value} />);
-      };
+    tprintRaw: () => (value) => {
+      Terminal.printRaw(
+        <CustomBoundary key={`PlayerContent${customElementKey++}`} children={value as React.ReactNode} />,
+      );
     },
     printRaw: (ctx) => (value) => {
       ctx.workerScript.print(

--- a/src/NetscriptFunctions/Extra.tsx
+++ b/src/NetscriptFunctions/Extra.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React from "react";
 import { Player } from "../Player";
 import { Exploit } from "../Exploits/Exploit";
 import * as bcrypt from "bcryptjs";
@@ -7,6 +7,10 @@ import { InternalAPI } from "../Netscript/APIWrapper";
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { Terminal } from "../Terminal";
 import { RamCostConstants } from "../Netscript/RamCostGenerator";
+import { CustomBoundary } from "../ui/Components/CustomBoundary";
+
+// Incrementing value for custom element keys
+let customElementKey = 0;
 
 export interface INetscriptExtra {
   heart: {
@@ -70,11 +74,14 @@ export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
     iKnowWhatImDoing: (ctx) => () => {
       helpers.log(ctx, () => "Unlocking unsupported feature: window.tprintRaw");
       // @ts-expect-error window has no tprintRaw property defined
-      window.tprintRaw = Terminal.printRaw.bind(Terminal);
+      window.tprintRaw = (value: React.ReactNode) => {
+        Terminal.printRaw(<CustomBoundary key={`PlayerContent${customElementKey++}`} children={value} />);
+      };
     },
     printRaw: (ctx) => (value) => {
-      // Using this voids the warranty on your tail log
-      ctx.workerScript.print(value as React.ReactNode);
+      ctx.workerScript.print(
+        <CustomBoundary key={`PlayerContent${customElementKey++}`} children={value as React.ReactNode} />,
+      );
     },
   };
 }

--- a/src/ui/Components/CustomBoundary.tsx
+++ b/src/ui/Components/CustomBoundary.tsx
@@ -35,7 +35,7 @@ export class CustomBoundary extends React.Component<PlayerBoundaryProps, PlayerB
  * correctly by the PlayerBoundary. This function checks the tree for a function before render. */
 function probeChildrenForFunction(tree: string[], children: unknown): undefined | Error {
   switch (typeof children) {
-    case "function":
+    case "function": {
       const error = new Error(
         `React content tree contains a function (invalid): ${[...tree, "function"].join(" -> ")}.`,
       );
@@ -47,6 +47,7 @@ function probeChildrenForFunction(tree: string[], children: unknown): undefined 
         "If this is a function component, render it using React.createElement instead of rendering the function directly.",
       );
       return error;
+    }
     case "object":
       if (Array.isArray(children)) {
         for (const child of children) {

--- a/src/ui/Components/CustomBoundary.tsx
+++ b/src/ui/Components/CustomBoundary.tsx
@@ -1,0 +1,75 @@
+import { Typography } from "@mui/material";
+import React from "react";
+
+interface PlayerBoundaryProps {
+  children: React.ReactNode;
+}
+interface PlayerBoundaryState {
+  error?: Error;
+}
+/** Error boundary for custom content printed by the player using printRaw-like functions.
+ * Error boundaries are required to be class components due to no FC equivalent to componentDidCatch. */
+export class CustomBoundary extends React.Component<PlayerBoundaryProps, PlayerBoundaryState> {
+  state: PlayerBoundaryState;
+  constructor(props: PlayerBoundaryProps) {
+    super(props);
+    let error: Error | undefined = undefined;
+    const childCheck = probeChildrenForFunction([], props.children);
+    if (childCheck) {
+      error = new Error(`React content tree contains a function (invalid): ${childCheck.tree.join(" -> ")}.`);
+      console.warn("Error in custom react content:");
+      console.error(error);
+      console.warn("Function content:");
+      console.error(childCheck.function);
+      console.warn(
+        "If this is a function component, render it using React.createElement instead of rendering the function directly.",
+      );
+    }
+    this.state = { error };
+  }
+  componentDidCatch(error: Error): void {
+    this.setState({ error });
+    console.warn("Error in custom react content:");
+    console.error(error);
+  }
+  render(): React.ReactNode {
+    if (this.state.error) {
+      // Typography is used because there are no default page styles.
+      // Span is used because it does not conflict with the DOM validation nesting (default Typography element of p is invalid at this location in dom tree)
+      return <Typography component={"span"}>Error in custom react content. See console for details.</Typography>;
+    }
+    return <Typography component={"span"}>{this.props.children}</Typography>;
+  }
+}
+
+/** Attempting to render a react tree containing a function as a child will cause an error that doesn't get displayed
+ * correctly by the PlayerBoundary. This function checks the tree for a function before render. */
+function probeChildrenForFunction(tree: string[], children: unknown): false | { tree: string[]; function: Function } {
+  switch (typeof children) {
+    case "function":
+      return { tree: [...tree, "function"], function: children };
+    case "object":
+      if (Array.isArray(children)) {
+        for (const child of children) {
+          const probeResult = probeChildrenForFunction([...tree, "Array"], child);
+          if (probeResult) return probeResult;
+        }
+        return false;
+      }
+      if (children === null) return false;
+      if ("props" in children && typeof children.props === "object" && children.props && "children" in children.props) {
+        const name = getObjectName(children);
+        return probeChildrenForFunction([...tree, name], children.props.children);
+      }
+      return false;
+    default:
+      return false;
+  }
+}
+/** Gets the component name from a react child that is a component */
+function getObjectName(obj: object) {
+  if (!("type" in obj)) return "unknown";
+  if (typeof obj.type === "string") return obj.type; // For builtin html components e.g. span
+  if (typeof obj.type === "function") return obj.type.name; // For custom components
+  return "unknown";
+}

--- a/src/ui/Components/CustomBoundary.tsx
+++ b/src/ui/Components/CustomBoundary.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
 
+interface CustomBoundaryProps {
+  children: React.ReactNode;
+}
 interface CustomBoundaryState {
   error?: Error;
 }
 /** Error boundary for custom content printed by the player using printRaw-like functions.
  * Error boundaries are required to be class components due to no hook equivalent to componentDidCatch. */
-export class CustomBoundary extends React.Component<{}, CustomBoundaryState> {
+export class CustomBoundary extends React.Component<CustomBoundaryProps, CustomBoundaryState> {
   state: CustomBoundaryState;
-  constructor(props: {}) {
+  constructor(props: CustomBoundaryProps) {
     super(props);
     this.state = { error: undefined };
   }

--- a/src/ui/Components/CustomBoundary.tsx
+++ b/src/ui/Components/CustomBoundary.tsx
@@ -1,20 +1,16 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
 
-interface PlayerBoundaryProps {
-  children: React.ReactNode;
-}
-interface PlayerBoundaryState {
+interface CustomBoundaryState {
   error?: Error;
 }
 /** Error boundary for custom content printed by the player using printRaw-like functions.
- * Error boundaries are required to be class components due to no FC equivalent to componentDidCatch. */
-export class CustomBoundary extends React.Component<PlayerBoundaryProps, PlayerBoundaryState> {
-  state: PlayerBoundaryState;
-  constructor(props: PlayerBoundaryProps) {
+ * Error boundaries are required to be class components due to no hook equivalent to componentDidCatch. */
+export class CustomBoundary extends React.Component<{}, CustomBoundaryState> {
+  state: CustomBoundaryState;
+  constructor(props: {}) {
     super(props);
-    const error = probeChildrenForFunction([], props.children);
-    this.state = { error };
+    this.state = { error: undefined };
   }
   componentDidCatch(error: Error): void {
     this.setState({ error });
@@ -29,47 +25,4 @@ export class CustomBoundary extends React.Component<PlayerBoundaryProps, PlayerB
     }
     return <Typography component={"span"}>{this.props.children}</Typography>;
   }
-}
-
-/** Attempting to render a react tree containing a function as a child will cause an error that doesn't get displayed
- * correctly by the PlayerBoundary. This function checks the tree for a function before render. */
-function probeChildrenForFunction(tree: string[], children: unknown): undefined | Error {
-  switch (typeof children) {
-    case "function": {
-      const error = new Error(
-        `React content tree contains a function (invalid): ${[...tree, "function"].join(" -> ")}.`,
-      );
-      console.warn("Error in custom react content:");
-      console.error(error);
-      console.warn("Function content:");
-      console.error(children);
-      console.warn(
-        "If this is a function component, render it using React.createElement instead of rendering the function directly.",
-      );
-      return error;
-    }
-    case "object":
-      if (Array.isArray(children)) {
-        for (const child of children) {
-          const probeResult = probeChildrenForFunction([...tree, "Array"], child);
-          if (probeResult) return probeResult;
-        }
-        return;
-      }
-      if (children === null) return;
-      if ("props" in children && typeof children.props === "object" && children.props && "children" in children.props) {
-        const name = getObjectName(children);
-        return probeChildrenForFunction([...tree, name], children.props.children);
-      }
-      return;
-    default:
-      return;
-  }
-}
-/** Gets the component name from a react child that is a component */
-function getObjectName(obj: object) {
-  if (!("type" in obj)) return "unknown";
-  if (typeof obj.type === "string") return obj.type; // For builtin html components e.g. span
-  if (typeof obj.type === "function") return obj.type.name; // For custom components
-  return "unknown";
 }


### PR DESCRIPTION
* Prevent erroring out the page / telling user to submit github issue when their own custom react content has errors
* Provide default styling for text content printed with printRaw (other content types will still not have the correct default styles applied)

Basically adds an extra error boundary to prevent sending errors in custom player code up to the main ErrorBoundary that handles other React errors in the game.