### PR TITLE
UI: Fix regression for crime in progress

### DIFF
--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-
-import { Box, Container, Paper, Table, TableBody, TableRow, TableCell, Tooltip } from "@mui/material";
-import Button from "@mui/material/Button";
-import Typography from "@mui/material/Typography";
+import { Box, Button, Container, Paper, Table, TableBody, Tooltip, Typography } from "@mui/material";
 
 import { Player } from "@player";
 import { FactionWorkType, LocationName } from "@enums";
@@ -220,14 +217,12 @@ export function WorkInProgressRoot(): React.ReactElement {
       title: `You are attempting ${crime.workName}`,
 
       gains: [
-        <TableRow key="header">
-          <TableCell>
-            <Typography>Success chance: ${formatPercent(successChance)}</Typography>
-          </TableCell>
-          <TableCell>
+        <tr key="header">
+          <td>
+            <Typography>Success chance: {formatPercent(successChance)}</Typography>
             <Typography>Gains (on success)</Typography>
-          </TableCell>
-        </TableRow>,
+          </td>
+        </tr>,
         <StatsRow key="money" name="Money:" color={Settings.theme.money}>
           <Typography>
             <Money money={gains.money} />


### PR DESCRIPTION
Just fixes the structure so that the `Gains (on success)` header is still displayed on the left side, and fixed an issue with a rogue $ in the success chance %

2.3.1:
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/e0ff4cb9-4330-4931-8df9-1bfb76b809cb)

2.3.2 Pre-PR:
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/5c7f6508-7cc0-4982-9232-a77e0c203e76)

After PR:
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/df00310e-5e64-4ff0-9e98-3bf7170e7f2d)