### PR TITLE
DOC: Fix renamePurchasedServer.rst

### DIFF
--- a/doc/source/netscript/basicfunctions/renamePurchasedServer.rst
+++ b/doc/source/netscript/basicfunctions/renamePurchasedServer.rst
@@ -8,12 +8,7 @@ renamePurchasedServer() Netscript Function
     :param string newName: New name for the given server.
     :returns: ``true`` if the renaming was succesful.
 
-    Upgrades the purchased server with the specified hostname to have specified amount of RAM.
-
-    The ``hostname`` argument can be any data type, but it will be converted to
-    a string and have whitespace removed. New RAM amount has to be higher than the current RAM
-    and a power of 2. Upgrading a server costs the difference of old RAM server cost and new RAM
-    server cost.
+    Renames the purchased server with the specified ``hostname`` to have the new name ``newName``.
 
     Example:
 


### PR DESCRIPTION
DOCS, TYPO: Fixed description of renamePurchasedServer() which was incorrectly copied from upgradePurchasedServer().