### PR TITLE
UI: Prevent log scrolling on Active Script window drag

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -290,7 +290,9 @@ function LogWindow(props: IProps): React.ReactElement {
     return !(bounds.right < 0 || bounds.bottom < 0 || bounds.left > innerWidth || bounds.top > outerWidth);
   };
 
-  const boundToBody = (e: DraggableEvent): void | false => {
+  const onDrag = (e: DraggableEvent): void | false => {
+    e.preventDefault();
+    // bound to body
     if (
       e instanceof MouseEvent &&
       (e.clientX < 0 || e.clientY < 0 || e.clientX > innerWidth || e.clientY > innerHeight)
@@ -302,7 +304,7 @@ function LogWindow(props: IProps): React.ReactElement {
   const minConstraints: [number, number] = [150, 33];
 
   return (
-    <Draggable handle=".drag" onDrag={boundToBody} ref={rootRef} onMouseDown={updateLayer}>
+    <Draggable handle=".drag" onDrag={onDrag} ref={rootRef} onMouseDown={updateLayer}>
       <Box
         display="flex"
         sx={{


### PR DESCRIPTION
This bug was originally reported in [discord](https://discord.com/channels/415207508303544321/415213413745164318/1117144649807704134).

The fix was tested on the latest dev version locally.