### PR TITLE
DOC: Specify optional parameters in hacknet functions

### DIFF
--- a/markdown/bitburner.hacknet.getcacheupgradecost.md
+++ b/markdown/bitburner.hacknet.getcacheupgradecost.md
@@ -9,7 +9,7 @@ Calculate the cost of upgrading hacknet node cache.
 **Signature:**
 
 ```typescript
-getCacheUpgradeCost(index: number, n: number): number;
+getCacheUpgradeCost(index: number, n?: number): number;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ getCacheUpgradeCost(index: number, n: number): number;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of times to upgrade cache. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of times to upgrade cache. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.getcoreupgradecost.md
+++ b/markdown/bitburner.hacknet.getcoreupgradecost.md
@@ -9,7 +9,7 @@ Calculate the cost of upgrading hacknet node cores.
 **Signature:**
 
 ```typescript
-getCoreUpgradeCost(index: number, n: number): number;
+getCoreUpgradeCost(index: number, n?: number): number;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ getCoreUpgradeCost(index: number, n: number): number;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of times to upgrade cores. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of times to upgrade cores. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.getlevelupgradecost.md
+++ b/markdown/bitburner.hacknet.getlevelupgradecost.md
@@ -9,7 +9,7 @@ Calculate the cost of upgrading hacknet node levels.
 **Signature:**
 
 ```typescript
-getLevelUpgradeCost(index: number, n: number): number;
+getLevelUpgradeCost(index: number, n?: number): number;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ getLevelUpgradeCost(index: number, n: number): number;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of levels to upgrade. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of levels to upgrade. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.getramupgradecost.md
+++ b/markdown/bitburner.hacknet.getramupgradecost.md
@@ -9,7 +9,7 @@ Calculate the cost of upgrading hacknet node RAM.
 **Signature:**
 
 ```typescript
-getRamUpgradeCost(index: number, n: number): number;
+getRamUpgradeCost(index: number, n?: number): number;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ getRamUpgradeCost(index: number, n: number): number;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of times to upgrade RAM. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of times to upgrade RAM. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.upgradecache.md
+++ b/markdown/bitburner.hacknet.upgradecache.md
@@ -9,7 +9,7 @@ Upgrade the cache of a hacknet node.
 **Signature:**
 
 ```typescript
-upgradeCache(index: number, n: number): boolean;
+upgradeCache(index: number, n?: number): boolean;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ upgradeCache(index: number, n: number): boolean;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of cache levels to purchase. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of cache levels to purchase. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.upgradecore.md
+++ b/markdown/bitburner.hacknet.upgradecore.md
@@ -9,7 +9,7 @@ Upgrade the core of a hacknet node.
 **Signature:**
 
 ```typescript
-upgradeCore(index: number, n: number): boolean;
+upgradeCore(index: number, n?: number): boolean;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ upgradeCore(index: number, n: number): boolean;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of cores to purchase. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of cores to purchase. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.upgradelevel.md
+++ b/markdown/bitburner.hacknet.upgradelevel.md
@@ -9,7 +9,7 @@ Upgrade the level of a hacknet node.
 **Signature:**
 
 ```typescript
-upgradeLevel(index: number, n: number): boolean;
+upgradeLevel(index: number, n?: number): boolean;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ upgradeLevel(index: number, n: number): boolean;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of levels to purchase. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of levels to purchase. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.upgraderam.md
+++ b/markdown/bitburner.hacknet.upgraderam.md
@@ -9,7 +9,7 @@ Upgrade the RAM of a hacknet node.
 **Signature:**
 
 ```typescript
-upgradeRam(index: number, n: number): boolean;
+upgradeRam(index: number, n?: number): boolean;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ upgradeRam(index: number, n: number): boolean;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  index | number | Index/Identifier of Hacknet Node. |
-|  n | number | Number of times to upgrade RAM. Must be positive. Rounded to nearest integer. |
+|  n | number | _(Optional)_ Number of times to upgrade RAM. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified. |
 
 **Returns:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2405,10 +2405,10 @@ export interface Hacknet {
    * Returns false otherwise.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of levels to purchase. Must be positive. Rounded to nearest integer.
+   * @param n - Number of levels to purchase. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns True if the Hacknet Node’s level is successfully upgraded, false otherwise.
    */
-  upgradeLevel(index: number, n: number): boolean;
+  upgradeLevel(index: number, n?: number): boolean;
 
   /**
    * Upgrade the RAM of a hacknet node.
@@ -2425,10 +2425,10 @@ export interface Hacknet {
    * Returns false otherwise.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of times to upgrade RAM. Must be positive. Rounded to nearest integer.
+   * @param n - Number of times to upgrade RAM. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns True if the Hacknet Node’s RAM is successfully upgraded, false otherwise.
    */
-  upgradeRam(index: number, n: number): boolean;
+  upgradeRam(index: number, n?: number): boolean;
 
   /**
    * Upgrade the core of a hacknet node.
@@ -2443,10 +2443,10 @@ export interface Hacknet {
    * Returns false otherwise.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of cores to purchase. Must be positive. Rounded to nearest integer.
+   * @param n - Number of cores to purchase. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns True if the Hacknet Node’s cores are successfully purchased, false otherwise.
    */
-  upgradeCore(index: number, n: number): boolean;
+  upgradeCore(index: number, n?: number): boolean;
 
   /**
    * Upgrade the cache of a hacknet node.
@@ -2463,10 +2463,10 @@ export interface Hacknet {
    * Returns false otherwise.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of cache levels to purchase. Must be positive. Rounded to nearest integer.
+   * @param n - Number of cache levels to purchase. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns True if the Hacknet Node’s cache level is successfully upgraded, false otherwise.
    */
-  upgradeCache(index: number, n: number): boolean;
+  upgradeCache(index: number, n?: number): boolean;
 
   /**
    * Calculate the cost of upgrading hacknet node levels.
@@ -2479,10 +2479,10 @@ export interface Hacknet {
    * If the specified Hacknet Node is already at max level, then Infinity is returned.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of levels to upgrade. Must be positive. Rounded to nearest integer.
+   * @param n - Number of levels to upgrade. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns Cost of upgrading the specified Hacknet Node.
    */
-  getLevelUpgradeCost(index: number, n: number): number;
+  getLevelUpgradeCost(index: number, n?: number): number;
 
   /**
    * Calculate the cost of upgrading hacknet node RAM.
@@ -2495,10 +2495,10 @@ export interface Hacknet {
    * If the specified Hacknet Node already has max RAM, then Infinity is returned.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of times to upgrade RAM. Must be positive. Rounded to nearest integer.
+   * @param n - Number of times to upgrade RAM. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns Cost of upgrading the specified Hacknet Node's RAM.
    */
-  getRamUpgradeCost(index: number, n: number): number;
+  getRamUpgradeCost(index: number, n?: number): number;
 
   /**
    * Calculate the cost of upgrading hacknet node cores.
@@ -2511,10 +2511,10 @@ export interface Hacknet {
    * If the specified Hacknet Node is already at max level, then Infinity is returned.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of times to upgrade cores. Must be positive. Rounded to nearest integer.
+   * @param n - Number of times to upgrade cores. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns Cost of upgrading the specified Hacknet Node's number of cores.
    */
-  getCoreUpgradeCost(index: number, n: number): number;
+  getCoreUpgradeCost(index: number, n?: number): number;
 
   /**
    * Calculate the cost of upgrading hacknet node cache.
@@ -2529,10 +2529,10 @@ export interface Hacknet {
    * If the specified Hacknet Node is already at max level, then Infinity is returned.
    *
    * @param index - Index/Identifier of Hacknet Node.
-   * @param n - Number of times to upgrade cache. Must be positive. Rounded to nearest integer.
+   * @param n - Number of times to upgrade cache. Must be positive. Rounded to nearest integer. Defaults to 1 if not specified.
    * @returns Cost of upgrading the specified Hacknet Node's cache.
    */
-  getCacheUpgradeCost(index: number, n: number): number;
+  getCacheUpgradeCost(index: number, n?: number): number;
 
   /**
    * Get the total number of hashes stored.


### PR DESCRIPTION
Seems that this change is pretty trivial. These parameters are optional and default to 1. Found it confusing in help VS Code UI that it didn't state that these parameters are optional while functions work without specifying them.

Proof that arguments are optional and default to 1:
https://github.com/bitburner-official/bitburner-src/blob/75706d273a915063bb094011426c94ec33150466/src/NetscriptFunctions/Hacknet.ts#L94-L175

# Documentation

- [x] If your PR includes ns API function changes, do not manually modify markdown files.
- [x] Instead, you can run `npm run doc` to autogenerate new markdown files that reflect your submitted API changes.
- [x] Make sure you run `npm run format` and `npm run lint` before pushing.
