### PR TITLE
DOCS: Fix example code for scp

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5482,7 +5482,7 @@ export interface NS {
    * ns.scp("foo.lit", "home", "helios" );
    *
    * //Tries to copy three files from rothman-uni to home computer:
-   * files = ["foo1.lit", "foo2.txt", "foo3.js"];
+   * const files = ["foo1.lit", "foo2.txt", "foo3.js"];
    * ns.scp(files, "home", "rothman-uni");
    * ```
    * @example


### PR DESCRIPTION
"files" need to be a const, otherwise the example doesn't work. Tested directly in Bitburner.
Wanted to commit it directly to the .md files first. Snarling said that i would need to change it here.
