### PR TITLE
UI: BladeBurner successes to next level tooltip fix

### DIFF
--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -26,7 +26,6 @@ export async function main(ns) {
  await ns.hack('n00dles');
 }
 ```
-[ns2 in-game docs](https://bitburner-official.readthedocs.io/en/latest/netscript/netscriptjs.html) <hr> For (deprecated) .script usage, see: [ns1 in-game docs](https://bitburner-official.readthedocs.io/en/latest/netscript/netscript1.html) <hr>
 
 ## Properties
 

--- a/src/Bladeburner/ui/ActionLevel.tsx
+++ b/src/Bladeburner/ui/ActionLevel.tsx
@@ -41,8 +41,8 @@ export function ActionLevel({ action, isActive, bladeburner, rerender }: IProps)
         <Tooltip
           title={
             <Typography>
-              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel)} successes needed
-              for next level
+              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel) - action.successes}{" "}
+              successes needed for next level
             </Typography>
           }
         >

--- a/src/Bladeburner/ui/ActionLevel.tsx
+++ b/src/Bladeburner/ui/ActionLevel.tsx
@@ -39,15 +39,18 @@ export function ActionLevel({ action, isActive, bladeburner, rerender }: IProps)
     <Box display="flex" flexDirection="row" alignItems="center">
       <Box display="flex">
         <Tooltip
-            title={ (action.constructor.name === "Contract")?
-            <Typography>
-              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel) - action.successes}{" C"}
-              successes needed for next level
-            </Typography>
-            :<Typography>
-              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.OperationSuccessesPerLevel) - action.successes}{" O"}
-              successes needed for next level
-            </Typography>
+          title={
+            action.constructor.name === "Contract" ? (
+              <Typography>
+                {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel)} successes needed
+                for next level
+              </Typography>
+            ) : (
+              <Typography>
+                {action.getSuccessesNeededForNextLevel(BladeburnerConstants.OperationSuccessesPerLevel)} successes
+                needed for next level
+              </Typography>
+            )
           }
         >
           <Typography>

--- a/src/Bladeburner/ui/ActionLevel.tsx
+++ b/src/Bladeburner/ui/ActionLevel.tsx
@@ -39,9 +39,13 @@ export function ActionLevel({ action, isActive, bladeburner, rerender }: IProps)
     <Box display="flex" flexDirection="row" alignItems="center">
       <Box display="flex">
         <Tooltip
-          title={
+            title={ (action.constructor.name === "Contract")?
             <Typography>
-              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel) - action.successes}{" "}
+              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel) - action.successes}{" C"}
+              successes needed for next level
+            </Typography>
+            :<Typography>
+              {action.getSuccessesNeededForNextLevel(BladeburnerConstants.OperationSuccessesPerLevel) - action.successes}{" O"}
               successes needed for next level
             </Typography>
           }


### PR DESCRIPTION
fixes #670

# Bug fix

On the BitBurner page, the Operations and Contracts components are built with 2 separate files, OperationElem.tsx and ContractElem.tsx which both utilize 
      `ActionLevel.tsx`
and point to the same tooltip, which previously returned a single formula using `BladeburnerConstants.ContractSuccessesPerLevel`, (never `OperationSuccessesPerLevel`) causing issue #670 (wrong data shown on Operations tooltips).

I've added a ternary condition `action.constructor.name === "Contract" ?` based on a property that changes depending on which component page is currently displayed
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/c4e3facc-6aab-4b01-97c4-601ae0f5786b)

This allows for future updates to the number or names of contract or operations, and should be much preferable to directing the 2 components to 2 separate files.

        <Tooltip
          title={
            action.constructor.name === "Contract" ? (
              <Typography>
                {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel)} successes needed
                for next level
              </Typography>
            ) : (
              <Typography>
                {action.getSuccessesNeededForNextLevel(BladeburnerConstants.OperationSuccessesPerLevel)} successes
                needed for next level
              </Typography>
            )
          }

- **NOTE** I do not know why [markdown/bitburner.ns.md](https://github.com/bitburner-official/bitburner-src/compare/dev...myCatsName:bitburner-src:BladeBurner-UI-successes-to-next-level-tooltip-fix?expand=1#diff-8315cfe4482b1e7fbf406049da3212a6ff908569d061cca90284df1edec95c02) has changed, I think it was while running `npm run doc`, but I don't have any reason to change that file at all.