### PR TITLE
CORP: Validate city with office for starting product development

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -386,23 +386,18 @@ export function MakeProduct(
   designInvest: number,
   marketingInvest: number,
 ): void {
-  if (designInvest < 0) {
-    designInvest = 0;
-  }
-  if (marketingInvest < 0) {
-    marketingInvest = 0;
+  // For invalid investment inputs, just use 0
+  if (isNaN(designInvest) || designInvest < 0) designInvest = 0;
+  if (isNaN(marketingInvest) || marketingInvest < 0) marketingInvest = 0;
+
+  if (!division.offices[city]) {
+    throw new Error(`Cannot develop a product in a city without an office!`);
   }
   if (productName == null || productName === "") {
     throw new Error("You must specify a name for your product!");
   }
   if (!division.makesProducts) {
     throw new Error("You cannot create products for this industry!");
-  }
-  if (isNaN(designInvest)) {
-    throw new Error("Invalid value for design investment");
-  }
-  if (isNaN(marketingInvest)) {
-    throw new Error("Invalid value for marketing investment");
   }
   if (corp.funds < designInvest + marketingInvest) {
     throw new Error("You don't have enough company funds to make this large of an investment");
@@ -412,7 +407,7 @@ export function MakeProduct(
   }
 
   const product = new Product({
-    name: productName.replace(/[<>]/g, "").trim(), //Sanitize for HTMl elements
+    name: productName.replace(/[<>]/g, "").trim(), //Sanitize for HTMl elements?
     createCity: city,
     designInvestment: designInvest,
     advertisingInvestment: marketingInvest,

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -713,8 +713,10 @@ export class Division {
         if (this.state !== "PRODUCTION") continue;
         const city = product.creationCity;
         const office = this.offices[city];
-        if (!office) throw new Error(`Product ${name} being created in a city without an office. This is a bug.`);
-
+        if (!office) {
+          console.error(`Product ${name} being created in a city without an office. This is a bug.`);
+          continue;
+        }
         product.createProduct(marketCycles, office.employeeProductionByJob);
         if (product.developmentProgress >= 100) {
           product.finishProduct(this);


### PR DESCRIPTION
Using ns.makeProduct, it was possible to start product development in an invalid city, which would error out the corp processing loop.

Now an error will be generated if a product development is started with an invalid city (and the product will not begin development), and also savegames with this invalid data can be safely loaded without immediately erroring out (error for an existing product having a wrong office is now just logged to console).

Fixes #569 