### PR TITLE
UI: Fix scan analyze display

### DIFF
--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -106,19 +106,10 @@ export function TerminalRoot(): React.ReactElement {
                 </Typography>
               )}
               {item instanceof Link && (
-                <>
-                  <Typography>{item.dashes}&gt;&nbsp;</Typography>
-                  <MuiLink
-                    classes={{ root: classes.preformatted }}
-                    color={"secondary"}
-                    paragraph={false}
-                    onClick={() => Terminal.connectToServer(item.hostname)}
-                  >
-                    <Typography sx={{ textDecoration: "underline", "&:hover": { textDecoration: "none" } }}>
-                      {item.hostname}
-                    </Typography>
-                  </MuiLink>
-                </>
+                <Typography>
+                  {item.dashes + "> "}
+                  <MuiLink onClick={() => Terminal.connectToServer(item.hostname)}>{item.hostname}</MuiLink>
+                </Typography>
               )}
             </ListItem>
           ))}


### PR DESCRIPTION
When the player has AutoLink, the display of scan-analyze was broken. Fixed, and simplified the display of server link text.

Pre-changes:
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/4f300f02-4f37-405f-b2a4-e3b5ff3cc600)

Post-changes:
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/b303e1f6-79b7-47fb-8e6f-5877fa264b31)
