### PR TITLE
TERMINAL: Allow new lines in terminal when empty  

### DIFF
--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -194,11 +194,11 @@ export function TerminalInput(): React.ReactElement {
   async function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): Promise<void> {
     const ref = terminalInput.current;
 
-    // Run command or insert newline.
+    // Run command or insert newline
     if (event.key === KEY.ENTER) {
       event.preventDefault();
       Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
-      if (value !== "") {
+      if (value) {
         Terminal.executeCommands(value);
         saveValue("");
       }

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -194,12 +194,14 @@ export function TerminalInput(): React.ReactElement {
   async function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): Promise<void> {
     const ref = terminalInput.current;
 
-    // Run command.
-    if (event.key === KEY.ENTER && value !== "") {
+    // Run command or insert newline.
+    if (event.key === KEY.ENTER) {
       event.preventDefault();
       Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
-      Terminal.executeCommands(value);
-      saveValue("");
+      if (value !== "") {
+        Terminal.executeCommands(value);
+        saveValue("");
+      }
       return;
     }
 


### PR DESCRIPTION
CATEGORY: UI
Allowing empty prompts in terminal so that someone who is used to the terminal can utilise the spamming of Enter to visually separate the commands he already ran and thus creating new lines.
P.S. Thanks to User: Snarling for tips and directions on improving the implementation of the code! 