### PR TITLE
BUGFIX: Proper default title for loaded RunningScripts

### DIFF
--- a/src/Script/RunningScript.ts
+++ b/src/Script/RunningScript.ts
@@ -163,6 +163,7 @@ export class RunningScript {
   static fromJSON(value: IReviverValue): RunningScript {
     const runningScript = Generic_fromJSON(RunningScript, value.data, includedProperties);
     if (!runningScript.scriptKey) runningScript.scriptKey = scriptKey(runningScript.filename, runningScript.args);
+    if (!runningScript.title) runningScript.title = `${runningScript.filename} ${runningScript.args.join(" ")}`;
     return runningScript;
   }
 }


### PR DESCRIPTION
It was showing up as blank, primarily for games that were pre-2.3.1 but it could also be engineered to happen with React-based titles.