### PR TITLE
MISC: Various small fixes

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -902,7 +902,7 @@ export const ns: InternalAPI<NSFull> = {
     ];
 
     if (!substring) return allFilenames.sort();
-    return allFilenames.filter((filename) => filename.includes(substring)).sort();
+    return allFilenames.filter((filename) => ("/" + filename).includes(substring)).sort();
   },
   getRecentScripts: () => (): RecentScript[] => {
     return recentScripts.map((rs) => ({

--- a/src/Terminal/commands/cd.ts
+++ b/src/Terminal/commands/cd.ts
@@ -4,8 +4,8 @@ import { directoryExistsOnServer, resolveDirectory } from "../../Paths/Directory
 
 export function cd(args: (string | number | boolean)[], server: BaseServer): void {
   if (args.length > 1) return Terminal.error("Incorrect number of arguments. Usage: cd [dir]");
-  // If no arg was provided, just use "".
-  const userInput = String(args[0] ?? "");
+  // If no arg was provided, just use "/".
+  const userInput = String(args[0] ?? "/");
   const targetDir = resolveDirectory(userInput, Terminal.currDir);
   // Explicitly checking null due to root being ""
   if (targetDir === null) return Terminal.error(`Could not resolve directory ${userInput}`);

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -163,7 +163,7 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
   // Just some booleans so the mismatch between command length and arg number are not as confusing.
   const onCommand = commandLength === 1;
   const onFirstCommandArg = commandLength === 2;
-  const onSecondCommandArg = commandLength === 3;
+  // const onSecondCommandArg = commandLength === 3; // unused
 
   // These are always added.
   addGlobalAliases();

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -239,11 +239,12 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
       return possibilities;
 
     case "scp":
-      if (onFirstCommandArg) {
-        addScripts();
-        addTextFiles();
-        addLiterature();
-      } else if (onSecondCommandArg) addServerNames();
+      if (!onFirstCommandArg) {
+        addServerNames();
+      }
+      addScripts();
+      addTextFiles();
+      addLiterature();
       return possibilities;
 
     case "rm":

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -197,7 +197,7 @@ export function TerminalInput(): React.ReactElement {
     // Run command.
     if (event.key === KEY.ENTER && value !== "") {
       event.preventDefault();
-      Terminal.print(`[${Player.getCurrentServer().hostname} ~${Terminal.cwd()}]> ${value}`);
+      Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
       Terminal.executeCommands(value);
       saveValue("");
       return;
@@ -282,7 +282,7 @@ export function TerminalInput(): React.ReactElement {
     if (Settings.EnableBashHotkeys) {
       if (event.code === KEYCODE.C && event.ctrlKey && ref && ref.selectionStart === ref.selectionEnd) {
         event.preventDefault();
-        Terminal.print(`[${Player.getCurrentServer().hostname} ~${Terminal.cwd()}]> ${value}`);
+        Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
         modifyInput("clearall");
       }
 
@@ -361,7 +361,7 @@ export function TerminalInput(): React.ReactElement {
           className: classes.input,
           startAdornment: (
             <Typography color={Terminal.action === null ? "primary" : "secondary"} flexShrink={0}>
-              [{Player.getCurrentServer().hostname}&nbsp;~{Terminal.cwd()}]&gt;&nbsp;
+              [{Player.getCurrentServer().hostname}&nbsp;/{Terminal.cwd()}]&gt;&nbsp;
             </Typography>
           ),
           spellCheck: false,

--- a/test/jest/Terminal/tabCompletion.test.ts
+++ b/test/jest/Terminal/tabCompletion.test.ts
@@ -13,6 +13,7 @@ import { hasScriptExtension } from "../../../src/Paths/ScriptFilePath";
 import { LiteratureName } from "../../../src/Literature/data/LiteratureNames";
 import { MessageFilename } from "../../../src/Message/MessageHelpers";
 import { Terminal } from "../../../src/Terminal";
+import { IPAddress } from "../../../src/Types/strings";
 
 describe("getTabCompletionPossibilities", function () {
   let closeServer: Server;
@@ -23,7 +24,7 @@ describe("getTabCompletionPossibilities", function () {
     Player.init();
 
     closeServer = new Server({
-      ip: "8.8.8.8",
+      ip: "8.8.8.8" as IPAddress,
       hostname: "near",
       hackDifficulty: 1,
       moneyAvailable: 70000,
@@ -33,7 +34,7 @@ describe("getTabCompletionPossibilities", function () {
       serverGrowth: 3000,
     });
     farServer = new Server({
-      ip: "4.4.4.4",
+      ip: "4.4.4.4" as IPAddress,
       hostname: "far",
       hackDifficulty: 1,
       moneyAvailable: 70000,
@@ -87,23 +88,22 @@ describe("getTabCompletionPossibilities", function () {
   it("completes the scp command", async () => {
     writeFiles();
     let options = await getTabCompletionPossibilities("scp ", root);
-    expect(options.sort()).toEqual(
-      [
-        "note.txt",
-        "folder1/text.txt",
-        "folder1/text2.txt",
-        "hack.js",
-        "weaken.js",
-        "grow.js",
-        "old.script",
-        "folder1/test.js",
-        "anotherFolder/win.js",
-        LiteratureName.AGreenTomorrow,
-      ].sort(),
-    );
+    const filesToMatch = [
+      "note.txt",
+      "folder1/text.txt",
+      "folder1/text2.txt",
+      "hack.js",
+      "weaken.js",
+      "grow.js",
+      "old.script",
+      "folder1/test.js",
+      "anotherFolder/win.js",
+      LiteratureName.AGreenTomorrow,
+    ];
+    expect(options.sort()).toEqual(filesToMatch.sort());
     // Test the second command argument (server name)
     options = await getTabCompletionPossibilities("scp note.txt ", root);
-    expect(options).toEqual(["home", "near", "far"]);
+    expect(options.sort()).toEqual(["home", "near", "far", ...filesToMatch].sort());
   });
 
   it("completes the kill, tail, mem, and check commands", async () => {


### PR DESCRIPTION
1. When determining matches against filenames, ns.ls will match against filepaths as if they had leading slashes, to allow legacy search-by-directory to work (e.g. "/scripts/" matches files in a directory named scripts).
2. scp now accepts multiple filenames, matching text from `help scp`.
3. terminal display shows / instead of ~ as the directory
4. cd with no arguments returns to root folder