### PR TITLE
MISC: fix sleeve university job

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -214,23 +214,25 @@ export class Sleeve extends Person implements SleevePerson {
 
     // Set experience/money gains based on class
     let classType: ClassType | undefined;
+    // TODO: why lower case??? It's not effecient, not typesafe and in general a bad idea
     switch (className.toLowerCase()) {
-      case "study computer science":
+      case "study computer science": // deprecated, leave it here for backwards compatibility
+      case ClassType.computerScience.toLowerCase():
         classType = UniversityClassType.computerScience;
         break;
-      case "data structures":
+      case ClassType.dataStructures.toLowerCase():
         classType = UniversityClassType.dataStructures;
         break;
-      case "networks":
+      case ClassType.networks.toLowerCase():
         classType = UniversityClassType.networks;
         break;
-      case "algorithms":
+      case ClassType.algorithms.toLowerCase():
         classType = UniversityClassType.algorithms;
         break;
-      case "management":
+      case ClassType.management.toLowerCase():
         classType = UniversityClassType.management;
         break;
-      case "leadership":
+      case ClassType.leadership.toLowerCase():
         classType = UniversityClassType.leadership;
         break;
     }


### PR DESCRIPTION
The "compute since" class type was mistyped as "study computer science".
Used the ClassType enum to fix this issue.
Ideally `takeUniversityCourse` should accept only ClassType as an argument, but `SleeveElem.tsx` will have to be rewritten to support this. So this is just a quick fix.