### PR TITLE
CORP: Prevent issues with invalid materials in warehouse

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -249,14 +249,26 @@ export function SetSmartSupplyOption(warehouse: Warehouse, material: Material, u
   warehouse.smartSupplyOptions[material.name] = useOption;
 }
 
-export function BuyMaterial(material: Material, amt: number): void {
+export function BuyMaterial(division: Division, material: Material, amt: number): void {
+  if (!isRelevantMaterial(material.name, division)) {
+    throw new Error(`${material.name} is not a relevant material for industry ${division.type}`);
+  }
   if (isNaN(amt) || amt < 0) {
     throw new Error(`Invalid amount '${amt}' to buy material '${material.name}'`);
   }
   material.buyAmount = amt;
 }
 
-export function BulkPurchase(corp: Corporation, warehouse: Warehouse, material: Material, amt: number): void {
+export function BulkPurchase(
+  corp: Corporation,
+  division: Division,
+  warehouse: Warehouse,
+  material: Material,
+  amt: number,
+): void {
+  if (!isRelevantMaterial(material.name, division)) {
+    throw new Error(`${material.name} is not a relevant material for industry ${division.type}`);
+  }
   const matSize = MaterialInfo[material.name].size;
   const maxAmount = (warehouse.size - warehouse.sizeUsed) / matSize;
   if (isNaN(amt) || amt < 0) {

--- a/src/Corporation/ui/modals/PurchaseMaterialModal.tsx
+++ b/src/Corporation/ui/modals/PurchaseMaterialModal.tsx
@@ -6,7 +6,7 @@ import { Material } from "../../Material";
 import { formatMatPurchaseAmount, formatMoney } from "../../../ui/formatNumber";
 import { BulkPurchase, BuyMaterial } from "../../Actions";
 import { Modal } from "../../../ui/React/Modal";
-import { useCorporation } from "../Context";
+import { useCorporation, useDivision } from "../Context";
 import Typography from "@mui/material/Typography";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
@@ -26,6 +26,7 @@ interface IBPProps {
 
 function BulkPurchaseSection(props: IBPProps): React.ReactElement {
   const corp = useCorporation();
+  const division = useDivision();
   const [buyAmt, setBuyAmt] = useState("");
   const [disabled, setDisabled] = useState(false);
 
@@ -64,7 +65,7 @@ function BulkPurchaseSection(props: IBPProps): React.ReactElement {
 
   function bulkPurchase(): void {
     try {
-      BulkPurchase(corp, props.warehouse, props.mat, parseFloat(buyAmt));
+      BulkPurchase(corp, division, props.warehouse, props.mat, parseFloat(buyAmt));
     } catch (err) {
       dialogBoxCreate(err + "");
     }
@@ -110,12 +111,13 @@ interface IProps {
 
 // Create a popup that lets the player purchase a Material
 export function PurchaseMaterialModal(props: IProps): React.ReactElement {
+  const division = useDivision();
   const [buyAmt, setBuyAmt] = useState(props.mat.buyAmount ? props.mat.buyAmount : 0);
 
   function purchaseMaterial(): void {
     if (buyAmt === null) return;
     try {
-      BuyMaterial(props.mat, buyAmt);
+      BuyMaterial(division, props.mat, buyAmt);
     } catch (err) {
       dialogBoxCreate(err + "");
     }

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -416,24 +416,28 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
     buyMaterial: (ctx) => (_divisionName, _cityName, _materialName, _amt) => {
       checkAccess(ctx, CorpUnlockName.WarehouseAPI);
       const divisionName = helpers.string(ctx, "divisionName", _divisionName);
+      const division = getCorporation().divisions.get(divisionName);
+      if (!division) throw helpers.makeRuntimeErrorMsg(ctx, `No division with provided name ${divisionName}`);
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
       const materialName = getEnumHelper("CorpMaterialName").nsGetMember(ctx, _materialName, "materialName");
       const amt = helpers.number(ctx, "amt", _amt);
       if (amt < 0 || !Number.isFinite(amt))
         throw new Error("Invalid value for amount field! Must be numeric and greater than 0");
       const material = getMaterial(divisionName, cityName, materialName);
-      BuyMaterial(material, amt);
+      BuyMaterial(division, material, amt);
     },
     bulkPurchase: (ctx) => (_divisionName, _cityName, _materialName, _amt) => {
       checkAccess(ctx, CorpUnlockName.WarehouseAPI);
       const divisionName = helpers.string(ctx, "divisionName", _divisionName);
+      const division = getCorporation().divisions.get(divisionName);
+      if (!division) throw helpers.makeRuntimeErrorMsg(ctx, `No division with provided name ${divisionName}`);
       const corporation = getCorporation();
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
       const materialName = getEnumHelper("CorpMaterialName").nsGetMember(ctx, _materialName, "materialName");
       const amt = helpers.number(ctx, "amt", _amt);
       const warehouse = getWarehouse(divisionName, cityName);
       const material = getMaterial(divisionName, cityName, materialName);
-      BulkPurchase(corporation, warehouse, material, amt);
+      BulkPurchase(corporation, division, warehouse, material, amt);
     },
     makeProduct:
       (ctx) =>


### PR DESCRIPTION
The UI only allows purchasing materials that are relevant to an industry (those involved in production or that provide bonuses). However, the API was not preventing purchase of other materials, which allowed a warehouse to get materials that were not expected and have no use for the division.

This PR prevents purchase of materials through the API that are not relevant to the industry, and also prevents an error that occurs in the export modal if a warehouse has any invalid materials.

Fixes #643 