### PR TITLE
CORPORATION: fixed Sell Buttons

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -552,7 +552,7 @@ export class Division {
             } else {
               sCost = mat.desiredSellPrice;
             }
-            mat.GUImarketPrice = sCost;
+            mat.uiMarketPrice = sCost;
 
             // Calculate how much of the material sells (per second)
             let markup = 1;
@@ -901,7 +901,7 @@ export class Division {
           } else {
             sCost = sellPrice;
           }
-          product.GUImarketPrice[city] = sCost;
+          product.uiMarketPrice[city] = sCost;
           let markup = 1;
           if (sCost > product.productionCost) {
             if (sCost - product.productionCost > markupLimit) {

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -542,7 +542,6 @@ export class Division {
 
               // We'll store this "Optimal Price" in a property so that we don't have
               // to re-calculate it for the UI
-              mat.marketTa2Price = optimalPrice;
 
               sCost = optimalPrice;
             } else if (mat.marketTa1) {
@@ -553,6 +552,7 @@ export class Division {
             } else {
               sCost = mat.desiredSellPrice;
             }
+            mat.GUImarketPrice = sCost;
 
             // Calculate how much of the material sells (per second)
             let markup = 1;
@@ -887,7 +887,6 @@ export class Division {
             }
 
             // Store this "optimal Price" in a property so we don't have to re-calculate for UI
-            product.marketTa2Price[city] = optimalPrice;
             sCost = optimalPrice;
           } else if (product.marketTa1) {
             sCost = product.productionCost + markupLimit;
@@ -902,7 +901,7 @@ export class Division {
           } else {
             sCost = sellPrice;
           }
-
+          product.GUImarketPrice[city] = sCost;
           let markup = 1;
           if (sCost > product.productionCost) {
             if (sCost - product.productionCost > markupLimit) {

--- a/src/Corporation/Material.ts
+++ b/src/Corporation/Material.ts
@@ -62,7 +62,7 @@ export class Material {
   // Flags that signal whether automatic sale pricing through Market TA is enabled
   marketTa1 = false;
   marketTa2 = false;
-  GUImarketPrice = 0;
+  uiMarketPrice = 0;
 
   // Determines the maximum amount of this material that can be sold in one market cycle
   maxSellPerCycle = 0;

--- a/src/Corporation/Material.ts
+++ b/src/Corporation/Material.ts
@@ -62,7 +62,7 @@ export class Material {
   // Flags that signal whether automatic sale pricing through Market TA is enabled
   marketTa1 = false;
   marketTa2 = false;
-  marketTa2Price = 0;
+  GUImarketPrice = 0;
 
   // Determines the maximum amount of this material that can be sold in one market cycle
   maxSellPerCycle = 0;

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -93,7 +93,7 @@ export class Product {
   // Flags that signal whether automatic sale pricing through Market TA is enabled
   marketTa1 = false;
   marketTa2 = false;
-  GUImarketPrice = createEnumKeyedRecord(CityName, () => 0);
+  uiMarketPrice = createEnumKeyedRecord(CityName, () => 0);
 
   /** Effective number that "MAX" represents in a sell amount */
   maxSellAmount = 0;

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -93,7 +93,7 @@ export class Product {
   // Flags that signal whether automatic sale pricing through Market TA is enabled
   marketTa1 = false;
   marketTa2 = false;
-  marketTa2Price = createEnumKeyedRecord(CityName, () => 0);
+  GUImarketPrice = createEnumKeyedRecord(CityName, () => 0);
 
   /** Effective number that "MAX" represents in a sell amount */
   maxSellAmount = 0;

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -78,7 +78,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
       );
     }
     <>
-      {sellButtonText} @ <Money money={mat.GUImarketPrice} />
+      {sellButtonText} @ <Money money={mat.uiMarketPrice} />
     </>;
   } else {
     sellButtonText = <>Sell (0.000/0.000)</>;

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -44,7 +44,6 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
   const warehouse = props.warehouse;
   const city = props.city;
   const mat = props.mat;
-  const markupLimit = mat.getMarkupLimit();
   const office = division.offices[city];
   if (!office) {
     throw new Error(`Could not get OfficeSpace object for this city (${city})`);
@@ -68,7 +67,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
     if (isString(mat.desiredSellAmount)) {
       sellButtonText = (
         <>
-          Sell ({formatBigNumber(mat.actualSellAmount)}/{mat.desiredSellAmount[1]})
+          Sell ({formatBigNumber(mat.actualSellAmount)}/{mat.desiredSellAmount})
         </>
       );
     } else {
@@ -78,35 +77,9 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
         </>
       );
     }
-
-    if (mat.marketTa2) {
-      sellButtonText = (
-        <>
-          {sellButtonText} @ <Money money={mat.marketTa2Price} />
-        </>
-      );
-    } else if (mat.marketTa1) {
-      sellButtonText = (
-        <>
-          {sellButtonText} @ <Money money={mat.marketPrice + markupLimit} />
-        </>
-      );
-    } else if (mat.desiredSellPrice) {
-      if (isString(mat.desiredSellPrice)) {
-        const sCost = mat.desiredSellPrice.replace(/MP/g, mat.marketPrice + "");
-        sellButtonText = (
-          <>
-            {sellButtonText} @ <Money money={eval(sCost)} />
-          </>
-        );
-      } else {
-        sellButtonText = (
-          <>
-            {sellButtonText} @ <Money money={mat.desiredSellPrice} />
-          </>
-        );
-      }
-    }
+    <>
+      {sellButtonText} @ <Money money={mat.GUImarketPrice} />
+    </>;
   } else {
     sellButtonText = <>Sell (0.000/0.000)</>;
   }

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -68,7 +68,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
 
   sellButtonText = (
     <>
-      {sellButtonText} @ <Money money={product.GUImarketPrice[city]} />
+      {sellButtonText} @ <Money money={product.uiMarketPrice[city]} />
     </>
   );
   // Limit Production button

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -66,37 +66,11 @@ export function ProductElem(props: IProductProps): React.ReactElement {
     sellButtonText = <>Sell (0.000/0.000)</>;
   }
 
-  if (product.marketTa2) {
-    sellButtonText = (
-      <>
-        {sellButtonText} @ <Money money={product.marketTa2Price[city]} />
-      </>
-    );
-  } else if (product.marketTa1) {
-    const markupLimit = product.rating / product.markup;
-    sellButtonText = (
-      <>
-        {sellButtonText} @ <Money money={product.productionCost + markupLimit} />
-      </>
-    );
-  } else if (product.cityData[city].desiredSellPrice) {
-    const desiredSellPrice = product.cityData[city].desiredSellPrice;
-    if (isString(desiredSellPrice)) {
-      const sCost = desiredSellPrice.replace(/MP/g, product.productionCost + product.rating / product.markup + "");
-      sellButtonText = (
-        <>
-          {sellButtonText} @ <Money money={eval(sCost)} />
-        </>
-      );
-    } else {
-      sellButtonText = (
-        <>
-          {sellButtonText} @ <Money money={product.cityData[city].desiredSellPrice} />
-        </>
-      );
-    }
-  }
-
+  sellButtonText = (
+    <>
+      {sellButtonText} @ <Money money={product.GUImarketPrice[city]} />
+    </>
+  );
   // Limit Production button
   const productionLimit = product.cityData[city].productionLimit;
   const limitProductionButtonText =


### PR DESCRIPTION
Product Sell Button displayed wrong price when MP was used
Material Sell Button displayed only the second character when a string was used as amount (MAX => A)

actual price used in division in SALE state is now cached to be reused in the UI (has been like this for TA2 now for all prices)
