### PR TITLE
CORPORATION: parse material Sell field once

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -578,25 +578,7 @@ export class Division {
               corporation.getSalesMult() *
               advertisingFactor *
               this.getSalesMultiplier();
-            if (isString(mat.desiredSellAmount)) {
-              //Dynamically evaluated
-              let tmp = mat.desiredSellAmount.replace(/MAX/g, (mat.maxSellPerCycle + "").toUpperCase());
-              tmp = tmp.replace(/PROD/g, mat.productionAmount + "");
-
-              try {
-                sellAmt = eval(tmp);
-              } catch (e) {
-                dialogBoxCreate(
-                  `Error evaluating your sell amount for material ${mat.name} in ${this.name}'s ${city} office. The sell amount is being set to zero, sellAmt is set to ${sellAmt}`,
-                );
-                sellAmt = 0;
-              }
-              sellAmt = Math.min(mat.maxSellPerCycle, sellAmt);
-              sellAmt = Math.max(sellAmt, 0);
-            } else {
-              //Player's input value is just a number
-              sellAmt = Math.min(mat.maxSellPerCycle, mat.desiredSellAmount);
-            }
+            
             sellAmt = Math.min(mat.maxSellPerCycle, sellAmt);
             sellAmt = sellAmt * corpConstants.secondsPerMarketCycle * marketCycles;
             sellAmt = Math.min(mat.stored, sellAmt);
@@ -836,7 +818,7 @@ export class Division {
           const desiredSellAmount = product.cityData[city].desiredSellAmount;
           if (isString(desiredSellAmount)) {
             //Sell amount is dynamically evaluated
-            let tmp: number | string = desiredSellAmount.replace(/MAX/g, (adjustedQty + "").toUpperCase());
+            let tmp: number | string = desiredSellAmount.replace(/MAX/g, adjustedQty.toString());
             tmp = tmp.replace(/PROD/g, product.cityData[city].productionAmount.toString());
             try {
               tmp = eval(tmp);

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -496,8 +496,8 @@ export class Division {
             const adjustedQty = mat.stored / (corpConstants.secondsPerMarketCycle * marketCycles);
             if (isString(mat.desiredSellAmount)) {
               //Dynamically evaluated
-              let tmp = mat.desiredSellAmount.replace(/MAX/g, (adjustedQty + "").toUpperCase());
-              tmp = tmp.replace(/PROD/g, mat.productionAmount + "");
+              let tmp = mat.desiredSellAmount.replace(/MAX/g, adjustedQty.toString());
+              tmp = tmp.replace(/PROD/g, mat.productionAmount.toString());
               try {
                 sellAmt = eval(tmp);
               } catch (e) {
@@ -548,7 +548,7 @@ export class Division {
             } else if (mat.marketTa1) {
               sCost = mat.marketPrice + markupLimit;
             } else if (isString(mat.desiredSellPrice)) {
-              sCost = mat.desiredSellPrice.replace(/MP/g, mat.marketPrice + "");
+              sCost = mat.desiredSellPrice.replace(/MP/g, mat.marketPrice.toString());
               sCost = eval(sCost);
             } else {
               sCost = mat.desiredSellPrice;
@@ -619,7 +619,7 @@ export class Division {
 
                 let amtStr = exp.amount.replace(
                   /MAX/g,
-                  (mat.stored / (corpConstants.secondsPerMarketCycle * marketCycles) + "").toUpperCase(),
+                  (mat.stored / (corpConstants.secondsPerMarketCycle * marketCycles)).toString(),
                 );
                 amtStr = amtStr.replace(/EPROD/g, mat.productionAmount.toString());
                 amtStr = amtStr.replace(/IPROD/g, tempMaterial.productionAmount.toString());
@@ -879,7 +879,7 @@ export class Division {
               console.error(`mku is zero, reverting to 1 to avoid Infinity`);
               product.markup = 1;
             }
-            sCostString = sCostString.replace(/MP/g, product.productionCost + "");
+            sCostString = sCostString.replace(/MP/g, product.productionCost.toString());
             sCost = Math.max(product.productionCost, eval(sCostString));
           } else {
             sCost = sellPrice;

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -578,7 +578,7 @@ export class Division {
               corporation.getSalesMult() *
               advertisingFactor *
               this.getSalesMultiplier();
-            
+
             sellAmt = Math.min(mat.maxSellPerCycle, sellAmt);
             sellAmt = sellAmt * corpConstants.secondsPerMarketCycle * marketCycles;
             sellAmt = Math.min(mat.stored, sellAmt);


### PR DESCRIPTION
Material Sell Field was parsed twice and one time wrong when MAX was used
reduced it to one parse fixing the bug

when MAX was used it would replace it with the max possible based on the current price not the max currently present in the warehouse resulting in overselling when the input was MAX-10 or any other Amount based on and lower as MAX
