### PR TITLE
PRESTIGE: Make bitnode reset synchronous again

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1206,7 +1206,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         : false;
       if (cbScript === null) throw helpers.makeRuntimeErrorMsg(ctx, `Could not resolve file path: ${_cbScript}`);
       enterBitNode(true, Player.bitNodeN, nextBN);
-      if (cbScript) setTimeout(() => runAfterReset(cbScript), 0);
+      if (cbScript) setTimeout(() => runAfterReset(cbScript), 500);
     },
     destroyW0r1dD43m0n: (ctx) => (_nextBN, _cbScript) => {
       helpers.checkSingularityAccess(ctx);
@@ -1239,7 +1239,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       wd.backdoorInstalled = true;
       calculateAchievements();
       enterBitNode(false, Player.bitNodeN, nextBN);
-      if (cbScript) setTimeout(() => runAfterReset(cbScript), 0);
+      if (cbScript) setTimeout(() => runAfterReset(cbScript), 500);
     },
     getCurrentWork: () => () => {
       if (!Player.currentWork) return null;

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -161,7 +161,7 @@ export function prestigeAugmentation(): void {
 }
 
 // Prestige by destroying Bit Node and gaining a Source File
-export function prestigeSourceFile(flume: boolean): void {
+export function prestigeSourceFile(isFlume: boolean): void {
   initBitNodeMultipliers();
 
   Player.prestigeSourceFile();
@@ -297,7 +297,7 @@ export function prestigeSourceFile(flume: boolean): void {
   staneksGift.prestigeSourceFile();
 
   // Gain int exp
-  if (Player.sourceFileLvl(5) !== 0 && !flume) Player.gainIntelligenceExp(300);
+  if (Player.sourceFileLvl(5) !== 0 && !isFlume) Player.gainIntelligenceExp(300);
 
   // Clear recent scripts
   recentScripts.splice(0, recentScripts.length);

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -31,6 +31,9 @@ import { CONSTANTS } from "./Constants";
 import { LogBoxClearEvents } from "./ui/React/LogBoxManager";
 
 const BitNode8StartingMoney = 250e6;
+function delayedDialog(message: string) {
+  setTimeout(() => dialogBoxCreate(message), 200);
+}
 
 // Prestige by purchasing augmentation
 export function prestigeAugmentation(): void {
@@ -233,7 +236,7 @@ export function prestigeSourceFile(isFlume: boolean): void {
   if (Player.bitNodeN === 3) {
     // Easiest way to comply with type constraint, instead of revalidating the enum member's file path
     homeComp.messages.push(LiteratureName.CorporationManagementHandbook);
-    dialogBoxCreate(
+    delayedDialog(
       "You received a copy of the Corporation Management Handbook on your home computer. " +
         "Read it if you need help getting started with Corporations!",
     );
@@ -241,7 +244,7 @@ export function prestigeSourceFile(isFlume: boolean): void {
 
   // BitNode 6: Bladeburners and BitNode 7: Bladeburners 2079
   if (Player.bitNodeN === 6 || Player.bitNodeN === 7) {
-    dialogBoxCreate("NSA would like to have a word with you once you're ready.");
+    delayedDialog("NSA would like to have a word with you once you're ready.");
   }
 
   // BitNode 8: Ghost of Wall Street
@@ -255,18 +258,18 @@ export function prestigeSourceFile(isFlume: boolean): void {
 
   // BitNode 10: Digital Carbon
   if (Player.bitNodeN === 10) {
-    dialogBoxCreate(
+    delayedDialog(
       "Seek out The Covenant if you'd like to purchase a new sleeve or two! And see what VitaLife in New Tokyo has to offer for you",
     );
   }
 
   // BitNode 12: Digital Carbon
   if (Player.bitNodeN === 12 && Player.sourceFileLvl(10) > 100) {
-    dialogBoxCreate("Saynt_Garmo is watching you");
+    delayedDialog("Saynt_Garmo is watching you");
   }
 
   if (Player.bitNodeN === 13) {
-    dialogBoxCreate(`Trouble is brewing in ${CityName.Chongqing}`);
+    delayedDialog(`Trouble is brewing in ${CityName.Chongqing}`);
   }
 
   // Reset Stock market, gang, and corporation

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -6,7 +6,7 @@ import { SourceFiles } from "./SourceFile/SourceFiles";
 import { dialogBoxCreate } from "./ui/React/DialogBox";
 import { Router } from "./ui/GameRoot";
 import { Page } from "./ui/Router";
-import { Engine } from "./engine";
+import { prestigeSourceFile } from "./Prestige";
 
 function giveSourceFile(bitNodeNumber: number): void {
   const sourceFileKey = "SourceFile" + bitNodeNumber.toString();
@@ -48,8 +48,8 @@ function giveSourceFile(bitNodeNumber: number): void {
   }
 }
 
-export function enterBitNode(flume: boolean, destroyedBitNode: number, newBitNode: number): void {
-  if (!flume) {
+export function enterBitNode(isFlume: boolean, destroyedBitNode: number, newBitNode: number): void {
+  if (!isFlume) {
     giveSourceFile(destroyedBitNode);
   } else if (Player.sourceFileLvl(5) === 0 && newBitNode !== 5) {
     Player.skills.intelligence = 0;
@@ -66,5 +66,5 @@ export function enterBitNode(flume: boolean, destroyedBitNode: number, newBitNod
   } else {
     Router.toPage(Page.Terminal);
   }
-  Engine.nodeTransfer = flume;
+  prestigeSourceFile(isFlume);
 }

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -45,13 +45,11 @@ import React from "react";
 import { setupUncaughtPromiseHandler } from "./UncaughtPromiseHandler";
 import { Button, Typography } from "@mui/material";
 import { SnackbarEvents, ToastVariant } from "./ui/React/Snackbar";
-import { prestigeSourceFile } from "./Prestige";
 
 /** Game engine. Handles the main game loop. */
 const Engine: {
   _lastUpdate: number;
   updateGame: (numCycles?: number) => void;
-  nodeTransfer: boolean | undefined;
   Counters: {
     [key: string]: number | undefined;
     autoSaveCounter: number;
@@ -75,12 +73,7 @@ const Engine: {
 } = {
   // Time variables (milliseconds unix epoch time)
   _lastUpdate: new Date().getTime(),
-  nodeTransfer: undefined,
   updateGame: function (numCycles = 1) {
-    if (this.nodeTransfer != undefined) {
-      prestigeSourceFile(this.nodeTransfer);
-      this.nodeTransfer = undefined;
-    }
     const time = numCycles * CONSTANTS.MilliPerCycle;
     if (Player.totalPlaytime == null) {
       Player.totalPlaytime = 0;


### PR DESCRIPTION
Fixes a bug where singularity callback scripts could be launched before the next engine cycle and therefore before the node change.

* Bitnode transfers are again performed without delay, reverts a change from #397 and solves the original issue a different way (delayed dialogs instead of delaying the entire node transition)
* Added 500ms timeout to the bitnode reset singularity functions (for consistency with the aug install functions)
* Not super related, but while I was in some functions I renamed instances of a `flume` variable to `isFlume` so it's more obvious that it's a boolean representing whether the reset was due to bitflume