### PR TITLE
Hotfix 30 May 2023

### DIFF
--- a/src/Corporation/ResearchTree.ts
+++ b/src/Corporation/ResearchTree.ts
@@ -217,9 +217,7 @@ export class ResearchTree {
 
   // Marks a Node as researched
   research(name: CorpResearchName): void {
-    if (this.root == null) {
-      return;
-    }
+    if (!this.root || this.researched.has(name)) return;
 
     const queue: Node[] = [];
     queue.push(this.root);
@@ -233,9 +231,7 @@ export class ResearchTree {
         return;
       }
 
-      for (let i = 0; i < node.children.length; ++i) {
-        queue.push(node.children[i]);
-      }
+      queue.push(...node.children);
     }
 
     console.warn(`ResearchTree.research() did not find the specified Research node for: ${name}`);

--- a/src/SaveObject.tsx
+++ b/src/SaveObject.tsx
@@ -652,6 +652,7 @@ function evaluateVersionCompatibility(ver: string | number): void {
     // Prior to v2.2.0, sleeve shock was 0 to 100 internally but displayed as 100 to 0. This unifies them as 100 to 0.
     for (const sleeve of Player.sleeves) sleeve.shock = 100 - sleeve.shock;
   }
+  // Some 2.3 changes are actually in BaseServer.js fromJSONBase function
   if (ver < 31) {
     Terminal.warn("Migrating to 2.3.0, loading with no scripts.");
     for (const server of GetAllServers()) {
@@ -679,6 +680,20 @@ function evaluateVersionCompatibility(ver: string | number): void {
       Terminal.warn("Loading corporation from version prior to 2.3. Corporation has been reset.");
     }
     // End 2.3 changes
+  }
+  //2.3 hotfix changes and 2.3.1 changes
+  if (ver < 32) {
+    // Due to a bug from before 2.3, some scripts have the wrong server listed. In 2.3 this caused issues.
+    for (const server of GetAllServers()) {
+      for (const script of server.scripts.values()) {
+        if (script.server !== server.hostname) {
+          console.warn(
+            `Detected script ${script.filename} on ${server.hostname} with incorrect server property: ${script.server}. Repairing.`,
+          );
+          script.server = server.hostname;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Research tree fix

In 2.3.0, player is allowed to have multiple divisions in the same industry, which also means they share research trees. However, there were issues that could prevent the division and the research tree from agreeing about what was researched. Additionally, the code for updating the research tree was being ran very frequently, when it is only needed once (on game load or on division creation). After that the tree and division are kept in sync via the Research action in Actions.ts.

Actions.ts:
* In Research action, add research to all divisions with the same type as the researching division.

Division.ts:
* Add a new non-saved property to track whether the research tree has been initialized.
* Only update the tree manually once instead of every single time a mutliplier is requested.
* Load researches from the tree as well (for new divisions where the industry already has researches)

ResearchTree.ts
* Early return in research function if research has already been marked as researched in the tree.

## Script mismatch fix

Additionally, also fixed an issue where scripts could have the wrong server name stored. This was due to a bug from before 2.3, but in 2.3 the discrepancy caused a serious issue due to changes in script launching and cleanup, where it didn't really matter beforehand.

Tests are not set to run automatically against PRs to stable branch, but I ran lint/format/test and all passed locally, as well as performed operational tests of the changes (loaded saves with script mismatch error to verify they are repaired correctly, performed a tests with research and multiple divisions with the same industry type). Will also cherry pick the hotfix to dev afterwards.