### PR TITLE
CORP: Robotics industry NaN fix + better exports validation

### DIFF
--- a/markdown/bitburner.basichgwoptions.additionalmsec.md
+++ b/markdown/bitburner.basichgwoptions.additionalmsec.md
@@ -4,7 +4,7 @@
 
 ## BasicHGWOptions.additionalMsec property
 
-Number of additional milliseconds that will be spent waiting between the start of the function and when it completes. Experimental in 2.2.2, may be removed in 2.3.
+Number of additional milliseconds that will be spent waiting between the start of the function and when it completes.
 
 **Signature:**
 

--- a/markdown/bitburner.basichgwoptions.md
+++ b/markdown/bitburner.basichgwoptions.md
@@ -16,7 +16,7 @@ interface BasicHGWOptions
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [additionalMsec?](./bitburner.basichgwoptions.additionalmsec.md) |  | number | _(Optional)_ Number of additional milliseconds that will be spent waiting between the start of the function and when it completes. Experimental in 2.2.2, may be removed in 2.3. |
+|  [additionalMsec?](./bitburner.basichgwoptions.additionalmsec.md) |  | number | _(Optional)_ Number of additional milliseconds that will be spent waiting between the start of the function and when it completes. |
 |  [stock?](./bitburner.basichgwoptions.stock.md) |  | boolean | _(Optional)_ Set to true this action will affect the stock market. |
 |  [threads?](./bitburner.basichgwoptions.threads.md) |  | number | _(Optional)_ Number of threads to use for this function. Must be less than or equal to the number of threads the script is running with. |
 

--- a/markdown/bitburner.warehouseapi.cancelexportmaterial.md
+++ b/markdown/bitburner.warehouseapi.cancelexportmaterial.md
@@ -15,7 +15,6 @@ cancelExportMaterial(
     targetDivision: string,
     targetCity: CityName | `${CityName}`,
     materialName: string,
-    amt: number,
   ): void;
 ```
 
@@ -28,7 +27,6 @@ cancelExportMaterial(
 |  targetDivision | string | Target division |
 |  targetCity | [CityName](./bitburner.cityname.md) \| \`${[CityName](./bitburner.cityname.md)<!-- -->}\` | Target city |
 |  materialName | string | Name of the material |
-|  amt | number | Amount of material to export. |
 
 **Returns:**
 

--- a/markdown/bitburner.warehouseapi.md
+++ b/markdown/bitburner.warehouseapi.md
@@ -22,7 +22,7 @@ Requires the Warehouse API upgrade from your corporation.
 |  --- | --- |
 |  [bulkPurchase(divisionName, city, materialName, amt)](./bitburner.warehouseapi.bulkpurchase.md) | Set material to bulk buy |
 |  [buyMaterial(divisionName, city, materialName, amt)](./bitburner.warehouseapi.buymaterial.md) | Set material buy data |
-|  [cancelExportMaterial(sourceDivision, sourceCity, targetDivision, targetCity, materialName, amt)](./bitburner.warehouseapi.cancelexportmaterial.md) | Cancel material export |
+|  [cancelExportMaterial(sourceDivision, sourceCity, targetDivision, targetCity, materialName)](./bitburner.warehouseapi.cancelexportmaterial.md) | Cancel material export |
 |  [discontinueProduct(divisionName, productName)](./bitburner.warehouseapi.discontinueproduct.md) | Discontinue a product. |
 |  [exportMaterial(sourceDivision, sourceCity, targetDivision, targetCity, materialName, amt)](./bitburner.warehouseapi.exportmaterial.md) | Set material export data |
 |  [getMaterial(divisionName, city, materialName)](./bitburner.warehouseapi.getmaterial.md) | Get material data |

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -463,7 +463,7 @@ export function ExportMaterial(
   // Perform sanitization and tests
   let sanitizedAmt = amount.replace(/\s+/g, "").toUpperCase();
   sanitizedAmt = sanitizedAmt.replace(/[^-()\d/*+.MAXEPRODINV]/g, "");
-  for (const testReplacement of ["1.23", "-1.23", "1.23e1"]) {
+  for (const testReplacement of ["(1.23)", "(-1.23)"]) {
     const replaced = sanitizedAmt.replace(/(IPROD|EPROD|IINV|EINV)/g, testReplacement);
     let evaluated, error;
     try {

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -506,17 +506,10 @@ Error encountered: ${error}`);
   material.exports.push(exportObj);
 }
 
-export function CancelExportMaterial(divisionName: string, cityName: string, material: Material, amt: string): void {
-  for (let i = 0; i < material.exports.length; ++i) {
-    if (
-      material.exports[i].division !== divisionName ||
-      material.exports[i].city !== cityName ||
-      material.exports[i].amount !== amt
-    )
-      continue;
-    material.exports.splice(i, 1);
-    break;
-  }
+export function CancelExportMaterial(divisionName: string, cityName: CityName, material: Material): void {
+  const index = material.exports.findIndex((exp) => exp.division === divisionName && exp.city === cityName);
+  if (index === -1) return;
+  material.exports.splice(index, 1);
 }
 
 export function LimitProductProduction(product: Product, cityName: CityName, quantity: number): void {

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -434,7 +434,12 @@ export class Division {
               const divider = requiredMatsEntries.length;
               for (const [reqMatName, reqMat] of requiredMatsEntries) {
                 const reqMatQtyNeeded = reqMat * prod * producableFrac;
-                warehouse.materials[reqMatName].stored -= reqMatQtyNeeded;
+                // producableFrac already takes into account that we have enough stored
+                // Math.max is used here to avoid stored becoming negative (which can lead to NaNs)
+                warehouse.materials[reqMatName].stored = Math.max(
+                  0,
+                  warehouse.materials[reqMatName].stored - reqMatQtyNeeded,
+                );
                 warehouse.materials[reqMatName].productionAmount = 0;
                 warehouse.materials[reqMatName].productionAmount -=
                   reqMatQtyNeeded / (corpConstants.secondsPerMarketCycle * marketCycles);
@@ -446,7 +451,7 @@ export class Division {
                 let tempQlt =
                   office.employeeProductionByJob[CorpEmployeeJob.Engineer] / 90 +
                   Math.pow(this.researchPoints, this.researchFactor) +
-                  Math.pow(warehouse.materials["AI Cores"].stored, this.aiCoreFactor) / 10e3;
+                  Math.pow(Math.max(0, warehouse.materials["AI Cores"].stored), this.aiCoreFactor) / 10e3;
                 const logQlt = Math.max(Math.pow(tempQlt, 0.5), 1);
                 tempQlt = Math.min(tempQlt, avgQlt * logQlt);
                 warehouse.materials[this.producedMaterials[j]].quality = Math.max(

--- a/src/Corporation/ui/modals/ExportModal.tsx
+++ b/src/Corporation/ui/modals/ExportModal.tsx
@@ -54,7 +54,7 @@ export function ExportModal(props: IProps): React.ReactElement {
 
   function exportMaterial(): void {
     try {
-      ExportMaterial(targetDivision.name, targetCity, props.mat, exportAmount, targetDivision);
+      ExportMaterial(targetDivision, targetCity, props.mat, exportAmount);
     } catch (err) {
       dialogBoxCreate(err + "");
     }

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -465,17 +465,11 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
         checkAccess(ctx, CorpUnlockName.WarehouseAPI);
         const sourceDivision = helpers.string(ctx, "sourceDivision", _sourceDivision);
         assertMember(ctx, CityName, "City", "sourceCity", sourceCity);
-        const targetDivision = helpers.string(ctx, "targetDivision", _targetDivision);
+        const targetDivision = getDivision(helpers.string(ctx, "targetDivision", _targetDivision));
         assertMember(ctx, CityName, "City", "targetCity", targetCity);
         assertMember(ctx, corpConstants.materialNames, "Material Name", "materialName", materialName);
         const amt = helpers.string(ctx, "amt", _amt);
-        ExportMaterial(
-          targetDivision,
-          targetCity,
-          getMaterial(sourceDivision, sourceCity, materialName),
-          amt + "",
-          getDivision(targetDivision),
-        );
+        ExportMaterial(targetDivision, targetCity, getMaterial(sourceDivision, sourceCity, materialName), amt);
       },
     cancelExportMaterial:
       (ctx) =>

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -473,15 +473,14 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       },
     cancelExportMaterial:
       (ctx) =>
-      (_sourceDivision, sourceCity, _targetDivision, targetCity, materialName, _amt): void => {
+      (_sourceDivision, sourceCity, _targetDivision, targetCity, materialName): void => {
         checkAccess(ctx, CorpUnlockName.WarehouseAPI);
         const sourceDivision = helpers.string(ctx, "sourceDivision", _sourceDivision);
         assertMember(ctx, CityName, "City Name", "sourceCity", sourceCity);
         const targetDivision = helpers.string(ctx, "targetDivision", _targetDivision);
         assertMember(ctx, CityName, "City Name", "targetCity", targetCity);
         assertMember(ctx, corpConstants.materialNames, "Material Name", "materialName", materialName);
-        const amt = helpers.string(ctx, "amt", _amt);
-        CancelExportMaterial(targetDivision, targetCity, getMaterial(sourceDivision, sourceCity, materialName), amt);
+        CancelExportMaterial(targetDivision, targetCity, getMaterial(sourceDivision, sourceCity, materialName));
       },
     limitMaterialProduction: (ctx) => (_divisionName, cityName, materialName, _qty) => {
       checkAccess(ctx, CorpUnlockName.WarehouseAPI);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7093,7 +7093,6 @@ export interface WarehouseAPI {
    * @param targetDivision - Target division
    * @param targetCity - Target city
    * @param materialName - Name of the material
-   * @param amt - Amount of material to export.
    */
   cancelExportMaterial(
     sourceDivision: string,
@@ -7101,7 +7100,6 @@ export interface WarehouseAPI {
     targetDivision: string,
     targetCity: CityName | `${CityName}`,
     materialName: string,
-    amt: number,
   ): void;
   /**
    * Purchase warehouse for a new city


### PR DESCRIPTION
1. Corrected the testing for player input on exports, now uses parentheses like the way the replacement is performed ingame.
2. Prevents exporting to the source city.
3. Prevents exporting to a city that does not have a warehouse for the target division. 
4. Provide better error messaging to player when an export fails.
    * Old error message, would display constantly during processing: 
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/bee6051a-0164-4f3f-8051-f13377827f7e)
    * New error message: Checks before setting export to prevent setting invalid amount: (outdated image, -IPROD is fine as an input)
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/05b6d11f-39b7-4bfc-8d08-d130dc813387)
5. Same validation is performed on gameload for saves older than 2.3.1 release.
    * Terminal error informs the player if any of their exports failed: 
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/17ee6755-4196-452e-b40e-7ccffb4e691c)
    * Console error shows full details ("sellAmt" is just the source division's name): 
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/74d7657f-43df-4577-9ef8-11a8ffdeaf7d)
6. Can no longer have the same material get exported from one warehouse to another multiple times through duplicate exports objects.
7. Canceling an export no longer requires the exact stored amount for the export.

Separate from exports, also fixed a NaN bug that could affect produced materials in Robotics industry (or any other industry that uses AI Cores as a required material)