### PR TITLE
UI: IssueNewShares Modal spacing typo fix

### DIFF
--- a/src/Corporation/ui/modals/IssueNewSharesModal.tsx
+++ b/src/Corporation/ui/modals/IssueNewSharesModal.tsx
@@ -66,7 +66,7 @@ export function IssueNewSharesModal(props: IProps): React.ReactElement {
 
     let dialogContents =
       `Issued ${formatShares(newShares)} new shares` + ` and raised ${formatMoney(profit)}.` + (privateShares > 0)
-        ? "\n" + formatShares(privateShares) + "of these shares were bought by private investors."
+        ? "\n" + formatShares(privateShares) + " of these shares were bought by private investors."
         : "";
     dialogContents += `\n\nStock price decreased to ${formatMoney(corp.sharePrice)}`;
     dialogBoxCreate(dialogContents);


### PR DESCRIPTION
Discord issue : https://discord.com/channels/415207508303544321/415213413745164318/1137209089353580586

**IssueNewShares Modal misses a space after share count in the following message:**

![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/069a2ea2-2c0d-4426-a76a-565ff5718e52)

My code has not been tested, but this is the only instance I found for the specific message, so it should fix the spacing.
