### PR TITLE
CORP: Update exportMaterial amount to number | string

### DIFF
--- a/markdown/bitburner.warehouseapi.exportmaterial.md
+++ b/markdown/bitburner.warehouseapi.exportmaterial.md
@@ -15,7 +15,7 @@ exportMaterial(
     targetDivision: string,
     targetCity: CityName | `${CityName}`,
     materialName: string,
-    amt: number,
+    amt: number | string,
   ): void;
 ```
 
@@ -28,7 +28,7 @@ exportMaterial(
 |  targetDivision | string | Target division |
 |  targetCity | [CityName](./bitburner.cityname.md) \| \`${[CityName](./bitburner.cityname.md)<!-- -->}\` | Target city |
 |  materialName | string | Name of the material |
-|  amt | number | Amount of material to export. |
+|  amt | number \| string | Amount of material to export. |
 
 **Returns:**
 

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -478,7 +478,7 @@ Attempted export amount: ${amount}`);
   let sanitizedAmt = amount.replace(/\s+/g, "").toUpperCase();
   sanitizedAmt = sanitizedAmt.replace(/[^-()\d/*+.MAXEPRODINV]/g, "");
   for (const testReplacement of ["(1.23)", "(-1.23)"]) {
-    const replaced = sanitizedAmt.replace(/(IPROD|EPROD|IINV|EINV)/g, testReplacement);
+    const replaced = sanitizedAmt.replace(/(MAX|IPROD|EPROD|IINV|EINV)/g, testReplacement);
     let evaluated, error;
     try {
       evaluated = eval(replaced);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7084,7 +7084,7 @@ export interface WarehouseAPI {
     targetDivision: string,
     targetCity: CityName | `${CityName}`,
     materialName: string,
-    amt: number,
+    amt: number | string,
   ): void;
   /**
    * Cancel material export


### PR DESCRIPTION
`exportMaterial` in the typescript definitions was just a number, should be a string to match the interface (so you can use MAX, IPROD, etc)
Fix bug with exportMaterial amount MAX, looks like it was missed in the or condition when the last update for robotics was pushed.  


