### PR TITLE
UI: Fix incorrect progress

### DIFF
--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -97,11 +97,10 @@ interface SkillBarProps {
   color?: string;
 }
 function SkillBar({ name, color }: SkillBarProps): React.ReactElement {
-  const [mult, setMult] = useState(skillMultUpdaters[name]());
-  const [progress, setProgress] = useState(calculateSkillProgress(Player.exp[skillNameMap[name]], mult));
+  const [progress, setProgress] = useState(calculateSkillProgress(0));
   useEffect(() => {
     const clearSubscription = OverviewEventEmitter.subscribe(() => {
-      setMult(skillMultUpdaters[name]());
+      const mult = skillMultUpdaters[name]();
       setProgress(calculateSkillProgress(Player.exp[skillNameMap[name]], mult));
     });
     return clearSubscription;


### PR DESCRIPTION
The closure for the effect bound the initial value for `mult`, so it would never get updated. This led to issues after installing augs. There was no reason for it to be state anyway, since it was being recalculated on every update.

Fixes #465
