### PR TITLE
UI: "Contract in Progress" window can no longer get lost

### DIFF
--- a/src/ui/React/CodingContractModal.tsx
+++ b/src/ui/React/CodingContractModal.tsx
@@ -24,6 +24,12 @@ export function CodingContractModal(): React.ReactElement {
   useEffect(() => {
     CodingContractEvent.subscribe((props) => setContract(props));
   });
+  useEffect(() => {
+    return () => {
+      contract?.onClose();
+    };
+  }, [contract]);
+
   if (contract === null) return <></>;
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>): void {


### PR DESCRIPTION
#28

# Bug fix

Added a clean up useEffect which runs the .onClose function if modal is unexpectedly unmounted, resolving the CCT promise as "cancelled" (which prints in terminal).

Some [testing details](https://github.com/bitburner-official/bitburner-src/issues/28#issuecomment-1666578711) and a [script used for testing](https://github.com/bitburner-official/bitburner-src/issues/28#issuecomment-1666128871) are included in issue #28 , I would encourage additional testing since at some points the code I used had significant unwanted behaviors (not allowing solution input, for example).

There is an additional / related issue, also mentioned in issue #28 about a React console error. I think that can be corrected by adding unsubscribing in the cleanup - the error points to line 25, the CC Event props subscription useEffect.   https://www.rockyourcode.com/avoid-memory-leak-with-react-setstate-on-an-unmounted-component/

But it may be a non-issue.

![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/24ffb03f-8f5d-4c20-a0d5-214e9ee9efb0)
 - https://stackoverflow.com/questions/71258604/how-to-fix-react-warning-cant-perform-a-react-state-update-on-an-unmounted-co

