### PR TITLE
UI: Prevent terminal scroll on progress bar update (#94)

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -6,7 +6,7 @@ import { BaseServer } from "../Server/BaseServer";
 import { Server } from "../Server/Server";
 import { CompletedProgramName } from "../Programs/Programs";
 import { CodingContractResult } from "../CodingContracts";
-import { TerminalEvents, TerminalClearEvents, TerminalProcessEvents } from "./TerminalEvents";
+import { TerminalEvents, TerminalClearEvents } from "./TerminalEvents";
 
 import { TextFile } from "../TextFile";
 import { Script } from "../Script/Script";
@@ -102,7 +102,6 @@ export class Terminal {
     if (this.action === null) return;
     this.action.timeLeft -= (CONSTANTS.MilliPerCycle * cycles) / 1000;
     if (this.action.timeLeft < 0.01) this.finishAction(false);
-    TerminalProcessEvents.emit();
   }
 
   append(item: Output | Link | RawOutput): void {

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -6,7 +6,7 @@ import { BaseServer } from "../Server/BaseServer";
 import { Server } from "../Server/Server";
 import { CompletedProgramName } from "../Programs/Programs";
 import { CodingContractResult } from "../CodingContracts";
-import { TerminalEvents, TerminalClearEvents } from "./TerminalEvents";
+import { TerminalEvents, TerminalClearEvents, TerminalProcessEvents } from "./TerminalEvents";
 
 import { TextFile } from "../TextFile";
 import { Script } from "../Script/Script";
@@ -102,7 +102,7 @@ export class Terminal {
     if (this.action === null) return;
     this.action.timeLeft -= (CONSTANTS.MilliPerCycle * cycles) / 1000;
     if (this.action.timeLeft < 0.01) this.finishAction(false);
-    TerminalEvents.emit();
+    TerminalProcessEvents.emit();
   }
 
   append(item: Output | Link | RawOutput): void {

--- a/src/Terminal/TerminalEvents.ts
+++ b/src/Terminal/TerminalEvents.ts
@@ -1,4 +1,3 @@
 import { EventEmitter } from "../utils/EventEmitter";
 export const TerminalEvents = new EventEmitter<[]>();
 export const TerminalClearEvents = new EventEmitter<[]>();
-export const TerminalProcessEvents = new EventEmitter<[]>();

--- a/src/Terminal/TerminalEvents.ts
+++ b/src/Terminal/TerminalEvents.ts
@@ -1,3 +1,4 @@
 import { EventEmitter } from "../utils/EventEmitter";
 export const TerminalEvents = new EventEmitter<[]>();
 export const TerminalClearEvents = new EventEmitter<[]>();
+export const TerminalProcessEvents = new EventEmitter<[]>();

--- a/src/Terminal/ui/TerminalActionTimer.tsx
+++ b/src/Terminal/ui/TerminalActionTimer.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import _ from "lodash";
 import Typography from "@mui/material/Typography";
 
 import { useRerender } from "../../ui/React/hooks";
@@ -10,12 +9,8 @@ export function TerminalActionTimer(): React.ReactElement {
   const rerender = useRerender();
 
   useEffect(() => {
-    const debounced = _.debounce(rerender, 25, { maxWait: 50 });
-    const unsubscribe = TerminalProcessEvents.subscribe(debounced);
-    return () => {
-      debounced.cancel();
-      unsubscribe();
-    };
+    const unsubscribe = TerminalProcessEvents.subscribe(rerender);
+    return unsubscribe;
   }, []);
 
   return (

--- a/src/Terminal/ui/TerminalActionTimer.tsx
+++ b/src/Terminal/ui/TerminalActionTimer.tsx
@@ -1,21 +1,11 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Typography from "@mui/material/Typography";
 
 import { useRerender } from "../../ui/React/hooks";
 import { Terminal } from "../../Terminal";
-import { TerminalProcessEvents } from "../TerminalEvents";
 
 export function TerminalActionTimer(): React.ReactElement {
-  const rerender = useRerender();
+  useRerender(200);
 
-  useEffect(() => {
-    const unsubscribe = TerminalProcessEvents.subscribe(rerender);
-    return unsubscribe;
-  }, []);
-
-  return (
-    <Typography color="primary" paragraph={false}>
-      {Terminal.getProgressText()}
-    </Typography>
-  );
+  return <Typography color="primary">{Terminal.getProgressText()}</Typography>;
 }

--- a/src/Terminal/ui/TerminalActionTimer.tsx
+++ b/src/Terminal/ui/TerminalActionTimer.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from "react";
+import _ from "lodash";
+import Typography from "@mui/material/Typography";
+
+import { useRerender } from "../../ui/React/hooks";
+import { Terminal } from "../../Terminal";
+import { TerminalProcessEvents } from "../TerminalEvents";
+
+export function TerminalActionTimer(): React.ReactElement {
+  const rerender = useRerender();
+
+  useEffect(() => {
+    const debounced = _.debounce(rerender, 25, { maxWait: 50 });
+    const unsubscribe = TerminalProcessEvents.subscribe(debounced);
+    return () => {
+      debounced.cancel();
+      unsubscribe();
+    };
+  }, []);
+
+  return (
+    <Typography color="primary" paragraph={false}>
+      {Terminal.getProgressText()}
+    </Typography>
+  );
+}

--- a/src/Terminal/ui/TerminalActionTimer.tsx
+++ b/src/Terminal/ui/TerminalActionTimer.tsx
@@ -7,5 +7,5 @@ import { Terminal } from "../../Terminal";
 export function TerminalActionTimer(): React.ReactElement {
   useRerender(200);
 
-  return <Typography color="primary">{Terminal.getProgressText()}</Typography>;
+  return <Typography color="primary">{Terminal.action && Terminal.getProgressText()}</Typography>;
 }

--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -7,6 +7,8 @@ import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
 import Box from "@mui/material/Box";
+import _ from "lodash";
+
 import { Output, Link, RawOutput } from "../OutputTypes";
 import { Terminal } from "../../Terminal";
 import { TerminalInput } from "./TerminalInput";
@@ -14,17 +16,9 @@ import { TerminalEvents, TerminalClearEvents } from "../TerminalEvents";
 import { BitFlumeModal } from "../../BitNode/ui/BitFlumeModal";
 import { CodingContractModal } from "../../ui/React/CodingContractModal";
 
-import _ from "lodash";
 import { ANSIITypography } from "../../ui/React/ANSIITypography";
 import { useRerender } from "../../ui/React/hooks";
-
-function ActionTimer(): React.ReactElement {
-  return (
-    <Typography color={"primary"} paragraph={false}>
-      {Terminal.getProgressText()}
-    </Typography>
-  );
-}
+import { TerminalActionTimer } from "./TerminalActionTimer";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -116,7 +110,7 @@ export function TerminalRoot(): React.ReactElement {
 
           {Terminal.action !== null && (
             <ListItem classes={{ root: classes.nopadding }}>
-              <ActionTimer />{" "}
+              <TerminalActionTimer />{" "}
             </ListItem>
           )}
         </List>


### PR DESCRIPTION
UI: Prevent terminal scroll on progress bar update

closes #94 

Tested locally in the browser after starting server via `npm run start:dev`
