### PR TITLE
QUICKFIX: Fix drained money being floored in hack

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -491,7 +491,7 @@ function hack(
         maxThreadNeeded = 1e6;
       }
 
-      let moneyDrained = Math.floor(server.moneyAvailable * percentHacked) * threads;
+      let moneyDrained = server.moneyAvailable * percentHacked * threads;
 
       // Over-the-top safety checks
       if (moneyDrained <= 0) {


### PR DESCRIPTION
After discussion in the discord, it was discovered the hack function is flooring the money stolen when it probably shouldn't be.
This fix should make the actual money stolen from servers in the game more precise.

From hydro:
"The game says that the algorithm should be percent_for_one_thread * amount_of_threads However by adding the floor there it breaks that promise as the game can only ever take away a whole number of dollars from a server"