### PR TITLE
UI: BladeBurner successes to next level tooltip fix

### DIFF
--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -26,7 +26,6 @@ export async function main(ns) {
  await ns.hack('n00dles');
 }
 ```
-[ns2 in-game docs](https://bitburner-official.readthedocs.io/en/latest/netscript/netscriptjs.html) <hr> For (deprecated) .script usage, see: [ns1 in-game docs](https://bitburner-official.readthedocs.io/en/latest/netscript/netscript1.html) <hr>
 
 ## Properties
 

--- a/src/Bladeburner/ui/ActionLevel.tsx
+++ b/src/Bladeburner/ui/ActionLevel.tsx
@@ -41,8 +41,8 @@ export function ActionLevel({ action, isActive, bladeburner, rerender }: IProps)
         <Tooltip
           title={
             <Typography>
-              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel)} successes needed
-              for next level
+              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel) - action.successes}{" "}
+              successes needed for next level
             </Typography>
           }
         >


### PR DESCRIPTION
fixes #670

# Documentation

Updated the formula used in a tooltip shown in issue #670 . Previously using `action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel)` 
, which is the formula to return the successes needed by maxLevel; now using
`action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel) - action.successes`
to correctly subtract the successes for the specific action.

- Note: `{" "}` is the linter's addition to ensure the space separating the variable and the text.
- and I guess **bitburner.ns.md** updated during `npm run doc` ?? I did not edit that myself for any reason.
- testing with dev menu is a bit funny bc the successes can artificially exceed the level, showing negative numbers, but that is not a natural player situation (and not an incorrect behavior).
- If you want to test, dev menu join bladeburners, increase "count" for some operations or contracts , add lots of agility, in bladeburners menu start operations or contracts and hover over "level x/y"

I tested this enough to see each type of Operations and Contracts can now decrement as expected for each success, rolls over to a new value when maxLevel increases. When values are very high, the display is abbreviated
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/eaa57767-7a9d-4622-93e5-e0a6af9ee50e)

