### PR TITLE
CCT: accept IP solutions with matched single or double quotes, or none

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -537,7 +537,7 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
       }
 
       const sanitizedAns: string = removeBracketsFromArrayString(ans).replace(/\s/g, "");
-      const ansArr: string[] = sanitizedAns.split(",").map((ip) => ip.replace(/^"|"$/g, ""));
+      const ansArr: string[] = sanitizedAns.split(",").map((ip) => ip.replace(/^['"]|['"]$/g, ""));
       if (ansArr.length !== ret.length) {
         return false;
       }

--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -537,7 +537,9 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
       }
 
       const sanitizedAns: string = removeBracketsFromArrayString(ans).replace(/\s/g, "");
-      const ansArr: string[] = sanitizedAns.split(",").map((ip) => ip.replace(/^['"]|['"]$/g, ""));
+      const ansArr: string[] = sanitizedAns
+        .split(",")
+        .map((ip) => ip.replace(/^(?<quote>['"])([\d.]*)\k<quote>$/g, "$2"));
       if (ansArr.length !== ret.length) {
         return false;
       }


### PR DESCRIPTION
From a discord issue https://discord.com/channels/415207508303544321/923282733332054126/1137052241388392530

"For the IP address contracts, I found that entering an IP list like ['127.0.0.1'] doesn't work, but ["127.0.0.1"] does. Is that intentional?"

more information : "how did your answer get formatted that way? did you write your answer by hand?"

[New player] : "Yes, I did."


# Bug fix

Currently the answer input is sanitized by replacing (only) a double quote " from the start and end of each IP with an empty string, for ex. "12.59.159.35" becomes 12.59.159.35

My suggested solution is based on **regex demo** here : https://regex101.com/r/0Ooa2M/1

name the first quote, which can be either single or double, ie ['"]; capture digits and periods; match the end character only if it is  same as the named capture group; then return the IP group.

Rewards solutions like `1.111.11` or `'1.1.1.1'` or `"1.1.1.1"` so any matching quotes or none. In array, **each IP can be wrapped differently**.

Fails solutions like `'1.1.1.1"` or `""1.1.1.1""`

For testing I've attached an IP cracking script that when run will prompt to input a single IP CCT data. I tested by manually changing quotation style in solutions of various length and submitting. I have not tested this PR with an automated cracking script, but I don't think it would fail.

[IP cracker.txt](https://github.com/bitburner-official/bitburner-src/files/12263819/IP.cracker.txt)






