### PR TITLE
FIX: RAM calculation on a different server

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -137,7 +137,10 @@ function Root(props: IProps): React.ReactElement {
 
   const debouncedCodeParsing = debounce((newCode: string) => {
     infLoop(newCode);
-    updateRAM(!currentScript || currentScript.isTxt ? null : newCode);
+    updateRAM(
+      !currentScript || currentScript.isTxt ? null : newCode,
+      currentScript && GetServer(currentScript.hostname),
+    );
     finishUpdatingRAM();
   }, 300);
 


### PR DESCRIPTION
Steps to reproduce the original bug:
1. create two script files on the same server
2. import the second script from the first script
3. open the first script in the script editor, check RAM usage
4. open the terminal and switch server, then open the script editor and check RAM again - should print the same value as in step no.3, but currently prints "Import error"

Tested locally using steps above. 
