### PR TITLE
DOC: `additionalMsec` is no longer experimental

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -326,7 +326,7 @@ interface BasicHGWOptions {
   /** Set to true this action will affect the stock market. */
   stock?: boolean;
   /** Number of additional milliseconds that will be spent waiting between the start of the function and when it
-   * completes. Experimental in 2.2.2, may be removed in 2.3. */
+   * completes. */
   additionalMsec?: number;
 }
 


### PR DESCRIPTION
The attribute `additionalMsec` of the object `BasicHGWOptions` was experimental in v2.2.2.  It is now a stable feature.
