### PR TITLE
MISC: add log window size lock/unlock feature

### DIFF
--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -9,7 +9,7 @@ Collection of all functions passed to scripts
 **Signature:**
 
 ```typescript
-export interface NS 
+export interface NS
 ```
 
 ## Remarks
@@ -145,6 +145,7 @@ export async function main(ns) {
 |  [relaysmtp(host)](./bitburner.ns.relaysmtp.md) | Runs relaySMTP.exe on a server. |
 |  [renamePurchasedServer(hostname, newName)](./bitburner.ns.renamepurchasedserver.md) | Rename a purchased server. |
 |  [resizeTail(width, height, pid)](./bitburner.ns.resizetail.md) | Resize a tail window. |
+|  [setTailSizeLocked(isLocked, pid)](./bitburner.ns.setTailSizeLocked.md) | Resize a tail window. |
 |  [rm(name, host)](./bitburner.ns.rm.md) | Delete a file. |
 |  [run(script, threadOrOptions, args)](./bitburner.ns.run.md) | Start another script on the current server. |
 |  [scan(host)](./bitburner.ns.scan.md) | Get the list of servers connected to a server. |

--- a/markdown/bitburner.ns.resizetail.md
+++ b/markdown/bitburner.ns.resizetail.md
@@ -11,6 +11,15 @@ Resize a tail window.
 ```typescript
 resizeTail(width: number, height: number, pid?: number): void;
 ```
+## NS.setTailSizeLocked() method
+
+Locks or unlocks tail window resize.
+
+**Signature:**
+
+```typescript
+setTailSizeLocked(isLocked: boolean, pid?: number): void;
+```
 
 ## Parameters
 

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -539,6 +539,7 @@ export const RamCosts: RamCostTree<NSFull> = {
   toast: 0,
   moveTail: 0,
   resizeTail: 0,
+  setTailSizeLocked: 0,
   closeTail: 0,
   setTitle: 0,
   clearPort: 0,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -584,6 +584,17 @@ export const ns: InternalAPI<NSFull> = {
       }
       runningScriptObj.tailProps?.setSize(w, h);
     },
+  setTailSizeLocked:
+    (ctx) =>
+    (isLocked, _pid = ctx.workerScript.scriptRef.pid) => {
+      const pid = helpers.number(ctx, "pid", _pid);
+      const runningScriptObj = helpers.getRunningScript(ctx, pid);
+      if (runningScriptObj == null) {
+        helpers.log(ctx, () => helpers.getCannotFindRunningScriptErrorMessage(pid));
+        return;
+      }
+      runningScriptObj.tailProps?.setSizeLocked(!!isLocked);
+    },
   closeTail:
     (ctx) =>
     (_pid = ctx.workerScript.scriptRef.pid) => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5121,6 +5121,13 @@ export interface NS {
   resizeTail(width: number, height: number, pid?: number): void;
 
   /**
+   * Locks or unlocks tail window size
+   * @param isLocked - true to disable resizing, false to enable resizing
+   * @param pid - Optional. PID of the script having its tail resized. If omitted, the current script is used.
+   */
+  setTailSizeLocked(isLocked: boolean, pid?: number): void;
+
+  /**
    * Close the tail window of a script.
    * @remarks
    * RAM cost: 0 GB


### PR DESCRIPTION
There was a bit strange feature request in Discord: https://discord.com/channels/415207508303544321/415213435974975508/1120357898158080001

One of the options to address it could be
- add an icon to the tail window to lock/unlock window resize.
- add a new netscript function: `setTailSizeLocked`

Note: as per the current solution window won't be resized even with netscript functions if it's locked.

https://github.com/bitburner-official/bitburner-src/assets/5138959/50a873d1-cff5-44a6-b5f7-323a31a934e3

