### PR TITLE
DOC: Fix URL for Speaking JavaScript

### DIFF
--- a/doc/source/netscript/netscriptlearntoprogram.rst
+++ b/doc/source/netscript/netscriptlearntoprogram.rst
@@ -16,7 +16,7 @@ Here are some good tutorials for learning programming/JavaScript as a beginner:
 
 * `Learn-JS <http://www.learn-js.org/en/Welcome>`_
 * `programiz <https://www.programiz.com/javascript/get-started>`_
-* `Speaking JavaScript <http://speakingjs.com/es5/index.html>`_
+* `Speaking JavaScript <https://exploringjs.com/es5/>`_
    This is a bit on the longer side. You can skip all of the historical
    background stuff. Recommended chapters: 1, 7-18
 


### PR DESCRIPTION
# Fix URL for Speaking JavaScript

Formatted as such:
DOC: Updated the link for the "Speaking JavaScript" URL as the page has from http://speakingjs.com/es5/index.html to https://exploringjs.com/es5/.

# Linked issues

closes #657 
