### PR TITLE
BLADEBURNER: Added BB Training to sleeve actions

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -394,6 +394,9 @@ export class Sleeve extends Person implements SleevePerson {
   bladeburner(action: string, contract: string): boolean {
     if (!Player.bladeburner) return false;
     switch (action) {
+      case "Training":
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training" }));
+        return true;
       case "Field analysis":
       case "Field Analysis":
         this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Field Analysis" }));

--- a/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
+++ b/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
@@ -24,6 +24,7 @@ const universitySelectorOptions: string[] = [
 const gymSelectorOptions: string[] = ["Train Strength", "Train Defense", "Train Dexterity", "Train Agility"];
 
 const bladeburnerSelectorOptions: string[] = [
+  "Training",
   "Field Analysis",
   "Recruitment",
   "Diplomacy",


### PR DESCRIPTION
Training seemed to be the only general action sleeves where missing from BB, this aims to correct that. The Training action appeared to already be written with the player or sleeve performing the task in mind.

![image](https://github.com/bitburner-official/bitburner-src/assets/32428876/7d69a699-af15-44c4-b884-f5b32d70a33f)
![image](https://github.com/bitburner-official/bitburner-src/assets/32428876/ee8114cf-2c9b-4c8e-96d3-5da629b96f32)

This does add a free alternative to the Gym, but I think there is a few pros and cons to consider. The gym may cost money and only do one stat at a time, but it is much faster (per second iirc), while BB training (not only requires BB), but also takes 30 seconds to complete.