### PR TITLE
QUICKFIX: Issue #630

### DIFF
--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -76,6 +76,7 @@ export function substituteAliases(origCommand: string): string {
 
     let somethingSubstituted = true;
     let depth = 0;
+    let lastAlias;
 
     while (somethingSubstituted && depth < 10) {
       depth++;
@@ -88,8 +89,9 @@ export function substituteAliases(origCommand: string): string {
       }
       for (let i = 0; i < commandArray.length; ++i) {
         const alias = GlobalAliases.get(commandArray[i])?.split(" ");
-        if (alias !== undefined) {
+        if (alias !== undefined && (commandArray[i] != lastAlias || somethingSubstituted)) {
           somethingSubstituted = true;
+          lastAlias = commandArray[i];
           commandArray.splice(i, 1, ...alias);
           i += alias.length - 1;
           //commandArray[i] = alias;


### PR DESCRIPTION
Prevent recursive alias by checking if the last resolved alias is about to be resolved again. Includes check to make sure chaining the same alias still works as expected:

alias script="run script.js script";
"script" will now resolve to "run script.js script"
"script script" would still resolve to "run script.js script run script.js script"