### PR TITLE
DOC: clean up documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[md]
+[*.md]
 trim_trailing_whitespace = false

--- a/src/Documentation/ui/doc/advanced/bitnodes.md
+++ b/src/Documentation/ui/doc/advanced/bitnodes.md
@@ -11,7 +11,7 @@ the Enders, using virtual simulations that trapped the minds of humans.
 
 However, the Enders didn't just create a single virtual reality to enslave humans, but many
 different simulations. In other words, there are many different BitNodes that exist.
-These BitNode are very different from each other.
+These BitNodes are very different from each other.
 
 jump3r tells you that the only hope for humanity is to destroy all of these BitNodes.
 Therefore, the end goal for the player is to enter and then destroy each BitNode.

--- a/src/Documentation/ui/doc/advanced/bitnodes.md
+++ b/src/Documentation/ui/doc/advanced/bitnodes.md
@@ -20,7 +20,7 @@ Different BitNodes grant different [Source-Files](sourcefiles.md).
 
 Each BitNode has unique characteristics that are related to varying backstories.
 For example, in one BitNode the world is in the middle of a financial catastrophe with a collapsing market.
-In another BitNode, most forms of income such as working at a [Company](../basic/companies.md) or [Hacknet Nodes](../basic/hacknet_nodes.md) are significantly less profitable.
+In this BitNode, most forms of income such as working at a [Company](../basic/companies.md) or [Hacknet Nodes](../basic/hacknet_nodes.md) are significantly less profitable.
 [Servers](../basic/servers.md) have less money on them and lowered growth rates, but it is easier to lower their security level using the `weaken` function.
 
 Furthermore, some BitNodes introduce new content and mechanics.

--- a/src/Documentation/ui/doc/advanced/bitnodes.md
+++ b/src/Documentation/ui/doc/advanced/bitnodes.md
@@ -1,29 +1,30 @@
 # BitNodes
 
-A BitNode is an important part of the game's storyline. In the game, you discover
-what BitNodes are by following the trail of clues left by the mysterious `jump3r`.
+A BitNode is an important part of the game's storyline.
+In the game, you discover what BitNodes are by following the trail of clues left by the mysterious `jump3r`.
 
 ## What is a BitNode
 
-A BitNode is the complex simulated reality in which you reside. By following the messages
-from `jump3r`, you discover that humanity was enslaved by an advanced alien race, called
-the Enders, using virtual simulations that trapped the minds of humans.
+A BitNode is the complex simulated reality in which you reside.
+By following the messages from `jump3r`, you discover that humanity was enslaved by an advanced alien race, called the Enders, using virtual simulations that trapped the minds of humans.
 
-However, the Enders didn't just create a single virtual reality to enslave humans, but many
-different simulations. In other words, there are many different BitNodes that exist.
+However, the Enders didn't just create a single virtual reality to enslave humans, but many different simulations.
+In other words, there are many different BitNodes that exist.
 These BitNodes are very different from each other.
 
 jump3r tells you that the only hope for humanity is to destroy all of these BitNodes.
 Therefore, the end goal for the player is to enter and then destroy each BitNode.
 
-Destroying a BitNode resets most of the player's progress but grants the player a
-powerful second-tier persistent upgrade called a [Source-File](sourcefiles.md).
+Destroying a BitNode resets most of the player's progress but grants the player a powerful second-tier persistent upgrade called a [Source-File](sourcefiles.md).
 Different BitNodes grant different [Source-Files](sourcefiles.md).
 
-Each BitNode has unique characteristics that are related to varying backstories. For example, in one BitNode the world is in the middle of a financial catastrophe with a collapsing market. In another BitNode, most forms of income such as working at a [Company](../basic/companies.md) or [Hacknet Nodes](../basic/hacknet_nodes.md) are significantly less profitable. [Servers](../basic/servers.md) have less money on them and lowered growth rates, but it is easier to lower their security level using the `weaken` function.
+Each BitNode has unique characteristics that are related to varying backstories.
+For example, in one BitNode the world is in the middle of a financial catastrophe with a collapsing market.
+In another BitNode, most forms of income such as working at a [Company](../basic/companies.md) or [Hacknet Nodes](../basic/hacknet_nodes.md) are significantly less profitable.
+[Servers](../basic/servers.md) have less money on them and lowered growth rates, but it is easier to lower their security level using the `weaken` function.
 
-Furthermore, some BitNodes introduce new content and mechanics. For example there is one
-BitNode that grants access to the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md).
+Furthermore, some BitNodes introduce new content and mechanics.
+For example, there is one BitNode that grants access to the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md).
 There is another BitNode in which you can manage a [Gang](gang.md) to earn money and [Reputation](../basic/reputation.md).
 
 ## How to destroy a BitNode
@@ -31,13 +32,15 @@ There is another BitNode in which you can manage a [Gang](gang.md) to earn money
 Initially, the only way to destroy a BitNode is to join Daedalus.
 From Daedalus, the player can obtain an [Augmentation](../basic/augmentations.md) called `The Red Pill`, which doesn't cost any money but does require a good amount of [Faction](../basic/factions.md) [Reputation](../basic/reputation.md).
 
-After installing `The Red Pill`, the player must search for and then manually `hack` a
-server called `w0r1d_d43m0n`. This server requires a hacking level of `3000`, sometimes more, in order to successfully hack it. This will destroy the player's current BitNode.
+After installing `The Red Pill`, the player must search for and then manually `hack` a server called `w0r1d_d43m0n`.
+This server requires a hacking level of `3000`, sometimes more, in order to successfully hack it.
+This will destroy the player's current BitNode.
 
-There is a second method of destroying a BitNode, but it must be unlocked by first
-destroying BitNode-6 or BitNode-7 ([Bladeburners](bladeburners.md)).
+There is a second method of destroying a BitNode, but it must be unlocked by first destroying BitNode-6 or BitNode-7 ([Bladeburners](bladeburners.md)).
 
-When the player destroys a BitNode, most of their progress will be reset. This includes things such as [Augmentations](../basic/augmentations.md) and [RAM](../basic/ram.md) upgrades on the home computer. The only things that will persist through destroying BitNodes is:
+When the player destroys a BitNode, most of their progress will be reset.
+This includes things such as [Augmentations](../basic/augmentations.md) and [RAM](../basic/ram.md) upgrades on the home computer.
+The only things that will persist through destroying BitNodes are:
 
 - [Source-Files](sourcefiles.md)
 - [Scripts](../basic/scripts.md) on the home computer

--- a/src/Documentation/ui/doc/advanced/grafting.md
+++ b/src/Documentation/ui/doc/advanced/grafting.md
@@ -12,5 +12,5 @@ Be warned, some who have tested grafting have reported an unidentified malware. 
 `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted,
 causing unpredictable affects to the victim.
 
-Note that when crafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress,
+Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress,
 and the money spent will **not** be returned.

--- a/src/Documentation/ui/doc/advanced/grafting.md
+++ b/src/Documentation/ui/doc/advanced/grafting.md
@@ -1,16 +1,13 @@
 # Grafting
 
-Grafting is an experimental process through which you can obtain the benefits of
-[Augmentations](../basic/augmentations.md), without needing to reboot your body.
+Grafting is an experimental process through which you can obtain the benefits of [Augmentations](../basic/augmentations.md), without needing to reboot your body.
 
-Grafting can be done at VitaLife in New Tokyo, where you'll find a shady researcher with
-questionable connections. From there, you can spend a sum of money to begin grafting
-[Augmentations](../basic/augmentations.md). This will take some time. When done, the [Augmentation](../basic/augmentations.md) will be applied to
-your character without needing to install.
+Grafting can be done at VitaLife in New Tokyo, where you'll find a shady researcher with questionable connections.
+From there, you can spend a sum of money to begin grafting [Augmentations](../basic/augmentations.md).
+This will take some time.
+When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned, some who have tested grafting have reported an unidentified malware. Dubbed
-`Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted,
-causing unpredictable affects to the victim.
+Be warned, some who have tested grafting have reported an unidentified malware.
+Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, causing unpredictable affects to the victim.
 
-Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress,
-and the money spent will **not** be returned.
+Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress, and the money spent will **not** be returned.

--- a/src/Documentation/ui/doc/advanced/hacknetservers.md
+++ b/src/Documentation/ui/doc/advanced/hacknetservers.md
@@ -1,5 +1,8 @@
 # Hacknet Servers
 
-These are a very powerful upgrade to [Hacknet Nodes](../basic/hacknet_nodes.md). Instead of producing money, the Hacknet Servers produce `hashes`. This currency can be exchanged for a variety of upgrades that boost most other mechanics of the game.
+These are a very powerful upgrade to [Hacknet Nodes](../basic/hacknet_nodes.md).
+Instead of producing money, the Hacknet Servers produce `hashes`.
+This currency can be exchanged for a variety of upgrades that boost most other mechanics of the game.
 
-They can also be used to run scripts on. However, this reduces the amount of `hash` produced.
+They can also be used to run scripts on.
+However, this reduces the amount of `hash` produced.

--- a/src/Documentation/ui/doc/advanced/hacknetservers.md
+++ b/src/Documentation/ui/doc/advanced/hacknetservers.md
@@ -1,5 +1,5 @@
 # Hacknet Servers
 
-These are a very powerful upgrade to [Hacknet Nodes](../basic/hacknet_nodes.md). Instead of producing money the Hacknet Servers produce `hashes`. This currency can be exchanged for a variety of upgrade that boost most other mechanics of the game.
+These are a very powerful upgrade to [Hacknet Nodes](../basic/hacknet_nodes.md). Instead of producing money, the Hacknet Servers produce `hashes`. This currency can be exchanged for a variety of upgrades that boost most other mechanics of the game.
 
-They can also be used to run scripts on. However this reduces the amount of `hash` produced.
+They can also be used to run scripts on. However, this reduces the amount of `hash` produced.

--- a/src/Documentation/ui/doc/advanced/intelligence.md
+++ b/src/Documentation/ui/doc/advanced/intelligence.md
@@ -1,11 +1,11 @@
 # Intelligence
 
-Intelligence is a stat that is unlocked by having
-[Source-File 5](sourcefiles.md) (i.e. Destroying [BitNode-5](bitnodes.md)).
+Intelligence is a stat that is unlocked by having [Source-File 5](sourcefiles.md) (i.e. Destroying [BitNode-5](bitnodes.md)).
 
-Intelligence is unique because it is permanent and persistent. It never gets reset
-back to 1. However, gaining Intelligence experience is extremely slow. It is a stat
-that gradually builds up as you continue to play the game.
+Intelligence is unique because it is permanent and persistent.
+It never gets reset back to 1.
+However, gaining Intelligence experience is extremely slow.
+It is a stat that gradually builds up as you continue to play the game.
 
 Intelligence will boost your production for many actions in the game, including:
 

--- a/src/Documentation/ui/doc/advanced/sleeves.md
+++ b/src/Documentation/ui/doc/advanced/sleeves.md
@@ -1,9 +1,7 @@
 # Sleeves
 
-When VitaLife unveiled their Persona Core technology that allowed people to digitize
-and transfer their consciousness into other vessels, human bodies became nothing more
-than 'sleeves' for the human consciousness. This technology thus became known as
-"Sleeve technology".
+When VitaLife unveiled their Persona Core technology that allowed people to digitize and transfer their consciousness into other vessels, human bodies became nothing more than 'sleeves' for the human consciousness.
+This technology thus became known as "Sleeve technology".
 
 Sleeve technology unlocks two different gameplay features:
 
@@ -14,77 +12,70 @@ Sleeve technology is unlocked in [BitNode-10](bitnodes.md).
 
 ## Duplicate Sleeves
 
-Duplicate Sleeves are MK-V Synthoids (synthetic androids) into which your consciousness
-has been copied. In other words, these Synthoids contain a perfect duplicate of your mind.
+Duplicate Sleeves are MK-V Synthoids (synthetic androids) into which your consciousness has been copied.
+In other words, these Synthoids contain a perfect duplicate of your mind.
 
-Duplicate Sleeves are essentially clones which you can use to perform work-type actions,
-such as working for a [Company](../basic/companies.md) / [Faction](../basic/factions.md) or committing a [Crime](../basic/crimes.md). When sleeves perform these tasks,
-they will earn money, experience, and [Reputation](../basic/reputation.md).
+Duplicate Sleeves are essentially clones which you can use to perform work-type actions, such as working for a [Company](../basic/companies.md) / [Faction](../basic/factions.md) or committing a [Crime](../basic/crimes.md).
+When sleeves perform these tasks, they will earn money, experience, and [Reputation](../basic/reputation.md).
 
 Sleeves are their own individuals, which means they each have their own experience and stats.
 
-When a sleeve earns experience, it earns experience for itself, the player's
-original consciousness, as well as all of the player's other sleeves.
+When a sleeve earns experience, it earns experience for itself, the player's original consciousness, as well as all of the player's other sleeves.
 
-Duplicate Sleeves are **not** reset when installing [Augmentations](../basic/augmentations.md), but they are reset
-when switching [BitNodes](bitnodes.md).
+Duplicate Sleeves are **not** reset when installing [Augmentations](../basic/augmentations.md), but they are reset when switching [BitNodes](bitnodes.md).
 
 ## Obtaining Duplicate Sleeves
 
 There are two methods of obtaining Duplicate Sleeves:
 
-1. Destroy [BitNode-10](bitnodes.md). Each completion gives you one additional Duplicate Sleeve.
+1. Destroy [BitNode-10](bitnodes.md).
+   Each completion gives you one additional Duplicate Sleeve.
 2. Purchase Duplicate Sleeves from The Covenant.
-   This is only available in [BitNode-10](bitnodes.md). Sleeves purchased this way are **permanent** (they persist
-   through [BitNodes](bitnodes.md)). You can purchase up to 5 Duplicate Sleeves from The Covenant.
+   This is only available in [BitNode-10](bitnodes.md).
+   Sleeves purchased this way are **permanent** (they persist through [BitNodes](bitnodes.md)).
+   You can purchase up to 5 Duplicate Sleeves from The Covenant.
 
 ## Synchronization
 
-Synchronization is a measure of how aligned your consciousness is with that of your
-Duplicate Sleeves. It is a numerical value between `1` and `100`, and it affects how much experience
-is earned when the sleeve is performing a task.
+Synchronization is a measure of how aligned your consciousness is with that of your Duplicate Sleeves.
+It is a numerical value between `1` and `100`, and it affects how much experience is earned when the sleeve is performing a task.
 
 Synchronization can be increased by assigning sleeves to the `Synchronize` task.
 
 ## Sleeve Shock
 
-Sleeve shock is a measure of how much trauma the sleeve has due to being placed in a new
-body. It is a numerical value between `0` and `100`, where `100` indicates full shock and `0` indicates
-no shock. Shock affects the amount of experience earned by the sleeve.
+Sleeve shock is a measure of how much trauma the sleeve has due to being placed in a new body.
+It is a numerical value between `0` and `100`, where `100` indicates full shock and `0` indicates no shock.
+Shock affects the amount of experience earned by the sleeve.
 
-Sleeve shock slowly decreases over time. You can further increase the rate at which
-it decreases by assigning sleeves to the `Shock Recovery` task.
+Sleeve shock slowly decreases over time.
+You can further increase the rate at which it decreases by assigning sleeves to the `Shock Recovery` task.
 
-Let `X` be the sleeve's shock and `Y` be the sleeve's synchronization. When the sleeve earns experience by performing
-a task, the sleeve gains `X%` of the amount of experience normally earned by the task. player’s original host consciousness and all of the player's other sleeves
-earn `Y%` of the experience that the sleeve gained, or `X\*Y %` of the normal experience amount.
+Let `X` be the sleeve's shock and `Y` be the sleeve's synchronization.
+When the sleeve earns experience by performing a task, the sleeve gains `X%` of the amount of experience normally earned by the task.
+The player’s original host consciousness and all of the player's other sleeves earn `Y%` of the experience that the sleeve gained, or `X\*Y %` of the normal experience amount.
 
 ## Augmentations
 
-You can purchase [Augmentations](../basic/augmentations.md) for your Duplicate
-Sleeves. In order to do this, the sleeve's shock must be at `0`. Any [Augmentation](../basic/augmentations.md)
-that is currently available to you through a faction is also available for your
-Duplicate Sleeves. There are a few [Augmentations](../basic/augmentations.md), such as NeuroFlux Governor and
-[Bladeburner](bladeburners.md)-specific ones, that cannot be purchased for a Duplicate Sleeve.
+You can purchase [Augmentations](../basic/augmentations.md) for your Duplicate Sleeves.
+In order to do this, the sleeve's shock must be at `0`.
+Any [Augmentation](../basic/augmentations.md) that is currently available to you through a faction is also available for your Duplicate Sleeves.
+There are a few [Augmentations](../basic/augmentations.md), such as NeuroFlux Governor and [Bladeburner](bladeburners.md)-specific ones, that cannot be purchased for a Duplicate Sleeve.
 
 When you purchase an [Augmentation](../basic/augmentations.md) for a Duplicate Sleeve, it is instantly installed.
-When this happens, the sleeve's stats are instantly reset back to 0, similar to
-when you normally install [Augmentations](../basic/augmentations.md).
+When this happens, the sleeve's stats are instantly reset back to 0, similar to when you normally install [Augmentations](../basic/augmentations.md).
 
-The cost of purchasing an [Augmentation](../basic/augmentations.md) for a Duplicate Sleeve is **not** affected
-by how many [Augmentations](../basic/augmentations.md) you have purchased for yourself, and vice versa.
+The cost of purchasing an [Augmentation](../basic/augmentations.md) for a Duplicate Sleeve is **not** affected by how many [Augmentations](../basic/augmentations.md) you have purchased for yourself, and vice versa.
 
 ## Memory
 
-Sleeve memory dictates what a sleeve's synchronization will be when it is reset by
-switching [BitNodes](bitnodes.md). For example, if a sleeve has a memory of `10`, then when you
-switch [BitNodes](bitnodes.md) its synchronization will initially be set to `10`, rather than 1.
+Sleeve memory dictates what a sleeve's synchronization will be when it is reset by switching [BitNodes](bitnodes.md).
+For example, if a sleeve has a memory of `10`, then when you switch [BitNodes](bitnodes.md) its synchronization will initially be set to `10`, rather than 1.
 
-Memory can only be increased by purchasing upgrades from The Covenant. Just like
-the ability to purchase additional sleeves, this is only available in [BitNode-10](bitnodes.md).
+Memory can only be increased by purchasing upgrades from The Covenant.
+Just like the ability to purchase additional sleeves, this is only available in [BitNode-10](bitnodes.md).
 
 Memory is a persistent stat, meaning it never gets reset back to `1`.
 The maximum possible value for a sleeve's memory is `100`.
 
-Buying memory has no instant affect on synchronization,
-memory affects only the starting synchronization upon entering a [BitNode](bitnodes.md).
+Buying memory has no instant affect on synchronization - memory affects only the starting synchronization upon entering a [BitNode](bitnodes.md).

--- a/src/Documentation/ui/doc/advanced/sleeves.md
+++ b/src/Documentation/ui/doc/advanced/sleeves.md
@@ -28,12 +28,12 @@ Duplicate Sleeves are **not** reset when installing [Augmentations](../basic/aug
 
 There are two methods of obtaining Duplicate Sleeves:
 
-1. Destroy [BitNode-10](bitnodes.md).
-   Each completion gives you one additional Duplicate Sleeve.
-2. Purchase Duplicate Sleeves from The Covenant.
-   This is only available in [BitNode-10](bitnodes.md).
-   Sleeves purchased this way are **permanent** (they persist through [BitNodes](bitnodes.md)).
-   You can purchase up to 5 Duplicate Sleeves from The Covenant.
+- Destroy [BitNode-10](bitnodes.md).
+  Each completion gives you one additional Duplicate Sleeve.
+- Purchase Duplicate Sleeves from The Covenant.
+  This is only available in [BitNode-10](bitnodes.md).
+  Sleeves purchased this way are **permanent** (they persist through [BitNodes](bitnodes.md)).
+  You can purchase up to 5 Duplicate Sleeves from The Covenant.
 
 ## Synchronization
 

--- a/src/Documentation/ui/doc/advanced/sourcefiles.md
+++ b/src/Documentation/ui/doc/advanced/sourcefiles.md
@@ -1,9 +1,8 @@
 # Source-Files
 
 Source-Files are a type of persistent upgrade that is more powerful than [Augmentations](../basic/augmentations.md).
-Source-Files are received by destroying a [Bitnode](bitnodes.md). There are many different [BitNodes](bitnodes.md)
-in the game and each [BitNode](bitnodes.md) will grant a different Source-File when it is destroyed.
+Source-Files are received by destroying a [Bitnode](bitnodes.md).
+There are many different [BitNodes](bitnodes.md) in the game and each [BitNode](bitnodes.md) will grant a different Source-File when it is destroyed.
 
-A Source-File can be upgraded by destroying its corresponding [BitNode](bitnodes.md) a second or
-third time (playing through that [BitNode](bitnodes.md) again). It can be upgraded to a maximum
-of level 3, with the exception of Source-File 12, which has no hard limit.
+A Source-File can be upgraded by destroying its corresponding [BitNode](bitnodes.md) a second or third time (playing through that [BitNode](bitnodes.md) again).
+It can be upgraded to a maximum of level 3, with the exception of Source-File 12, which has no hard limit.

--- a/src/Documentation/ui/doc/advanced/stanek.md
+++ b/src/Documentation/ui/doc/advanced/stanek.md
@@ -1,7 +1,7 @@
 # Stanek
 
 Allison is a bit crazy.
-But her special [Augmentation](../basic/augmentations.md) is very useful despites its ~~bugs~~ features.
+But her special [Augmentation](../basic/augmentations.md) is very useful despite its ~~bugs~~ features.
 The Gift consists of a grid of squares in which tetris-like pieces called fragments can be placed.
 Each fragment boost a different player multiplier.
 However, the fragments are not very powerful by themselves.

--- a/src/Documentation/ui/doc/advanced/stanek.md
+++ b/src/Documentation/ui/doc/advanced/stanek.md
@@ -1,7 +1,7 @@
 # Stanek
 
-Allison is a bit crazy. But her special [Augmentation](../basic/augmentations.md) is very useful despites it's ~~bugs~~ features. The Gift is consists of a grid of squares in which tetris-like pieces called fragments can be placed. Each fragment boost a different player multiplier. However the fragments are not very powerful by themselves.
+Allison is a bit crazy. But her special [Augmentation](../basic/augmentations.md) is very useful despites its ~~bugs~~ features. The Gift consists of a grid of squares in which tetris-like pieces called fragments can be placed. Each fragment boost a different player multiplier. However the fragments are not very powerful by themselves.
 
-To increase the power of a fragment the `ns.stanek.charge()` function needs to be called. More thread means more power.
+To increase the power of a fragment, the `ns.stanek.charge()` function needs to be called. More threads means more power.
 
 There are also special fragments called booster fragments which increase the power of the fragment it touches.

--- a/src/Documentation/ui/doc/advanced/stanek.md
+++ b/src/Documentation/ui/doc/advanced/stanek.md
@@ -1,7 +1,12 @@
 # Stanek
 
-Allison is a bit crazy. But her special [Augmentation](../basic/augmentations.md) is very useful despites its ~~bugs~~ features. The Gift consists of a grid of squares in which tetris-like pieces called fragments can be placed. Each fragment boost a different player multiplier. However the fragments are not very powerful by themselves.
+Allison is a bit crazy.
+But her special [Augmentation](../basic/augmentations.md) is very useful despites its ~~bugs~~ features.
+The Gift consists of a grid of squares in which tetris-like pieces called fragments can be placed.
+Each fragment boost a different player multiplier.
+However, the fragments are not very powerful by themselves.
 
-To increase the power of a fragment, the `ns.stanek.charge()` function needs to be called. More threads means more power.
+To increase the power of a fragment, the `ns.stanek.charge()` function needs to be called.
+More threads means more power.
 
 There are also special fragments called booster fragments which increase the power of the fragment it touches.

--- a/src/Documentation/ui/doc/basic/augmentations.md
+++ b/src/Documentation/ui/doc/basic/augmentations.md
@@ -1,40 +1,34 @@
 # Augmentations
 
-Advances in science and medicine have led to powerful new technologies
-that allow people to augment themselves beyond normal human capabilities.
-There are many different types of Augmentations, ranging from cybernetic
-to genetic to biological. Acquiring these Augmentations enhances the
-user's physical and mental faculties.
+Advances in science and medicine have led to powerful new technologies that allow people to augment themselves beyond normal human capabilities.
+There are many different types of Augmentations, ranging from cybernetic to genetic to biological.
+Acquiring these Augmentations enhances the user's physical and mental faculties.
 
 Augmentations provide persistent upgrades in the form of multipliers.
-These multipliers apply to a wide variety of things such as stats,
-experience gain, and [hacking](hacking.md), just to name a few. The effects of
-Augmentations stack multiplicatively. Your multipliers can be viewed in
-the `Character` pages.
+These multipliers apply to a wide variety of things such as stats, experience gain, and [hacking](hacking.md), just to name a few.
+The effects of Augmentations stack multiplicatively.
+Your multipliers can be viewed in the `Character` pages.
 
 ## How to acquire Augmentations
 
-Because of how powerful Augmentations are, the technology behind them
-is kept private and secret by the corporations and organizations that
-create them. Therefore, the only way for the player to obtain
-Augmentations is through [Factions](factions.md). After joining a [Faction](factions.md) and earning
-enough [Reputation](reputation.md) in it, you will be able to purchase its Augmentations.
-Different [Factions](factions.md) offer different Augmentations. Augmentations must be
-purchased in order to be installed, and they are fairly expensive. They also require [Reputation](reputation.md) with a [Faction](factions.md) before they will let you purchase their Augmentations.
+Because of how powerful Augmentations are, the technology behind them is kept private and secret by the corporations and organizations that create them.
+Therefore, the only way for the player to obtain Augmentations is through [Factions](factions.md).
+After joining a [Faction](factions.md) and earning enough [Reputation](reputation.md) in it, you will be able to purchase its Augmentations.
+Different [Factions](factions.md) offer different Augmentations.
+Augmentations must be purchased in order to be installed, and they are fairly expensive.
+They also require [Reputation](reputation.md) with a [Faction](factions.md) before they will let you purchase their Augmentations.
 
 ## Installing Augmentations
 
-You will not gain the benefits of your purchased Augmentations until you install them. You can choose to install Augmentations through
-the `Augmentations` menu tab, found under `Character`.
+You will not gain the benefits of your purchased Augmentations until you install them.
+You can choose to install Augmentations through the `Augmentations` menu tab, found under `Character`.
 
-Unfortunately, installing Augmentations has side effects. You will lose
-most of the progress you've made, including your skills, stats, and
-money. You will have to start over, but you will have all of the
-Augmentations you have installed to help you progress. This is the
-game's "soft reset" or "prestige" mechanic.
+Unfortunately, installing Augmentations has side effects.
+You will lose most of the progress you've made, including your skills, stats, and money.
+You will have to start over, but you will have all of the Augmentations you have installed to help you progress.
+This is the game's "soft reset" or "prestige" mechanic.
 
-To summarize, here is a list of everything you will **LOSE** when you install
-an Augmentation:
+To summarize, here is a list of everything you will **LOSE** when you install an Augmentation:
 
 - Stats/Skills
 - Money
@@ -47,7 +41,7 @@ an Augmentation:
 - [Stocks](stockmarket.md)
 - TOR router
 
-Here is everything you will KEEP when you install an Augmentation:
+Here is everything you will **KEEP** when you install an Augmentation:
 
 - Every Augmentation you have previously installed
 - [Scripts](scripts.md) on your home computer
@@ -57,17 +51,13 @@ Here is everything you will KEEP when you install an Augmentation:
 ## Purchasing Multiple Augmentations
 
 You do not have to install an Augmentation right after you purchase it.
-You can purchase as many Augmentations as you'd like before you choose to
-install them. When you install your purchased Augmentations they will **ALL**
-get installed at once.
+You can purchase as many Augmentations as you'd like before you choose to install them.
+When you install your purchased Augmentations they will **ALL** get installed at once.
 
-There are a few drawbacks to this, however. First, obviously, you won't
-gain the benefits of your purchased Augmentations until after you install
-them. Second, purchasing multiple Augmentations before installing them
-will cause the Augmentations to get progressively more expensive. When
-you purchase an Augmentation, the price of purchasing another Augmentation
-doubles. This multiplier stacks for each Augmentation you
-purchase. Once you install your purchased Augmentations, their costs
-are reset back to the original prices. You can only purchase each augmentation
-once, with the exception of `NeuroFlux Governor`, which can be purchased infinitely
-at increasing cost.
+There are a few drawbacks to this, however.
+First, obviously, you won't gain the benefits of your purchased Augmentations until after you install them.
+Second, purchasing multiple Augmentations before installing them will cause the Augmentations to get progressively more expensive.
+When you purchase an Augmentation, the price of purchasing another Augmentation doubles.
+This multiplier stacks for each Augmentation you purchase.
+Once you install your purchased Augmentations, their costs are reset back to the original prices.
+You can only purchase each augmentation once, with the exception of `NeuroFlux Governor`, which can be purchased infinitely at increasing cost.

--- a/src/Documentation/ui/doc/basic/augmentations.md
+++ b/src/Documentation/ui/doc/basic/augmentations.md
@@ -20,7 +20,7 @@ create them. Therefore, the only way for the player to obtain
 Augmentations is through [Factions](factions.md). After joining a [Faction](factions.md) and earning
 enough [Reputation](reputation.md) in it, you will be able to purchase its Augmentations.
 Different [Factions](factions.md) offer different Augmentations. Augmentations must be
-purchased in order to be installed, and they are fairly expensive. They also require [Reputation](reputation.md) from a [Factions](factions.md) before they will let you purchase their Augmentations.
+purchased in order to be installed, and they are fairly expensive. They also require [Reputation](reputation.md) with a [Faction](factions.md) before they will let you purchase their Augmentations.
 
 ## Installing Augmentations
 
@@ -41,7 +41,7 @@ an Augmentation:
 - [Scripts](scripts.md) on all [servers](servers.md) EXCEPT your home computer
 - Purchased [servers](servers.md)
 - [Hacknet Nodes](hacknet_nodes.md)
-- [Company](companies.md) / [Faction](factions.md) [Reputation](reputation.md), but you gain [Reputation](reputation.md).
+- [Company](companies.md) / [Faction](factions.md) [Reputation](reputation.md), but you gain [Favor](reputation.md).
 - Jobs and [Faction](factions.md) memberships
 - Programs
 - [Stocks](stockmarket.md)
@@ -49,11 +49,10 @@ an Augmentation:
 
 Here is everything you will KEEP when you install an Augmentation:
 
-- Every Augmentation you have installed
+- Every Augmentation you have previously installed
 - [Scripts](scripts.md) on your home computer
 - [RAM](ram.md) / Core Upgrades on your home computer
 - [World Stock Exchange account](stockmarket.md) and [TIX API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.tix.md) Access
-- Previously installed Augmentations
 
 ## Purchasing Multiple Augmentations
 

--- a/src/Documentation/ui/doc/basic/codingcontracts.md
+++ b/src/Documentation/ui/doc/basic/codingcontracts.md
@@ -2,7 +2,7 @@
 
 Coding Contracts are a mechanic that lets players earn rewards in exchange for solving programming problems.
 
-Coding Contracts are files with the `.cct` extensions.
+Coding Contracts are files with the `.cct` extension.
 They can be accessed through the [Terminal](terminal.md) or through [Scripts](scripts.md) using the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
 
 Each contract has a limited number of attempts.
@@ -45,15 +45,12 @@ Otherwise, follow these rules when submitting solutions:
 - Array-type solutions should be submitted with each element in the array separated by commas.
   Brackets are optional.
   For example, both of the following are valid solution formats:
-
   - `1,2,3`
   - `[1,2,3]`
-
-However, if the solution is a multidimensional array, then all arrays that are not the outer-most array DO require the brackets.
-For example, an array of arrays can be submitted as one of the following:
-
-- `[1,2],[3,4]`
-- `[[1,2],[3,4]]`
+- If the solution is a multidimensional array, then all arrays that are not the outer-most array DO require the brackets.
+  For example, an array of arrays can be submitted as one of the following:
+  - `[1,2],[3,4]`
+  - `[[1,2],[3,4]]`
 
 Numeric solutions should be submitted normally, as expected
 

--- a/src/Documentation/ui/doc/basic/codingcontracts.md
+++ b/src/Documentation/ui/doc/basic/codingcontracts.md
@@ -1,66 +1,55 @@
 # Coding Contracts
 
-Coding Contracts are a mechanic that lets players earn rewards in
-exchange for solving programming problems.
+Coding Contracts are a mechanic that lets players earn rewards in exchange for solving programming problems.
 
-Coding Contracts are files with the `.cct` extensions. They can
-be accessed through the [Terminal](terminal.md) or through [Scripts](scripts.md) using
-the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md)
+Coding Contracts are files with the `.cct` extensions.
+They can be accessed through the [Terminal](terminal.md) or through [Scripts](scripts.md) using the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
 
-Each contract has a limited number of attempts. If you
-provide the wrong answer too many times and exceed the
-number of attempts, the contract will self destruct (delete itself)
+Each contract has a limited number of attempts.
+If you provide the wrong answer too many times and exceed the number of attempts, the contract will self destruct (delete itself).
 
-Currently, Coding Contracts are randomly generated and
-spawned over time. They can appear on any [server](servers.md) (including your
-home computer), except for your purchased [servers](servers.md).
+Currently, Coding Contracts are randomly generated and spawned over time.
+They can appear on any [server](servers.md) (including your home computer), except for your purchased [servers](servers.md).
 
 ## Running in Terminal
 
-To run a Coding Contract in the [Terminal](terminal.md), simply use the
-`run` command:
+To run a Coding Contract in the [Terminal](terminal.md), simply use the `run` command:
 
     $ run some-contract.cct
 
-Doing this will bring up a popup. The popup will display
-the contract's problem, the number of attempts remaining, and
-an area to provide an answer.
+Doing this will bring up a popup.
+The popup will display the contract's problem, the number of attempts remaining, and an area to provide an answer.
 
 ## Interacting through Scripts
 
 See the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
-Interacting with Coding Contracts via the [Terminal](terminal.md) can be tedious the more
-contracts you solve. Consider using the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) to automate various aspects of
-your solution. For example, some contracts have long solutions while others
-have even longer solutions. You might want to use the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) to automate the
-process of submitting your solution rather than copy and paste a long
-solution into an answer box.
+Interacting with Coding Contracts via the [Terminal](terminal.md) can be tedious the more contracts you solve.
+Consider using the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) to automate various aspects of your solution.
+For example, some contracts have long solutions while others have even longer solutions.
+You might want to use the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) to automate the process of submitting your solution rather than copy and paste a long solution into an answer box.
 
-However, using the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) comes at a cost. Like most functions in other APIs,
-each function in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) has a RAM cost. Depending on which
-function you use, the initial [RAM](ram.md) on your home server might not be enough
-to allow you to use various [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) functions. Plan on upgrading the [RAM](ram.md) on your
-home server if you want to use the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
+However, using the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) comes at a cost.
+Like most functions in other APIs, each function in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) has a RAM cost.
+Depending on which function you use, the initial [RAM](ram.md) on your home server might not be enough to allow you to use various [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) functions.
+Plan on upgrading the [RAM](ram.md) on your home server if you want to use the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
 
 ## Submitting Solutions
 
-Different contract problem types will require different types of
-solutions. Some may be numbers, others may be strings or arrays.
-If a contract asks for a specific solution format, then
-use that. Otherwise, follow these rules when submitting solutions:
+Different contract problem types will require different types of solutions.
+Some may be numbers, others may be strings or arrays.
+If a contract asks for a specific solution format, then use that.
+Otherwise, follow these rules when submitting solutions:
 
-- String-type solutions should **not** have quotation marks surrounding
-  the string (unless specifically asked for). Only quotation
-  marks that are part of the actual string solution should be included.
-- Array-type solutions should be submitted with each element
-  in the array separated by commas. Brackets are optional. For example,
-  both of the following are valid solution formats::
+- String-type solutions should **not** have quotation marks surrounding the string (unless specifically asked for).
+  Only quotation marks that are part of the actual string solution should be included.
+- Array-type solutions should be submitted with each element in the array separated by commas.
+  Brackets are optional.
+  For example, both of the following are valid solution formats:
 
   - `1,2,3`
   - `[1,2,3]`
 
-However, if the solution is a multidimensional array, then
-all arrays that are not the outer-most array DO require the brackets.
+However, if the solution is a multidimensional array, then all arrays that are not the outer-most array DO require the brackets.
 For example, an array of arrays can be submitted as one of the following:
 
 - `[1,2],[3,4]`
@@ -77,9 +66,8 @@ There are currently four possible rewards for solving a Coding Contract:
 - [Company](companies.md) [Reputation](reputation.md) for a specific [Company](companies.md)
 - Money
 
-The `amount` of the reward varies based on the difficulty of the problem
-posed by the Coding Contract. There is no way to know what a
-Coding Contract's exact reward will be until it is solved.
+The `amount` of the reward varies based on the difficulty of the problem posed by the Coding Contract.
+There is no way to know what a Coding Contract's exact reward will be until it is solved.
 
 ## Notes
 

--- a/src/Documentation/ui/doc/basic/companies.md
+++ b/src/Documentation/ui/doc/basic/companies.md
@@ -1,15 +1,14 @@
 # Companies
 
-When exploring the [World](world.md), you can visit various companies. At
-these companies, you can apply for jobs.
+When exploring the [World](world.md), you can visit various companies.
+At these companies, you can apply for jobs.
 
 Working a job lets you earn money, experience, and [Reputation](reputation.md) with that company.
 
-While working for a company, you can click `Do something else simultaneously` to be able
-to do things while you continue to work in the background. There is a 20% penalty to the
-related gains. Clicking the `Focus` button under the overview will return you to the
-current work.
+While working for a company, you can click `Do something else simultaneously` to be able to do things while you continue to work in the background.
+There is a 20% penalty to the related gains.
+Clicking the `Focus` button under the overview will return you to the current work.
 
-If you've been hired to do a job you can click that `Apply for X Job` button again to get a
-promotion if you meet the requirements. You can see the requirements by hovering your cursor
-over the button. Higher positions give increased rewards.
+If you've been hired to do a job you can click that `Apply for X Job` button again to get a promotion if you meet the requirements.
+You can see the requirements by hovering your cursor over the button.
+Higher positions give increased rewards.

--- a/src/Documentation/ui/doc/basic/crimes.md
+++ b/src/Documentation/ui/doc/basic/crimes.md
@@ -1,27 +1,24 @@
 # Crimes
 
-Committing crimes is an active gameplay mechanic that allows the player to train
-their [Stats](stats.md) and potentially earn money. The player can attempt to commit crimes
-by visiting `The Slums` through the `City` tab (Alt + w).
+Committing crimes is an active gameplay mechanic that allows the player to train their [Stats](stats.md) and potentially earn money.
+The player can attempt to commit crimes by visiting `The Slums` through the `City` tab (Alt + w).
 `The Slums` is available in every city.
 
 ## Basic Mechanics
 
-When you visit `The Slums` you will see a list of buttons that show all of the
-available crimes. Simply select one of the options to begin attempting that
-crime. Attempting to commit a crime takes a certain amount of time. This time
-varies between crimes.
+When you visit `The Slums` you will see a list of buttons that show all of the available crimes.
+Simply select one of the options to begin attempting that crime.
+Attempting to commit a crime takes a certain amount of time.
+This time varies between crimes.
 
-While doing crimes, you can click `Do something else simultaneously`
-to be able to do things while you continue to do crimes in the background. There is a
-20% penalty to the related gains. Clicking the `Focus` button under the overview
-will return you to the current task.
+While doing crimes, you can click `Do something else simultaneously` to be able to do things while you continue to do crimes in the background.
+There is a 20% penalty to the related gains.
+Clicking the `Focus` button under the overview will return you to the current task.
 
-Crimes are not always successful. Your rate of success is determined by your
-[Stats](stats.md) and [Augmentations](augmentations.md). The odds can be seen on the crime-selection
-page. If you are unsuccessful at committing a crime you will gain EXP,
-but you will not earn money. If you are successful at committing the crime
-you will gain extra EXP (4x of what an unsuccessful attempt would give)
-and earn money.
+Crimes are not always successful.
+Your rate of success is determined by your [Stats](stats.md) and [Augmentations](augmentations.md).
+The odds can be seen on the crime-selection page.
+If you are unsuccessful at committing a crime you will gain EXP, but you will not earn money.
+If you are successful at committing the crime you will gain extra EXP (4x of what an unsuccessful attempt would give) and earn money.
 
 Harder crimes are typically more profitable, and also give more EXP.

--- a/src/Documentation/ui/doc/basic/factions.md
+++ b/src/Documentation/ui/doc/basic/factions.md
@@ -1,26 +1,20 @@
 # Factions
 
-Throughout the game you may receive invitations from factions. There are
-many different factions, and each faction has different criteria for
-determining its potential members. Joining a faction and furthering
-its cause is crucial to progressing in the game and unlocking endgame
-content.
+Throughout the game you may receive invitations from factions.
+There are many different factions, and each faction has different criteria for determining its potential members.
+Joining a faction and furthering its cause is crucial to progressing in the game and unlocking endgame content.
 
-It is possible to join multiple factions if you receive invitations from
-them. However, note that joining a faction may prevent you from joining
-other rival factions. (Don't worry, this usually isn't the case. Also,
-it would only be temporary since resetting the game by installing
-[Augmentations](augmentations.md) will clear all your factions)
+It is possible to join multiple factions if you receive invitations from them.
+However, note that joining a faction may prevent you from joining other rival factions.
+(Don't worry, this usually isn't the case.
+Also, it would only be temporary since resetting the game by installing [Augmentations](augmentations.md) will clear all your factions)
 
-The `Factions` link on the menu brings up a list of all factions that
-you have joined. You can select a Faction on this list to go to that
-Faction page. This page displays general information about the Faction
-and also lets you perform work for the faction. Working for a Faction
-is similar to working for a [Company](companies.md) except that you don't get paid a
-salary. You will only earn [Reputation](reputation.md) in your Faction and train your
-[Stats](stats.md).
+The `Factions` link on the menu brings up a list of all factions that you have joined.
+You can select a Faction on this list to go to that Faction page.
+This page displays general information about the Faction and also lets you perform work for the faction.
+Working for a Faction is similar to working for a [Company](companies.md) except that you don't get paid a salary.
+You will only earn [Reputation](reputation.md) in your Faction and train your [Stats](stats.md).
 
 Earning [Reputation](reputation.md) for a Faction unlocks powerful [Augmentations](augmentations.md).
-Purchasing and installing these [Augmentations](augmentations.md) will upgrade your
-abilities. The [Augmentations](augmentations.md) that are available to unlock vary
-from Faction to Faction.
+Purchasing and installing these [Augmentations](augmentations.md) will upgrade your abilities.
+The [Augmentations](augmentations.md) that are available to unlock vary from Faction to Faction.

--- a/src/Documentation/ui/doc/basic/hacking.md
+++ b/src/Documentation/ui/doc/basic/hacking.md
@@ -1,25 +1,22 @@
 # Hacking
 
 In the year 2077, currency has become digital and decentralized.
-People and corporations store their money on [servers](servers.md). By hacking
-these [servers](servers.md), you can steal their money and gain experience.
+People and corporations store their money on [servers](servers.md).
+By hacking these [servers](servers.md), you can steal their money and gain experience.
 
 ## Gaining Root Access
 
 The first step to hacking a [server](servers.md) is to gain root access to that [server](servers.md).
-This can be done using the `NUKE.exe` virus. You start the
-game with a copy of the `NUKE.exe` virus on your home computer. The
-`NUKE.exe` virus attacks the target [server](servers.md)'s open ports using buffer
-overflow exploits. When successful, you are granted root
-administrative access to the machine.
+This can be done using the `NUKE.exe` virus.
+You start the game with a copy of the `NUKE.exe` virus on your home computer.
+The `NUKE.exe` virus attacks the target [server](servers.md)'s open ports using buffer overflow exploits.
+When successful, you are granted root administrative access to the machine.
 
-In order for the `NUKE.exe` virus to succeed, the target [server](servers.md)
-needs to have enough open ports. Some [servers](servers.md) have no
-security and will not need any ports opened. Some will have very high
-security and will need many ports opened. In order to open ports on
-another [server](servers.md), you will need to run programs that attack the [server](servers.md)
-to open specific ports. These programs can be coded once your hacking
-skill gets high enough, or they can be purchased if you can find a seller.
+In order for the `NUKE.exe` virus to succeed, the target [server](servers.md) needs to have enough open ports.
+Some [servers](servers.md) have no security and will not need any ports opened.
+Some will have very high security and will need many ports opened.
+In order to open ports on another [server](servers.md), you will need to run programs that attack the [server](servers.md) to open specific ports.
+These programs can be coded once your hacking skill gets high enough, or they can be purchased if you can find a seller.
 
 **There are two ways to execute port-opening programs and the NUKE virus:**
 
@@ -42,61 +39,49 @@ on a [server](servers.md) in order to successfully NUKE it:**
 1. Connect to that [server](servers.md) through the [Terminal](terminal.md) and use the `analyze` command.
 1. Use the `getServerNumPortsRequired` function.
 
-Once you have enough ports opened on a [server](servers.md) and have ran the NUKE virus
-to gain root access, you will be able to hack it.
+Once you have enough ports opened on a [server](servers.md) and have ran the NUKE virus to gain root access, you will be able to hack it.
 
 ## General Hacking Mechanics
 
-When you execute the `hack` command, either manually through the [Terminal](terminal.md)
-or automatically through a script, you attempt to hack the [server](servers.md).
-This action takes time. The more advanced a [server](servers.md)'s security is,
-the more time it will take. Your hacking skill level also affects
-the hacking time, with a higher hacking skill leading to shorter
-hacking times. Also, running the hack command manually through [Terminal](terminal.md)
+When you execute the `hack` command, either manually through the [Terminal](terminal.md) or automatically through a script, you attempt to hack the [server](servers.md).
+This action takes time.
+The more advanced a [server](servers.md)'s security is, the more time it will take.
+Your hacking skill level also affects the hacking time, with a higher hacking skill leading to shorter hacking times.
+Also, running the hack command manually through [Terminal](terminal.md)
 is faster than hacking from a script.
 
-Your attempt to hack a [server](servers.md) will not always succeed. The chance you
-have to successfully hack a [server](servers.md) is also determined by the [server](servers.md)'s
-security and your hacking skill level. Even if your hacking attempt
-is unsuccessful, you will still gain experience points.
+Your attempt to hack a [server](servers.md) will not always succeed.
+The chance you have to successfully hack a [server](servers.md) is also determined by the [server](servers.md)'s security and your hacking skill level.
+Even if your hacking attempt is unsuccessful, you will still gain experience points.
 
-When you successfully hack a [server](servers.md). You steal a certain percentage
-of that [server](servers.md)'s total money. This percentage is, once again, determined by the
-[server](servers.md)'s security and your hacking skill level. The amount of money
-on a [server](servers.md) is not limitless. So, if you constantly hack a [server](servers.md)
-and deplete its money, then you will encounter diminishing returns
-in your hacking (since you are only hacking a certain percentage).
-You can increase the amount of money on a [server](servers.md) using a script and
-the `grow` function.
+When you successfully hack a [server](servers.md).
+You steal a certain percentage of that [server](servers.md)'s total money.
+This percentage is, once again, determined by the [server](servers.md)'s security and your hacking skill level.
+The amount of money on a [server](servers.md) is not limitless.
+So, if you constantly hack a [server](servers.md) and deplete its money, then you will encounter diminishing returns in your hacking (since you are only hacking a certain percentage).
+You can increase the amount of money on a [server](servers.md) using a script and the `grow` function.
 
 ## Server Security
 
 Each [server](servers.md) has a security level, typically between `1` and `100`.
 A higher number means the [server](servers.md) has stronger security.
 
-As mentioned above, a [server](servers.md)'s security level is an important factor
-to consider when hacking. You can check a [server](servers.md)'s security level
-using the `analyze` [Terminal](terminal.md) command. You can
-also check a [server](servers.md)'s security in
-a script, using the `getServerSecurityLevel` function.
+As mentioned above, a [server](servers.md)'s security level is an important factor to consider when hacking.
+You can check a [server](servers.md)'s security level using the `analyze` [Terminal](terminal.md) command.
+You can also check a [server](servers.md)'s security in a script, using the `getServerSecurityLevel` function.
 
-Whenever a [server](servers.md) is hacked manually or through a script, its security
-level increases by a small amount. Calling the `grow` function in a
-script will also increase security level of the target [server](servers.md). These
-actions will make it harder for you to hack the [server](servers.md), and decrease
-the amount of money you can steal. You can lower a [server](servers.md)'s security
-level in a script using the `weaken` function.
+Whenever a [server](servers.md) is hacked manually or through a script, its security level increases by a small amount.
+Calling the `grow` function in a script will also increase security level of the target [server](servers.md).
+These actions will make it harder for you to hack the [server](servers.md), and decrease the amount of money you can steal.
+You can lower a [server](servers.md)'s security level in a script using the `weaken` function.
 
-This means that a [server](servers.md)'s security level will not fall below this
-value if you are trying to `weaken` it.
+This means that a [server](servers.md)'s security level will not fall below this value if you are trying to `weaken` it.
 
 ## Backdoors
 
-[server](servers.md) that can be hacked can also have backdoors installed. These backdoors
-will provide you with a benefit - the services may be cheaper, penalties may
-be reduced or there may be other results. Honeypots exist and will let factions
-know when you have succeeded at backdooring their system. Once you have a
-backdoor installed, you can connect to that [server](servers.md) directly.
+[server](servers.md) that can be hacked can also have backdoors installed.
+These backdoors will provide you with a benefit - the services may be cheaper, penalties may be reduced or there may be other results.
+Honeypots exist and will let factions know when you have succeeded at backdooring their system.
+Once you have a backdoor installed, you can connect to that [server](servers.md) directly.
 
-When you visit a location in the city and see that the name is partially scrambled,
-this indicates that you have backdoored the [server](servers.md) related to the location.
+When you visit a location in the city and see that the name is partially scrambled, this indicates that you have backdoored the [server](servers.md) related to the location.

--- a/src/Documentation/ui/doc/basic/hacking.md
+++ b/src/Documentation/ui/doc/basic/hacking.md
@@ -93,7 +93,7 @@ value if you are trying to `weaken` it.
 ## Backdoors
 
 [server](servers.md) that can be hacked can also have backdoors installed. These backdoors
-will provide you with a benefit; the services may be cheaper, penalties may
+will provide you with a benefit - the services may be cheaper, penalties may
 be reduced or there may be other results. Honeypots exist and will let factions
 know when you have succeeded at backdooring their system. Once you have a
 backdoor installed, you can connect to that [server](servers.md) directly.

--- a/src/Documentation/ui/doc/basic/hacking.md
+++ b/src/Documentation/ui/doc/basic/hacking.md
@@ -20,24 +20,20 @@ These programs can be coded once your hacking skill gets high enough, or they ca
 
 **There are two ways to execute port-opening programs and the NUKE virus:**
 
-1.  Connect to the target [server](servers.md) through the [Terminal](terminal.md) and use the `run` command:
-
-         $ run [programName]
-
-1.  Use a function:
-
-- `nuke`
-- `brutessh`
-- `ftpcrack`
-- `relaysmtp`
-- `httpworm`
-- `sqlinject`
+- Connect to the target [server](servers.md) through the [Terminal](terminal.md) and use the `run` command: `$ run [programName]`
+- Use a function:
+  - `nuke`
+  - `brutessh`
+  - `ftpcrack`
+  - `relaysmtp`
+  - `httpworm`
+  - `sqlinject`
 
 **There are two ways to determine how many ports need to be opened
 on a [server](servers.md) in order to successfully NUKE it:**
 
-1. Connect to that [server](servers.md) through the [Terminal](terminal.md) and use the `analyze` command.
-1. Use the `getServerNumPortsRequired` function.
+- Connect to that [server](servers.md) through the [Terminal](terminal.md) and use the `analyze` command.
+- Use the `getServerNumPortsRequired` function.
 
 Once you have enough ports opened on a [server](servers.md) and have ran the NUKE virus to gain root access, you will be able to hack it.
 
@@ -79,7 +75,7 @@ This means that a [server](servers.md)'s security level will not fall below this
 
 ## Backdoors
 
-[server](servers.md) that can be hacked can also have backdoors installed.
+[Servers](servers.md) that can be hacked can also have backdoors installed.
 These backdoors will provide you with a benefit - the services may be cheaper, penalties may be reduced or there may be other results.
 Honeypots exist and will let factions know when you have succeeded at backdooring their system.
 Once you have a backdoor installed, you can connect to that [server](servers.md) directly.

--- a/src/Documentation/ui/doc/basic/hacknet_nodes.md
+++ b/src/Documentation/ui/doc/basic/hacknet_nodes.md
@@ -1,7 +1,7 @@
 # Hacknet nodes
 
-This distributed network of computer allows you to gain money passively. By upgrading a nodes stats you can increase the amount of money it earns. If the cost gets too high it is also possile to purchase brand new nodes.
+This distributed network of computers allows you to gain money passively. By upgrading a node's stats you can increase the amount of money it earns. If the cost gets too high, it is also possile to purchase brand new nodes.
 
-Hacknet nodes won't make as much money as scripts but they can be useful at the start.
+Hacknet nodes won't make as much money as scripts, but they can be useful at the start.
 
 There is a very powerful upgrade to them called [Hacknet Servers](../advanced/hacknetservers.md)

--- a/src/Documentation/ui/doc/basic/hacknet_nodes.md
+++ b/src/Documentation/ui/doc/basic/hacknet_nodes.md
@@ -1,6 +1,8 @@
 # Hacknet nodes
 
-This distributed network of computers allows you to gain money passively. By upgrading a node's stats you can increase the amount of money it earns. If the cost gets too high, it is also possile to purchase brand new nodes.
+This distributed network of computers allows you to gain money passively.
+By upgrading a node's stats you can increase the amount of money it earns.
+If the cost gets too high, it is also possile to purchase brand new nodes.
 
 Hacknet nodes won't make as much money as scripts, but they can be useful at the start.
 

--- a/src/Documentation/ui/doc/basic/infiltration.md
+++ b/src/Documentation/ui/doc/basic/infiltration.md
@@ -28,10 +28,12 @@ If you are reduced to `0` hp or below, the infiltration will immediately end.
 ### Slash when his guard is down!
 
 Press space when the guard is preparing to attack you.
-There are 3 phases
-The first is guarding, where attacking back will result in failure.
-The 2nd is preparing, where attacking will result in a victory.
-The 3rd is attack, where the guard will attack you resulting in failure.
+
+There are 3 phases:
+
+1. guarding - attacking back will result in failure.
+2. preparing - attacking will result in a victory.
+3. attacking - the guard will attack you resulting in failure.
 
 ### Close the brackets
 
@@ -55,8 +57,8 @@ Move the cursor to the matching symbol and press space to confirm.
 
 ### Remember all the mines!
 
-At first, the cursor cannot be moved - remember the positions of the mines.
-Then move the cursor and press space to mark the mines on the board.
+At first, the cursor cannot be moved - remember the positions of the mines.  
+Next, move the cursor and press space to mark the mines on the board.
 
 ### Cut the wires
 

--- a/src/Documentation/ui/doc/basic/infiltration.md
+++ b/src/Documentation/ui/doc/basic/infiltration.md
@@ -12,7 +12,7 @@ these for money or for [Faction](factions.md) [Reputation](reputation.md). To tr
 visit a [Company](companies.md) through the [World](world.md) menu. There will be an option that
 says 'Infiltrate [Company](companies.md)'.
 
-When infiltrating a [Company](companies.md) you will be presented with short active challenges.
+When infiltrating a [Company](companies.md), you will be presented with short active challenges.
 None of the challenges use the mouse.
 
 The difficulty at the top lowers with better combat stats and charisma. It is not recommended
@@ -32,7 +32,7 @@ infiltration will immediately end.
 ### Slash when his guard is down!
 
 Press space when the guard is preparing to attack you.
-There's 3 phases
+There are 3 phases
 The first is guarding, where attacking back will result in failure.
 The 2nd is preparing, where attacking will result in a victory.
 The 3rd is attack, where the guard will attack you resulting in failure.
@@ -51,7 +51,7 @@ Use the arrows to find a compliment for the guard.
 
 ### Enter the Code!
 
-Match the arrows as they appears.
+Match the arrows as they appear.
 
 ### Match the symbols!
 
@@ -59,7 +59,7 @@ Move the cursor to the matching symbol and press space to confirm.
 
 ### Remember all the mines!
 
-At first the cursor cannot be moved, remember the positions of the X.
+At first, the cursor cannot be moved - remember the positions of the mines.
 Then move the cursor and press space to mark the mines on the board.
 
 ### Cut the wires

--- a/src/Documentation/ui/doc/basic/infiltration.md
+++ b/src/Documentation/ui/doc/basic/infiltration.md
@@ -1,29 +1,25 @@
 # Infiltration
 
-Infiltration is a gameplay mechanic that allows you to infiltrate a
-[Company](companies.md)'s facility to try and steal the [Company](companies.md)'s classified secrets.
+Infiltration is a gameplay mechanic that allows you to infiltrate a [Company](companies.md)'s facility to try and steal the [Company](companies.md)'s classified secrets.
 These secrets can be sold for money or for [Reputation](reputation.md) with a [Faction](factions.md).
 
 ## Overview
 
 Many companies have facilities that you can attempt to infiltrate.
-By infiltrating, you can steal classified [Company](companies.md) secrets and then sell
-these for money or for [Faction](factions.md) [Reputation](reputation.md). To try and infiltrate a [Company](companies.md),
-visit a [Company](companies.md) through the [World](world.md) menu. There will be an option that
-says 'Infiltrate [Company](companies.md)'.
+By infiltrating, you can steal classified [Company](companies.md) secrets and then sell these for money or for [Faction](factions.md) [Reputation](reputation.md).
+To try and infiltrate a [Company](companies.md), visit a [Company](companies.md) through the [World](world.md) menu.
+There will be an option that says 'Infiltrate [Company](companies.md)'.
 
 When infiltrating a [Company](companies.md), you will be presented with short active challenges.
 None of the challenges use the mouse.
 
-The difficulty at the top lowers with better combat stats and charisma. It is not recommended
-to attempt infiltrations above mid-normal.
+The difficulty at the top lowers with better combat stats and charisma.
+It is not recommended to attempt infiltrations above mid-normal.
 
-The `maximum level` is the number of challenges you will need to pass to receive
-the infiltration reward.
+The `maximum level` is the number of challenges you will need to pass to receive the infiltration reward.
 
-Every time you fail an infiltration challenge, you will take damage based on the
-difficulty of the infiltration. If you are reduced to `0` hp or below, the
-infiltration will immediately end.
+Every time you fail an infiltration challenge, you will take damage based on the difficulty of the infiltration.
+If you are reduced to `0` hp or below, the infiltration will immediately end.
 
 - Most use spacebar as `action`
 - Some use WASD or arrows interchangeably.

--- a/src/Documentation/ui/doc/basic/ram.md
+++ b/src/Documentation/ui/doc/basic/ram.md
@@ -1,7 +1,7 @@
 # RAM
 
-In bitburner RAM determines how many [Scripts](scripts.md) can run on a [Server](servers.md).
+In Bitburner, RAM determines how many [Scripts](scripts.md) can run on a [Server](servers.md).
 
-Multiplying the number of threads a [Script](scripts.md) uses multiplies it RAM cost but also multiplies the effectiveness of several functions, like `ns.hack()`, `ns.grow()`, and `ns.weaken()`.
+Multiplying the number of threads a [Script](scripts.md) uses multiplies its RAM cost, but also multiplies the effectiveness of several functions such as `ns.hack()`, `ns.grow()`, and `ns.weaken()`.
 
 You can purchase more RAM for your home computer from tech vendors. You can also use other computers as source of additional RAM.

--- a/src/Documentation/ui/doc/basic/ram.md
+++ b/src/Documentation/ui/doc/basic/ram.md
@@ -4,4 +4,5 @@ In Bitburner, RAM determines how many [Scripts](scripts.md) can run on a [Server
 
 Multiplying the number of threads a [Script](scripts.md) uses multiplies its RAM cost, but also multiplies the effectiveness of several functions such as `ns.hack()`, `ns.grow()`, and `ns.weaken()`.
 
-You can purchase more RAM for your home computer from tech vendors. You can also use other computers as source of additional RAM.
+You can purchase more RAM for your home computer from tech vendors.
+You can also use other computers as source of additional RAM.

--- a/src/Documentation/ui/doc/basic/reputation.md
+++ b/src/Documentation/ui/doc/basic/reputation.md
@@ -1,9 +1,9 @@
 # Reputation
 
-In order to acquire [Augmentations](augmentations.md) from [Factions](factions.md) you need to acquire their trust.
+In order to acquire [Augmentations](augmentations.md) from [Factions](factions.md), you need to earn their trust.
 
-This can be done in a variety of ways but the most common is offering your services to a [Faction](faction.md). But also from [Infiltrations](infiltration.md).
+This can be done in a variety of ways, but the most common is offering your services to a [Faction](faction.md). Another option is to give them intel from [Infiltrations](infiltration.md).
 
-When installing [Augmentations](augmentations.md) all your reputation gets converted to favor. Favor increases the rate at which reputation is gained with that faction.
+When installing [Augmentations](augmentations.md), all your reputation gets converted to favor. Favor increases the rate at which reputation is gained with that faction.
 
 With enough favor, donations are unlocked. Donations allow you to spend money to acquire reputation directly. Without working for the faction. This feature is particularily useful when a very large amount of reputation is needed for an augmentation.

--- a/src/Documentation/ui/doc/basic/reputation.md
+++ b/src/Documentation/ui/doc/basic/reputation.md
@@ -2,8 +2,13 @@
 
 In order to acquire [Augmentations](augmentations.md) from [Factions](factions.md), you need to earn their trust.
 
-This can be done in a variety of ways, but the most common is offering your services to a [Faction](faction.md). Another option is to give them intel from [Infiltrations](infiltration.md).
+This can be done in a variety of ways, but the most common is offering your services to a [Faction](faction.md).
+Another option is to give them intel from [Infiltrations](infiltration.md).
 
-When installing [Augmentations](augmentations.md), all your reputation gets converted to favor. Favor increases the rate at which reputation is gained with that faction.
+When installing [Augmentations](augmentations.md), all your reputation gets converted to favor.
+Favor increases the rate at which reputation is gained with that faction.
 
-With enough favor, donations are unlocked. Donations allow you to spend money to acquire reputation directly. Without working for the faction. This feature is particularily useful when a very large amount of reputation is needed for an augmentation.
+With enough favor, donations are unlocked.
+Donations allow you to spend money to acquire reputation directly.
+Without working for the faction.
+This feature is particularily useful when a very large amount of reputation is needed for an augmentation.

--- a/src/Documentation/ui/doc/basic/scripts.md
+++ b/src/Documentation/ui/doc/basic/scripts.md
@@ -2,7 +2,7 @@
 
 Scripts are programs that can be used to automate the hacking process
 and almost every other part of the game. Scripts must be written
-in javascript.
+in JavaScript.
 
 It is highly recommended that you have a basic background in programming
 to start writing scripts. You by no means need to be an expert. All you
@@ -16,9 +16,6 @@ If you'd like to learn a little bit about programming, see
 When running a script, you can choose to pass arguments to that script.
 The script's logic can access and act on these arguments. This allows
 for flexibility in your scripts.
-
-For information on how to run scripts with arguments, see
-[Scripts](scripts.md)
 
 ## Identifying a Script
 
@@ -154,7 +151,7 @@ Displays all active scripts and their [RAM](ram.md) usage
 
 ## Notes about how Scripts work offline
 
-The scripts that you write and execute are in Javascript.
+The scripts that you write and execute are in JavaScript.
 For this reason, it is not possible for these scripts to run while
 offline (when the game is closed). It is important to note that for
 this reason, conditionals such as `if`/`else` statements and certain
@@ -173,7 +170,7 @@ when the game is online. These calculated rates are used to determine
 how many times these function calls would be made while the game is
 offline.
 
-Also, note that because of the way the javascript engine works, whenever you reload or re-open the game all of the
+Also, note that because of the way the JavaScript engine works, whenever you reload or re-open the game all of the
 scripts that you are running will start running from the BEGINNING
 of the code. The game does not keep track of where exactly the
 execution of a script is when it saves/loads.

--- a/src/Documentation/ui/doc/basic/scripts.md
+++ b/src/Documentation/ui/doc/basic/scripts.md
@@ -41,7 +41,7 @@ For example, if a normal single-threaded script is able to hack $10,000, then ru
 Scripts will not actually become multithreaded in the real-world sense.)
 
 When multithreading a script, the total [RAM](ram.md) cost can be calculated by simply multiplying the base [RAM](ram.md) cost of the script with the number of threads, where the base cost refers to the amount of [RAM](ram.md) required to run the script single-threaded.
-In the [terminal](terminal.md), you can run the `mem` [Terminal](terminal.md) command to see how much [RAM](ram.md) a script requires with `n` threads::
+In the [terminal](terminal.md), you can run the `mem` [Terminal](terminal.md) command to see how much [RAM](ram.md) a script requires with `n` threads:
 
     $ mem [scriptname] -t n
 

--- a/src/Documentation/ui/doc/basic/scripts.md
+++ b/src/Documentation/ui/doc/basic/scripts.md
@@ -1,83 +1,64 @@
 # Scripts
 
-Scripts are programs that can be used to automate the hacking process
-and almost every other part of the game. Scripts must be written
-in JavaScript.
+Scripts are programs that can be used to automate the hacking process and almost every other part of the game.
+Scripts must be written in JavaScript.
 
-It is highly recommended that you have a basic background in programming
-to start writing scripts. You by no means need to be an expert. All you
-need is some familiarity with basic programming constructs like
-`for`/`while` loops, conditionals (`if`/`else`), `functions`, `variables`, etc.
-If you'd like to learn a little bit about programming, see
-[this page](../programming/learn.md).
+It is highly recommended that you have a basic background in programming to start writing scripts.
+You by no means need to be an expert.
+All you need is some familiarity with basic programming constructs like `for`/`while` loops, conditionals (`if`/`else`), `functions`, `variables`, etc.
+If you'd like to learn a little bit about programming, see [this page](../programming/learn.md).
 
 ## Script Arguments
 
 When running a script, you can choose to pass arguments to that script.
-The script's logic can access and act on these arguments. This allows
-for flexibility in your scripts.
+The script's logic can access and act on these arguments.
+This allows for flexibility in your scripts.
 
 ## Identifying a Script
 
-Many commands and functions act on an executing script
-(i.e. a script that is running). Therefore, there must
-be a way to specify which script you want those commands & functions
-to act on.
+Many commands and functions act on an executing script (i.e. a script that is running).
+Therefore, there must be a way to specify which script you want those commands & functions to act on.
 
-The best way to identify a script is by its PID (Process IDentifier). This
-unique number is returned from `run`, `exec`, etc., and also
-shows in the output of `ps`.
+The best way to identify a script is by its PID (Process IDentifier).
+This unique number is returned from `run`, `exec`, etc., and also shows in the output of `ps`.
 
-A secondary way to identify scripts is by name **and** arguments. However (by
-default) you can run a multiple copies of a script with the same arguments, so
-this does not necessarily **uniquely** identify a script. In case of multiple
-matches, most functions will return an arbitrary one (typically the first one
-to be started). An exception is `kill`, which will kill all the
-matching scripts.
+A secondary way to identify scripts is by name **and** arguments.
+However (by default) you can run a multiple copies of a script with the same arguments, so this does not necessarily **uniquely** identify a script.
+In case of multiple matches, most functions will return an arbitrary one (typically the first one to be started).
+An exception is `kill`, which will kill all the matching scripts.
 
-The arguments must be an **exact** match. This means that both
-the order and type of the arguments matter.
+The arguments must be an **exact** match.
+This means that both the order and type of the arguments matter.
 
 ## Multithreading scripts
 
-A script can be run with multiple threads. This is also called multithreading.
-The effect of multithreading is that every call to the
-`hack`, `grow`, and `weaken` functions
-will have their results multiplied by the number of threads.
-For example, if a normal single-threaded script
-is able to hack $10,000, then running the same script with 5 threads would
-yield $50,000.
+A script can be run with multiple threads.
+This is also called multithreading.
+The effect of multithreading is that every call to the `hack`, `grow`, and `weaken` functions will have their results multiplied by the number of threads.
+For example, if a normal single-threaded script is able to hack $10,000, then running the same script with 5 threads would yield $50,000.
 
 (This is the **only** affect of running a script with multiple threads.
-Scripts will not actually become multithreaded in the real-world
-sense.)
+Scripts will not actually become multithreaded in the real-world sense.)
 
-When multithreading a script, the total [RAM](ram.md) cost can be calculated by
-simply multiplying the base [RAM](ram.md) cost of the script with the number of
-threads, where the base cost refers to the amount of [RAM](ram.md) required to
-run the script single-threaded. In the [terminal](terminal.md), you can run the
-`mem` [Terminal](terminal.md) command to see how much [RAM](ram.md) a script
-requires with `n` threads::
+When multithreading a script, the total [RAM](ram.md) cost can be calculated by simply multiplying the base [RAM](ram.md) cost of the script with the number of threads, where the base cost refers to the amount of [RAM](ram.md) required to run the script single-threaded.
+In the [terminal](terminal.md), you can run the `mem` [Terminal](terminal.md) command to see how much [RAM](ram.md) a script requires with `n` threads::
 
     $ mem [scriptname] -t n
 
 ## Working with Scripts in Terminal
 
-Running a script requires [RAM](ram.md). The more complex a script is, the more
-[RAM](ram.md) it requires to run. Scripts can be run on any [server](server.md) you have root
-access to.
+Running a script requires [RAM](ram.md).
+The more complex a script is, the more [RAM](ram.md) it requires to run.
+Scripts can be run on any [server](server.md) you have root access to.
 
-Here are some [terminal](terminal.md) commands that are useful when working
-with scripts:
+Here are some [terminal](terminal.md) commands that are useful when working with scripts:
 
 **check [script] [args...]**
 
-Prints the logs of the script specified by the name and arguments to
-[Terminal](terminal.md). Arguments should be separated by a space. Remember that scripts
-are uniquely identified by their arguments as well as their name. For
-example, if you ran a script `foo.js` with the argument `foodnstuff`
-then in order to 'check' it you must also add the `foodnstuff` argument
-to the check command::
+Prints the logs of the script specified by the name and arguments to [Terminal](terminal.md).
+Arguments should be separated by a space.
+Remember that scripts are uniquely identified by their arguments as well as their name.
+For example, if you ran a script `foo.js` with the argument `foodnstuff` then in order to 'check' it you must also add the `foodnstuff` argument to the check command::
 
     $ check foo.js foodnstuff
 
@@ -87,12 +68,11 @@ Shows the current server's [RAM](ram.md) usage and availability
 
 **kill [pid]** or **kill [script] [args...]**
 
-Stops a script that is running with the specified PID, or script name and
-arguments. Arguments should be separated by a space. Remember that
-scripts are identified by their arguments as well as their name.
-For example, if you ran a script `foo.js` with
-the argument 1 and 2, then just typing `kill foo.js` will
-not work. You have to use:
+Stops a script that is running with the specified PID, or script name and arguments.
+Arguments should be separated by a space.
+Remember that scripts are identified by their arguments as well as their name.
+For example, if you ran a script `foo.js` with the argument 1 and 2, then just typing `kill foo.js` will not work.
+You have to use:
 
     $ kill foo.js 1 2
 
@@ -102,7 +82,8 @@ Check how much [RAM](ram.md) a script requires to run with n threads
 
 **nano [script]**
 
-Create/Edit a script. The name of the script must end with `.js`
+Create/Edit a script.
+The name of the script must end with `.js`
 
 **ps**
 
@@ -114,10 +95,10 @@ Delete a script from the [server](servers.md). This is permanent
 
 **run [script] [-t] [n] [args...]**
 
-Run a script with n threads and the specified arguments. Each argument should
-be separated by a space. Both the arguments and thread specification are
-optional. If neither are specified, then the script will be run single-threaded
-with no arguments.
+Run a script with n threads and the specified arguments.
+Each argument should be separated by a space.
+Both the arguments and thread specification are optional.
+If neither are specified, then the script will be run single-threaded with no arguments.
 
 Examples:
 
@@ -139,11 +120,9 @@ Run `foo.js` with 50 threads and a single argument: [foodnstuff]:
 
 **tail [pid]** or **tail [script] [args...]**
 
-Displays the logs of the script specified by the PID or name and arguments. Note that
-scripts are identified by their arguments as well as their name. For example,
-if you ran a script `foo.js` with the argument `foodnstuff` then in order to
-`tail` it you must also add the `foodnstuff` argument to the tail command as
-so: `tail foo.js foodnstuff`
+Displays the logs of the script specified by the PID or name and arguments.
+Note that scripts are identified by their arguments as well as their name.
+For example, if you ran a script `foo.js` with the argument `foodnstuff` then in order to `tail` it you must also add the `foodnstuff` argument to the tail command as so: `tail foo.js foodnstuff`
 
 **top**
 
@@ -152,25 +131,15 @@ Displays all active scripts and their [RAM](ram.md) usage
 ## Notes about how Scripts work offline
 
 The scripts that you write and execute are in JavaScript.
-For this reason, it is not possible for these scripts to run while
-offline (when the game is closed). It is important to note that for
-this reason, conditionals such as `if`/`else` statements and certain
-commands such as `purchaseHacknetNode()` or `nuke()` will not work while
-the game is offline.
+For this reason, it is not possible for these scripts to run while offline (when the game is closed).
+It is important to note that for this reason, conditionals such as `if`/`else` statements and certain commands such as `purchaseHacknetNode()` or `nuke()` will not work while the game is offline.
 
-However, Scripts WILL continue to generate money and hacking exp
-for you while the game is offline. This offline production is based
-off of the scripts' production while the game is online.
+However, Scripts WILL continue to generate money and hacking exp for you while the game is offline.
+This offline production is based off of the scripts' production while the game is online.
 
-`grow()` and `weaken()` are two functions that will also be
-applied when the game is offline, although at a slower rate compared
-to if the game was open. This is done by having each script keep
-track of the rate at which the `grow()` and `weaken()` commands are called
-when the game is online. These calculated rates are used to determine
-how many times these function calls would be made while the game is
-offline.
+`grow()` and `weaken()` are two functions that will also be applied when the game is offline, although at a slower rate compared to if the game was open.
+This is done by having each script keep track of the rate at which the `grow()` and `weaken()` commands are called when the game is online.
+These calculated rates are used to determine how many times these function calls would be made while the game is offline.
 
-Also, note that because of the way the JavaScript engine works, whenever you reload or re-open the game all of the
-scripts that you are running will start running from the BEGINNING
-of the code. The game does not keep track of where exactly the
-execution of a script is when it saves/loads.
+Also, note that because of the way the JavaScript engine works, whenever you reload or re-open the game all of the scripts that you are running will start running from the BEGINNING of the code.
+The game does not keep track of where exactly the execution of a script is when it saves/loads.

--- a/src/Documentation/ui/doc/basic/servers.md
+++ b/src/Documentation/ui/doc/basic/servers.md
@@ -34,12 +34,11 @@ The player starts with a single server: his/her home computer.
 This server will have the hostname `home`.
 The player's home computer is special for a variety of reasons:
 
-1. The home computer's [RAM](ram.md) can be upgraded.
-   This can be done by visiting certain locations in the [World](world.md).
-
-2. The home computer persists through [Augmentation](augmentations.md) installations.
-   This means that you will not lose any [RAM](ram.md) upgrades or [Scripts](scripts.md) on your home computer when you install [Augmentations](augmentations.md)
-   (you will, however, lose programs and messages on your home computer).
+- The home computer's [RAM](ram.md) can be upgraded.
+  This can be done by visiting certain locations in the [World](world.md).
+- The home computer persists through [Augmentation](augmentations.md) installations.
+  This means that you will not lose any [RAM](ram.md) upgrades or [Scripts](scripts.md) on your home computer when you install [Augmentations](augmentations.md)
+  (you will, however, lose programs and messages on your home computer).
 
 The player can also purchase additional servers.
 This can be done by visiting certain locations in the [World](world.md), or it can be done automatically through a script using the `purchaseServer` function.

--- a/src/Documentation/ui/doc/basic/servers.md
+++ b/src/Documentation/ui/doc/basic/servers.md
@@ -8,19 +8,19 @@ servers, see the [terminal](terminal.md) page.
 
 ## Server Statistics
 
-Each server has it's own statistics, such as [RAM](ram.md), required hacking level and number of
+Each server has its own statistics, such as [RAM](ram.md), required hacking level, and number of
 ports required to successfully `NUKE` it.
 
 Perhaps the most important property of a server to make note of is its [RAM](ram.md),
 which refers to how much memory is available on that machine. [RAM](ram.md) is
 important because it is required to run [Scripts](scripts.md). More [RAM](ram.md) allows
-the user to run more powerful and complicated [scripts](scripts.md) as well as executing
-a script with more threads.
+the user to run more powerful and complicated [scripts](scripts.md), as well as executing
+scripts with more threads.
 
 The `free`, `scan-analyze`, and `analyze` [Terminal](terminal.md) commands
 can be used to check how much [RAM](ram.md) a server has.
 
-Some servers have some randomized statistics, such as [RAM](ram.md), max Money or
+Some servers have some randomized statistics, such as [RAM](ram.md), max Money, or
 required hacking level. These statistics are randomly generated from a range of values.
 
 ## Identifying Servers
@@ -46,15 +46,15 @@ This server will have the hostname `home`. The player's home
 computer is special for a variety of reasons:
 
 1. The home computer's [RAM](ram.md) can be upgraded. This can be done by visiting
-   certain locations in the World.
+   certain locations in the [World](world.md).
 
-2. The home computer persists through [Augmentation](augmentations.md) Installations. This means
+2. The home computer persists through [Augmentation](augmentations.md) installations. This means
    that you will not lose any [RAM](ram.md) upgrades or [Scripts](scripts.md) on your
-   home computer when you install [Augmentations](augmentations.md) (you will
+   home computer when you install [Augmentations](augmentations.md) (you will,
    however, lose programs and messages on your home computer).
 
 The player can also purchase additional servers. This can be
-done by visiting certain locations in the World, or it can be
+done by visiting certain locations in the [World](world.md), or it can be
 done automatically through a script using the `purchaseServer`
 function. The advantage of purchased servers is that,
 in terms of [RAM](ram.md), they are cheaper than upgrading your home
@@ -63,8 +63,8 @@ are lost when you install [Augmentations](augmentations.md).
 
 ## Hackable Servers
 
-Most servers that are not owned by the player can be hacked for money
-and exp. See the hacking page for more details.
+Most servers that are not owned by the player can be [hacked](hacking.md) for money
+and exp.
 
 Different servers have different levels of security, but also offer
 different rewards when being hacked.
@@ -73,5 +73,5 @@ different rewards when being hacked.
 
 The servers are in a randomly organized tree-structure. The distance from
 the home computer to each server is fixed, but the exact route to them is
-randomized when you install [augmentations](augmentations.md). In general the
-further away from home computer a server is the higher it's statistics are.
+randomized when you install [augmentations](augmentations.md). In general, the
+further away from home computer a server is the higher its statistics are.

--- a/src/Documentation/ui/doc/basic/servers.md
+++ b/src/Documentation/ui/doc/basic/servers.md
@@ -1,77 +1,59 @@
 # Servers
 
-In this game, a server refers to a computer that can be connected to,
-accessed, and manipulated through the [Terminal](terminal.md). All servers in the
-game are connected to each other to form a large, global network.
-To learn about how to navigate this network and connect to other
-servers, see the [terminal](terminal.md) page.
+In this game, a server refers to a computer that can be connected to, accessed, and manipulated through the [Terminal](terminal.md).
+All servers in the game are connected to each other to form a large, global network.
+To learn about how to navigate this network and connect to other servers, see the [terminal](terminal.md) page.
 
 ## Server Statistics
 
-Each server has its own statistics, such as [RAM](ram.md), required hacking level, and number of
-ports required to successfully `NUKE` it.
+Each server has its own statistics, such as [RAM](ram.md), required hacking level, and number of ports required to successfully `NUKE` it.
 
-Perhaps the most important property of a server to make note of is its [RAM](ram.md),
-which refers to how much memory is available on that machine. [RAM](ram.md) is
-important because it is required to run [Scripts](scripts.md). More [RAM](ram.md) allows
-the user to run more powerful and complicated [scripts](scripts.md), as well as executing
-scripts with more threads.
+Perhaps the most important property of a server to make note of is its [RAM](ram.md), which refers to how much memory is available on that machine. [RAM](ram.md) is important because it is required to run [Scripts](scripts.md).
+More [RAM](ram.md) allows the user to run more powerful and complicated [scripts](scripts.md), as well as executing scripts with more threads.
 
-The `free`, `scan-analyze`, and `analyze` [Terminal](terminal.md) commands
-can be used to check how much [RAM](ram.md) a server has.
+The `free`, `scan-analyze`, and `analyze` [Terminal](terminal.md) commands can be used to check how much [RAM](ram.md) a server has.
 
-Some servers have some randomized statistics, such as [RAM](ram.md), max Money, or
-required hacking level. These statistics are randomly generated from a range of values.
+Some servers have some randomized statistics, such as [RAM](ram.md), max Money, or required hacking level.
+These statistics are randomly generated from a range of values.
 
 ## Identifying Servers
 
 A server is identified by its hostname.
 A hostname is a label assigned to a server.
-A hostname will usually give you a general idea of what the server
-is. For example, the company Nova Medical might have a server with
-the hostname `nova-med`.
+A hostname will usually give you a general idea of what the server is.
+For example, the company Nova Medical might have a server with the hostname `nova-med`.
 
-Hostnames are unique. This means that if one
-server has the the hostname `some-server`, then no other server
-in the game can have that that hostname.
+Hostnames are unique.
+This means that if one server has the the hostname `some-server`, then no other server in the game can have that that hostname.
 
-There are many `functions`
-and [terminal](terminal.md) commands in the game
-that will require you to target a specific server by hostname.
+There are many `functions` and [terminal](terminal.md) commands in the game that will require you to target a specific server by hostname.
 
 ## Player-owned Servers
 
 The player starts with a single server: his/her home computer.
-This server will have the hostname `home`. The player's home
-computer is special for a variety of reasons:
+This server will have the hostname `home`.
+The player's home computer is special for a variety of reasons:
 
-1. The home computer's [RAM](ram.md) can be upgraded. This can be done by visiting
-   certain locations in the [World](world.md).
+1. The home computer's [RAM](ram.md) can be upgraded.
+   This can be done by visiting certain locations in the [World](world.md).
 
-2. The home computer persists through [Augmentation](augmentations.md) installations. This means
-   that you will not lose any [RAM](ram.md) upgrades or [Scripts](scripts.md) on your
-   home computer when you install [Augmentations](augmentations.md) (you will,
-   however, lose programs and messages on your home computer).
+2. The home computer persists through [Augmentation](augmentations.md) installations.
+   This means that you will not lose any [RAM](ram.md) upgrades or [Scripts](scripts.md) on your home computer when you install [Augmentations](augmentations.md)
+   (you will, however, lose programs and messages on your home computer).
 
-The player can also purchase additional servers. This can be
-done by visiting certain locations in the [World](world.md), or it can be
-done automatically through a script using the `purchaseServer`
-function. The advantage of purchased servers is that,
-in terms of [RAM](ram.md), they are cheaper than upgrading your home
-computer. The disadvantage is that your purchased servers
-are lost when you install [Augmentations](augmentations.md).
+The player can also purchase additional servers.
+This can be done by visiting certain locations in the [World](world.md), or it can be done automatically through a script using the `purchaseServer` function.
+The advantage of purchased servers is that, in terms of [RAM](ram.md), they are cheaper than upgrading your home computer.
+The disadvantage is that your purchased servers are lost when you install [Augmentations](augmentations.md).
 
 ## Hackable Servers
 
-Most servers that are not owned by the player can be [hacked](hacking.md) for money
-and exp.
+Most servers that are not owned by the player can be [hacked](hacking.md) for money and exp.
 
-Different servers have different levels of security, but also offer
-different rewards when being hacked.
+Different servers have different levels of security, but also offer different rewards when being hacked.
 
 ## Server Connections
 
-The servers are in a randomly organized tree-structure. The distance from
-the home computer to each server is fixed, but the exact route to them is
-randomized when you install [augmentations](augmentations.md). In general, the
-further away from home computer a server is the higher its statistics are.
+The servers are in a randomly organized tree-structure.
+The distance from the home computer to each server is fixed, but the exact route to them is randomized when you install [augmentations](augmentations.md).
+In general, the further away from home computer a server is the higher its statistics are.

--- a/src/Documentation/ui/doc/basic/stats.md
+++ b/src/Documentation/ui/doc/basic/stats.md
@@ -12,7 +12,7 @@ Affects:
 - Time it takes to hack a server
 - Time it takes to execute the `grow()` and `weaken()` function
 - Chance to successfully hack a server
-- Percent money stolen when hacking a server
+- Percent of money stolen when hacking a server
 - Success rate of certain [crimes](crimes.md)
 - Time it takes to create a program
 - [Faction](factions.md) [Reputation](reputation.md) gain when carrying out Hacking Contracts or Field Work

--- a/src/Documentation/ui/doc/basic/stats.md
+++ b/src/Documentation/ui/doc/basic/stats.md
@@ -1,7 +1,6 @@
 # Stats
 
-The player has several stats that can be increased in order to progress
-in the game.
+The player has several stats that can be increased in order to progress in the game.
 
 ## Hacking
 

--- a/src/Documentation/ui/doc/basic/stockmarket.md
+++ b/src/Documentation/ui/doc/basic/stockmarket.md
@@ -1,109 +1,92 @@
 # Stock Market
 
-The Stock Market refers to the World Stock Exchange (WSE), through which you can
-buy and sell stocks in order to make money.
+The Stock Market refers to the World Stock Exchange (WSE), through which you can buy and sell stocks in order to make money.
 
 The WSE can be found in the `City` tab, and is accessible in every city.
 
 ## Fundamentals
 
-The Stock Market is not as simple as "buy at price X and sell at price Y". The following
-are several fundamental concepts you need to understand about the stock market.
+The Stock Market is not as simple as "buy at price X and sell at price Y".
+The following are several fundamental concepts you need to understand about the stock market.
 
-For those that have experience with finance/trading/investing, please be aware
-that the game's stock market does not function exactly like it does in the real
-world. So these concepts below should seem similar, but won't be exactly the same.
+For those that have experience with finance/trading/investing, please be aware that the game's stock market does not function exactly like it does in the real world.
+So these concepts below should seem similar, but won't be exactly the same.
 
 ## Positions: Long vs Short
 
-When making a transaction on the stock market, there are two types of positions:
-Long and Short. A Long position is the typical scenario where you buy a stock and
-earn a profit if the price of that stock increases. Meanwhile, a Short position
-is the exact opposite. In a Short position, you purchase shares of a stock and
-earn a profit if the price of that stock decreases. This is also called 'shorting'
-a stock.
+When making a transaction on the stock market, there are two types of positions: Long and Short.
+A Long position is the typical scenario where you buy a stock and earn a profit if the price of that stock increases.
+Meanwhile, a Short position is the exact opposite.
+In a Short position, you purchase shares of a stock and earn a profit if the price of that stock decreases.
+This is also called 'shorting' a stock.
 
-Shorting stocks is not available immediately, and must be unlocked later in the
-game.
+Shorting stocks is not available immediately, and must be unlocked later in the game.
 
 ## Forecast & Second-Order Forecast
 
-A stock's forecast is its likelihood of increasing or decreasing in value. The
-forecast is typically represented by its probability of increasing in either
-a decimal or percentage form. For example, a forecast of `70%` means the stock
-has a `70%` chance of increasing and a `30%` chance of decreasing.
+A stock's forecast is its likelihood of increasing or decreasing in value.
+The forecast is typically represented by its probability of increasing in either a decimal or percentage form.
+For example, a forecast of `70%` means the stock has a `70%` chance of increasing and a `30%` chance of decreasing.
 
 A stock's second-order forecast is the target value that its forecast trends towards.
-For example, if a stock has a forecast of `60%` and a second-order forecast of `70%`,
-then the stock's forecast should slowly trend towards `70%` over time. However, this is
-determined by RNG so there is a chance that it may never reach `70%`.
+For example, if a stock has a forecast of `60%` and a second-order forecast of `70%`, then the stock's forecast should slowly trend towards `70%` over time.
+However, this is determined by RNG so there is a chance that it may never reach `70%`.
 
 Both the forecast and the second-order forecast change over time.
 
-A stock's forecast can be viewed after purchasing Four Sigma (4S) Market Data
-access. This lets you see the forecast info on the Stock Market UI. If you also
-purchase access to the 4S Market Data TIX API, then you can view a stock's forecast
-using the `getStockForecast` function.
+A stock's forecast can be viewed after purchasing Four Sigma (4S) Market Data access.
+This lets you see the forecast info on the Stock Market UI.
+If you also purchase access to the 4S Market Data TIX API, then you can view a stock's forecast using the `getStockForecast` function.
 
 A stock's second-order forecast is always hidden.
 
 ## Spread (Bid Price & Ask Price)
 
-The **bid price** is the maximum price at which someone will buy a stock on the
-stock market.
+The **bid price** is the maximum price at which someone will buy a stock on the stock market.
 
-The **ask price** is the minimum price that a seller is willing to receive for a stock
-on the stock market
+The **ask price** is the minimum price that a seller is willing to receive for a stock on the stock market
 
-The ask price will always be higher than the bid price (This is because if a seller
-is willing to receive less than the bid price, that transaction is guaranteed to
-happen). The difference between the bid and ask price is known as the **spread**.
+The ask price will always be higher than the bid price (This is because if a seller is willing to receive less than the bid price, that transaction is guaranteed to happen).
+The difference between the bid and ask price is known as the **spread**.
 A stock's "price" will be the average of the bid and ask price.
 
-The bid and ask price are important because these are the prices at which a
-transaction actually occurs. If you purchase a stock in the long position, the cost
-of your purchase depends on that stock's ask price. If you then try to sell that
-stock (still in the long position), the price at which you sell is the stock's
-bid price. Note that this is reversed for a short position. Purchasing a stock
-in the short position will occur at the stock's bid price, and selling a stock
-in the short position will occur at the stock's ask price.
+The bid and ask price are important because these are the prices at which a transaction actually occurs.
+If you purchase a stock in the long position, the cost of your purchase depends on that stock's ask price.
+If you then try to sell that stock (still in the long position), the price at which you sell is the stock's bid price.
+Note that this is reversed for a short position.
+Purchasing a stock in the short position will occur at the stock's bid price, and selling a stock in the short position will occur at the stock's ask price.
 
 ## Transactions Influencing Stock Forecast
 
-Buying or selling a large number of shares
-of a stock will influence that stock's forecast & second-order forecast.
+Buying or selling a large number of shares of a stock will influence that stock's forecast & second-order forecast.
 The forecast is the likelihood that the stock will increase or decrease in price.
 The magnitude of this effect depends on the number of shares being transacted.
 More shares will have a bigger effect.
 
-The effect that transactions have on a stock's second-order forecast is
-significantly smaller than the effect on its forecast.
+The effect that transactions have on a stock's second-order forecast is significantly smaller than the effect on its forecast.
 
 ## Order Types
 
 There are three different types of orders you can make to buy or sell stocks on the exchange:
 Market Order, Limit Order, and Stop Order.
 
-Limit Orders and Stop Orders are not available immediately, and must be unlocked
-later in the game.
+Limit Orders and Stop Orders are not available immediately, and must be unlocked later in the game.
 
-When you place a Market Order to buy or sell a stock, the order executes immediately at
-whatever the current price of the stock is. For example if you choose to short a stock
-with 5000 shares using a Market Order, you immediately purchase those 5000 shares in a
-Short position at whatever the current market price is for that stock.
+When you place a Market Order to buy or sell a stock, the order executes immediately at whatever the current price of the stock is.
+For example if you choose to short a stock with 5000 shares using a Market Order, you immediately purchase those 5000 shares in a Short position at whatever the current market price is for that stock.
 
-A Limit Order is an order that only executes under certain conditions. A Limit Order is
-used to buy or sell a stock at a specified price or better. For example, lets say you
-purchased a Long position of 100 shares of some stock at a price of $10 per share. You
-can place a Limit Order to sell those 100 shares at $50 or better. The Limit Order will
-execute when the price of the stock reaches a value of $50 or higher.
+A Limit Order is an order that only executes under certain conditions.
+A Limit Order is used to buy or sell a stock at a specified price or better.
+For example, lets say you purchased a Long position of 100 shares of some stock at a price of $10 per share.
+You can place a Limit Order to sell those 100 shares at $50 or better.
+The Limit Order will execute when the price of the stock reaches a value of $50 or higher.
 
-A Stop Order is the opposite of a Limit Order. It is used to buy or sell a stock at a
-specified price (before the price gets 'worse'). For example, lets say you purchased a
-Short position of 100 shares of some stock at a price of $100 per share. The current
-price of the stock is $80 (a profit of $20 per share). You can place a Stop Order to
-sell the Short position if the stock's price reaches $90 or higher. This can be used
-to lock in your profits and limit any losses.
+A Stop Order is the opposite of a Limit Order.
+It is used to buy or sell a stock at a specified price (before the price gets 'worse').
+For example, lets say you purchased a Short position of 100 shares of some stock at a price of $100 per share.
+The current price of the stock is $80 (a profit of $20 per share).
+You can place a Stop Order to sell the Short position if the stock's price reaches $90 or higher.
+This can be used to lock in your profits and limit any losses.
 
 Here is a summary of how each order works and when they execute:
 
@@ -132,44 +115,31 @@ A Stop Order to sell will execute if the stock's price >= order's price.
 It is possible for your actions elsewhere in the game to influence the stock market.
 
 Hacking
-If a server has a corresponding stock (e.g. _foodnstuff_ server -> FoodNStuff
-stock), then hacking that server can decrease the stock's second-order
-forecast. This causes the corresponding stock's forecast to trend downwards in value
-over time.
 
-This effect only occurs if you set the stock option to
-true when calling the `hack` function. The chance that hacking a
-server will cause this effect is based on what percentage of the
-server's total money you steal.
+If a server has a corresponding stock (e.g. _foodnstuff_ server -> FoodNStuff stock), then hacking that server can decrease the stock's second-order forecast.
+This causes the corresponding stock's forecast to trend downwards in value over time.
 
-A single hack will have a minor
-effect, but continuously hacking a server for lots of money over time
-will have a noticeable effect in making the stock's forecast trend downwards.
+This effect only occurs if you set the stock option to true when calling the `hack` function.
+The chance that hacking a server will cause this effect is based on what percentage of the server's total money you steal.
+
+A single hack will have a minor effect, but continuously hacking a server for lots of money over time will have a noticeable effect in making the stock's forecast trend downwards.
 
 ## Growing
 
-If a server has a corresponding stock (e.g. `foodnstuff` server -> FoodNStuff
-stock), then growing that server's money can increase the stock's
-second-order forecast. This causes the corresponding stock's
-forecast to trend upwards in value over time.
+If a server has a corresponding stock (e.g. `foodnstuff` server -> FoodNStuff stock), then growing that server's money can increase the stock's second-order forecast.
+This causes the corresponding stock's forecast to trend upwards in value over time.
 
-This effect only occurs if you set the `stock` option to true when calling the
-`grow` function. The chance that growing a server will cause this
-effect is based on what percentage of the server's total money to add to it.
+This effect only occurs if you set the `stock` option to true when calling the `grow` function.
+The chance that growing a server will cause this effect is based on what percentage of the server's total money to add to it.
 
-A single grow operation will have a minor effect, but continuously growing
-a server for lots of money over time will have a noticeable effect in making
-the stock's forecast trend upwards.
+A single grow operation will have a minor effect, but continuously growing a server for lots of money over time will have a noticeable effect in making the stock's forecast trend upwards.
 
 ## Working for a Company
 
-If a [Company](companies.md) has a corresponding stock, then working for that [Company](companies.md) will
-increase the corresponding stock's second-order forecast. This will
-cause the stock's forecast to (slowly) trend upwards in value
-over time.
+If a [Company](companies.md) has a corresponding stock, then working for that [Company](companies.md) will increase the corresponding stock's second-order forecast.
+This will cause the stock's forecast to (slowly) trend upwards in value over time.
 
-The potency of this effect is based on how effective you are when you work
-(i.e. its based on your stats and multipliers).
+The potency of this effect is based on how effective you are when you work (i.e. its based on your stats and multipliers).
 
 ## Automating the Stock Market
 
@@ -180,10 +150,10 @@ See [TIX API](https://github.com/bitburner-official/bitburner-src/blob/dev/markd
 
 Stock prices are updated every ~6 seconds.
 
-Whether a stock's price moves up or down is random. However,
-stocks have properties that can influence the way their price moves. These properties
-are hidden, although some of them can be made visible by purchasing the
-Four Sigma (4S) Market Data upgrade. Some examples of these properties are:
+Whether a stock's price moves up or down is random.
+However, stocks have properties that can influence the way their price moves.
+These properties are hidden, although some of them can be made visible by purchasing the Four Sigma (4S) Market Data upgrade.
+Some examples of these properties are:
 
 - Volatility
 - Likelihood of increasing or decreasing (i.e. the stock's forecast)
@@ -197,6 +167,6 @@ Each stock has its own unique values for these properties.
 ## Offline Progression
 
 The Stock Market does not change or process anything while the game has closed.
-However, it does accumulate time when offline. This accumulated time allows
-the stock market to run `50%` faster when the game is opened again. This means
-that stock prices will update every ~4 seconds instead of 6.
+However, it does accumulate time when offline.
+This accumulated time allows the stock market to run `50%` faster when the game is opened again.
+This means that stock prices will update every ~4 seconds instead of 6.

--- a/src/Documentation/ui/doc/basic/stockmarket.md
+++ b/src/Documentation/ui/doc/basic/stockmarket.md
@@ -19,7 +19,7 @@ world. So these concepts below should seem similar, but won't be exactly the sam
 When making a transaction on the stock market, there are two types of positions:
 Long and Short. A Long position is the typical scenario where you buy a stock and
 earn a profit if the price of that stock increases. Meanwhile, a Short position
-is the exact opposite. In a Short position you purchase shares of a stock and
+is the exact opposite. In a Short position, you purchase shares of a stock and
 earn a profit if the price of that stock decreases. This is also called 'shorting'
 a stock.
 

--- a/src/Documentation/ui/doc/basic/stockmarket.md
+++ b/src/Documentation/ui/doc/basic/stockmarket.md
@@ -114,7 +114,7 @@ A Stop Order to sell will execute if the stock's price >= order's price.
 
 It is possible for your actions elsewhere in the game to influence the stock market.
 
-Hacking
+### Hacking
 
 If a server has a corresponding stock (e.g. _foodnstuff_ server -> FoodNStuff stock), then hacking that server can decrease the stock's second-order forecast.
 This causes the corresponding stock's forecast to trend downwards in value over time.
@@ -124,7 +124,7 @@ The chance that hacking a server will cause this effect is based on what percent
 
 A single hack will have a minor effect, but continuously hacking a server for lots of money over time will have a noticeable effect in making the stock's forecast trend downwards.
 
-## Growing
+### Growing
 
 If a server has a corresponding stock (e.g. `foodnstuff` server -> FoodNStuff stock), then growing that server's money can increase the stock's second-order forecast.
 This causes the corresponding stock's forecast to trend upwards in value over time.
@@ -134,12 +134,12 @@ The chance that growing a server will cause this effect is based on what percent
 
 A single grow operation will have a minor effect, but continuously growing a server for lots of money over time will have a noticeable effect in making the stock's forecast trend upwards.
 
-## Working for a Company
+### Working for a Company
 
 If a [Company](companies.md) has a corresponding stock, then working for that [Company](companies.md) will increase the corresponding stock's second-order forecast.
 This will cause the stock's forecast to (slowly) trend upwards in value over time.
 
-The potency of this effect is based on how effective you are when you work (i.e. its based on your stats and multipliers).
+The potency of this effect is based on how effective you are when you work (i.e. it's based on your stats and multipliers).
 
 ## Automating the Stock Market
 

--- a/src/Documentation/ui/doc/basic/terminal.md
+++ b/src/Documentation/ui/doc/basic/terminal.md
@@ -1,17 +1,15 @@
 # Terminal
 
-The Terminal is a console emulator program that lets you interface with all of the
-[Servers](servers.md) in the game. The Terminal can be accessed by clicking the `Terminal` tab
-on the navigation menu on the left-hand side of the game (you may need to expand
-the 'Hacking' header in order to see the `Terminal` tab). Alternatively, the shortcut Alt + t can be used to open the Terminal.
+The Terminal is a console emulator program that lets you interface with all of the [Servers](servers.md) in the game.
+The Terminal can be accessed by clicking the `Terminal` tab on the navigation menu on the left-hand side of the game (you may need to expand the 'Hacking' header in order to see the `Terminal` tab).
+Alternatively, the shortcut Alt + t can be used to open the Terminal.
 
 ## Filesystem (Directories)
 
-The Terminal contains a **very** basic filesystem that allows you to store and
-organize your files into different directories. Note that this is **not** a true
-filesystem implementation. Instead, it is done almost entirely using string manipulation.
-For this reason, many of the nice & useful features you'd find in a real
-filesystem do not exist.
+The Terminal contains a **very** basic filesystem that allows you to store and organize your files into different directories.
+Note that this is **not** a true filesystem implementation.
+Instead, it is done almost entirely using string manipulation.
+For this reason, many of the nice & useful features you'd find in a real filesystem do not exist.
 
 Here are the Terminal commands you'll commonly use when dealing with the filesystem.
 
@@ -25,8 +23,8 @@ In order to create a directory, simply name a file using a full absolute Linux-s
 
     /scripts/myScript.js
 
-This will automatically create a "directory" called `scripts`. This will also work
-for subdirectories:
+This will automatically create a "directory" called `scripts`.
+This will also work for subdirectories:
 
     /scripts/hacking/helpers/myHelperScripts.js
 
@@ -34,14 +32,12 @@ Files in the root directory do not need to begin with a forward slash:
 
     thisIsAFileInTheRootDirectory.txt
 
-Note that there is no way to manually create or remove directories. The creation and
-deletion of directories is automatically handled as you name/rename/delete
-files.
+Note that there is no way to manually create or remove directories.
+The creation and deletion of directories is automatically handled as you name/rename/delete files.
 
 ## Absolute vs Relative Paths
 
-Many Terminal commands accept both absolute and relative paths for specifying a
-file.
+Many Terminal commands accept both absolute and relative paths for specifying a file.
 
 An absolute path specifies the location of the file from the root directory (/).
 Any path that begins with the forward slash is an absolute path:
@@ -50,8 +46,8 @@ Any path that begins with the forward slash is an absolute path:
     $ cat /serverList.txt
 
 A relative path specifies the location of the file relative to the current working directory.
-Any path that does **not** begin with a forward slash is a relative path. Note that the
-Linux-style dot symbols will work for relative paths:
+Any path that does **not** begin with a forward slash is a relative path.
+Note that the Linux-style dot symbols will work for relative paths:
 
     . (a single dot) - represents the current directory
     .. (two dots) - represents the parent directory
@@ -62,28 +58,28 @@ Linux-style dot symbols will work for relative paths:
 
 ## Scripts
 
-Note that in order to reference a file, `functions` require the
-**full** absolute file path. For example
+Note that in order to reference a file, `functions` require the **full** absolute file path.
+For example
 
     ns.run("/scripts/hacking/helpers.myHelperScripts.js");
     ns.rm("/logs/myHackingLogs.txt");
     ns.rm("thisIsAFileInTheRootDirectory.txt");
 
-A full file path **must** begin with a forward slash (/) if that file
-is not in the root directory.
+A full file path **must** begin with a forward slash (/) if that file is not in the root directory.
 
 ## Missing Features
 
 These features that are typically in Linux filesystems have not yet been added to the game:
 
 - Tab autocompletion does not work with relative paths
-- `mv` only accepts full filepaths for the destination argument. It does not accept directories
+- `mv` only accepts full filepaths for the destination argument.
+  It does not accept directories
 
 ## Argument Parsing
 
 When evaluating a terminal command, arguments are initially parsed based on whitespace (usually spaces).
-Each whitespace character signifies the end of an argument, and potentially the start
-of new one. For most terminal commands, this is all you need to know.
+Each whitespace character signifies the end of an argument, and potentially the start of new one.
+For most terminal commands, this is all you need to know.
 
 When running scripts, however, it is important to know in more detail how arguments are parsed.
 There are two main points:
@@ -94,7 +90,8 @@ There are two main points:
 2. Anything that can represent a number is automatically cast to a number, unless it's
    surrounded by quotation marks.
 
-Here's an example to show how these rules work. Consider the following script `argType.js`:
+Here's an example to show how these rules work.
+Consider the following script `argType.js`:
 
     export async function main(ns) {
         ns.tprint("Number of args: " + ns.args.length);
@@ -125,5 +122,4 @@ Example:
 
     $ run foo.js; tail foo.js
 
-This does **not** wait for commands with a delay to finish executing, so it
-generally doesn't work with things like `hack`, `wget`, etc.
+This does **not** wait for commands with a delay to finish executing, so it generally doesn't work with things like `hack`, `wget`, etc.

--- a/src/Documentation/ui/doc/basic/terminal.md
+++ b/src/Documentation/ui/doc/basic/terminal.md
@@ -1,7 +1,7 @@
 # Terminal
 
 The Terminal is a console emulator program that lets you interface with all of the
-Servers in the game. The Terminal can be accessed by clicking the `Terminal` tab
+[Servers](servers.md) in the game. The Terminal can be accessed by clicking the `Terminal` tab
 on the navigation menu on the left-hand side of the game (you may need to expand
 the 'Hacking' header in order to see the `Terminal` tab). Alternatively, the shortcut Alt + t can be used to open the Terminal.
 
@@ -91,7 +91,7 @@ There are two main points:
 1. Quotation marks can be used to wrap a single argument and force it to be parsed as
    a string. Any whitespace inside the quotation marks will not cause a new argument
    to be parsed.
-2. Anything that can represent a number is automatically cast to a number, unless its
+2. Anything that can represent a number is automatically cast to a number, unless it's
    surrounded by quotation marks.
 
 Here's an example to show how these rules work. Consider the following script `argType.js`:
@@ -109,8 +109,7 @@ Then if we run the following terminal command:
 
 We'll see the following in the Terminal:
 
-    Running script with 1 thread(s) and args: [123, 1000, "5", "this is a single argument"].
-    May take a few seconds to start up the process...
+    Running script with 1 thread(s), pid 1 and args: [123, 1000, "5", "this is a single argument"].
     argType.js: Number of args: 4
     argType.js: number
     argType.js: number
@@ -126,5 +125,5 @@ Example:
 
     $ run foo.js; tail foo.js
 
-This does `not` wait for commands with a delay to finish executing, so it
+This does **not** wait for commands with a delay to finish executing, so it
 generally doesn't work with things like `hack`, `wget`, etc.

--- a/src/Documentation/ui/doc/basic/terminal.md
+++ b/src/Documentation/ui/doc/basic/terminal.md
@@ -84,11 +84,9 @@ For most terminal commands, this is all you need to know.
 When running scripts, however, it is important to know in more detail how arguments are parsed.
 There are two main points:
 
-1. Quotation marks can be used to wrap a single argument and force it to be parsed as
-   a string. Any whitespace inside the quotation marks will not cause a new argument
-   to be parsed.
-2. Anything that can represent a number is automatically cast to a number, unless it's
-   surrounded by quotation marks.
+- Quotation marks can be used to wrap a single argument and force it to be parsed as a string.
+  Any whitespace inside the quotation marks will not cause a new argument to be parsed.
+- Anything that can represent a number is automatically cast to a number, unless it's surrounded by quotation marks.
 
 Here's an example to show how these rules work.
 Consider the following script `argType.js`:

--- a/src/Documentation/ui/doc/basic/world.md
+++ b/src/Documentation/ui/doc/basic/world.md
@@ -9,6 +9,5 @@ In Bitburner, the world consists of six different cities:
 - Chongqing
 - Volhaven
 
-Each city has its own map and [Factions](factions.md). Each city also
-offers different services such as gyms, universities, hardware
-stores, and places of work.
+Each city has its own map and [Factions](factions.md).
+Each city also offers different services such as gyms, universities, hardware stores, and places of work.

--- a/src/Documentation/ui/doc/basic/world.md
+++ b/src/Documentation/ui/doc/basic/world.md
@@ -9,6 +9,6 @@ In Bitburner, the world consists of six different cities:
 - Chongqing
 - Volhaven
 
-Each city has it's own map and [Factions](factions.md). Each city also
-offers different services, such as gyms, universities, hardware
-stores and places of work.
+Each city has its own map and [Factions](factions.md). Each city also
+offers different services such as gyms, universities, hardware
+stores, and places of work.

--- a/src/Documentation/ui/doc/help/bitnode_order.md
+++ b/src/Documentation/ui/doc/help/bitnode_order.md
@@ -17,15 +17,15 @@ These paths do not recommend the absolute fastest path, since speed of progressi
 highly dependant on playing style.
 
 1. Repeat BN-1 until you max out its [Source-File](../advanced/sourcefiles.md). Its [Source-File](../advanced/sourcefiles.md)
-   is extremely powerful, as it raises all multipliers by a significant amount. This also a let's you
+   is extremely powerful, as it raises all multipliers by a significant amount. This also allows you to
    get used to augments and other features resetting.
 
 2. Do BN-3 at least once to unlock the [Corporation](../advanced/corporations.md) mechanic, finishing all
-   3 levels unlocks the full API for free allowing fully scripted corp. This mechanic has highest
+   3 levels unlocks the full API for free, allowing fully scripted corp. This mechanic has the highest
    profit potential in the game.
 
 3. Do BN-10 once to unlock [Sleeves](../advanced/sleeves.md) and [Grafting](../advanced/grafting.md). [Sleeves](../advanced/sleeves.md) are useful in all nodes
-   and grafting can be useful in future [BitNodes](../advanced/bitnodes.md) (especially 8). It's recommended to buy all purchasable [Sleeves](../advanced/sleeves.md) and
+   and grafting can be useful in future [BitNodes](../advanced/bitnodes.md), especially BN-8. It's recommended to buy all purchasable [Sleeves](../advanced/sleeves.md) and
    their memory during the first run.
 
    The ordering of the next three is dependant on playing style and wants/needs.
@@ -36,8 +36,8 @@ highly dependant on playing style.
    strong because [hacking](../basic/hacking.md) is typically one of the best ways of earning money.
 
 5. Do BN-4. Its [Source-File](../advanced/sourcefiles.md) does not directly make you
-   more powerful in any way, but it does unlock the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md) which
-   let you automate significantly more aspects of the game. Consider repeating until Level 3,
+   more powerful in any way, but unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md).
+   This API allows you to automate significantly more aspects of the game. Consider repeating until Level 3,
    since each level decreases the [RAM](../basic/ram.md) cost of the functions.
 
 6. Do BN-2 once to unlock the [Gang](../advanced/gang.md) mechanic. This mechanic
@@ -105,12 +105,12 @@ simple money-generator to a more interesting mechanic.
 BN-10 unlocks two new mechanics: [Sleeves](../advanced/sleeves.md) and [Grafting](../advanced/grafting.md)
 
 BN-13 unlocks [Stanek's Gift](../advanced/stanek.md). This gift can improve skills,
-[hacknet](../basic/hacknet_nodes.md) production and costs, working and [crime](../basic/crimes.md) gains as well [hacking](../basic/hacking.md) power and speed.
+[hacknet](../basic/hacknet_nodes.md) production and costs, working and [crime](../basic/crimes.md) gains, and [hacking](../basic/hacking.md) power and speed.
 
 ## For a Challenge
 
 In general, the higher [BitNodes](../advanced/bitnodes.md) are more difficult than the lower ones.
 BN-12 is an obvious exception as it gets progressively harder.
 
-BN-8 provides a unique challenge as the only method
+BN-8 provides a unique challenge, as the only method
 of earning money in that [BitNode](../advanced/bitnodes.md) is through trading at the stock market.

--- a/src/Documentation/ui/doc/help/bitnode_order.md
+++ b/src/Documentation/ui/doc/help/bitnode_order.md
@@ -1,116 +1,96 @@
 # What BitNode should I do?
 
-After destroying their first [BitNode](../advanced/bitnodes.md), many players
-wonder which [BitNode](../advanced/bitnodes.md) they should tackle next. This guide hopefully helps answer
-that question.
+After destroying their first [BitNode](../advanced/bitnodes.md), many players wonder which [BitNode](../advanced/bitnodes.md) they should tackle next.
+This guide hopefully helps answer that question.
 
 ## Recommended BitNodes
 
-As a player, you are not forced to tackle the [BitNodes](../advanced/bitnodes.md) in any particular order. You are
-free to choose whichever ones you want. The "best" order can vary between players,
-depending on what you like to do any what kind of player you are. In general, here
-are the recommended [BitNodes](../advanced/bitnodes.md) for different things:
+As a player, you are not forced to tackle the [BitNodes](../advanced/bitnodes.md) in any particular order.
+You are free to choose whichever ones you want.
+The "best" order can vary between players, depending on what you like to do any what kind of player you are.
+In general, here are the recommended [BitNodes](../advanced/bitnodes.md) for different things:
 
 ## For fast progression
 
-These paths do not recommend the absolute fastest path, since speed of progression is
-highly dependant on playing style.
+These paths do not recommend the absolute fastest path, since speed of progression is highly dependant on playing style.
 
-1. Repeat BN-1 until you max out its [Source-File](../advanced/sourcefiles.md). Its [Source-File](../advanced/sourcefiles.md)
-   is extremely powerful, as it raises all multipliers by a significant amount. This also allows you to
-   get used to augments and other features resetting.
+1. Repeat BN-1 until you max out its [Source-File](../advanced/sourcefiles.md).
+   Its [Source-File](../advanced/sourcefiles.md) is extremely powerful, as it raises all multipliers by a significant amount.
+   This also allows you to get used to augments and other features resetting.
 
-2. Do BN-3 at least once to unlock the [Corporation](../advanced/corporations.md) mechanic, finishing all
-   3 levels unlocks the full API for free, allowing fully scripted corp. This mechanic has the highest
-   profit potential in the game.
+2. Do BN-3 at least once to unlock the [Corporation](../advanced/corporations.md) mechanic, finishing all 3 levels unlocks the full API for free, allowing fully scripted corp.
+   This mechanic has the highest profit potential in the game.
 
-3. Do BN-10 once to unlock [Sleeves](../advanced/sleeves.md) and [Grafting](../advanced/grafting.md). [Sleeves](../advanced/sleeves.md) are useful in all nodes
-   and grafting can be useful in future [BitNodes](../advanced/bitnodes.md), especially BN-8. It's recommended to buy all purchasable [Sleeves](../advanced/sleeves.md) and
-   their memory during the first run.
+3. Do BN-10 once to unlock [Sleeves](../advanced/sleeves.md) and [Grafting](../advanced/grafting.md).
+   [Sleeves](../advanced/sleeves.md) are useful in all nodes and grafting can be useful in future [BitNodes](../advanced/bitnodes.md), especially BN-8.
+   It's recommended to buy all purchasable [Sleeves](../advanced/sleeves.md) and their memory during the first run.
 
    The ordering of the next three is dependant on playing style and wants/needs.
 
-4. Do BN-5 once or twice. The [Intelligence](../advanced/intelligence.md) stat it unlocks
-   will gradually build up as you continue to play the game, and will be helpful
-   in the future. The [Source-File](../advanced/sourcefiles.md) also provides [hacking](../basic/hacking.md) multipliers, which are
-   strong because [hacking](../basic/hacking.md) is typically one of the best ways of earning money.
+4. Do BN-5 once or twice.
+   The [Intelligence](../advanced/intelligence.md) stat it unlocks will gradually build up as you continue to play the game, and will be helpful in the future.
+   The [Source-File](../advanced/sourcefiles.md) also provides [hacking](../basic/hacking.md) multipliers, which are strong because [hacking](../basic/hacking.md) is typically one of the best ways of earning money.
 
-5. Do BN-4. Its [Source-File](../advanced/sourcefiles.md) does not directly make you
-   more powerful in any way, but unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md).
-   This API allows you to automate significantly more aspects of the game. Consider repeating until Level 3,
-   since each level decreases the [RAM](../basic/ram.md) cost of the functions.
+5. Do BN-4. Its [Source-File](../advanced/sourcefiles.md) does not directly make you more powerful in any way, but unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md).
+   This API allows you to automate significantly more aspects of the game.
+   Consider repeating until Level 3, since each level decreases the [RAM](../basic/ram.md) cost of the functions.
 
-6. Do BN-2 once to unlock the [Gang](../advanced/gang.md) mechanic. This mechanic
-   has high profit potential and offers large amounts of [Augmentations](../basic/augmentations.md) in a single faction.
-   Having sleeves ([Source-File](../advanced/sourcefiles.md) 10) greatly reduces the time it takes to get access to [Gangs](../advanced/gang.md)
-   outside this [BitNode](../advanced/bitnodes.md).
+6. Do BN-2 once to unlock the [Gang](../advanced/gang.md) mechanic.
+   This mechanic has high profit potential and offers large amounts of [Augmentations](../basic/augmentations.md) in a single faction.
+   Having sleeves ([Source-File](../advanced/sourcefiles.md) 10) greatly reduces the time it takes to get access to [Gangs](../advanced/gang.md) outside this [BitNode](../advanced/bitnodes.md).
 
-7. Do BN-9 to unlock the [Hacknet Server](../advanced/hacknetservers.md) mechanic. You can
-   consider repeating it as well, as its Level 2 and 3 effects are pretty helpful as well.
+7. Do BN-9 to unlock the [Hacknet Server](../advanced/hacknetservers.md) mechanic.
+   You can consider repeating it as well, as its Level 2 and 3 effects are pretty helpful as well.
 
 ## For the strongest Source-Files
 
 Note that the strongest [Source-Files](../advanced/sourcefiles.md) are typically rewarded by the hardest [BitNodes](../advanced/bitnodes.md).
 
-The strongest [Source-File](../advanced/sourcefiles.md) is that from BN-1, as it raises
-all multipliers by a significant amount.
+The strongest [Source-File](../advanced/sourcefiles.md) is that from BN-1, as it raises all multipliers by a significant amount.
 
-The [Source-File](../advanced/sourcefiles.md) from BN-9 is good because it unlocks the Hacknet
-Server mechanic. The [Hacknet Server](../advanced/hacknetservers.md) mechanic causes [Hacknet Nodes](../basic/hacknet_nodes.md) to produce a new
-currency called `hashes`, rather than money. `Hashes` can be spent on powerful upgrades
-that benefit your [hacking](../basic/hacking.md), [Corporation](../advanced/corporations.md), [Bladeburner](../advanced/bladeburners.md), etc.
+The [Source-File](../advanced/sourcefiles.md) from BN-9 is good because it unlocks the Hacknet Server mechanic.
+The [Hacknet Server](../advanced/hacknetservers.md) mechanic causes [Hacknet Nodes](../basic/hacknet_nodes.md) to produce a new currency called `hashes`, rather than money.
+`Hashes` can be spent on powerful upgrades that benefit your [hacking](../basic/hacking.md), [Corporation](../advanced/corporations.md), [Bladeburner](../advanced/bladeburners.md), etc.
 
-The [Sleeves](../advanced/sleeves.md) granted by the [Source-File](../advanced/sourcefiles.md) from BN-10
-are strong, but only after you have several of them and have spent some time/money upgrading
-them.
+The [Sleeves](../advanced/sleeves.md) granted by the [Source-File](../advanced/sourcefiles.md) from BN-10 are strong, but only after you have several of them and have spent some time/money upgrading them.
 
 ## For more scripting/hacking
 
-BN-4 unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md), which
-can be used to automate many different aspects of the game, including working for [Factions](../basic/factions.md) / [Companies](../basic/companies.md),
-purchasing & installing [Augmentations](../basic/augmentations.md), and creating programs
+BN-4 unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md), which can be used to automate many different aspects of the game, including working for [Factions](../basic/factions.md) / [Companies](../basic/companies.md), purchasing & installing [Augmentations](../basic/augmentations.md), and creating programs
 
-BN-6 and BN-7 unlock [Bladeburner](../advanced/bladeburners.md) and its corresponding
-[Bladeburner API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.bladeburner.md). This allows you to automate an entire
-new mechanic.
+BN-6 and BN-7 unlock [Bladeburner](../advanced/bladeburners.md) and its corresponding [Bladeburner API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.bladeburner.md).
+This allows you to automate an entire new mechanic.
 
-BN-2 also unlocks a new mechanic and API for automating
-the [Gang](../advanced/gang.md) mechanic. However, it is not as interesting as [Bladeburner](../advanced/bladeburners.md)
+BN-2 also unlocks a new mechanic and API for automating the [Gang](../advanced/gang.md) mechanic.
+However, it is not as interesting as [Bladeburner](../advanced/bladeburners.md)
 
-BN-9 unlocks the [Hacknet Server](../advanced/hacknetservers.md) mechanic and several new
-functions in the [Hacknet Node API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.hacknet.md) for using it.
+BN-9 unlocks the [Hacknet Server](../advanced/hacknetservers.md) mechanic and several new functions in the [Hacknet Node API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.hacknet.md) for using it.
 
 ## For new mechanics
 
-BN-2 unlocks a new mechanic in which you can
-manage a [Gang](../advanced/gang.md). [Gangs](../advanced/gang.md) earn you money and can be very profitable once they get large
-and powerful. The biggest benefit of [Gangs](../advanced/gang.md), however, is that they make all
-[Augmentations](../basic/augmentations.md) available to you through their corresponding [Faction](../basic/factions.md).
+BN-2 unlocks a new mechanic in which you can manage a [Gang](../advanced/gang.md).
+[Gangs](../advanced/gang.md) earn you money and can be very profitable once they get large and powerful.
+The biggest benefit of [Gangs](../advanced/gang.md), however, is that they make all [Augmentations](../basic/augmentations.md) available to you through their corresponding [Faction](../basic/factions.md).
 
-BN-3 unlocks a new mechanic in which you can manage a
-[Corporation](../advanced/corporations.md). You can earn money through [Corporations](../advanced/corporations.md) by selling your stocks, or by
-configuring your [Corporation](../advanced/corporations.md) to pay dividends to shareholders. If your [Corporation](../advanced/corporations.md)
-gets big enough, it can also bribe [Factions](../basic/factions.md) in exchange for [Faction](../basic/factions.md) [Reputation](../basic/reputation.md).
+BN-3 unlocks a new mechanic in which you can manage a [Corporation](../advanced/corporations.md).
+You can earn money through [Corporations](../advanced/corporations.md) by selling your stocks, or by configuring your [Corporation](../advanced/corporations.md) to pay dividends to shareholders.
+If your [Corporation](../advanced/corporations.md) gets big enough, it can also bribe [Factions](../basic/factions.md) in exchange for [Faction](../basic/factions.md) [Reputation](../basic/reputation.md).
 
-BN-6 unlocks a new mechanic that centers around combat rather
-than hacking. The main benefit of the [Bladeburner](../advanced/bladeburners.md) mechanic is that it offers a new
-method of destroying a [BitNode](../advanced/bitnodes.md).
+BN-6 unlocks a new mechanic that centers around combat rather than hacking.
+The main benefit of the [Bladeburner](../advanced/bladeburners.md) mechanic is that it offers a new method of destroying a [BitNode](../advanced/bitnodes.md).
 
-BN-9 unlocks the [Hacknet Server](../advanced/hacknetservers.md), which is an upgraded version of a
-[Hacknet Node](../basic/hacknet_nodes.md). The [Hacknet Server](../advanced/hacknetservers.md) generates a computational unit called a `hash`. `Hashes`
-can be spent on a variety of different upgrades that can benefit your hacking,
-[Corporation](../advanced/corporations.md), [Bladeburner](../advanced/bladeburners.md) progress, and more. It transforms the [Hacknet Node](../basic/hacknet_nodes.md) from a
-simple money-generator to a more interesting mechanic.
+BN-9 unlocks the [Hacknet Server](../advanced/hacknetservers.md), which is an upgraded version of a [Hacknet Node](../basic/hacknet_nodes.md).
+The [Hacknet Server](../advanced/hacknetservers.md) generates a computational unit called a `hash`.
+`Hashes` can be spent on a variety of different upgrades that can benefit your hacking, [Corporation](../advanced/corporations.md), [Bladeburner](../advanced/bladeburners.md) progress, and more.
+It transforms the [Hacknet Node](../basic/hacknet_nodes.md) from a simple money-generator to a more interesting mechanic.
 
 BN-10 unlocks two new mechanics: [Sleeves](../advanced/sleeves.md) and [Grafting](../advanced/grafting.md)
 
-BN-13 unlocks [Stanek's Gift](../advanced/stanek.md). This gift can improve skills,
-[hacknet](../basic/hacknet_nodes.md) production and costs, working and [crime](../basic/crimes.md) gains, and [hacking](../basic/hacking.md) power and speed.
+BN-13 unlocks [Stanek's Gift](../advanced/stanek.md). This gift can improve skills, [hacknet](../basic/hacknet_nodes.md) production and costs, working and [crime](../basic/crimes.md) gains, and [hacking](../basic/hacking.md) power and speed.
 
 ## For a Challenge
 
 In general, the higher [BitNodes](../advanced/bitnodes.md) are more difficult than the lower ones.
 BN-12 is an obvious exception as it gets progressively harder.
 
-BN-8 provides a unique challenge, as the only method
-of earning money in that [BitNode](../advanced/bitnodes.md) is through trading at the stock market.
+BN-8 provides a unique challenge, as the only method of earning money in that [BitNode](../advanced/bitnodes.md) is through trading at the stock market.

--- a/src/Documentation/ui/doc/help/getting_started.md
+++ b/src/Documentation/ui/doc/help/getting_started.md
@@ -17,8 +17,8 @@ Bitburner is a cyberpunk-themed incremental RPG. The player progresses by raisin
 their [Stats](../basic/stats.md), earning money, and climbing the corporate ladder.
 Eventually, after reaching certain criteria, the player will begin receiving invitations
 from [Factions](../basic/factions.md). Joining these [Factions](../basic/factions.md) and working for them will unlock
-[Augmentations](../basic/augmentations.md). Purchasing and installing [Augmentations](../basic/augmentations.md) provide persistent
-upgrades and are necessary for progressing in the game.
+[Augmentations](../basic/augmentations.md). Purchasing and installing [Augmentations](../basic/augmentations.md) provides persistent
+upgrades and is necessary for progressing in the game.
 
 The game has a minimal story/quest-line that can be followed to reach the end of the game.
 Since this guide is only about getting started with Bitburner, it will not cover the
@@ -27,7 +27,7 @@ entire "quest-line".
 ## First Steps
 
 I'm going to assume you followed the introductory tutorial when you first began the game.
-In this introductory tutorial you created a [Script](../basic/scripts.md) called `n00dles.js` and ran it
+In this introductory tutorial, you created a [Script](../basic/scripts.md) called `n00dles.js` and ran it
 on the `n00dles` server. Right now, we'll kill this [Script](../basic/scripts.md). There are two ways
 to do this:
 
@@ -57,7 +57,7 @@ Before we write the [Script](../basic/scripts.md), here are some things you'll w
 - `brutessh`
 - `nuke`
 
-To briefly summarize the information from the links above: Each [Server](../basic/servers.md) has a
+To briefly summarize: Each [Server](../basic/servers.md) has a
 security level that affects how difficult it is to hack. Each [Server](../basic/servers.md) also has a
 certain amount of money, as well as a maximum amount of money it can hold. [Hacking](../basic/hacking.md) a
 [Server](../basic/servers.md) steals a percentage of that [Server](../basic/servers.md)'s money. The `hack()` function
@@ -117,7 +117,7 @@ Enter the following code in the [Script](../basic/scripts.md) editor:
     }
 
 The [Script](../basic/scripts.md) above contains comments that document what it does, but let's go through it
-step-by-step anyways.
+step-by-step anyway.
 
     const target = "n00dles";
 
@@ -138,7 +138,7 @@ The `getServerMaxMoney()` function is used to find this value
 
     const securityThresh = ns.getServerMinSecurityLevel(target);
 
-This third command defines a numerical value representing the maximum security level
+This third command defines a numerical value representing the minimum security level
 the target [Server](../basic/servers.md) can have. If the target [Server](../basic/servers.md)'s security level is higher than
 this value, then our [Script](../basic/scripts.md) will `weaken()` the [Script](../basic/scripts.md) before doing anything else.
 
@@ -177,8 +177,8 @@ important is that await can only be used in functions marked `async` (note that 
 ## Running our Scripts
 
 Now we want to start running our [hacking](../basic/hacking.md) [Script](../basic/scripts.md) so that it can start earning us
-money and experience. Our home computer only has 8GB of [RAM](../basic/ram.md) and we'll be using it for
-something else later. So instead, we'll take advantage of the [RAM](../basic/ram.md) on other machines.
+money and experience. Our home computer only has 8GB of [RAM](../basic/ram.md), and we'll be using it for
+something else later. Instead, we'll take advantage of the [RAM](../basic/ram.md) on other machines.
 
 Go to `Terminal` and enter the following command:
 
@@ -234,7 +234,7 @@ Here's what mine showed at the time I made this:
         ┃   Number of open ports required to NUKE: 1
         ┃   RAM: 32.00GB
         ┕ CSEC
-                Root Access: NO, Required hacking skill: 55
+              Root Access: NO, Required hacking skill: 55
               Number of open ports required to NUKE: 1
               RAM: 8.00GB
 
@@ -251,7 +251,8 @@ any open ports in order to NUKE. In other words, we can gain root access to all 
 servers and then run [Scripts](../basic/scripts.md) on them.
 
 First, let's determine how many threads of our [hacking](../basic/hacking.md) [Script](../basic/scripts.md) we can run.
-`Read more about multithreading scripts here`
+(See the page on [scripts](../basic/scripts.md) for more information on multithreading.)
+
 The [Script](../basic/scripts.md) we wrote
 uses 2.6GB of [RAM](../basic/ram.md). You can check this using the following `Terminal` command:
 
@@ -328,21 +329,21 @@ higher required hacking levels. Therefore, we should raise our hacking level. No
 will this let us hack more [Servers](../basic/servers.md), but it will also increase the effectiveness of our [hacking](../basic/hacking.md)
 against `n00dles`.
 
-The easiest way to train your hacking level is to visit Rothman University. You can do this by
-clicking the `City` tab on the left-hand navigation menu, or you can use Alt + w. Rothman University should be one of the buttons
-near the top. Click the button to go to the location.
+The easiest way to train your hacking level is to visit Rothman University. You can do this
+from the `City` tab on the left-hand navigation menu (click on it or press Alt + w). Rothman University should be the "U"
+near the bottom-right. Click the "U" to go to the location.
 
 Once you go to Rothman University, you should see a screen with several options. These
 options describe different courses you can take. You should click the first button, which
 says: `Study Computer Science (free)`.
 
 After you click the button, you will start studying and earning hacking experience. While you
-are doing this, you cannot interact with any other part of the game until you click the button
-that says "Stop taking course".
+are doing this, you cannot interact with any other part of the game until you click
+either "Stop taking course" or "Do something else simultaneously".
 
 Right now, we want a hacking level of 10. You need approximately 174 hacking experience to reach
-level 10. You can check how much hacking experience you have by clicking the `Stats` tab
-on the left-hand navigation menu, or by using Alt + c.
+level 10. You can check how much hacking experience you have by either hovering over the progress bar in the overview window
+or going to the `Stats` tab on the left-hand navigation menu (click on it or press Alt + c).
 Since studying at Rothman University earns you 1 experience per second, this will take
 174 seconds, or approximately 3 minutes. Feel free to do something in the meantime!
 
@@ -452,47 +453,43 @@ There are other ways to gain money in this game besides [Scripts](../basic/scrip
 
 ## Hacknet Nodes
 
-If you completed the introductory tutorial, you were already introduced to this method: Hacknet Nodes.
-Once you have enough money, you can start upgrading your Hacknet Nodes in order to increase
-your passive income stream. This is completely optional. Since each Hacknet Node upgrade
+If you completed the introductory tutorial, you were already introduced to this method: [Hacknet Nodes](../basic/hacknet_nodes.md).
+Once you have enough money, you can start upgrading your [Hacknet Nodes](../basic/hacknet_nodes.md) in order to increase
+your passive income stream. This is completely optional. Since each [Hacknet Node](../basic/hacknet_nodes.md) upgrade
 takes a certain amount of time to "pay itself off", it may not necessarily be in your best
 interest to use these.
 
-Nonetheless, Hacknet Nodes are a good source of income early in the game, although
-their effectiveness tapers off later on. If you do wind up purchasing and upgrading Hacknet Nodes,
+Nonetheless, [Hacknet Nodes](../basic/hacknet_nodes.md) are a good source of income early in the game, although
+their effectiveness tapers off later on. If you do wind up purchasing and upgrading [Hacknet Nodes](../basic/hacknet_nodes.md),
 I would suggest only upgrading their levels for now. I wouldn't bother with [RAM](../basic/ram.md) and Core
 upgrades until later on.
 
 ## Crime
 
-The best source of income right now is from crimes.
+The best source of income right now is from [crimes](../basic/crimes.md).
 This is because it not only gives you a large amount of money, but it also raises your
-hacking level. To commit crimes, click on the `City` tab on the left-hand
-navigation menu or use the Alt + w.
+hacking level. To commit [crimes](../basic/crimes.md), click on the `City` tab on the left-hand
+navigation menu or press Alt + w.
 Then, click on the link that says `The Slums`.
 
-In the Slums, you can attempt to commit a variety of crimes, each of which gives certain
-types of experience and money if successful. See crimes for more details.
+In the Slums, you can attempt to commit a variety of [crimes](../basic/crimes.md), each of which gives certain
+types of experience and money if successful. See [crimes](../basic/crimes.md) for more details.
 
 You are not always successful when you attempt to commit a crime. Nothing bad happens
-if you fail a crime, but you won't earn any money and the experience gained will be
-reduced. Raising your stats improves your chance of successfully committing a crime.
+if you fail a [crime](../basic/crimes.md), but you won't earn any money and the experience gained will be
+reduced. Raising your stats improves your chance of successfully committing a [crime](../basic/crimes.md).
 
-Right now, the best option is the `Rob Store` crime. This takes 60 seconds to attempt
-and gives $400k if successful. I suggest this crime because you don't have to click or check
-in too often since it takes a whole minute to attempt. Furthermore, it gives hacking experience,
-which is very important right now.
+Right now, the best option is the `Rob Store` [crime](../basic/crimes.md). This takes 60 seconds to attempt,
+gives $400k if successful, and gives hacking experience (which is very important right now).
 
-Alternatively, you can also use the `Shoplift` crime. This takes 2 seconds to attempt
-and gives $15k if successful. This crime is slightly easier and is more profitable
-than `Rob Store`, but it requires constant clicking and it doesn't give
-hacking experience.
+Alternatively, you can also use the `Shoplift` [crime](../basic/crimes.md). This takes 2 seconds to attempt
+and gives $15k if successful. This [crime](../basic/crimes.md) is slightly easier and more profitable
+than `Rob Store`, but doesn't give hacking experience.
 
 ## Work for a Company
 
-If you don't want to constantly check in on the game to commit crimes, there's another option
-that's much more passive: working for a company.
-This will not be nearly as profitable as crimes, but it's completely passive.
+If you don't want to commit [crimes](../basic/crimes.md), there's another option - working for a [company](../basic/companies.md)
+This will not be nearly as profitable as [crimes](../basic/crimes.md), but will provide [company](../basic/companies.md) [reputation](../basic/reputation.md)
 
 Go to the `City` tab on the left-hand navigation menu and then go to
 `Joe's Guns`. At `Joe's Guns`, there will be an option that says
@@ -501,12 +498,10 @@ will appear that simply says `Work`. Click this to start working.
 Working at `Joe's Guns` earns $110 per second and also grants some experience
 for every stat except hacking.
 
-Working for a company is completely passive. You can choose to focus on your work, do
+Working for a [company](../basic/companies.md), like [crime](../basic/crimes.md), is completely passive. You can choose to focus on your work, do
 something else simultaneously, or switch between those two. While you focus on work,
-you will not be able to do anything else in the game. If you do something else meanwhile,
-you will not gain reputation at the same speed. You can cancel working at any time.
-You'll notice that cancelling your work early causes you to lose out on some reputation
-gains, but you shouldn't worry about this. Company reputation isn't important right now.
+you will not be able to do anything else in the game. If you do something else simultaneously,
+you will not gain [reputation](../basic/reputation.md) at the same speed. You can cancel working at any time.
 
 Once your hacking hits level 75, you can visit `Carmichael Security` in the city
 and get a software job there. This job offers higher pay and also earns you
@@ -541,7 +536,6 @@ to open up SSH ports on [Servers](../basic/servers.md). This will allow you to h
 as many [Servers](../basic/servers.md) in the game require a certain number of opened ports in order for
 `NUKE.exe` to gain root access.
 
-When you are creating a program, you cannot interact with any other part of the game.
 Feel free to cancel your work on creating a program at any time, as your progress will
 be saved and can be picked back up later. `BruteSSH.exe` takes about
 10 minutes to complete.
@@ -551,7 +545,7 @@ be saved and can be picked back up later. `BruteSSH.exe` takes about
 On the `Create Programs` page, you will notice another program you can create
 called `AutoLink.exe`. If you don't mind waiting another 10-15 minutes, you should
 go ahead and create this program. It makes it much less tedious to connect to other [Servers](../basic/servers.md),
-but it's not necessary for progressing.
+but it's not necessary for progression.
 
 ## Joining your first faction: CyberSec
 
@@ -560,10 +554,11 @@ said this:
 
     Message received from unknown sender:
 
-    We've been watching you. Your skills are very impressive. But you're wasting
-    your talents. If you join us, you can put your skills to good use and change
-    the world for the better. If you join us, we can unlock your full potential.
-    But first, you must pass our test. Find and hack our server using the Terminal.
+    We've been watching you. Your skills are very impressive. But you're wasting your talents.
+    If you join us, you can put your skills to good use and change the world for the better.
+    If you join us, we can unlock your full potential.
+
+    But first, you must pass our test. Find and install the backdoor on our server.
 
     -CyberSec
 
@@ -576,9 +571,9 @@ your home computer. Enter the following `Terminal` commands to view the message:
     $ cat csec-test.msg
 
 This message is part of the game's main "quest-line". It is a message from the
-|CyberSec faction| that is asking you to pass their test.
-Passing their test is simple, you just have to find their [Server](../basic/servers.md) and hack it through
-the `Terminal`. Their [Server](../basic/servers.md) is called `CSEC`.
+`CyberSec` [faction](../basic/factions.md) that is asking you to pass their test.
+Passing their test is simple, you just have to find their [Server](../basic/servers.md), hack it, and
+install a backdoor through the `Terminal`. Their [Server](../basic/servers.md) is called `CSEC`.
 To do this, we'll use the `scan-analyze`
 Terminal command, just like we did before:
 
@@ -630,14 +625,14 @@ using the `BruteSSH.exe` program we created earlier. In `Terminal`:
     $ run NUKE.exe
     $ backdoor
 
-After you successfully install the backdoor, you should receive a faction
+After you successfully install the backdoor, you should receive a [faction](../basic/factions.md)
 invitation from `CyberSec` shortly afterwards. Accept it. If you accidentally
 reject the invitation, that's okay. Just go to the `Factions` tab
 (Alt + f) and you should see an option that lets you
 accept the invitation.
 
-Congrats! You just joined your first faction. Don't worry about doing anything
-with this faction yet, we can come back to it later.
+Congrats! You just joined your first [faction](../basic/factions.md). Don't worry about doing anything
+with this [faction](../basic/factions.md) yet, we can come back to it later.
 
 ## Using Additional Servers to Hack Joesguns
 
@@ -648,7 +643,7 @@ run [Scripts](../basic/scripts.md). We'll use the [RAM](../basic/ram.md) on thes
 
 ## Copying our Scripts
 
-The [Server](../basic/servers.md)'s we'll be using to run our [Scripts](../basic/scripts.md) are:
+The [Servers](../basic/servers.md) we'll be using to run our [Scripts](../basic/scripts.md) are:
 
 - `neo-net`
 - `zer0`
@@ -690,19 +685,19 @@ production rate of $20k per second and had earned a total of $70 million.
 After another 15 minutes, the production rate had increased to $25k per second
 and the [Scripts](../basic/scripts.md) had made an additional $55 million.
 
-Your results will vary based on how fast you earned money from crime/working/hacknet nodes,
+Your results will vary based on how fast you earned money from [crime](../basic/crimes.md)/[working](../basic/companies.md)/[hacknet nodes](../basic/hacknet_nodes.md),
 but this will hopefully give you a good indication of how much the [Scripts](../basic/scripts.md) can earn.
 
-In the meantime, we are going to be gaining reputation with the `CyberSec` faction.
+In the meantime, we are going to be gaining reputation with the `CyberSec` [faction](../basic/factions.md).
 Go to the `Factions` tab on the left-hand
-navigation menu, and from there select `CyberSec`. In the middle of
+navigation menu (Alt + F), and from there select `CyberSec`. In the middle of
 the page there should be a button for `Hacking Contracts`.
-Click it to start earning reputation for the `CyberSec` faction (as well
-as some hacking experience). The higher your hacking level, the more reputation you
-will gain. Note that while you are working for a faction, you can choose to not interact
-with the rest of the game in any way to gain reputation at full speed. You can also select to
-do something else simultaneously, gaining reputation a bit more slowly, until you focus again.
-You can cancel your faction work at any time with no penalty to your reputation gained so far.
+Click it to start earning [reputation](../basic/reputation.md) for the `CyberSec` [faction](../basic/factions.md)
+(as well as some hacking experience). The higher your hacking level, the more [reputation](../basic/reputation.md) you
+will gain. Note that while you are working for a [faction](../basic/factions.md), you can choose to not interact
+with the rest of the game in any way to gain [reputation](../basic/reputation.md) at full speed. You can also select to
+do something else simultaneously, gaining [reputation](../basic/reputation.md) a bit more slowly, until you focus again.
+You can cancel your [faction](../basic/factions.md) work at any time with no penalty to your [reputation](../basic/reputation.md) gained so far.
 
 ## Purchasing Upgrades and Augmentations
 
@@ -715,40 +710,40 @@ The most important thing to upgrade right now is the [RAM](../basic/ram.md) on y
 will allow you to run more [Scripts](../basic/scripts.md).
 
 To upgrade your [RAM](../basic/ram.md), go to the `City` tab and visit the company `Alpha Enterprises`.
-There will be an option that says `Purchase additional RAM for Home Computer`.
-Click it and follow the dialog box to upgrade your [RAM](../basic/ram.md).
+There will be a button that says `Upgrade 'home' RAM (8.00GB -> 16.00GB) - $1.010m`.
+Click it to upgrade your [RAM](../basic/ram.md).
 
 I recommend getting your home computer's [RAM](../basic/ram.md) to **at least** 128GB. Getting it even
 higher would be better.
 
 ## Purchasing your First Augmentations
 
-Once you get ~1000 reputation with the `CyberSec` faction, you can purchase
-your first `Augmentation` from them.
+Once you get ~1000 [reputation](../basic/reputation.md) with the `CyberSec` [faction](../basic/factions.md), you can purchase
+your first [Augmentation](../basic/augmentations.md) from them.
 
 To do this, go to the `Factions` tab on the left-hand navigation menu
 (Alt + f) and select `CyberSec`. There is an button
 near the bottom that says `Purchase Augmentations`. This will bring up a
-page that displays all of the Augmentations available from `CyberSec`. Some of them
+page that displays all of the [Augmentations](../basic/augmentations.md) available from `CyberSec`. Some of them
 may be locked right now. To unlock these, you will need to earn more
-reputation with `CyberSec`.
+[reputation](../basic/reputation.md) with `CyberSec`.
 
-Augmentations give persistent upgrades in the form of multipliers. These aren't very
+[Augmentations](../basic/augmentations.md) give persistent upgrades in the form of multipliers. These aren't very
 powerful early in the game because the multipliers are small. However, the effects
-of Augmentations stack multiplicatively **with each other**, so as you continue to install
-many Augmentations their effects will increase significantly.
+of [Augmentations](../basic/augmentations.md) stack multiplicatively **with each other**, so as you continue to install
+many [Augmentations](../basic/augmentations.md), their effects will increase significantly.
 
 Because of this, I would recommend investing more in [RAM](../basic/ram.md) upgrades for your home computer rather
-than Augmentations early on. Having enough [RAM](../basic/ram.md) to run many [Scripts](../basic/scripts.md) will allow you to make
-much more money, and then you can come back later on and get all these Augmentations.
+than [Augmentations](../basic/augmentations.md) early on. Having enough [RAM](../basic/ram.md) to run many [Scripts](../basic/scripts.md) will allow you to make
+much more money, and then you can come back later on and get all these [Augmentations](../basic/augmentations.md).
 
-Right now, I suggest purchasing at the very least the `Neurotrainer I` Augmentation from
+Right now, I suggest purchasing at the very least the `Neurotrainer I` [Augmentation](../basic/augmentations.md) from
 `CyberSec`. If you have the money to spare, I would also suggest getting `BitWire` and
-several levels of the `NeuroFlux Governor` (`NFG`) Augmentations. Note that each time
-you purchase an Augmentation,
+several levels of the `NeuroFlux Governor` (`NFG`) [Augmentations](../basic/augmentations.md). Note that each time
+you purchase an [Augmentation](../basic/augmentations.md),
 **the price of purchasing another increases by 90%**,
-so make sure you buy the most expensive Augmentation first. Don't worry, once you choose to
-install Augmentations, their prices will reset back to their original values.
+so make sure you buy the most expensive [Augmentation](../basic/augmentations.md) first. Don't worry, once you choose to
+install [Augmentations](../basic/augmentations.md), their prices will reset back to their original values.
 
 ## Next Steps
 
@@ -764,19 +759,19 @@ The following are a few things you may want to consider doing in the near future
 
 ## Installing Augmentations (and Resetting)
 
-If you've purchased any Augmentations, you'll need to install them before you
-actually gain their effects. Installing Augmentations is the game's "soft-reset" or "prestige"
-mechanic. You can [read more details about it here]().
+If you've purchased any [Augmentations](../basic/augmentations.md), you'll need to install them before you
+actually gain their effects. Installing [Augmentations](../basic/augmentations.md) is the game's "soft-reset" or "prestige"
+mechanic.
 
-To install your Augmentations, click the `Augmentations` tab on the left-hand navigation
-menu (Alt + a). You will see a list of all of the Augmentations
+To install your [Augmentations](../basic/augmentations.md), click the `Augmentations` tab on the left-hand navigation
+menu (Alt + a). You will see a list of all of the [Augmentations](../basic/augmentations.md)
 you have purchased. Below that, you will see a button that says `Install Augmentations`.
 Be warned, after clicking this there is no way to undo it (unless you load an earlier save).
 
 ## Automating the Script Startup Process
 
-Whenever you install Augmentations, all of your [Scripts](../basic/scripts.md) are killed and you'll have to
-re-run them. Doing this every time you install Augmentations would be very tedious and annoying,
+Whenever you install [Augmentations](../basic/augmentations.md), all of your [Scripts](../basic/scripts.md) are killed and you'll have to
+re-run them. Doing this every time you install [Augmentations](../basic/augmentations.md) would be very tedious and annoying,
 so you should write a [Script](../basic/scripts.md) to automate the process. Here's a simple example for a
 startup [Script](../basic/scripts.md). Feel free to adjust it to your liking.
 
@@ -829,7 +824,7 @@ startup [Script](../basic/scripts.md). Feel free to adjust it to your liking.
 ## Random Tips
 
 - Early on in the game, it's better to spend your money on upgrading [RAM](../basic/ram.md) and purchasing
-  new [Servers](../basic/servers.md) rather than spending it on Augmentations
+  new [Servers](../basic/servers.md) rather than spending it on [Augmentations](../basic/augmentations.md)
 - The more money available on a [Server](../basic/servers.md), the more effective the `hack()` and
   `grow()` functions will be. This is because both of these functions
   use percentages rather than flat values. `hack()` steals a percentage of a [Server](../basic/servers.md)'s

--- a/src/Documentation/ui/doc/help/getting_started.md
+++ b/src/Documentation/ui/doc/help/getting_started.md
@@ -1,51 +1,43 @@
 # Getting Started Guide for Beginner Programmers
 
-note: Note that the [Scripts](../basic/scripts.md) and strategies given in this guide aren't necessarily
-optimal. They're just meant to introduce you to the game and help you get
-started.
+note: Note that the [Scripts](../basic/scripts.md) and strategies given in this guide aren't necessarily optimal.
+They're just meant to introduce you to the game and help you get started.
 
-This is an introductory guide to getting started with Bitburner. It is not meant to be a
-comprehensive guide for the entire game, only the early stages. If you are confused
-or overwhelmed by the game, especially the programming and scripting aspects, this
-guide is perfect for you!
+This is an introductory guide to getting started with Bitburner.
+It is not meant to be a comprehensive guide for the entire game, only the early stages.
+If you are confused or overwhelmed by the game, especially the programming and scripting aspects, this guide is perfect for you!
 
 Note that this guide is tailored towards those with minimal programming experience.
 
 ## Introduction
 
-Bitburner is a cyberpunk-themed incremental RPG. The player progresses by raising
-their [Stats](../basic/stats.md), earning money, and climbing the corporate ladder.
-Eventually, after reaching certain criteria, the player will begin receiving invitations
-from [Factions](../basic/factions.md). Joining these [Factions](../basic/factions.md) and working for them will unlock
-[Augmentations](../basic/augmentations.md). Purchasing and installing [Augmentations](../basic/augmentations.md) provides persistent
-upgrades and is necessary for progressing in the game.
+Bitburner is a cyberpunk-themed incremental RPG.
+The player progresses by raising their [Stats](../basic/stats.md), earning money, and climbing the corporate ladder.
+Eventually, after reaching certain criteria, the player will begin receiving invitations from [Factions](../basic/factions.md).
+Joining these [Factions](../basic/factions.md) and working for them will unlock [Augmentations](../basic/augmentations.md).
+Purchasing and installing [Augmentations](../basic/augmentations.md) provides persistent upgrades and is necessary for progressing in the game.
 
 The game has a minimal story/quest-line that can be followed to reach the end of the game.
-Since this guide is only about getting started with Bitburner, it will not cover the
-entire "quest-line".
+Since this guide is only about getting started with Bitburner, it will not cover the entire "quest-line".
 
 ## First Steps
 
 I'm going to assume you followed the introductory tutorial when you first began the game.
-In this introductory tutorial, you created a [Script](../basic/scripts.md) called `n00dles.js` and ran it
-on the `n00dles` server. Right now, we'll kill this [Script](../basic/scripts.md). There are two ways
-to do this:
+In this introductory tutorial, you created a [Script](../basic/scripts.md) called `n00dles.js` and ran it on the `n00dles` server.
+Right now, we'll kill this [Script](../basic/scripts.md). There are two ways to do this:
 
 1. You can go to the Terminal and enter:
 
    $ kill n00dles.js
 
-2. You can go to the `Active Scripts` page (Alt + s) and
-   press the `Kill Script` button for `n00dles.js`.
+2. You can go to the `Active Scripts` page (Alt + s) and press the `Kill Script` button for `n00dles.js`.
 
-If you skipped the introductory tutorial, then ignore the part above. Instead, go to the
-`Hacknet Nodes` page (Alt + h) and purchase a
-[Hacknet Node](../basic/hacknet_nodes.md) to start generating some passive income.
+If you skipped the introductory tutorial, then ignore the part above.
+Instead, go to the `Hacknet Nodes` page (Alt + h) and purchase a [Hacknet Node](../basic/hacknet_nodes.md) to start generating some passive income.
 
 ## Creating our First Script
 
-Now, we'll create a generic [hacking](../basic/hacking.md) [Script](../basic/scripts.md) that can be used early on in the game (or throughout the
-entire game, if you want).
+Now, we'll create a generic [hacking](../basic/hacking.md) [Script](../basic/scripts.md) that can be used early on in the game (or throughout the entire game, if you want).
 
 Before we write the [Script](../basic/scripts.md), here are some things you'll want to familiarize yourself with:
 
@@ -57,23 +49,20 @@ Before we write the [Script](../basic/scripts.md), here are some things you'll w
 - `brutessh`
 - `nuke`
 
-To briefly summarize: Each [Server](../basic/servers.md) has a
-security level that affects how difficult it is to hack. Each [Server](../basic/servers.md) also has a
-certain amount of money, as well as a maximum amount of money it can hold. [Hacking](../basic/hacking.md) a
-[Server](../basic/servers.md) steals a percentage of that [Server](../basic/servers.md)'s money. The `hack()` function
-is used to hack a [Server](../basic/servers.md). The `grow()` function is used to increase
-the amount of money available on a [Server](../basic/servers.md). The `weaken()` function is
-used to decrease a [Server](../basic/servers.md)'s security level.
+To briefly summarize: Each [Server](../basic/servers.md) has a security level that affects how difficult it is to hack.
+Each [Server](../basic/servers.md) also has a certain amount of money, as well as a maximum amount of money it can hold.
+[Hacking](../basic/hacking.md) a [Server](../basic/servers.md) steals a percentage of that [Server](../basic/servers.md)'s money.
+The `hack()` function is used to hack a [Server](../basic/servers.md).
+The `grow()` function is used to increase the amount of money available on a [Server](../basic/servers.md).
+The `weaken()` function is used to decrease a [Server](../basic/servers.md)'s security level.
 
 Now let's move on to actually creating the [Script](../basic/scripts.md).
-Go to your home computer and then create a [Script](../basic/scripts.md) called `early-hack-template.js` by
-going to [Terminal](../basic/terminal.md) and entering the following two commands:
+Go to your home computer and then create a [Script](../basic/scripts.md) called `early-hack-template.js` by going to [Terminal](../basic/terminal.md) and entering the following two commands:
 
     $ home
     $ nano early-hack-template.js
 
-This will take you to the [Script](../basic/scripts.md) editor, which you can use to code and create
-[Scripts](../basic/scripts.md).
+This will take you to the [Script](../basic/scripts.md) editor, which you can use to code and create [Scripts](../basic/scripts.md).
 
 Enter the following code in the [Script](../basic/scripts.md) editor:
 
@@ -116,31 +105,26 @@ Enter the following code in the [Script](../basic/scripts.md) editor:
         }
     }
 
-The [Script](../basic/scripts.md) above contains comments that document what it does, but let's go through it
-step-by-step anyway.
+The [Script](../basic/scripts.md) above contains comments that document what it does, but let's go through it step-by-step anyway.
 
     const target = "n00dles";
 
-This first command defines a string which contains our target [Server](../basic/servers.md). That's the [Server](../basic/servers.md)
-that we're going to [hack](../basic/hacking.md). For now, it's set to `"n00dles"` because that's the only
-[Server](../basic/servers.md) with a required hacking level of `1`. If you want to [hack](../basic/hacking.md) a different [Server](../basic/servers.md),
-simply change this
-variable to be the hostname of another [Server](../basic/servers.md).
+This first command defines a string which contains our target [Server](../basic/servers.md).
+That's the [Server](../basic/servers.md) that we're going to [hack](../basic/hacking.md).
+For now, it's set to `"n00dles"` because that's the only [Server](../basic/servers.md) with a required hacking level of `1`.
+If you want to [hack](../basic/hacking.md) a different [Server](../basic/servers.md), simply change this variable to be the hostname of another [Server](../basic/servers.md).
 
     const moneyThresh = ns.getServerMaxMoney(target);
 
-This second command defines a numerical value representing the minimum
-amount of money that must be available on the target [Server](../basic/servers.md) in order for our [Script](../basic/scripts.md)
-to [hack](../basic/hacking.md) it. If the money available on the target [Server](../basic/servers.md) is less than this value,
-then our [Script](../basic/scripts.md) will `grow()` the [Server](../basic/servers.md) rather than [hacking](../basic/hacking.md) it.
+This second command defines a numerical value representing the minimum amount of money that must be available on the target [Server](../basic/servers.md) in order for our [Script](../basic/scripts.md) to [hack](../basic/hacking.md) it.
+If the money available on the target [Server](../basic/servers.md) is less than this value, then our [Script](../basic/scripts.md) will `grow()` the [Server](../basic/servers.md) rather than [hacking](../basic/hacking.md) it.
 It is set to the maximum amount of money that can be available on the [Server](../basic/servers.md).
 The `getServerMaxMoney()` function is used to find this value
 
     const securityThresh = ns.getServerMinSecurityLevel(target);
 
-This third command defines a numerical value representing the minimum security level
-the target [Server](../basic/servers.md) can have. If the target [Server](../basic/servers.md)'s security level is higher than
-this value, then our [Script](../basic/scripts.md) will `weaken()` the [Script](../basic/scripts.md) before doing anything else.
+This third command defines a numerical value representing the minimum security level the target [Server](../basic/servers.md) can have.
+If the target [Server](../basic/servers.md)'s security level is higher than this value, then our [Script](../basic/scripts.md) will `weaken()` the [Script](../basic/scripts.md) before doing anything else.
 
     if (ns.fileExists("BruteSSH.exe", "home")) {
         ns.brutessh(target);
@@ -148,8 +132,8 @@ this value, then our [Script](../basic/scripts.md) will `weaken()` the [Script](
 
     ns.nuke(target);
 
-This section of code is used to gain root access on the target [Server](../basic/servers.md). This is
-necessary for [hacking](../basic/hacking.md).
+This section of code is used to gain root access on the target [Server](../basic/servers.md).
+This is necessary for [hacking](../basic/hacking.md).
 
     while (true) {
         if (ns.getServerSecurityLevel(target) > securityThresh) {
@@ -164,28 +148,26 @@ necessary for [hacking](../basic/hacking.md).
         }
     }
 
-This is the main section that drives our [Script](../basic/scripts.md). It dictates the [Script](../basic/scripts.md)'s logic
-and carries out the [hacking](../basic/hacking.md) operations. The `while (true)` creates an infinite loop
-that will continuously run the [hacking](../basic/hacking.md) logic until the the [Script](../basic/scripts.md) is killed.
+This is the main section that drives our [Script](../basic/scripts.md).
+It dictates the [Script](../basic/scripts.md)'s logic and carries out the [hacking](../basic/hacking.md) operations.
+The `while (true)` creates an infinite loop that will continuously run the [hacking](../basic/hacking.md) logic until the the [Script](../basic/scripts.md) is killed.
 
-The await keyword is needed for `hack()` / `grow()` / `weaken()` because these commands take
-time to execute, unlike the others. If you forget to await these commands, you will get
-an exception saying you tried to do multiple things at once, because your code will
-immediately finish the function call without waiting for the operation to be done. Also
-important is that await can only be used in functions marked `async` (note that `main()` is marked `async`).
+The await keyword is needed for `hack()` / `grow()` / `weaken()` because these commands take time to execute, unlike the others.
+If you forget to await these commands, you will get an exception saying you tried to do multiple things at once, because your code will immediately finish the function call without waiting for the operation to be done.
+Also important is that await can only be used in functions marked `async` (note that `main()` is marked `async`).
 
 ## Running our Scripts
 
-Now we want to start running our [hacking](../basic/hacking.md) [Script](../basic/scripts.md) so that it can start earning us
-money and experience. Our home computer only has 8GB of [RAM](../basic/ram.md), and we'll be using it for
-something else later. Instead, we'll take advantage of the [RAM](../basic/ram.md) on other machines.
+Now we want to start running our [hacking](../basic/hacking.md) [Script](../basic/scripts.md) so that it can start earning us money and experience.
+Our home computer only has 8GB of [RAM](../basic/ram.md), and we'll be using it for something else later.
+Instead, we'll take advantage of the [RAM](../basic/ram.md) on other machines.
 
 Go to `Terminal` and enter the following command:
 
     $ scan-analyze 2
 
-This will show detailed information about some [Servers](../basic/servers.md) on the network. The
-**network is randomized so it will be different for every person**.
+This will show detailed information about some [Servers](../basic/servers.md) on the network.
+The **network is randomized so it will be different for every person**.
 Here's what mine showed at the time I made this:
 
     [home ~]> scan-analyze 2
@@ -246,25 +228,24 @@ Take note of the following servers:
 - `hong-fang-tea`
 - `harakiri-sushi`
 
-All of these servers have 16GB of [RAM](../basic/ram.md). Furthermore, all of these servers do not require
-any open ports in order to NUKE. In other words, we can gain root access to all of these
-servers and then run [Scripts](../basic/scripts.md) on them.
+All of these servers have 16GB of [RAM](../basic/ram.md).
+Furthermore, all of these servers do not require any open ports in order to NUKE.
+In other words, we can gain root access to all of these servers and then run [Scripts](../basic/scripts.md) on them.
 
 First, let's determine how many threads of our [hacking](../basic/hacking.md) [Script](../basic/scripts.md) we can run.
 (See the page on [scripts](../basic/scripts.md) for more information on multithreading.)
 
-The [Script](../basic/scripts.md) we wrote
-uses 2.6GB of [RAM](../basic/ram.md). You can check this using the following `Terminal` command:
+The [Script](../basic/scripts.md) we wrote uses 2.6GB of [RAM](../basic/ram.md).
+You can check this using the following `Terminal` command:
 
     $ mem early-hack-template.js
 
-This means we can run 6 threads on a 16GB server. Now, to run our [Scripts](../basic/scripts.md) on all of these
-servers, we have to do the following:
+This means we can run 6 threads on a 16GB server.
+Now, to run our [Scripts](../basic/scripts.md) on all of these servers, we have to do the following:
 
 1. Use the `scp` command to copy our [Script](../basic/scripts.md) to each server.
 2. Use the `connect` command to connect to a server.
-3. Use the `run` command to run the `NUKE.exe` program and
-   gain root access.
+3. Use the `run` command to run the `NUKE.exe` program and gain root access.
 4. Use the `run` command again to run our [Script](../basic/scripts.md).
 5. Repeat steps 2-4 for each server.
 
@@ -302,56 +283,51 @@ Here's the sequence of `Terminal` commands I used in order to achieve this:
     $ run NUKE.exe
     $ run early-hack-template.js -t 6
 
-Pressing the `Tab` key in the middle of a Terminal command will attempt to
-auto-complete the command. For example, if you type in `scp ea` and then
-hit `Tab`, the rest of the [Script](../basic/scripts.md)'s name should automatically be filled in.
+Pressing the `Tab` key in the middle of a Terminal command will attempt to auto-complete the command.
+For example, if you type in `scp ea` and then hit `Tab`, the rest of the [Script](../basic/scripts.md)'s name should automatically be filled in.
 This works for most commands in the game!
 
-The `home` command is used to connect to the home
-computer. When running our [Scripts](../basic/scripts.md) with the `run early-hack-template.js -t 6`
-command, the `-t 6` specifies that the [Script](../basic/scripts.md) should be run with 6 threads.
+The `home` command is used to connect to the home computer. When running our [Scripts](../basic/scripts.md) with the `run early-hack-template.js -t 6` command, the `-t 6` specifies that the [Script](../basic/scripts.md) should be run with 6 threads.
 
 Note that the `nectar-net` [Server](../basic/servers.md) isn't in the home computer's immediate network.
-This means you can't directly connect to it from home. You will have to search for it
-inside the network. The results of the `scan-analyze 2` command we ran before
-will show where it is. In my case, I could connect to it by going from
-`hong-fang-tea` -> `nectar-net`. However, this will probably be different for you.
+This means you can't directly connect to it from home. You will have to search for it inside the network.
+The results of the `scan-analyze 2` command we ran before will show where it is.
+In my case, I could connect to it by going from `hong-fang-tea` -> `nectar-net`.
+However, this will probably be different for you.
 
 After running all of these `Terminal` commands, our [Scripts](../basic/scripts.md) are now up and running.
-These will earn money and hacking experience over time. These gains will be
-really slow right now, but they will increase once our hacking skill rises and
-we start running more [Scripts](../basic/scripts.md).
+These will earn money and hacking experience over time.
+These gains will be really slow right now, but they will increase once our hacking skill rises and we start running more [Scripts](../basic/scripts.md).
 
 ## Increasing Hacking Level
 
-There are many [Servers](../basic/servers.md) besides `n00dles` that can be hacked, but they have
-higher required hacking levels. Therefore, we should raise our hacking level. Not only
-will this let us hack more [Servers](../basic/servers.md), but it will also increase the effectiveness of our [hacking](../basic/hacking.md)
-against `n00dles`.
+There are many [Servers](../basic/servers.md) besides `n00dles` that can be hacked, but they have higher required hacking levels.
+Therefore, we should raise our hacking level.
+Not only will this let us hack more [Servers](../basic/servers.md), but it will also increase the effectiveness of our [hacking](../basic/hacking.md) against `n00dles`.
 
-The easiest way to train your hacking level is to visit Rothman University. You can do this
-from the `City` tab on the left-hand navigation menu (click on it or press Alt + w). Rothman University should be the "U"
-near the bottom-right. Click the "U" to go to the location.
+The easiest way to train your hacking level is to visit Rothman University.
+You can do this from the `City` tab on the left-hand navigation menu (click on it or press Alt + w).
+Rothman University should be the "U" near the bottom-right.
+Click the "U" to go to the location.
 
-Once you go to Rothman University, you should see a screen with several options. These
-options describe different courses you can take. You should click the first button, which
-says: `Study Computer Science (free)`.
+Once you go to Rothman University, you should see a screen with several options.
+These options describe different courses you can take.
+You should click the first button, which says: `Study Computer Science (free)`.
 
-After you click the button, you will start studying and earning hacking experience. While you
-are doing this, you cannot interact with any other part of the game until you click
-either "Stop taking course" or "Do something else simultaneously".
+After you click the button, you will start studying and earning hacking experience.
+While you are doing this, you cannot interact with any other part of the game until you click either "Stop taking course" or "Do something else simultaneously".
 
-Right now, we want a hacking level of 10. You need approximately 174 hacking experience to reach
-level 10. You can check how much hacking experience you have by either hovering over the progress bar in the overview window
-or going to the `Stats` tab on the left-hand navigation menu (click on it or press Alt + c).
-Since studying at Rothman University earns you 1 experience per second, this will take
-174 seconds, or approximately 3 minutes. Feel free to do something in the meantime!
+Right now, we want a hacking level of 10.
+You need approximately 174 hacking experience to reach level 10.
+You can check how much hacking experience you have by either hovering over the progress bar in the overview window or going to the `Stats` tab on the left-hand navigation menu (click on it or press Alt + c).
+Since studying at Rothman University earns you 1 experience per second, this will take 174 seconds, or approximately 3 minutes.
+Feel free to do something in the meantime!
 
 ## Editing our Hacking Script
 
-Now that we have a hacking level of 10, we can hack the `joesguns` [Server](../basic/servers.md). This [Server](../basic/servers.md)
-will be slightly more profitable than `n00dles`. Therefore, we want to change our [hacking](../basic/hacking.md)
-[Script](../basic/scripts.md) to target `joesguns` instead of `n00dles`.
+Now that we have a hacking level of 10, we can hack the `joesguns` [Server](../basic/servers.md).
+This [Server](../basic/servers.md) will be slightly more profitable than `n00dles`.
+Therefore, we want to change our [hacking](../basic/hacking.md) [Script](../basic/scripts.md) to target `joesguns` instead of `n00dles`.
 
 Go to `Terminal` and edit the [hacking](../basic/hacking.md) [Script](../basic/scripts.md) by entering:
 
@@ -367,12 +343,11 @@ This will only affect instances of the [Script](../basic/scripts.md) that are ra
 
 ## Creating a New Script to Purchase New Servers
 
-Next, we're going to create a [Script](../basic/scripts.md) that automatically purchases additional [Servers](../basic/servers.md). These
-[Servers](../basic/servers.md) will be used to run many [Scripts](../basic/scripts.md). Running this [Script](../basic/scripts.md) will initially be very
-expensive since purchasing a [Server](../basic/servers.md) costs money, but it will pay off in the long run.
+Next, we're going to create a [Script](../basic/scripts.md) that automatically purchases additional [Servers](../basic/servers.md).
+These [Servers](../basic/servers.md) will be used to run many [Scripts](../basic/scripts.md).
+Running this [Script](../basic/scripts.md) will initially be very expensive since purchasing a [Server](../basic/servers.md) costs money, but it will pay off in the long run.
 
-In order to create this [Script](../basic/scripts.md), you should familiarize yourself with the following
-functions:
+In order to create this [Script](../basic/scripts.md), you should familiarize yourself with the following functions:
 
 - `purchaseServer()`
 - `getPurchasedServerCost()`
@@ -418,34 +393,28 @@ Paste the following code into the [Script](../basic/scripts.md) editor:
         }
     }
 
-This code uses a while loop to purchase the maximum amount of [Servers](../basic/servers.md) using the
-`purchaseServer()` function. Each of these [Servers](../basic/servers.md) will have
-8GB of [RAM](../basic/ram.md), as defined in the `ram` variable. Note that the [Script](../basic/scripts.md) uses the command
-`getServerMoneyAvailable("home")` to get the amount of money you currently have.
+This code uses a while loop to purchase the maximum amount of [Servers](../basic/servers.md) using the `purchaseServer()` function.
+Each of these [Servers](../basic/servers.md) will have 8GB of [RAM](../basic/ram.md), as defined in the `ram` variable.
+Note that the [Script](../basic/scripts.md) uses the command `getServerMoneyAvailable("home")` to get the amount of money you currently have.
 This is then used to check if you can afford to purchase a [Server](../basic/servers.md).
 
-Whenever the script purchases a new [Server](../basic/servers.md), it uses the `scp()` function to copy
-our [Script](../basic/scripts.md) onto that new [Server](../basic/servers.md), and then it uses the `exec()` function to
-execute it on that [Server](../basic/servers.md).
+Whenever the script purchases a new [Server](../basic/servers.md), it uses the `scp()` function to copy our [Script](../basic/scripts.md) onto that new [Server](../basic/servers.md), and then it uses the `exec()` function to execute it on that [Server](../basic/servers.md).
 
 To run this [Script](../basic/scripts.md), go to `Terminal` and type:
 
     $ run purchase-server-8gb.js
 
 This purchase will continuously run until it has purchased the maximum number of [Servers](../basic/servers.md).
-When this happens, it'll mean that you have a bunch of new [Servers](../basic/servers.md) that are all running
-[hacking](../basic/hacking.md) [Scripts](../basic/scripts.md) against the `joesguns` [Server](../basic/servers.md)!
+When this happens, it'll mean that you have a bunch of new [Servers](../basic/servers.md) that are all running [hacking](../basic/hacking.md) [Scripts](../basic/scripts.md) against the `joesguns` [Server](../basic/servers.md)!
 
-The reason we're using so many [Scripts](../basic/scripts.md) to hack `joesguns` instead of targeting other
-[Servers](../basic/servers.md) is because it's more effective. This early in the game, we don't have enough [RAM](../basic/ram.md)
-to efficiently hack multiple targets, and trying to do so would be slow as we'd be spread
-too thin. You should definitely do this later on, though!
+The reason we're using so many [Scripts](../basic/scripts.md) to hack `joesguns` instead of targeting other [Servers](../basic/servers.md) is because it's more effective.
+This early in the game, we don't have enough [RAM](../basic/ram.md) to efficiently hack multiple targets, and trying to do so would be slow as we'd be spread too thin.
+You should definitely do this later on, though!
 
-Note that purchasing a [Server](../basic/servers.md) is fairly expensive, and purchasing the maximum amount of
-[Servers](../basic/servers.md) even more so. At the time of writing this guide, the [Script](../basic/scripts.md) above requires
-$11 million in order to finish purchasing all of the 8GB [Servers](../basic/servers.md).
-Therefore, we need to find additional ways to make money to speed
-up the process! These are covered in the next section.
+Note that purchasing a [Server](../basic/servers.md) is fairly expensive, and purchasing the maximum amount of [Servers](../basic/servers.md) even more so.
+At the time of writing this guide, the [Script](../basic/scripts.md) above requires $11 million in order to finish purchasing all of the 8GB [Servers](../basic/servers.md).
+Therefore, we need to find additional ways to make money to speed up the process!
+These are covered in the next section.
 
 ## Additional Sources of Income
 
@@ -454,67 +423,65 @@ There are other ways to gain money in this game besides [Scripts](../basic/scrip
 ## Hacknet Nodes
 
 If you completed the introductory tutorial, you were already introduced to this method: [Hacknet Nodes](../basic/hacknet_nodes.md).
-Once you have enough money, you can start upgrading your [Hacknet Nodes](../basic/hacknet_nodes.md) in order to increase
-your passive income stream. This is completely optional. Since each [Hacknet Node](../basic/hacknet_nodes.md) upgrade
-takes a certain amount of time to "pay itself off", it may not necessarily be in your best
-interest to use these.
+Once you have enough money, you can start upgrading your [Hacknet Nodes](../basic/hacknet_nodes.md) in order to increase your passive income stream.
+This is completely optional.
+Since each [Hacknet Node](../basic/hacknet_nodes.md) upgrade takes a certain amount of time to "pay itself off", it may not necessarily be in your best interest to use these.
 
-Nonetheless, [Hacknet Nodes](../basic/hacknet_nodes.md) are a good source of income early in the game, although
-their effectiveness tapers off later on. If you do wind up purchasing and upgrading [Hacknet Nodes](../basic/hacknet_nodes.md),
-I would suggest only upgrading their levels for now. I wouldn't bother with [RAM](../basic/ram.md) and Core
-upgrades until later on.
+Nonetheless, [Hacknet Nodes](../basic/hacknet_nodes.md) are a good source of income early in the game, although their effectiveness tapers off later on.
+If you do wind up purchasing and upgrading [Hacknet Nodes](../basic/hacknet_nodes.md), I would suggest only upgrading their levels for now.
+I wouldn't bother with [RAM](../basic/ram.md) and Core upgrades until later on.
 
 ## Crime
 
 The best source of income right now is from [crimes](../basic/crimes.md).
-This is because it not only gives you a large amount of money, but it also raises your
-hacking level. To commit [crimes](../basic/crimes.md), click on the `City` tab on the left-hand
-navigation menu or press Alt + w.
+This is because it not only gives you a large amount of money, but it also raises your hacking level.
+To commit [crimes](../basic/crimes.md), click on the `City` tab on the left-hand navigation menu or press Alt + w.
 Then, click on the link that says `The Slums`.
 
-In the Slums, you can attempt to commit a variety of [crimes](../basic/crimes.md), each of which gives certain
-types of experience and money if successful. See [crimes](../basic/crimes.md) for more details.
+In the Slums, you can attempt to commit a variety of [crimes](../basic/crimes.md), each of which gives certain types of experience and money if successful.
+See [crimes](../basic/crimes.md) for more details.
 
-You are not always successful when you attempt to commit a crime. Nothing bad happens
-if you fail a [crime](../basic/crimes.md), but you won't earn any money and the experience gained will be
-reduced. Raising your stats improves your chance of successfully committing a [crime](../basic/crimes.md).
+You are not always successful when you attempt to commit a crime.
+Nothing bad happens if you fail a [crime](../basic/crimes.md), but you won't earn any money and the experience gained will be reduced.
+Raising your stats improves your chance of successfully committing a [crime](../basic/crimes.md).
 
-Right now, the best option is the `Rob Store` [crime](../basic/crimes.md). This takes 60 seconds to attempt,
-gives $400k if successful, and gives hacking experience (which is very important right now).
+Right now, the best option is the `Rob Store` [crime](../basic/crimes.md).
+This takes 60 seconds to attempt, gives $400k if successful, and gives hacking experience (which is very important right now).
 
-Alternatively, you can also use the `Shoplift` [crime](../basic/crimes.md). This takes 2 seconds to attempt
-and gives $15k if successful. This [crime](../basic/crimes.md) is slightly easier and more profitable
-than `Rob Store`, but doesn't give hacking experience.
+Alternatively, you can also use the `Shoplift` [crime](../basic/crimes.md).
+This takes 2 seconds to attempt and gives $15k if successful.
+This [crime](../basic/crimes.md) is slightly easier and more profitable than `Rob Store`, but doesn't give hacking experience.
 
 ## Work for a Company
 
 If you don't want to commit [crimes](../basic/crimes.md), there's another option - working for a [company](../basic/companies.md)
 This will not be nearly as profitable as [crimes](../basic/crimes.md), but will provide [company](../basic/companies.md) [reputation](../basic/reputation.md)
 
-Go to the `City` tab on the left-hand navigation menu and then go to
-`Joe's Guns`. At `Joe's Guns`, there will be an option that says
-`Apply to be an Employee`. Click this to get the job. Then, a new option
-will appear that simply says `Work`. Click this to start working.
-Working at `Joe's Guns` earns $110 per second and also grants some experience
-for every stat except hacking.
+Go to the `City` tab on the left-hand navigation menu and then go to `Joe's Guns`.
+At `Joe's Guns`, there will be an option that says `Apply to be an Employee`.
+Click this to get the job.
+Then, a new option will appear that simply says `Work`.
+Click this to start working.
+Working at `Joe's Guns` earns $110 per second and also grants some experience for every stat except hacking.
 
-Working for a [company](../basic/companies.md), like [crime](../basic/crimes.md), is completely passive. You can choose to focus on your work, do
-something else simultaneously, or switch between those two. While you focus on work,
-you will not be able to do anything else in the game. If you do something else simultaneously,
-you will not gain [reputation](../basic/reputation.md) at the same speed. You can cancel working at any time.
+Working for a [company](../basic/companies.md), like [crime](../basic/crimes.md), is completely passive.
+You can choose to focus on your work, do something else simultaneously, or switch between those two.
+While you focus on work, you will not be able to do anything else in the game.
+If you do something else simultaneously, you will not gain [reputation](../basic/reputation.md) at the same speed.
+You can cancel working at any time.
 
-Once your hacking hits level 75, you can visit `Carmichael Security` in the city
-and get a software job there. This job offers higher pay and also earns you
-hacking experience.
+Once your hacking hits level 75, you can visit `Carmichael Security` in the city and get a software job there.
+This job offers higher pay and also earns you hacking experience.
 
-There are many more companies in the `City` tab that offer more pay and also more gameplay
-features. Feel free to explore!
+There are many more companies in the `City` tab that offer more pay and also more gameplay features.
+Feel free to explore!
 
 ## After you Purchase your New Servers
 
-After you've made a total of $11 million, your automatic [Server](../basic/servers.md)-purchasing [Script](../basic/scripts.md) should
-finish running. This will free up some [RAM](../basic/ram.md) on your home computer. We don't want this [RAM](../basic/ram.md)
-to go to waste, so we'll make use of it. Go to `Terminal` and enter the following commands:
+After you've made a total of $11 million, your automatic [Server](../basic/servers.md)-purchasing [Script](../basic/scripts.md) should finish running.
+This will free up some [RAM](../basic/ram.md) on your home computer.
+We don't want this [RAM](../basic/ram.md) to go to waste, so we'll make use of it.
+Go to `Terminal` and enter the following commands:
 
     $ home
     $ run early-hack-template.js -t 3
@@ -525,32 +492,29 @@ Once you reach a hacking level of 50, two new important parts of the game open u
 
 ## Creating your first program: BruteSSH.exe
 
-On the left-hand navigation menu you will notice a `Create Programs` tab with a
-red notification icon. This indicates that there are programs available to be created.
+On the left-hand navigation menu you will notice a `Create Programs` tab with a red notification icon.
+This indicates that there are programs available to be created.
 Click on that tab (or use Alt + p) and you'll see a
-list of all the programs you can currently create. Hovering over a program will give a
-brief description of its function. Simply click on a program to start creating it.
+list of all the programs you can currently create.
+Hovering over a program will give a brief description of its function.
+Simply click on a program to start creating it.
 
-Right now, the program we want to create is `BruteSSH.exe`. This program is used
-to open up SSH ports on [Servers](../basic/servers.md). This will allow you to hack more [Servers](../basic/servers.md),
-as many [Servers](../basic/servers.md) in the game require a certain number of opened ports in order for
-`NUKE.exe` to gain root access.
+Right now, the program we want to create is `BruteSSH.exe`.
+This program is used to open up SSH ports on [Servers](../basic/servers.md).
+This will allow you to hack more [Servers](../basic/servers.md), as many [Servers](../basic/servers.md) in the game require a certain number of opened ports in order for `NUKE.exe` to gain root access.
 
-Feel free to cancel your work on creating a program at any time, as your progress will
-be saved and can be picked back up later. `BruteSSH.exe` takes about
-10 minutes to complete.
+Feel free to cancel your work on creating a program at any time, as your progress will be saved and can be picked back up later.
+`BruteSSH.exe` takes about 10 minutes to complete.
 
 ## Optional: Create AutoLink.exe
 
-On the `Create Programs` page, you will notice another program you can create
-called `AutoLink.exe`. If you don't mind waiting another 10-15 minutes, you should
-go ahead and create this program. It makes it much less tedious to connect to other [Servers](../basic/servers.md),
-but it's not necessary for progression.
+On the `Create Programs` page, you will notice another program you can create called `AutoLink.exe`.
+If you don't mind waiting another 10-15 minutes, you should go ahead and create this program.
+It makes it much less tedious to connect to other [Servers](../basic/servers.md), but it's not necessary for progression.
 
 ## Joining your first faction: CyberSec
 
-Shortly after you reached level 50 hacking, you should have received a message that
-said this:
+Shortly after you reached level 50 hacking, you should have received a message that said this:
 
     Message received from unknown sender:
 
@@ -564,25 +528,25 @@ said this:
 
     This message was saved as csec-test.msg onto your home computer.
 
-If you didn't, or if you accidentally closed it, that's okay! Messages get saved onto
-your home computer. Enter the following `Terminal` commands to view the message:
+If you didn't, or if you accidentally closed it, that's okay!
+Messages get saved onto your home computer.
+Enter the following `Terminal` commands to view the message:
 
     $ home
     $ cat csec-test.msg
 
-This message is part of the game's main "quest-line". It is a message from the
-`CyberSec` [faction](../basic/factions.md) that is asking you to pass their test.
-Passing their test is simple, you just have to find their [Server](../basic/servers.md), hack it, and
-install a backdoor through the `Terminal`. Their [Server](../basic/servers.md) is called `CSEC`.
-To do this, we'll use the `scan-analyze`
-Terminal command, just like we did before:
+This message is part of the game's main "quest-line".
+It is a message from the `CyberSec` [faction](../basic/factions.md) that is asking you to pass their test.
+Passing their test is simple, you just have to find their [Server](../basic/servers.md), hack it, and install a backdoor through the `Terminal`.
+Their [Server](../basic/servers.md) is called `CSEC`.
+To do this, we'll use the `scan-analyze` Terminal command, just like we did before:
 
     $ home
     $ scan-analyze 2
 
-This will show you the network for all [Servers](../basic/servers.md) that are up to 2 "nodes" away from
-your home computer. Remember that the network is randomly generated so it'll look
-different for everyone. Here's the relevant part of my `scan-analyze` results:
+This will show you the network for all [Servers](../basic/servers.md) that are up to 2 "nodes" away from your home computer.
+Remember that the network is randomly generated so it'll look different for everyone.
+Here's the relevant part of my `scan-analyze` results:
 
     ┕ home
       ┃   Root Access: YES, Required hacking skill: 1
@@ -606,40 +570,38 @@ This tells me that I can reach `CSEC` by going through `iron-gym`:
     $ connect iron-gym
     $ connect CSEC
 
-If you created the `AutoLink.exe` program earlier, then there is an easier
-method of connecting to `CSEC`. You'll notice that in the `scan-analyze`
-results, all of the [Server](../basic/servers.md) hostnames are white and underlined. You can simply
-click one of the [Server](../basic/servers.md) hostnames in order to connect to it. So, simply click
-`CSEC`!
+If you created the `AutoLink.exe` program earlier, then there is an easier method of connecting to `CSEC`.
+You'll notice that in the `scan-analyze` results, all of the [Server](../basic/servers.md) hostnames are white and underlined.
+You can simply click one of the [Server](../basic/servers.md) hostnames in order to connect to it.
+So, simply click `CSEC`!
 
 Make sure you notice the required hacking skill for the `CSEC` [Server](../basic/servers.md).
-This is a random value between 51 and 60. Although you receive the message
-from CSEC once you hit 50 hacking, you cannot actually pass their test
-until your hacking is high enough to install a backdoor on their [Server](../basic/servers.md).
+This is a random value between 51 and 60.
+Although you receive the message from CSEC once you hit 50 hacking, you cannot actually pass their test until your hacking is high enough to install a backdoor on their [Server](../basic/servers.md).
 
-After you are connected to the `CSEC` [Server](../basic/servers.md), you can backdoor it. Note that this
-[Server](../basic/servers.md) requires one open port in order to gain root access. We can open the SSH port
-using the `BruteSSH.exe` program we created earlier. In `Terminal`:
+After you are connected to the `CSEC` [Server](../basic/servers.md), you can backdoor it.
+Note that this [Server](../basic/servers.md) requires one open port in order to gain root access.
+We can open the SSH port using the `BruteSSH.exe` program we created earlier.
+In `Terminal`:
 
     $ run BruteSSH.exe
     $ run NUKE.exe
     $ backdoor
 
-After you successfully install the backdoor, you should receive a [faction](../basic/factions.md)
-invitation from `CyberSec` shortly afterwards. Accept it. If you accidentally
-reject the invitation, that's okay. Just go to the `Factions` tab
-(Alt + f) and you should see an option that lets you
-accept the invitation.
+After you successfully install the backdoor, you should receive a [faction](../basic/factions.md) invitation from `CyberSec` shortly afterwards.
+Accept it.
+If you accidentally reject the invitation, that's okay.
+Just go to the `Factions` tab (Alt + f) and you should see an option that lets you accept the invitation.
 
-Congrats! You just joined your first [faction](../basic/factions.md). Don't worry about doing anything
-with this [faction](../basic/factions.md) yet, we can come back to it later.
+Congrats!
+You just joined your first [faction](../basic/factions.md).
+Don't worry about doing anything with this [faction](../basic/factions.md) yet, we can come back to it later.
 
 ## Using Additional Servers to Hack Joesguns
 
-Once you have the `BruteSSH` program, you will be able to gain root access
-to several additional [Servers](../basic/servers.md). These [Servers](../basic/servers.md) have more [RAM](../basic/ram.md) that you can use to
-run [Scripts](../basic/scripts.md). We'll use the [RAM](../basic/ram.md) on these [Servers](../basic/servers.md) to run more [Scripts](../basic/scripts.md) that target
-`joesguns`.
+Once you have the `BruteSSH` program, you will be able to gain root access to several additional [Servers](../basic/servers.md).
+These [Servers](../basic/servers.md) have more [RAM](../basic/ram.md) that you can use to run [Scripts](../basic/scripts.md).
+We'll use the [RAM](../basic/ram.md) on these [Servers](../basic/servers.md) to run more [Scripts](../basic/scripts.md) that target `joesguns`.
 
 ## Copying our Scripts
 
@@ -650,9 +612,9 @@ The [Servers](../basic/servers.md) we'll be using to run our [Scripts](../basic/
 - `max-hardware`
 - `iron-gym`
 
-All of these [Servers](../basic/servers.md) have 32GB of [RAM](../basic/ram.md). You can use the `Terminal` command
-`scan-analyze 3` to see for yourself. To copy our [hacking](../basic/hacking.md) [Scripts](../basic/scripts.md) onto these [Servers](../basic/servers.md),
-go to `Terminal` and run:
+All of these [Servers](../basic/servers.md) have 32GB of [RAM](../basic/ram.md).
+You can use the `Terminal` command `scan-analyze 3` to see for yourself.
+To copy our [hacking](../basic/hacking.md) [Scripts](../basic/scripts.md) onto these [Servers](../basic/servers.md), go to `Terminal` and run:
 
     $ home
     $ scp early-hack-template.js neo-net
@@ -660,120 +622,105 @@ go to `Terminal` and run:
     $ scp early-hack-template.js max-hardware
     $ scp early-hack-template.js iron-gym
 
-Since each of these [Servers](../basic/servers.md) has 32GB of [RAM](../basic/ram.md), we can run our [hacking](../basic/hacking.md) script with 12 threads
-on each [Server](../basic/servers.md). By now, you should know how to connect to [Servers](../basic/servers.md). So find and connect to
-each of the [Servers](../basic/servers.md) above using the `scan-analyze 3` `Terminal` command. Then, use
-following `Terminal` command to run our [hacking](../basic/hacking.md)
-script with 12 threads:
+Since each of these [Servers](../basic/servers.md) has 32GB of [RAM](../basic/ram.md), we can run our [hacking](../basic/hacking.md) script with 12 threads on each [Server](../basic/servers.md).
+By now, you should know how to connect to [Servers](../basic/servers.md).
+So find and connect to each of the [Servers](../basic/servers.md) above using the `scan-analyze 3` `Terminal` command.
+Then, use following `Terminal` command to run our [hacking](../basic/hacking.md) script with 12 threads:
 
     $ run early-hack-template.js -t 12
 
-Remember that if you have the `AutoLink` program, you can simply click on the hostname of a [Server](../basic/servers.md)
-after running `scan-analyze` to connect to it.
+Remember that if you have the `AutoLink` program, you can simply click on the hostname of a [Server](../basic/servers.md) after running `scan-analyze` to connect to it.
 
 ## Profiting from Scripts & Gaining Reputation with CyberSec
 
-Now it's time to play the waiting game. It will take some time for your [Scripts](../basic/scripts.md) to start
-earning money. Remember that most of your [Scripts](../basic/scripts.md) are targeting `joesguns`. It will take a
-bit for them to `grow()` and `weaken()` the [Server](../basic/servers.md) to the appropriate values
-before they start [hacking](../basic/hacking.md) it. Once they do, however, the [Scripts](../basic/scripts.md) will be very profitable.
+Now it's time to play the waiting game.
+It will take some time for your [Scripts](../basic/scripts.md) to start earning money.
+Remember that most of your [Scripts](../basic/scripts.md) are targeting `joesguns`.
+It will take a bit for them to `grow()` and `weaken()` the [Server](../basic/servers.md) to the appropriate values before they start [hacking](../basic/hacking.md) it.
+Once they do, however, the [Scripts](../basic/scripts.md) will be very profitable.
 
-For reference, in about two hours after starting my first [Script](../basic/scripts.md), my [Scripts](../basic/scripts.md) had a
-production rate of $20k per second and had earned a total of $70 million.
+For reference, in about two hours after starting my first [Script](../basic/scripts.md), my [Scripts](../basic/scripts.md) had a production rate of $20k per second and had earned a total of $70 million.
 (You can see these stats on the `Active Scripts` tab).
 
-After another 15 minutes, the production rate had increased to $25k per second
-and the [Scripts](../basic/scripts.md) had made an additional $55 million.
+After another 15 minutes, the production rate had increased to $25k per second and the [Scripts](../basic/scripts.md) had made an additional $55 million.
 
-Your results will vary based on how fast you earned money from [crime](../basic/crimes.md)/[working](../basic/companies.md)/[hacknet nodes](../basic/hacknet_nodes.md),
-but this will hopefully give you a good indication of how much the [Scripts](../basic/scripts.md) can earn.
+Your results will vary based on how fast you earned money from [crime](../basic/crimes.md)/[working](../basic/companies.md)/[hacknet nodes](../basic/hacknet_nodes.md), but this will hopefully give you a good indication of how much the [Scripts](../basic/scripts.md) can earn.
 
 In the meantime, we are going to be gaining reputation with the `CyberSec` [faction](../basic/factions.md).
-Go to the `Factions` tab on the left-hand
-navigation menu (Alt + F), and from there select `CyberSec`. In the middle of
-the page there should be a button for `Hacking Contracts`.
-Click it to start earning [reputation](../basic/reputation.md) for the `CyberSec` [faction](../basic/factions.md)
-(as well as some hacking experience). The higher your hacking level, the more [reputation](../basic/reputation.md) you
-will gain. Note that while you are working for a [faction](../basic/factions.md), you can choose to not interact
-with the rest of the game in any way to gain [reputation](../basic/reputation.md) at full speed. You can also select to
-do something else simultaneously, gaining [reputation](../basic/reputation.md) a bit more slowly, until you focus again.
+Go to the `Factions` tab on the left-hand navigation menu (Alt + F), and from there select `CyberSec`.
+In the middle of the page there should be a button for `Hacking Contracts`.
+Click it to start earning [reputation](../basic/reputation.md) for the `CyberSec` [faction](../basic/factions.md) (as well as some hacking experience).
+The higher your hacking level, the more [reputation](../basic/reputation.md) you will gain.
+Note that while you are working for a [faction](../basic/factions.md), you can choose to not interact with the rest of the game in any way to gain [reputation](../basic/reputation.md) at full speed.
+You can also select to do something else simultaneously, gaining [reputation](../basic/reputation.md) a bit more slowly, until you focus again.
 You can cancel your [faction](../basic/factions.md) work at any time with no penalty to your [reputation](../basic/reputation.md) gained so far.
 
 ## Purchasing Upgrades and Augmentations
 
-As I mentioned before, within 1-2 hours I had earned over $200 million. Now, it's time
-to spend all of this money on some persistent upgrades to help progress!
+As I mentioned before, within 1-2 hours I had earned over $200 million.
+Now, it's time to spend all of this money on some persistent upgrades to help progress!
 
 ## Upgrading RAM on Home computer
 
-The most important thing to upgrade right now is the [RAM](../basic/ram.md) on your home computer. This
-will allow you to run more [Scripts](../basic/scripts.md).
+The most important thing to upgrade right now is the [RAM](../basic/ram.md) on your home computer.
+This will allow you to run more [Scripts](../basic/scripts.md).
 
 To upgrade your [RAM](../basic/ram.md), go to the `City` tab and visit the company `Alpha Enterprises`.
 There will be a button that says `Upgrade 'home' RAM (8.00GB -> 16.00GB) - $1.010m`.
 Click it to upgrade your [RAM](../basic/ram.md).
 
-I recommend getting your home computer's [RAM](../basic/ram.md) to **at least** 128GB. Getting it even
-higher would be better.
+I recommend getting your home computer's [RAM](../basic/ram.md) to **at least** 128GB.
+Getting it even higher would be better.
 
 ## Purchasing your First Augmentations
 
-Once you get ~1000 [reputation](../basic/reputation.md) with the `CyberSec` [faction](../basic/factions.md), you can purchase
-your first [Augmentation](../basic/augmentations.md) from them.
+Once you get ~1000 [reputation](../basic/reputation.md) with the `CyberSec` [faction](../basic/factions.md), you can purchase your first [Augmentation](../basic/augmentations.md) from them.
 
-To do this, go to the `Factions` tab on the left-hand navigation menu
-(Alt + f) and select `CyberSec`. There is an button
-near the bottom that says `Purchase Augmentations`. This will bring up a
-page that displays all of the [Augmentations](../basic/augmentations.md) available from `CyberSec`. Some of them
-may be locked right now. To unlock these, you will need to earn more
-[reputation](../basic/reputation.md) with `CyberSec`.
+To do this, go to the `Factions` tab on the left-hand navigation menu (Alt + f) and select `CyberSec`.
+There is a button near the bottom that says `Purchase Augmentations`.
+This will bring up a page that displays all of the [Augmentations](../basic/augmentations.md) available from `CyberSec`.
+Some of them may be locked right now.
+To unlock these, you will need to earn more [reputation](../basic/reputation.md) with `CyberSec`.
 
-[Augmentations](../basic/augmentations.md) give persistent upgrades in the form of multipliers. These aren't very
-powerful early in the game because the multipliers are small. However, the effects
-of [Augmentations](../basic/augmentations.md) stack multiplicatively **with each other**, so as you continue to install
-many [Augmentations](../basic/augmentations.md), their effects will increase significantly.
+[Augmentations](../basic/augmentations.md) give persistent upgrades in the form of multipliers.
+These aren't very powerful early in the game because the multipliers are small.
+However, the effects of [Augmentations](../basic/augmentations.md) stack multiplicatively **with each other**, so as you continue to install many [Augmentations](../basic/augmentations.md), their effects will increase significantly.
 
-Because of this, I would recommend investing more in [RAM](../basic/ram.md) upgrades for your home computer rather
-than [Augmentations](../basic/augmentations.md) early on. Having enough [RAM](../basic/ram.md) to run many [Scripts](../basic/scripts.md) will allow you to make
-much more money, and then you can come back later on and get all these [Augmentations](../basic/augmentations.md).
+Because of this, I would recommend investing more in [RAM](../basic/ram.md) upgrades for your home computer rather than [Augmentations](../basic/augmentations.md) early on.
+Having enough [RAM](../basic/ram.md) to run many [Scripts](../basic/scripts.md) will allow you to make much more money, and then you can come back later on and get all these [Augmentations](../basic/augmentations.md).
 
-Right now, I suggest purchasing at the very least the `Neurotrainer I` [Augmentation](../basic/augmentations.md) from
-`CyberSec`. If you have the money to spare, I would also suggest getting `BitWire` and
-several levels of the `NeuroFlux Governor` (`NFG`) [Augmentations](../basic/augmentations.md). Note that each time
-you purchase an [Augmentation](../basic/augmentations.md),
-**the price of purchasing another increases by 90%**,
-so make sure you buy the most expensive [Augmentation](../basic/augmentations.md) first. Don't worry, once you choose to
-install [Augmentations](../basic/augmentations.md), their prices will reset back to their original values.
+Right now, I suggest purchasing at the very least the `Neurotrainer I` [Augmentation](../basic/augmentations.md) from `CyberSec`.
+If you have the money to spare, I would also suggest getting `BitWire` and several levels of the `NeuroFlux Governor` (`NFG`) [Augmentations](../basic/augmentations.md).
+Note that each time you purchase an [Augmentation](../basic/augmentations.md), **the price of purchasing another increases by 90%**, so make sure you buy the most expensive [Augmentation](../basic/augmentations.md) first.
+Don't worry, once you choose to install [Augmentations](../basic/augmentations.md), their prices will reset back to their original values.
 
 ## Next Steps
 
-That's the end of the walkthrough portion of this guide! You should continue to explore
-what the game has to offer. There's quite a few features that aren't covered or mentioned
-in this guide, and even more that get unlocked as you continue to play!
+That's the end of the walkthrough portion of this guide!
+You should continue to explore what the game has to offer.
+There's quite a few features that aren't covered or mentioned in this guide, and even more that get unlocked as you continue to play!
 
-Also, check out the api documentation to see what it has to offer. Writing
-[Scripts](../basic/scripts.md) to perform and automate various tasks is where most of the fun in the game comes
-from (in my opinion)!
+Also, check out the api documentation to see what it has to offer.
+Writing [Scripts](../basic/scripts.md) to perform and automate various tasks is where most of the fun in the game comes from (in my opinion)!
 
 The following are a few things you may want to consider doing in the near future.
 
 ## Installing Augmentations (and Resetting)
 
-If you've purchased any [Augmentations](../basic/augmentations.md), you'll need to install them before you
-actually gain their effects. Installing [Augmentations](../basic/augmentations.md) is the game's "soft-reset" or "prestige"
-mechanic.
+If you've purchased any [Augmentations](../basic/augmentations.md), you'll need to install them before you actually gain their effects.
+Installing [Augmentations](../basic/augmentations.md) is the game's "soft-reset" or "prestige" mechanic.
 
-To install your [Augmentations](../basic/augmentations.md), click the `Augmentations` tab on the left-hand navigation
-menu (Alt + a). You will see a list of all of the [Augmentations](../basic/augmentations.md)
-you have purchased. Below that, you will see a button that says `Install Augmentations`.
+To install your [Augmentations](../basic/augmentations.md), click the `Augmentations` tab on the left-hand navigation menu (Alt + a).
+You will see a list of all of the [Augmentations](../basic/augmentations.md) you have purchased.
+Below that, you will see a button that says `Install Augmentations`.
 Be warned, after clicking this there is no way to undo it (unless you load an earlier save).
 
 ## Automating the Script Startup Process
 
-Whenever you install [Augmentations](../basic/augmentations.md), all of your [Scripts](../basic/scripts.md) are killed and you'll have to
-re-run them. Doing this every time you install [Augmentations](../basic/augmentations.md) would be very tedious and annoying,
-so you should write a [Script](../basic/scripts.md) to automate the process. Here's a simple example for a
-startup [Script](../basic/scripts.md). Feel free to adjust it to your liking.
+Whenever you install [Augmentations](../basic/augmentations.md), all of your [Scripts](../basic/scripts.md) are killed and you'll have to re-run them.
+Doing this every time you install [Augmentations](../basic/augmentations.md) would be very tedious and annoying, so you should write a [Script](../basic/scripts.md) to automate the process.
+Here's a simple example for a startup [Script](../basic/scripts.md).
+Feel free to adjust it to your liking.
 
     /** @param {NS} ns */
     export async function main(ns) {
@@ -823,16 +770,13 @@ startup [Script](../basic/scripts.md). Feel free to adjust it to your liking.
 
 ## Random Tips
 
-- Early on in the game, it's better to spend your money on upgrading [RAM](../basic/ram.md) and purchasing
-  new [Servers](../basic/servers.md) rather than spending it on [Augmentations](../basic/augmentations.md)
-- The more money available on a [Server](../basic/servers.md), the more effective the `hack()` and
-  `grow()` functions will be. This is because both of these functions
-  use percentages rather than flat values. `hack()` steals a percentage of a [Server](../basic/servers.md)'s
-  total available money, and `grow()` increases a [Server](../basic/servers.md)'s money by X%.
-- There is a limit to how much money can exist on a [Server](../basic/servers.md). This value is different for each
-  [Server](../basic/servers.md). The `getServerMaxMoney()` function will tell you this maximum value.
-- At this stage in the game, your combat stats (strength, defense, etc.) are not nearly
-  as useful as your hacking stat. Do not invest too much time or money into gaining combat
-  stat exp.
-- As a rule of thumb, your hacking target should be the [Server](../basic/servers.md) with highest max money that's
-  required hacking level is under 1/2 of your hacking level.
+- Early on in the game, it's better to spend your money on upgrading [RAM](../basic/ram.md) and purchasing new [Servers](../basic/servers.md) rather than spending it on [Augmentations](../basic/augmentations.md)
+- The more money available on a [Server](../basic/servers.md), the more effective the `hack()` and   `grow()` functions will be.
+  This is because both of these functions use percentages rather than flat values.
+  `hack()` steals a percentage of a [Server](../basic/servers.md)'s total available money, and `grow()` increases a [Server](../basic/servers.md)'s money by X%.
+- There is a limit to how much money can exist on a [Server](../basic/servers.md).
+  This value is different for each [Server](../basic/servers.md).
+  The `getServerMaxMoney()` function will tell you this maximum value.
+- At this stage in the game, your combat stats (strength, defense, etc.) are not nearly as useful as your hacking stat.
+  Do not invest too much time or money into gaining combat stat exp.
+- As a rule of thumb, your hacking target should be the [Server](../basic/servers.md) with highest max money that's required hacking level is under 1/2 of your hacking level.

--- a/src/Documentation/ui/doc/help/getting_started.md
+++ b/src/Documentation/ui/doc/help/getting_started.md
@@ -1,6 +1,6 @@
 # Getting Started Guide for Beginner Programmers
 
-note: Note that the [Scripts](../basic/scripts.md) and strategies given in this guide aren't necessarily optimal.
+_Note_: The [Scripts](../basic/scripts.md) and strategies given in this guide aren't necessarily optimal.
 They're just meant to introduce you to the game and help you get started.
 
 This is an introductory guide to getting started with Bitburner.
@@ -26,11 +26,8 @@ I'm going to assume you followed the introductory tutorial when you first began 
 In this introductory tutorial, you created a [Script](../basic/scripts.md) called `n00dles.js` and ran it on the `n00dles` server.
 Right now, we'll kill this [Script](../basic/scripts.md). There are two ways to do this:
 
-1. You can go to the Terminal and enter:
-
-   $ kill n00dles.js
-
-2. You can go to the `Active Scripts` page (Alt + s) and press the `Kill Script` button for `n00dles.js`.
+- You can go to the Terminal and enter: `$ kill n00dles.js`
+- You can go to the `Active Scripts` page (Alt + s) and press the `Kill Script` button for `n00dles.js`.
 
 If you skipped the introductory tutorial, then ignore the part above.
 Instead, go to the `Hacknet Nodes` page (Alt + h) and purchase a [Hacknet Node](../basic/hacknet_nodes.md) to start generating some passive income.
@@ -306,7 +303,7 @@ Therefore, we should raise our hacking level.
 Not only will this let us hack more [Servers](../basic/servers.md), but it will also increase the effectiveness of our [hacking](../basic/hacking.md) against `n00dles`.
 
 The easiest way to train your hacking level is to visit Rothman University.
-You can do this from the `City` tab on the left-hand navigation menu (click on it or press Alt + w).
+You can do this from the `City` tab (Alt + w) on the left-hand navigation menu.
 Rothman University should be the "U" near the bottom-right.
 Click the "U" to go to the location.
 
@@ -315,11 +312,11 @@ These options describe different courses you can take.
 You should click the first button, which says: `Study Computer Science (free)`.
 
 After you click the button, you will start studying and earning hacking experience.
-While you are doing this, you cannot interact with any other part of the game until you click either "Stop taking course" or "Do something else simultaneously".
+While you are doing this, you cannot interact with any other part of the game until you click either `Stop taking course` or `Do something else simultaneously`.
 
 Right now, we want a hacking level of 10.
 You need approximately 174 hacking experience to reach level 10.
-You can check how much hacking experience you have by either hovering over the progress bar in the overview window or going to the `Stats` tab on the left-hand navigation menu (click on it or press Alt + c).
+You can check how much hacking experience you have by going to the `Stats` tab (Alt + c) on the left-hand navigation menu.
 Since studying at Rothman University earns you 1 experience per second, this will take 174 seconds, or approximately 3 minutes.
 Feel free to do something in the meantime!
 
@@ -339,7 +336,7 @@ At the top of the [Script](../basic/scripts.md), change the `target` variable to
     const target = "joesguns";
 
 Note that this will **NOT** affect any instances of the [Script](../basic/scripts.md) that are already running.
-This will only affect instances of the [Script](../basic/scripts.md) that are ran from this point forward.
+This will only affect instances of the [Script](../basic/scripts.md) that are run from this point forward.
 
 ## Creating a New Script to Purchase New Servers
 
@@ -435,7 +432,7 @@ I wouldn't bother with [RAM](../basic/ram.md) and Core upgrades until later on.
 
 The best source of income right now is from [crimes](../basic/crimes.md).
 This is because it not only gives you a large amount of money, but it also raises your hacking level.
-To commit [crimes](../basic/crimes.md), click on the `City` tab on the left-hand navigation menu or press Alt + w.
+To commit [crimes](../basic/crimes.md), go to the `City` tab (Alt + w).
 Then, click on the link that says `The Slums`.
 
 In the Slums, you can attempt to commit a variety of [crimes](../basic/crimes.md), each of which gives certain types of experience and money if successful.
@@ -454,8 +451,8 @@ This [crime](../basic/crimes.md) is slightly easier and more profitable than `Ro
 
 ## Work for a Company
 
-If you don't want to commit [crimes](../basic/crimes.md), there's another option - working for a [company](../basic/companies.md)
-This will not be nearly as profitable as [crimes](../basic/crimes.md), but will provide [company](../basic/companies.md) [reputation](../basic/reputation.md)
+If you don't want to commit [crimes](../basic/crimes.md), there's another option - working for a [company](../basic/companies.md).
+This will not be nearly as profitable as [crimes](../basic/crimes.md), but will provide [company](../basic/companies.md) [reputation](../basic/reputation.md).
 
 Go to the `City` tab on the left-hand navigation menu and then go to `Joe's Guns`.
 At `Joe's Guns`, there will be an option that says `Apply to be an Employee`.
@@ -492,10 +489,9 @@ Once you reach a hacking level of 50, two new important parts of the game open u
 
 ## Creating your first program: BruteSSH.exe
 
-On the left-hand navigation menu you will notice a `Create Programs` tab with a red notification icon.
+On the left-hand navigation menu you will notice a `Create Program` tab (Alt + p) with a red notification icon.
 This indicates that there are programs available to be created.
-Click on that tab (or use Alt + p) and you'll see a
-list of all the programs you can currently create.
+Go to that tab, and you'll see a list of all the programs you can currently create.
 Hovering over a program will give a brief description of its function.
 Simply click on a program to start creating it.
 
@@ -647,7 +643,7 @@ After another 15 minutes, the production rate had increased to $25k per second a
 Your results will vary based on how fast you earned money from [crime](../basic/crimes.md)/[working](../basic/companies.md)/[hacknet nodes](../basic/hacknet_nodes.md), but this will hopefully give you a good indication of how much the [Scripts](../basic/scripts.md) can earn.
 
 In the meantime, we are going to be gaining reputation with the `CyberSec` [faction](../basic/factions.md).
-Go to the `Factions` tab on the left-hand navigation menu (Alt + F), and from there select `CyberSec`.
+Go to the `Factions` tab (Alt + f) on the left-hand navigation menu, and from there select `CyberSec`.
 In the middle of the page there should be a button for `Hacking Contracts`.
 Click it to start earning [reputation](../basic/reputation.md) for the `CyberSec` [faction](../basic/factions.md) (as well as some hacking experience).
 The higher your hacking level, the more [reputation](../basic/reputation.md) you will gain.
@@ -710,7 +706,7 @@ The following are a few things you may want to consider doing in the near future
 If you've purchased any [Augmentations](../basic/augmentations.md), you'll need to install them before you actually gain their effects.
 Installing [Augmentations](../basic/augmentations.md) is the game's "soft-reset" or "prestige" mechanic.
 
-To install your [Augmentations](../basic/augmentations.md), click the `Augmentations` tab on the left-hand navigation menu (Alt + a).
+To install your [Augmentations](../basic/augmentations.md), go to the `Augmentations` tab (Alt + a) on the left-hand navigation menu.
 You will see a list of all of the [Augmentations](../basic/augmentations.md) you have purchased.
 Below that, you will see a button that says `Install Augmentations`.
 Be warned, after clicking this there is no way to undo it (unless you load an earlier save).
@@ -771,7 +767,7 @@ Feel free to adjust it to your liking.
 ## Random Tips
 
 - Early on in the game, it's better to spend your money on upgrading [RAM](../basic/ram.md) and purchasing new [Servers](../basic/servers.md) rather than spending it on [Augmentations](../basic/augmentations.md)
-- The more money available on a [Server](../basic/servers.md), the more effective the `hack()` and   `grow()` functions will be.
+- The more money available on a [Server](../basic/servers.md), the more effective the `hack()` and `grow()` functions will be.
   This is because both of these functions use percentages rather than flat values.
   `hack()` steals a percentage of a [Server](../basic/servers.md)'s total available money, and `grow()` increases a [Server](../basic/servers.md)'s money by X%.
 - There is a limit to how much money can exist on a [Server](../basic/servers.md).

--- a/src/Documentation/ui/doc/help/tools_and_resources.md
+++ b/src/Documentation/ui/doc/help/tools_and_resources.md
@@ -1,11 +1,10 @@
-# Tools & Resources
+# Tools & Resource
 
 ## Official Script Repository
 
-There are plans to create an official repository of Bitburner scripts. As of right now,
-this is not a priority and has not been started. However, if you'd like
-to contribute scripts now, you can find the repository
-[here](https://github.com/bitburner-official/bitburner-scripts) and submit pull requests.
+There are plans to create an official repository of Bitburner scripts.
+As of right now, this is not a priority and has not been started.
+However, if you'd like to contribute scripts now, you can find the repository [here](https://github.com/bitburner-official/bitburner-scripts) and submit pull requests.
 
 ## Visual Studio Code Extension
 
@@ -18,5 +17,4 @@ This extension includes several features such as:
 - Typescript definition files with jsdoc comments
 - Syntax highlighting
 
-You can find more information and download links
-[on this reddit post](https://www.reddit.com/r/Bitburner/comments/bh48y2/visual_studio_code_ram_calculator_extra/).
+You can find more information and download links [on this reddit post](https://www.reddit.com/r/Bitburner/comments/bh48y2/visual_studio_code_ram_calculator_extra/).

--- a/src/Documentation/ui/doc/programming/game_frozen.md
+++ b/src/Documentation/ui/doc/programming/game_frozen.md
@@ -2,14 +2,12 @@
 
 ## Infinite Loop in Scripts
 
-If your game is frozen or stuck in any way, then the most likely culprit is an
-infinitely running loop in your script. To get past the freezing, run the game with
-`?noScripts` in the URL:
+If your game is frozen or stuck in any way, then the most likely culprit is an infinitely running loop in your script.
+To get past the freezing, run the game with `?noScripts` in the URL:
 
 [Link to no freeze](https://danielyxie.github.io/bitburner/?noScripts)
 
-Then, to fix your script, make sure you have a `sleep()` or any other timed function like `hack()` or
-`grow()` in any infinite loops:
+Then, to fix your script, make sure you have a `sleep()` or any other timed function like `hack()` or `grow()` in any infinite loops:
 
     while(true) {
         // This is an infinite loop that does something
@@ -17,8 +15,7 @@ Then, to fix your script, make sure you have a `sleep()` or any other timed func
         await ns.sleep(1000); // Add a 1s sleep to prevent freezing
     }
 
-Also make sure that each while loop gets to the `await`ed function or `break`, for example the next snippet has a `sleep()`
-function, but it nor any possible conditional breaks are never reached and therefore will crash the game:
+Also make sure that each while loop gets to the `await`ed function or `break`, for example the next snippet has a `sleep()` function, but it nor any possible conditional breaks are never reached and therefore will crash the game:
 
     while(true) {
         let currentMoney = ns.getServerMoneyAvailable("n00dles");
@@ -34,8 +31,7 @@ function, but it nor any possible conditional breaks are never reached and there
 If `n00dles` current money is, for example, 75% of the maximum money, the script will reach neither `grow()` nor `break` and the game will crash.
 Adding a sleep like in the first example, or changing the code so that the `awaited` function or `break` is always reached, would prevent the crash.
 
-Common infinite loop when translating the server purchasing script in starting guide to scripts is to have a
-while loop, where the condition's change is conditional:
+Common infinite loop when translating the server purchasing script in starting guide to scripts is to have a while loop, where the condition's change is conditional:
 
     var ram = 8;
     var i = 0;
@@ -50,19 +46,16 @@ while loop, where the condition's change is conditional:
     }
 
 If the player does not currently have enough money to purchase a server, the `if`'s condition will be false and `++i` will not be reached.
-Since the script doesn't have `sleep()` and value `i` will not change without the `if` being true, this will crash the game. Adding a `sleep()`
-that is always reached would prevent the crash.
+Since the script doesn't have `sleep()` and value `i` will not change without the `if` being true, this will crash the game.
+Adding a `sleep()` that is always reached would prevent the crash.
 
 ## Blackscreen
 
-If the game window becomes a black screen without the game itself crashing, this is caused by
-the game running too many concurrent scripts (the game runs on a browser and each tab can only
-use so much ram until it crashes). Depending on which scripts are running and your hardware,
-this number can vary between 50000 to 100000 instances (in version 2.0.2. In prior versions this number
-was about 1/5th of that). To prevent this from happening make sure to multithread
-the scripts as much as possible.
+If the game window becomes a black screen without the game itself crashing, this is caused by the game running too many concurrent scripts (the game runs on a browser and each tab can only use so much ram until it crashes).
+Depending on which scripts are running and your hardware, this number can vary between 50000 to 100000 instances (in version 2.0.2. In prior versions this number was about 1/5th of that).
+To prevent this from happening make sure to multithread the scripts as much as possible.
 
 ## Bug
 
-Otherwise, the game is probably frozen/stuck due to a bug. To report a bug, follow
-the guidelines [here](https://github.com/bitburner-official/bitburner-src/blob/master/doc/CONTRIBUTING.md#reporting-bugs).
+Otherwise, the game is probably frozen/stuck due to a bug.
+To report a bug, follow the guidelines [here](https://github.com/bitburner-official/bitburner-src/blob/master/doc/CONTRIBUTING.md#reporting-bugs).

--- a/src/Documentation/ui/doc/programming/hackingalgorithms.md
+++ b/src/Documentation/ui/doc/programming/hackingalgorithms.md
@@ -113,4 +113,4 @@ It is also important that these 4 scripts finish in the order specified above, a
 
 Batches only function predictably when the target server is at minimum security and maximum money, so your script must also handle preparing a server for your batches. You can utilize batches to prepare a server by using no hack threads during preparation.
 
-Depending on your computer's performance as well as a few other factors, the necessary delay between script execution times may range between 20ms and 200ms, you want to fine-tune this value to be as low as possible while also avoiding your scripts finishing out of order. Anything lower than 20ms will not work due to javascript limitations.
+Depending on your computer's performance as well as a few other factors, the necessary delay between script execution times may range between 20ms and 200ms, you want to fine-tune this value to be as low as possible while also avoiding your scripts finishing out of order. Anything lower than 20ms will not work due to JavaScript limitations.

--- a/src/Documentation/ui/doc/programming/hackingalgorithms.md
+++ b/src/Documentation/ui/doc/programming/hackingalgorithms.md
@@ -1,6 +1,7 @@
 # Hacking algorithms
 
-There are three primary families of hacking algorithms. This guide will go over each of them and advise on how they can be implemented.
+There are three primary families of hacking algorithms.
+This guide will go over each of them and advise on how they can be implemented.
 
 ## Self-contained algorithms
 
@@ -19,7 +20,9 @@ Cons:
 - Utilizes script online time poorly
 - Risk of over hacking
 
-Self-contained algorithms are the simplest family of hacking algorithms to implement. Each script is tasked with choosing which function to execute based on the status of the target server. Because of this, they guarantee a consistent, but relatively small, flow of money.
+Self-contained algorithms are the simplest family of hacking algorithms to implement.
+Each script is tasked with choosing which function to execute based on the status of the target server.
+Because of this, they guarantee a consistent, but relatively small, flow of money.
 
 The general logic goes like this:
 
@@ -35,7 +38,8 @@ The general logic goes like this:
 
 This algorithm is perfectly capable of paving the way through the majority of the game, but it has a few significant issues.
 
-- It tends to make all your scripts on every server do the same thing. (e.g. If the target is 0.01 security above the minimum, all scripts will decide to weaken, when only a handful of threads should be devoted to the task)
+- It tends to make all your scripts on every server do the same thing.
+  (e.g. If the target is 0.01 security above the minimum, all scripts will decide to weaken, when only a handful of threads should be devoted to the task)
 - At higher thread counts, these scripts have the potential to hack the server to $0, or maximum security, requiring a long setup time while the scripts return the server to the best stats.
 - Requires function calls such as `getServerSecurityLevel` and `getServerMoneyAvailable`, as well as calling all three hacking functions, increasing RAM cost which is multiplied by the number of allocated threads
 
@@ -53,7 +57,8 @@ Cons:
 
 - Requires a script that handles deployment
 
-By splitting our hack, weaken, and grow functions into three separate scripts, we can both remove our reliance on functions such as `getServerSecurityLevel` as well as removing functions that cannot work concurrently, reducing RAM requirements, and thus increasing our thread limits. Loop scripts are formatted like this:
+By splitting our hack, weaken, and grow functions into three separate scripts, we can both remove our reliance on functions such as `getServerSecurityLevel` as well as removing functions that cannot work concurrently, reducing RAM requirements, and thus increasing our thread limits.
+Loop scripts are formatted like this:
 
     loop forever {
         await ns.hack(target) // or grow, or weaken
@@ -65,11 +70,13 @@ Now we can take the total amount of threads available and split it and allocate,
 - 10 parts to the grow scripts
 - 2 parts to the weaken scripts
 
-Meaning if we have space for 100 threads across the entire network 7 threads will go to the hack scripts, 76 threads will go to the grow scripts and 15 threads will go to the weaken scripts. The ratios described here are arbitrary and can be greatly improved through the use of the analyze functions, and later, through the use of Formulas.exe.
+Meaning if we have space for 100 threads across the entire network 7 threads will go to the hack scripts, 76 threads will go to the grow scripts and 15 threads will go to the weaken scripts.
+The ratios described here are arbitrary and can be greatly improved through the use of the analyze functions, and later, through the use of Formulas.exe.
 
 When utilizing this strategy, monitor the amount of money and security on the target server, if the money is not hovering around maximum and the security around the minimum, the ratios should be tweaked until that is the case.
 
-Utilizing `sleep` or `asleep` to ensure that your scripts do not all start at the same time can decrease the chance of issues associated with overhacking occurring. Both functions have a ram cost of zero.
+Utilizing `sleep` or `asleep` to ensure that your scripts do not all start at the same time can decrease the chance of issues associated with overhacking occurring.
+Both functions have a ram cost of zero.
 
 ## Batch algorithms (HGW, HWGW, or Cycles)
 
@@ -93,9 +100,14 @@ The scripts used to execute the hacking functions are even simpler than the prev
 
 A few things need to be known before this algorithm can be implemented:
 
-- The effects of hack and grow depend on the server security level, a higher security level results in a reduced effect. You only want these effects to occur when the security level is minimized.
-- The time taken to execute hack, grow, or weaken is determined when the function is called and is based on the security level of the target server and your hacking level. You only want these effects to start when the security level is minimized.
-- The effects of hack, grow, and weaken, are determined when the time is completed, rather than at the beginning. Hack should finish when security is minimum and money is maximum. Grow should finish when security is minimum, shortly after a hack occurred. Weaken should occur when security is not at a minimum due to a hack or grow increasing it.
+- The effects of hack and grow depend on the server security level, a higher security level results in a reduced effect.
+  You only want these effects to occur when the security level is minimized.
+- The time taken to execute hack, grow, or weaken is determined when the function is called and is based on the security level of the target server and your hacking level.
+  You only want these effects to start when the security level is minimized.
+- The effects of hack, grow, and weaken, are determined when the time is completed, rather than at the beginning.
+  Hack should finish when security is minimum and money is maximum.
+  Grow should finish when security is minimum, shortly after a hack occurred.
+  Weaken should occur when security is not at a minimum due to a hack or grow increasing it.
 
 A single batch consists of four actions:
 
@@ -104,13 +116,16 @@ A single batch consists of four actions:
 3. A grow script counters the money decrease caused by the hack script.
 4. A weaken script counters the security increase caused by the grow script.
 
-It is also important that these 4 scripts finish in the order specified above, and all of their effects be precalculated to optimize the ratios between them. This is the reason for the delay in the scripts.
+It is also important that these 4 scripts finish in the order specified above, and all of their effects be precalculated to optimize the ratios between them.
+This is the reason for the delay in the scripts.
 
                        |= hack ====================|
     |=weaken 1======================================|
                    |= grow ==========================|
       |=weaken 2======================================|
 
-Batches only function predictably when the target server is at minimum security and maximum money, so your script must also handle preparing a server for your batches. You can utilize batches to prepare a server by using no hack threads during preparation.
+Batches only function predictably when the target server is at minimum security and maximum money, so your script must also handle preparing a server for your batches.
+You can utilize batches to prepare a server by using no hack threads during preparation.
 
-Depending on your computer's performance as well as a few other factors, the necessary delay between script execution times may range between 20ms and 200ms, you want to fine-tune this value to be as low as possible while also avoiding your scripts finishing out of order. Anything lower than 20ms will not work due to JavaScript limitations.
+Depending on your computer's performance as well as a few other factors, the necessary delay between script execution times may range between 20ms and 200ms, you want to fine-tune this value to be as low as possible while also avoiding your scripts finishing out of order.
+Anything lower than 20ms will not work due to JavaScript limitations.

--- a/src/Documentation/ui/doc/programming/learn.md
+++ b/src/Documentation/ui/doc/programming/learn.md
@@ -2,32 +2,31 @@
 
 ## For Beginner Programmers
 
-If you have little to no programming experience, that's okay! You don't need to be
-a great programmer in order to enjoy or play this game. In fact, this game could
-help you learn some basic programming concepts.
+If you have little to no programming experience, that's okay!
+You don't need to be a great programmer in order to enjoy or play this game.
+In fact, this game could help you learn some basic programming concepts.
 
 Here are some good tutorials for learning programming/JavaScript as a beginner:
 
 - [Learn-JS](http://www.learn-js.org/en/Welcome)
 - [programiz](https://www.programiz.com/javascript/get-started)
 - [Speaking JavaScript](https://exploringjs.com/es5/)
-  This is a bit on the longer side. You can skip all of the historical
-  background stuff. Recommended chapters: 1, 7-18
+  This is a bit on the longer side.
+  You can skip all of the historical background stuff.
+  Recommended chapters: 1, 7-18
 
 ## For Experienced Programmers
 
-The following section lists several good tutorials/resources for those who have experience
-programming but who have not worked extensively with JavaScript before.
+The following section lists several good tutorials/resources for those who have experience programming but who have not worked extensively with JavaScript before.
 
-Before that, however, it's important to clarify some terminology about the different
-versions of JavaScript. These are summarized in this article:
+Before that, however, it's important to clarify some terminology about the different versions of JavaScript.
+These are summarized in this article:
 
 [WTF is ES6, ES8, ES2017, ECMAScript...](https://codeburst.io/javascript-wtf-is-es6-es8-es-2017-ecmascript-dca859e4821c)
 
-An important takeaway from this article is that ES6, also known as ES2015, introduced
-many major features that are commonly seen in modern JavaScript programming. However, this
-means that ES5 engines and interpreters will fail if they encounters these ES6 features. You'll see why this
-is important further down.
+An important takeaway from this article is that ES6, also known as ES2015, introduced many major features that are commonly seen in modern JavaScript programming.
+However, this means that ES5 engines and interpreters will fail if they encounters these ES6 features.
+You'll see why this is important further down.
 
 - [MDN Introduction to JS](https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript)
 - [Eloquent JavaScript (ES6+)](http://eloquentjavascript.net/)

--- a/src/Documentation/ui/doc/programming/learn.md
+++ b/src/Documentation/ui/doc/programming/learn.md
@@ -1,4 +1,4 @@
-# Learn to Program in Javascript
+# Learn to Program in JavaScript
 
 ## For Beginner Programmers
 
@@ -32,5 +32,5 @@ is important further down.
 - [MDN Introduction to JS](https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript)
 - [Eloquent JavaScript (ES6+)](http://eloquentjavascript.net/)
   Recommended Chapters: Introduction, 1-6
-- [Modern Javascript Tutorial (ES6+)](https://javascript.info/)
+- [Modern JavaScript Tutorial (ES6+)](https://javascript.info/)
   Recommended Chapters: 2, 4-6

--- a/src/Documentation/ui/doc/programming/remote_api.md
+++ b/src/Documentation/ui/doc/programming/remote_api.md
@@ -52,7 +52,7 @@ Create or update a file.
 
 ## `getFile`
 
-Read a file and it's content.
+Read a file and its content.
 
         {
             "jsonrpc": "2.0",


### PR DESCRIPTION
Cleans up some of the new Markdown documentation:
- various typos fixed
- several grammatical problems resolved
- some outdated info in the getting started guide is removed
- other miscellaneous wording changes 
- broken formatting (mostly with lists) fixed
- line breaks after each sentence for better readability (does not affect rendered documents)
