### PR TITLE
UI: script tabs management (#554)

### DIFF
--- a/src/ScriptEditor/ui/Tab.tsx
+++ b/src/ScriptEditor/ui/Tab.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef } from "react";
+import { DraggableProvided } from "react-beautiful-dnd";
+
+import Button from "@mui/material/Button";
+import Tooltip from "@mui/material/Tooltip";
+
+import SyncIcon from "@mui/icons-material/Sync";
+import CloseIcon from "@mui/icons-material/Close";
+
+import { Settings } from "../../Settings/Settings";
+
+interface IProps {
+  provided: DraggableProvided;
+  title: string;
+  isActive: boolean;
+  isExternal: boolean;
+
+  onClick: () => void;
+  onClose: () => void;
+  onUpdate: () => void;
+}
+
+const tabMargin = 5;
+const tabIconWidth = 25;
+const tabIconHeight = 38.5;
+
+export function Tab({ provided, title, isActive, isExternal, onClick, onClose, onUpdate }: IProps) {
+  const colorProps = isActive
+    ? {
+        background: Settings.theme.button,
+        borderColor: Settings.theme.button,
+        color: Settings.theme.primary,
+      }
+    : {
+        background: Settings.theme.backgroundsecondary,
+        borderColor: Settings.theme.backgroundsecondary,
+        color: Settings.theme.secondary,
+      };
+
+  if (isExternal) {
+    colorProps.color = Settings.theme.info;
+  }
+  const iconButtonStyle = {
+    maxWidth: tabIconWidth,
+    minWidth: tabIconWidth,
+    minHeight: tabIconHeight,
+    maxHeight: tabIconHeight,
+    ...colorProps,
+  };
+
+  const tabRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (tabRef.current && isActive) {
+      tabRef.current?.scrollIntoView();
+    }
+  }, [isActive]);
+
+  return (
+    <div
+      ref={(element) => {
+        tabRef.current = element;
+        provided.innerRef(element);
+      }}
+      {...provided.draggableProps}
+      {...provided.dragHandleProps}
+      style={{
+        ...provided.draggableProps.style,
+        marginRight: tabMargin,
+        flexShrink: 0,
+        border: "1px solid " + Settings.theme.well,
+      }}
+    >
+      <Tooltip title={title}>
+        <Button
+          onClick={onClick}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            if (e.button === 1) onClose();
+          }}
+          style={{
+            minHeight: tabIconHeight,
+            overflow: "hidden",
+            ...colorProps,
+          }}
+        >
+          <span style={{ overflow: "hidden", direction: "rtl", textOverflow: "ellipsis" }}>{title}</span>
+        </Button>
+      </Tooltip>
+      <Tooltip title="Overwrite editor content with saved file content">
+        <Button onClick={onUpdate} style={iconButtonStyle}>
+          <SyncIcon fontSize="small" />
+        </Button>
+      </Tooltip>
+      <Button onClick={onClose} style={iconButtonStyle}>
+        <CloseIcon fontSize="small" />
+      </Button>
+    </div>
+  );
+}

--- a/src/ScriptEditor/ui/Tabs.tsx
+++ b/src/ScriptEditor/ui/Tabs.tsx
@@ -10,7 +10,7 @@ import Tooltip from "@mui/material/Tooltip";
 import CloseIcon from "@mui/icons-material/Close";
 import SearchIcon from "@mui/icons-material/Search";
 
-import { useRerender } from "../../ui/React/hooks";
+import { useBoolean, useRerender } from "../../ui/React/hooks";
 import { Settings } from "../../Settings/Settings";
 
 import { dirty, reorder } from "./utils";
@@ -18,7 +18,7 @@ import { OpenScript } from "./OpenScript";
 import { Tab } from "./Tab";
 
 const tabsMaxWidth = 1640;
-const searchWidth = 150;
+const searchWidth = 180;
 
 interface IProps {
   scripts: OpenScript[];
@@ -31,6 +31,7 @@ interface IProps {
 
 export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpdate }: IProps) {
   const [filter, setFilter] = useState("");
+  const [isSearchTooltipOpen, { on: openSearchTooltip, off: closeSearchTooltip }] = useBoolean(false);
   const [searchExpanded, setSearchExpanded] = useState(false);
   const rerender = useRerender();
 
@@ -53,9 +54,10 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
     setFilter(event.target.value);
   }
 
-  function handleExpandSearch(): void {
+  function toggleSearch(): void {
     setFilter("");
     setSearchExpanded(!searchExpanded);
+    closeSearchTooltip();
   }
 
   function handleScroll(e: React.WheelEvent<HTMLDivElement>): void {
@@ -64,7 +66,12 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
 
   return (
     <Box display="flex" flexGrow="0" flexDirection="row" alignItems="center">
-      <Tooltip title={"Search Open Scripts"}>
+      <Tooltip
+        title={"Search Open Scripts"}
+        open={isSearchTooltipOpen}
+        onOpen={openSearchTooltip}
+        onClose={closeSearchTooltip}
+      >
         <span style={{ marginRight: 5 }}>
           {searchExpanded ? (
             <TextField
@@ -76,14 +83,14 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
                 startAdornment: <SearchIcon />,
                 spellCheck: false,
                 endAdornment: (
-                  <IconButton onClick={handleExpandSearch}>
+                  <IconButton onClick={toggleSearch}>
                     <CloseIcon />
                   </IconButton>
                 ),
               }}
             />
           ) : (
-            <Button onClick={handleExpandSearch}>
+            <Button onClick={toggleSearch}>
               <SearchIcon />
             </Button>
           )}

--- a/src/ScriptEditor/ui/Tabs.tsx
+++ b/src/ScriptEditor/ui/Tabs.tsx
@@ -1,20 +1,24 @@
 import React, { useState } from "react";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
-import { Box, Button, TextField, Tooltip } from "@mui/material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+
 import CloseIcon from "@mui/icons-material/Close";
 import SearchIcon from "@mui/icons-material/Search";
-import SyncIcon from "@mui/icons-material/Sync";
 
 import { useRerender } from "../../ui/React/hooks";
 import { Settings } from "../../Settings/Settings";
 
 import { dirty, reorder } from "./utils";
 import { OpenScript } from "./OpenScript";
+import { Tab } from "./Tab";
 
 const tabsMaxWidth = 1640;
-const tabMargin = 5;
-const tabIconWidth = 25;
+const searchWidth = 150;
 
 interface IProps {
   scripts: OpenScript[];
@@ -50,137 +54,88 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
     setSearchExpanded(!searchExpanded);
   }
 
-  const tabMaxWidth = filteredOpenScripts.length ? tabsMaxWidth / filteredOpenScripts.length - tabMargin : 0;
-  const tabTextWidth = tabMaxWidth - tabIconWidth * 2;
+  function handleScroll(e: React.WheelEvent<HTMLDivElement>): void {
+    e.currentTarget.scrollLeft += e.deltaY;
+  }
+
   return (
-    <DragDropContext onDragEnd={onDragEnd}>
-      <Droppable droppableId="tabs" direction="horizontal">
-        {(provided, snapshot) => (
-          <Box
-            maxWidth={`${tabsMaxWidth}px`}
-            display="flex"
-            flexGrow="0"
-            flexDirection="row"
-            alignItems="center"
-            whiteSpace="nowrap"
-            ref={provided.innerRef}
-            {...provided.droppableProps}
-            style={{
-              backgroundColor: snapshot.isDraggingOver
-                ? Settings.theme.backgroundsecondary
-                : Settings.theme.backgroundprimary,
-              overflowX: "scroll",
+    <Box display="flex" flexGrow="0" flexDirection="row">
+      <Tooltip title={"Search Open Scripts"}>
+        {searchExpanded ? (
+          <TextField
+            value={filter}
+            onChange={handleFilterChange}
+            autoFocus
+            sx={{ minWidth: searchWidth, maxWidth: searchWidth }}
+            InputProps={{
+              startAdornment: <SearchIcon />,
+              spellCheck: false,
+              endAdornment: (
+                <IconButton onClick={handleExpandSearch}>
+                  <CloseIcon />
+                </IconButton>
+              ),
             }}
-          >
-            <Tooltip title={"Search Open Scripts"}>
-              {searchExpanded ? (
-                <TextField
-                  value={filter}
-                  onChange={handleFilterChange}
-                  autoFocus
-                  InputProps={{
-                    startAdornment: <SearchIcon />,
-                    spellCheck: false,
-                    endAdornment: <CloseIcon onClick={handleExpandSearch} />,
-                    // TODO: reapply
-                    // sx: { minWidth: 200 },
-                  }}
-                />
-              ) : (
-                <Button onClick={handleExpandSearch}>
-                  <SearchIcon />
-                </Button>
-              )}
-            </Tooltip>
-            {filteredOpenScripts.map(({ path: fileName, hostname }, index) => {
-              const editingCurrentScript =
-                currentScript?.path === filteredOpenScripts[index].path &&
-                currentScript.hostname === filteredOpenScripts[index].hostname;
-              const externalScript = hostname !== "home";
-              const colorProps = editingCurrentScript
-                ? {
-                    background: Settings.theme.button,
-                    borderColor: Settings.theme.button,
-                    color: Settings.theme.primary,
-                  }
-                : {
-                    background: Settings.theme.backgroundsecondary,
-                    borderColor: Settings.theme.backgroundsecondary,
-                    color: Settings.theme.secondary,
-                  };
-
-              if (externalScript) {
-                colorProps.color = Settings.theme.info;
-              }
-              const iconButtonStyle = {
-                maxWidth: `${tabIconWidth}px`,
-                minWidth: `${tabIconWidth}px`,
-                minHeight: "38.5px",
-                maxHeight: "38.5px",
-                ...colorProps,
-              };
-
-              const scriptTabText = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(
-                scripts,
-                index,
-              )}`;
-
-              return (
-                <Draggable
-                  key={fileName + hostname}
-                  draggableId={fileName + hostname}
-                  index={index}
-                  disableInteractiveElementBlocking={true}
-                >
-                  {(provided) => (
-                    <div
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      {...provided.dragHandleProps}
-                      style={{
-                        ...provided.draggableProps.style,
-                        // maxWidth: `${tabMaxWidth}px`,
-                        marginRight: `${tabMargin}px`,
-                        flexShrink: 0,
-                        border: "1px solid " + Settings.theme.well,
-                      }}
-                    >
-                      <Tooltip title={scriptTabText}>
-                        <Button
-                          onClick={() => onTabClick(index)}
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            if (e.button === 1) onTabClose(index);
-                          }}
-                          style={{
-                            maxWidth: `${tabTextWidth}px`,
-                            minHeight: "38.5px",
-                            overflow: "hidden",
-                            ...colorProps,
-                          }}
-                        >
-                          <span style={{ overflow: "hidden", direction: "rtl", textOverflow: "ellipsis" }}>
-                            {scriptTabText}
-                          </span>
-                        </Button>
-                      </Tooltip>
-                      <Tooltip title="Overwrite editor content with saved file content">
-                        <Button onClick={() => onTabUpdate(index)} style={iconButtonStyle}>
-                          <SyncIcon fontSize="small" />
-                        </Button>
-                      </Tooltip>
-                      <Button onClick={() => onTabClose(index)} style={iconButtonStyle}>
-                        <CloseIcon fontSize="small" />
-                      </Button>
-                    </div>
-                  )}
-                </Draggable>
-              );
-            })}
-            {provided.placeholder}
-          </Box>
+          />
+        ) : (
+          <Button onClick={handleExpandSearch}>
+            <SearchIcon />
+          </Button>
         )}
-      </Droppable>
-    </DragDropContext>
+      </Tooltip>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId="tabs" direction="horizontal">
+          {(provided, snapshot) => (
+            <Box
+              maxWidth={`${tabsMaxWidth}px`}
+              display="flex"
+              flexGrow="1"
+              flexDirection="row"
+              alignItems="center"
+              whiteSpace="nowrap"
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              style={{
+                backgroundColor: snapshot.isDraggingOver
+                  ? Settings.theme.backgroundsecondary
+                  : Settings.theme.backgroundprimary,
+                overflowX: "scroll",
+              }}
+              onWheel={handleScroll}
+            >
+              {filteredOpenScripts.map(({ path: fileName, hostname }, index) => {
+                const isActive =
+                  currentScript?.path === filteredOpenScripts[index].path &&
+                  currentScript.hostname === filteredOpenScripts[index].hostname;
+
+                const title = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(scripts, index)}`;
+
+                return (
+                  <Draggable
+                    key={fileName + hostname}
+                    draggableId={fileName + hostname}
+                    index={index}
+                    disableInteractiveElementBlocking
+                  >
+                    {(provided) => (
+                      <Tab
+                        provided={provided}
+                        title={title}
+                        isActive={isActive}
+                        isExternal={hostname !== "home"}
+                        onClick={() => onTabClick(index)}
+                        onClose={() => onTabClose(index)}
+                        onUpdate={() => onTabUpdate(index)}
+                      />
+                    )}
+                  </Draggable>
+                );
+              })}
+              {provided.placeholder}
+            </Box>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </Box>
   );
 }

--- a/src/ScriptEditor/ui/Tabs.tsx
+++ b/src/ScriptEditor/ui/Tabs.tsx
@@ -59,29 +59,31 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
   }
 
   return (
-    <Box display="flex" flexGrow="0" flexDirection="row">
+    <Box display="flex" flexGrow="0" flexDirection="row" alignItems="center">
       <Tooltip title={"Search Open Scripts"}>
-        {searchExpanded ? (
-          <TextField
-            value={filter}
-            onChange={handleFilterChange}
-            autoFocus
-            sx={{ minWidth: searchWidth, maxWidth: searchWidth }}
-            InputProps={{
-              startAdornment: <SearchIcon />,
-              spellCheck: false,
-              endAdornment: (
-                <IconButton onClick={handleExpandSearch}>
-                  <CloseIcon />
-                </IconButton>
-              ),
-            }}
-          />
-        ) : (
-          <Button onClick={handleExpandSearch}>
-            <SearchIcon />
-          </Button>
-        )}
+        <span style={{ marginRight: 5 }}>
+          {searchExpanded ? (
+            <TextField
+              value={filter}
+              onChange={handleFilterChange}
+              autoFocus
+              sx={{ minWidth: searchWidth, maxWidth: searchWidth }}
+              InputProps={{
+                startAdornment: <SearchIcon />,
+                spellCheck: false,
+                endAdornment: (
+                  <IconButton onClick={handleExpandSearch}>
+                    <CloseIcon />
+                  </IconButton>
+                ),
+              }}
+            />
+          ) : (
+            <Button onClick={handleExpandSearch}>
+              <SearchIcon />
+            </Button>
+          )}
+        </span>
       </Tooltip>
       <DragDropContext onDragEnd={onDragEnd}>
         <Droppable droppableId="tabs" direction="horizontal">
@@ -103,12 +105,14 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
               }}
               onWheel={handleScroll}
             >
-              {filteredOpenScripts.map(({ path: fileName, hostname }, index) => {
+              {filteredOpenScripts.map((script, index) => {
+                const { path: fileName, hostname } = script;
                 const isActive =
                   currentScript?.path === filteredOpenScripts[index].path &&
                   currentScript.hostname === filteredOpenScripts[index].hostname;
 
                 const title = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(scripts, index)}`;
+                const originalIndex = scripts.indexOf(script);
 
                 return (
                   <Draggable
@@ -123,9 +127,9 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
                         title={title}
                         isActive={isActive}
                         isExternal={hostname !== "home"}
-                        onClick={() => onTabClick(index)}
-                        onClose={() => onTabClose(index)}
-                        onUpdate={() => onTabUpdate(index)}
+                        onClick={() => onTabClick(originalIndex)}
+                        onClose={() => onTabClose(originalIndex)}
+                        onUpdate={() => onTabUpdate(originalIndex)}
                       />
                     )}
                   </Draggable>


### PR DESCRIPTION
* removes script tab text and width calculation/limits
* enables vertical scroll with mouse wheel support (without shift).
* sticks the search field to the left so that it's not scrolled
* scrolls the current script tab into view
* fix an issue with activating, closing, reordering or updating a script tab when the script list is filtered

closes #554