### PR TITLE
DOC: Fix link on main page of documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,7 +7,7 @@ Welcome to Bitburner's documentation!
 =====================================
 Bitburner is a programming-based `incremental game <https://en.wikipedia.org/wiki/Incremental_game>`_
 that revolves around hacking and cyberpunk themes. The game is currently in the
-early beta stage of development. It `can be played here <https://bitburner-official.github.io/bitburner/>`_.
+early beta stage of development. It `can be played here <https://danielyxie.github.io/bitburner/>`_.
 
 What is Bitburner?
 ------------------


### PR DESCRIPTION
Fix link on main page of documentation as https://bitburner-official.github.io/bitburner/ gives 404