### PR TITLE
NETSCRIPT: Rebalance the cost of sing.getOwnedSourceFiles

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -187,7 +187,7 @@ const singularity = {
   getCrimeChance: SF4Cost(RamCostConstants.SingularityFn3),
   getCrimeStats: SF4Cost(RamCostConstants.SingularityFn3),
   getOwnedAugmentations: SF4Cost(RamCostConstants.SingularityFn3),
-  getOwnedSourceFiles: SF4Cost(RamCostConstants.SingularityFn3),
+  getOwnedSourceFiles: RamCostConstants.SingularityFn3, // Intentionally not SF4Cost, since it doesn't require SF4
   getAugmentationsFromFaction: SF4Cost(RamCostConstants.SingularityFn3),
   getAugmentationPrereq: SF4Cost(RamCostConstants.SingularityFn3),
   getAugmentationPrice: SF4Cost(RamCostConstants.SingularityFn3 / 2),


### PR DESCRIPTION
This function (rightly, imo) does not actually require SF4. However, since it currently has the SF4 cost multipliers applied to it, it is largely moot since using it without SF4 requires 80GB.

This changes the RAM cost to be a constant 5GB. Ideally this wouldn't live in the sing namespace at all (nothing that just returns information should), but for compatibility that's how it rolls.