### PR TITLE
UI: updated helper message for killall

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -824,10 +824,7 @@ export const ns: InternalAPI<NSFull> = {
           ++scriptsKilled;
         }
       }
-      helpers.log(
-        ctx,
-        () => `Killing all scripts on '${server.hostname}'. May take a few minutes for the scripts to die.`,
-      );
+      helpers.log(ctx, () => `Killing all scripts on '${server.hostname}'.`);
 
       return scriptsKilled > 0;
     },


### PR DESCRIPTION

#668

# Bug fix

- Helper UI update: removed last sentence "it may take a few minutes for all scripts to die."

I did some testing using a number of ns.hack() scripts on a number of host servers, ranging from 1 server 1 thread to maximum bought and public servers, and enough individual processes to crash the game. On both steam and dev online.

I timed killall with performance.now() and found the time to kill generally increases with number of scripts killed, and similar with the number of servers.

In the worst case, the time to kill was ~1089ms, which caused a noticeable hang. This was full network and pservers with ~325k script instances of ns.hack().

Since I couldn't produce significant "time to kill" in any case, I feel OK eliminating the sentence completely, which is this PR.

Note: this was tested on a recent PC, I don't know if lower spec systems are significantly slower, in which case a different helper message might be better, ex "it may take a _moment_ for all scripts to die."

old:
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/014f8173-40bb-4e8f-8ae1-6c61712ce875)

proposed new:
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/5168c7f2-b595-4d7c-82a8-83ca88582b49)
