### PR TITLE
FIX: Added checking export statements for renames

### DIFF
--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -360,6 +360,18 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsR
           const key = currentModule + "." + (node.id === null ? "__SPECIAL_DEFAULT_EXPORT__" : node.id.name);
           walk.recursive(node, { key: key }, commonVisitors());
         },
+        ExportNamedDeclaration: (node: Node, st: State, walkDeeper: walk.WalkerCallback<State>) => {
+          if (node.declaration !== null) {
+            // if this is true, the statement is not a named export, but rather a exported function/variable
+            walkDeeper(node.declaration, st);
+            return;
+          }
+          const specifiers = node.specifiers;
+
+          for (const specifier of specifiers) {
+            addRef(st.key, specifier.local.name);
+          }
+        },
       },
       commonVisitors(),
     ),


### PR DESCRIPTION
# Changes
The ram evaluation now includes any renames.

Before, exports like these were not included in the ram evaluation, leading to a wrong static ram count:

```ts
function expensiveFunction(ns) {
  ns.corporation.bribe();
}

export { expensiveFunction as myExportedFunction }
```

Now, the acorn walker checks if the export is an explicit export and adds the correct reference to the dependencies.

# Actions
- [X] lint
- [X] format
- [X] test