### PR TITLE
FIX: show ram calculation error reason to player

### DIFF
--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -362,17 +362,17 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsR
 
 /**
  * Calculate's a scripts RAM Usage
- * @param {string} codeCopy - The script's code
+ * @param {string} code - The script's code
  * @param {Script[]} otherScripts - All other scripts on the server.
  *                                  Used to account for imported scripts
  */
 export function calculateRamUsage(
-  codeCopy: string,
+  code: string,
   otherScripts: Map<ScriptFilePath, Script>,
   ns1?: boolean,
 ): RamCalculation {
   try {
-    return parseOnlyRamCalculate(otherScripts, codeCopy, ns1);
+    return parseOnlyRamCalculate(otherScripts, code, ns1);
   } catch (e) {
     console.error(`Failed to parse script for RAM calculations:`);
     console.error(e);

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -22,10 +22,17 @@ export interface RamUsageEntry {
   cost: number;
 }
 
-export interface RamCalculation {
+export type RamCalculationSuccess = {
   cost: number;
-  entries?: RamUsageEntry[];
-}
+  entries: RamUsageEntry[];
+};
+
+export type RamCalculationFailure = {
+  errorCode: RamCalculationErrorCode;
+  error?: Error;
+};
+
+export type RamCalculation = RamCalculationSuccess | RamCalculationFailure;
 
 // These special strings are used to reference the presence of a given logical
 // construct within a user script.
@@ -80,115 +87,108 @@ function parseOnlyRamCalculate(otherScripts: Map<ScriptFilePath, Script>, code: 
     dependencyMap = Object.assign(dependencyMap, result.dependencyMap);
   }
 
-  try {
-    // Parse the initial module, which is the "main" script that is being run
-    const initialModule = "__SPECIAL_INITIAL_MODULE__";
-    parseCode(code, initialModule);
+  // Parse the initial module, which is the "main" script that is being run
+  const initialModule = "__SPECIAL_INITIAL_MODULE__";
+  parseCode(code, initialModule);
 
-    // Process additional modules, which occurs if the "main" script has any imports
-    while (parseQueue.length > 0) {
-      const nextModule = parseQueue.shift();
-      if (nextModule === undefined) throw new Error("nextModule should not be undefined");
-      if (nextModule.startsWith("https://") || nextModule.startsWith("http://")) continue;
+  // Process additional modules, which occurs if the "main" script has any imports
+  while (parseQueue.length > 0) {
+    const nextModule = parseQueue.shift();
+    if (nextModule === undefined) throw new Error("nextModule should not be undefined");
+    if (nextModule.startsWith("https://") || nextModule.startsWith("http://")) continue;
 
-      // Using root as the path base right now. Difficult to implement
-      const filename = resolveScriptFilePath(nextModule, root, ns1 ? ".script" : ".js");
-      if (!filename) return { cost: RamCalculationErrorCode.ImportError }; // Invalid import path
-      const script = otherScripts.get(filename);
-      if (!script) return { cost: RamCalculationErrorCode.ImportError }; // No such file on server
+    // Using root as the path base right now. Difficult to implement
+    const filename = resolveScriptFilePath(nextModule, root, ns1 ? ".script" : ".js");
+    if (!filename) return { errorCode: RamCalculationErrorCode.ImportError }; // Invalid import path
+    const script = otherScripts.get(filename);
+    if (!script) return { errorCode: RamCalculationErrorCode.ImportError }; // No such file on server
 
-      parseCode(script.code, nextModule);
+    parseCode(script.code, nextModule);
+  }
+
+  // Finally, walk the reference map and generate a ram cost. The initial set of keys to scan
+  // are those that start with __SPECIAL_INITIAL_MODULE__.
+  let ram = RamCostConstants.Base;
+  const detailedCosts: RamUsageEntry[] = [{ type: "misc", name: "baseCost", cost: RamCostConstants.Base }];
+  const unresolvedRefs = Object.keys(dependencyMap).filter((s) => s.startsWith(initialModule));
+  const resolvedRefs = new Set();
+  const loadedFns: Record<string, boolean> = {};
+  while (unresolvedRefs.length > 0) {
+    const ref = unresolvedRefs.shift();
+    if (ref === undefined) throw new Error("ref should not be undefined");
+
+    // Check if this is one of the special keys, and add the appropriate ram cost if so.
+    if (ref === "hacknet" && !resolvedRefs.has("hacknet")) {
+      ram += RamCostConstants.HacknetNodes;
+      detailedCosts.push({ type: "ns", name: "hacknet", cost: RamCostConstants.HacknetNodes });
+    }
+    if (ref === "document" && !resolvedRefs.has("document")) {
+      ram += RamCostConstants.Dom;
+      detailedCosts.push({ type: "dom", name: "document", cost: RamCostConstants.Dom });
+    }
+    if (ref === "window" && !resolvedRefs.has("window")) {
+      ram += RamCostConstants.Dom;
+      detailedCosts.push({ type: "dom", name: "window", cost: RamCostConstants.Dom });
     }
 
-    // Finally, walk the reference map and generate a ram cost. The initial set of keys to scan
-    // are those that start with __SPECIAL_INITIAL_MODULE__.
-    let ram = RamCostConstants.Base;
-    const detailedCosts: RamUsageEntry[] = [{ type: "misc", name: "baseCost", cost: RamCostConstants.Base }];
-    const unresolvedRefs = Object.keys(dependencyMap).filter((s) => s.startsWith(initialModule));
-    const resolvedRefs = new Set();
-    const loadedFns: Record<string, boolean> = {};
-    while (unresolvedRefs.length > 0) {
-      const ref = unresolvedRefs.shift();
-      if (ref === undefined) throw new Error("ref should not be undefined");
+    resolvedRefs.add(ref);
 
-      // Check if this is one of the special keys, and add the appropriate ram cost if so.
-      if (ref === "hacknet" && !resolvedRefs.has("hacknet")) {
-        ram += RamCostConstants.HacknetNodes;
-        detailedCosts.push({ type: "ns", name: "hacknet", cost: RamCostConstants.HacknetNodes });
-      }
-      if (ref === "document" && !resolvedRefs.has("document")) {
-        ram += RamCostConstants.Dom;
-        detailedCosts.push({ type: "dom", name: "document", cost: RamCostConstants.Dom });
-      }
-      if (ref === "window" && !resolvedRefs.has("window")) {
-        ram += RamCostConstants.Dom;
-        detailedCosts.push({ type: "dom", name: "window", cost: RamCostConstants.Dom });
-      }
-
-      resolvedRefs.add(ref);
-
-      if (ref.endsWith(".*")) {
-        // A prefix reference. We need to find all matching identifiers.
-        const prefix = ref.slice(0, ref.length - 2);
-        for (const ident of Object.keys(dependencyMap).filter((k) => k.startsWith(prefix))) {
-          for (const dep of dependencyMap[ident] || []) {
-            if (!resolvedRefs.has(dep)) unresolvedRefs.push(dep);
-          }
-        }
-      } else {
-        // An exact reference. Add all dependencies of this ref.
-        for (const dep of dependencyMap[ref] || []) {
+    if (ref.endsWith(".*")) {
+      // A prefix reference. We need to find all matching identifiers.
+      const prefix = ref.slice(0, ref.length - 2);
+      for (const ident of Object.keys(dependencyMap).filter((k) => k.startsWith(prefix))) {
+        for (const dep of dependencyMap[ident] || []) {
           if (!resolvedRefs.has(dep)) unresolvedRefs.push(dep);
         }
       }
-
-      // Check if this identifier is a function in the workerScript environment.
-      // If it is, then we need to get its RAM cost.
-      try {
-        // Only count each function once
-        if (loadedFns[ref]) {
-          continue;
-        }
-        loadedFns[ref] = true;
-
-        // This accounts for namespaces (Bladeburner, CodingContract, etc.)
-        const findFunc = (
-          prefix: string,
-          obj: object,
-          ref: string,
-        ): { func: () => number | number; refDetail: string } | undefined => {
-          if (!obj) return;
-          const elem = Object.entries(obj).find(([key]) => key === ref);
-          if (elem !== undefined && (typeof elem[1] === "function" || typeof elem[1] === "number")) {
-            return { func: elem[1], refDetail: `${prefix}${ref}` };
-          }
-          for (const [key, value] of Object.entries(obj)) {
-            const found = findFunc(`${key}.`, value, ref);
-            if (found) return found;
-          }
-          return undefined;
-        };
-
-        const details = findFunc("", RamCosts, ref);
-        const fnRam = getNumericCost(details?.func ?? 0);
-        ram += fnRam;
-        detailedCosts.push({ type: "fn", name: details?.refDetail ?? "", cost: fnRam });
-      } catch (error) {
-        console.error(error);
-        continue;
+    } else {
+      // An exact reference. Add all dependencies of this ref.
+      for (const dep of dependencyMap[ref] || []) {
+        if (!resolvedRefs.has(dep)) unresolvedRefs.push(dep);
       }
     }
-    if (ram > RamCostConstants.Max) {
-      ram = RamCostConstants.Max;
-      detailedCosts.push({ type: "misc", name: "Max Ram Cap", cost: RamCostConstants.Max });
+
+    // Check if this identifier is a function in the workerScript environment.
+    // If it is, then we need to get its RAM cost.
+    try {
+      // Only count each function once
+      if (loadedFns[ref]) {
+        continue;
+      }
+      loadedFns[ref] = true;
+
+      // This accounts for namespaces (Bladeburner, CodingContract, etc.)
+      const findFunc = (
+        prefix: string,
+        obj: object,
+        ref: string,
+      ): { func: () => number | number; refDetail: string } | undefined => {
+        if (!obj) return;
+        const elem = Object.entries(obj).find(([key]) => key === ref);
+        if (elem !== undefined && (typeof elem[1] === "function" || typeof elem[1] === "number")) {
+          return { func: elem[1], refDetail: `${prefix}${ref}` };
+        }
+        for (const [key, value] of Object.entries(obj)) {
+          const found = findFunc(`${key}.`, value, ref);
+          if (found) return found;
+        }
+        return undefined;
+      };
+
+      const details = findFunc("", RamCosts, ref);
+      const fnRam = getNumericCost(details?.func ?? 0);
+      ram += fnRam;
+      detailedCosts.push({ type: "fn", name: details?.refDetail ?? "", cost: fnRam });
+    } catch (error) {
+      console.error(error);
+      continue;
     }
-    return { cost: ram, entries: detailedCosts.filter((e) => e.cost > 0) };
-  } catch (error) {
-    // console.info("parse or eval error: ", error);
-    // This is not unexpected. The user may be editing a script, and it may be in
-    // a transitory invalid state.
-    return { cost: RamCalculationErrorCode.SyntaxError };
   }
+  if (ram > RamCostConstants.Max) {
+    ram = RamCostConstants.Max;
+    detailedCosts.push({ type: "misc", name: "Max Ram Cap", cost: RamCostConstants.Max });
+  }
+  return { cost: ram, entries: detailedCosts.filter((e) => e.cost > 0) };
 }
 
 export function checkInfiniteLoop(code: string): number {
@@ -376,6 +376,14 @@ export function calculateRamUsage(
   } catch (e) {
     console.error(`Failed to parse script for RAM calculations:`);
     console.error(e);
-    return { cost: RamCalculationErrorCode.SyntaxError };
+    return { errorCode: RamCalculationErrorCode.SyntaxError, error: e instanceof Error ? e : undefined };
   }
+}
+
+export function isRamCalculationFailure(ramCalculation: RamCalculation): ramCalculation is RamCalculationFailure {
+  return "errorCode" in ramCalculation;
+}
+
+export function isRamCalculationSuccess(ramCalculation: RamCalculation): ramCalculation is RamCalculationSuccess {
+  return "cost" in ramCalculation;
 }

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -382,8 +382,9 @@ export function calculateRamUsage(
   try {
     return parseOnlyRamCalculate(otherScripts, code, ns1);
   } catch (e) {
-    console.error(`Failed to parse script for RAM calculations:`);
-    console.error(e);
-    return { errorCode: RamCalculationErrorCode.SyntaxError, errorMessage: e instanceof Error ? e.message : undefined };
+    return {
+      errorCode: RamCalculationErrorCode.SyntaxError,
+      errorMessage: e instanceof Error ? e.message : undefined,
+    };
   }
 }

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -25,9 +25,13 @@ export interface RamUsageEntry {
 export type RamCalculationSuccess = {
   cost: number;
   entries: RamUsageEntry[];
+  error?: never;
+  errorCode?: never;
 };
 
 export type RamCalculationFailure = {
+  cost?: never;
+  entries?: never;
   errorCode: RamCalculationErrorCode;
   error?: Error;
 };
@@ -378,12 +382,4 @@ export function calculateRamUsage(
     console.error(e);
     return { errorCode: RamCalculationErrorCode.SyntaxError, error: e instanceof Error ? e : undefined };
   }
-}
-
-export function isRamCalculationFailure(ramCalculation: RamCalculation): ramCalculation is RamCalculationFailure {
-  return "errorCode" in ramCalculation;
-}
-
-export function isRamCalculationSuccess(ramCalculation: RamCalculation): ramCalculation is RamCalculationSuccess {
-  return "cost" in ramCalculation;
 }

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -17,7 +17,7 @@ export class Script implements ContentFile {
   // Ram calculation, only exists after first poll of ram cost after updating
   ramUsage: number | null = null;
   ramUsageEntries: RamUsageEntry[] = [];
-  ramCalculationError?: Error | null = null;
+  ramCalculationError?: string | null = null;
 
   // Runtime data that only exists when the script has been initiated. Cleared when script or a dependency script is updated.
   mod: LoadedModule | null = null;
@@ -98,7 +98,7 @@ export class Script implements ContentFile {
     }
 
     this.ramUsage = null;
-    this.ramCalculationError = ramCalc.error ?? null;
+    this.ramCalculationError = ramCalc.errorMessage ?? null;
   }
 
   /** Remove script from server. Fails if the provided server isn't the server for this script. */

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -17,7 +17,7 @@ export class Script implements ContentFile {
   // Ram calculation, only exists after first poll of ram cost after updating
   ramUsage: number | null = null;
   ramUsageEntries: RamUsageEntry[] = [];
-  ramCalculationError?: string | null = null;
+  ramCalculationError: string | null = null;
 
   // Runtime data that only exists when the script has been initiated. Cleared when script or a dependency script is updated.
   mod: LoadedModule | null = null;

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -1,5 +1,5 @@
 import type { BaseServer } from "../Server/BaseServer";
-import { calculateRamUsage, isRamCalculationFailure, isRamCalculationSuccess, RamUsageEntry } from "./RamCalculations";
+import { calculateRamUsage, RamUsageEntry } from "./RamCalculations";
 import { LoadedModule, ScriptURL } from "./LoadedModule";
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, constructorsForReviver } from "../utils/JSONReviver";
 import { roundToTwo } from "../utils/helpers/roundToTwo";
@@ -90,7 +90,7 @@ export class Script implements ContentFile {
    */
   updateRamUsage(otherScripts: Map<ScriptFilePath, Script>): void {
     const ramCalc = calculateRamUsage(this.code, otherScripts, this.filename.endsWith(".script"));
-    if (isRamCalculationSuccess(ramCalc) && ramCalc.cost >= RamCostConstants.Base) {
+    if (ramCalc.cost && ramCalc.cost >= RamCostConstants.Base) {
       this.ramUsage = roundToTwo(ramCalc.cost);
       this.ramUsageEntries = ramCalc.entries as RamUsageEntry[];
       this.ramCalculationError = null;
@@ -98,7 +98,7 @@ export class Script implements ContentFile {
     }
 
     this.ramUsage = null;
-    this.ramCalculationError = isRamCalculationFailure(ramCalc) ? ramCalc.error ?? null : null;
+    this.ramCalculationError = ramCalc.error ?? null;
   }
 
   /** Remove script from server. Fails if the provided server isn't the server for this script. */

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -1,5 +1,5 @@
 import type { BaseServer } from "../Server/BaseServer";
-import { calculateRamUsage, RamUsageEntry } from "./RamCalculations";
+import { calculateRamUsage, isRamCalculationFailure, isRamCalculationSuccess, RamUsageEntry } from "./RamCalculations";
 import { LoadedModule, ScriptURL } from "./LoadedModule";
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, constructorsForReviver } from "../utils/JSONReviver";
 import { roundToTwo } from "../utils/helpers/roundToTwo";
@@ -17,6 +17,7 @@ export class Script implements ContentFile {
   // Ram calculation, only exists after first poll of ram cost after updating
   ramUsage: number | null = null;
   ramUsageEntries: RamUsageEntry[] = [];
+  ramCalculationError?: Error | null = null;
 
   // Runtime data that only exists when the script has been initiated. Cleared when script or a dependency script is updated.
   mod: LoadedModule | null = null;
@@ -65,6 +66,7 @@ export class Script implements ContentFile {
     // Always clear ram usage
     this.ramUsage = null;
     this.ramUsageEntries.length = 0;
+    this.ramCalculationError = null;
     // Early return if there's already no URL
     if (!this.mod) return;
     this.mod = null;
@@ -88,12 +90,15 @@ export class Script implements ContentFile {
    */
   updateRamUsage(otherScripts: Map<ScriptFilePath, Script>): void {
     const ramCalc = calculateRamUsage(this.code, otherScripts, this.filename.endsWith(".script"));
-    if (ramCalc.cost >= RamCostConstants.Base) {
+    if (isRamCalculationSuccess(ramCalc) && ramCalc.cost >= RamCostConstants.Base) {
       this.ramUsage = roundToTwo(ramCalc.cost);
       this.ramUsageEntries = ramCalc.entries as RamUsageEntry[];
-    } else {
-      this.ramUsage = null;
+      this.ramCalculationError = null;
+      return;
     }
+
+    this.ramUsage = null;
+    this.ramCalculationError = isRamCalculationFailure(ramCalc) ? ramCalc.error ?? null : null;
   }
 
   /** Remove script from server. Fails if the provided server isn't the server for this script. */

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -49,12 +49,14 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
     }
 
     if (ramUsage.errorCode !== undefined) {
-      if (ramUsage.errorCode === RamCalculationErrorCode.ImportError) {
-        setRAM("RAM: Import Error");
-        setRamEntries([["Import Error", ""]]);
-      } else if (ramUsage.errorCode === RamCalculationErrorCode.SyntaxError) {
-        setRAM("RAM: Syntax Error");
-        setRamEntries([["Syntax Error", ramUsage.error?.message ?? ""]]);
+      setRamEntries([["Syntax Error", ramUsage.errorMessage ?? ""]]);
+      switch (ramUsage.errorCode) {
+        case RamCalculationErrorCode.ImportError:
+          setRAM("RAM: Import Error");
+          break;
+        case RamCalculationErrorCode.SyntaxError:
+          setRAM("RAM: Syntax Error");
+          break;
       }
     } else {
       setRAM("RAM: Syntax Error");

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 
 import { Settings } from "../../Settings/Settings";
-import { calculateRamUsage, isRamCalculationFailure, isRamCalculationSuccess } from "../../Script/RamCalculations";
+import { calculateRamUsage } from "../../Script/RamCalculations";
 import { RamCalculationErrorCode } from "../../Script/RamCalculationErrorCodes";
 import { formatRam } from "../../ui/formatNumber";
 import { useBoolean } from "../../ui/React/hooks";
@@ -36,7 +36,7 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
     }
 
     const ramUsage = calculateRamUsage(newCode, server.scripts);
-    if (isRamCalculationSuccess(ramUsage) && ramUsage.cost > 0) {
+    if (ramUsage.cost && ramUsage.cost > 0) {
       const entries = ramUsage.entries?.sort((a, b) => b.cost - a.cost) ?? [];
       const entriesDisp = [];
       for (const entry of entries) {
@@ -48,7 +48,7 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
       return;
     }
 
-    if (isRamCalculationFailure(ramUsage)) {
+    if (ramUsage.errorCode !== undefined) {
       if (ramUsage.errorCode === RamCalculationErrorCode.ImportError) {
         setRAM("RAM: Import Error");
         setRamEntries([["Import Error", ""]]);

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -34,8 +34,8 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
       setRamEntries([["N/A", ""]]);
       return;
     }
-    const codeCopy = newCode + "";
-    const ramUsage = calculateRamUsage(codeCopy, server.scripts);
+
+    const ramUsage = calculateRamUsage(newCode, server.scripts);
     if (isRamCalculationSuccess(ramUsage) && ramUsage.cost > 0) {
       const entries = ramUsage.entries?.sort((a, b) => b.cost - a.cost) ?? [];
       const entriesDisp = [];

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -31,7 +31,7 @@ export function runScript(path: ScriptFilePath, commandArgs: (string | number | 
 
   const singleRamUsage = script.getRamUsage(server.scripts);
   if (!singleRamUsage) {
-    return Terminal.error(`Error while calculating ram usage for this script. ${script.ramCalculationError?.message}`);
+    return Terminal.error(`Error while calculating ram usage for this script. ${script.ramCalculationError}`);
   }
 
   const ramUsage = singleRamUsage * numThreads;

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -24,17 +24,18 @@ export function runScript(path: ScriptFilePath, commandArgs: (string | number | 
   if (!isPositiveInteger(numThreads)) {
     return Terminal.error("Invalid number of threads specified. Number of threads must be an integer greater than 0");
   }
+  if (!server.hasAdminRights) return Terminal.error("Need root access to run script");
 
   // Todo: Switch out arg for something with typescript support
   const args = flags._ as ScriptArg[];
 
   const singleRamUsage = script.getRamUsage(server.scripts);
-  if (!singleRamUsage) return Terminal.error("Error while calculating ram usage for this script.");
+  if (!singleRamUsage) {
+    return Terminal.error(`Error while calculating ram usage for this script. ${script.ramCalculationError?.message}`);
+  }
 
   const ramUsage = singleRamUsage * numThreads;
   const ramAvailable = server.maxRam - server.ramUsed;
-
-  if (!server.hasAdminRights) return Terminal.error("Need root access to run script");
 
   if (ramUsage > ramAvailable + 0.001) {
     return Terminal.error(


### PR DESCRIPTION
There was a discussion in Discord where people complained about not being able to understand where exactly syntax error was detected in their code. This PR should give players a bit more transparency on what went wrong.

Now when RAM button is clicked in the Code Editor toolbar player should see where syntax error was found:

![image](https://github.com/bitburner-official/bitburner-src/assets/5138959/981272f9-deae-465c-b611-59502216b219)

And the same for running such script in the Terminal:

![image](https://github.com/bitburner-official/bitburner-src/assets/5138959/19680202-f22d-43c1-ab92-66087429ba33)

PR is also adding more info in case of import error:

![image](https://github.com/bitburner-official/bitburner-src/assets/5138959/0f212dfc-3ad9-437d-9489-2f9a86076258)

![image](https://github.com/bitburner-official/bitburner-src/assets/5138959/6797b9ab-d11a-4808-9a92-550a1062ac9e)

