### PR TITLE
QUICKFIX: Fixed ram evaluation to include more edge-cases

### DIFF
--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -371,9 +371,9 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsR
           for (const specifier of specifiers) {
             // for every dependency with the local name, add a version with the exported name
 
-						const localDepName = currentModule + "." + specifier.local.name;
-						const exportedDepName = currentModule + "." + specifier.exported.name;
-            const localDep = (dependencyMap[localDepName] || (dependencyMap[localDepName] = new Set<string>()));
+            const localDepName = currentModule + "." + specifier.local.name;
+            const exportedDepName = currentModule + "." + specifier.exported.name;
+            const localDep = dependencyMap[localDepName] || (dependencyMap[localDepName] = new Set<string>());
             dependencyMap[exportedDepName] = localDep;
           }
         },

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -369,7 +369,9 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsR
           const specifiers = node.specifiers;
 
           for (const specifier of specifiers) {
-            addRef(st.key, specifier.local.name);
+            // for every dependency with the local name, add a version with the exported name
+            const localDep = dependencyMap[currentModule + "." + specifier.local.name];
+            dependencyMap[currentModule + "." + specifier.exported.name] = localDep;
           }
         },
       },

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -370,8 +370,11 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsR
 
           for (const specifier of specifiers) {
             // for every dependency with the local name, add a version with the exported name
-            const localDep = dependencyMap[currentModule + "." + specifier.local.name];
-            dependencyMap[currentModule + "." + specifier.exported.name] = localDep;
+
+						const localDepName = currentModule + "." + specifier.local.name;
+						const exportedDepName = currentModule + "." + specifier.exported.name;
+            const localDep = (dependencyMap[localDepName] || (dependencyMap[localDepName] = new Set<string>()));
+            dependencyMap[exportedDepName] = localDep;
           }
         },
       },


### PR DESCRIPTION
# Changes

I did some more testing regarding named exports. My last implementation had some big issues.
The code now no longer adds the entire imported file to the ram count, but only the actually imported function.
The code also accounts for situations, where the export statement comes before the actual declaration.

# Examples
```ts
import { expensiveFunction } from "expensive";

export async function main(ns) {
  const pos = expensiveFunction(ns);
}

// ---------------------
// expensive.js

export { a as expensiveFunction }
// before, because this comes before the declaration,
// this would reference undefined, instead of the actual dependencies

function a(ns) {
  return ns.stock.getPosition("ECP");
}

function b(ns) { // this function was included before
  ns.corporation.bribe();
}
```

# Actions
- [X] lint
- [X] format
- [X] test