### PR TITLE
allowing empty Terminal new lines

### DIFF
--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -194,11 +194,15 @@ export function TerminalInput(): React.ReactElement {
   async function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): Promise<void> {
     const ref = terminalInput.current;
 
-    // Run command.
-    if (event.key === KEY.ENTER && value !== "") {
+    // Run command or insert newline.
+    if (event.key === KEY.ENTER) {
       event.preventDefault();
-      Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
-      Terminal.executeCommands(value);
+      if (value !== "") {
+        Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
+        Terminal.executeCommands(value);
+      } else {
+        Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]>`);
+      }
       saveValue("");
       return;
     }


### PR DESCRIPTION
CATEGORY: UI 
Allowing empty prompts in terminal so that someone who is used to the terminal can utilize the spamming of Enter to visually separate the commands he already ran and thus creating new lines.