### PR TITLE
DOCUMENTATION: ns.share and getSharePower definition updates

### DIFF
--- a/markdown/bitburner.ns.getsharepower.md
+++ b/markdown/bitburner.ns.getsharepower.md
@@ -4,7 +4,7 @@
 
 ## NS.getSharePower() method
 
-Calculate your share power. Based on all the active share calls.
+Share Power has a multiplicative effect on rep/second while doing work for a faction. Share Power increases incrementally for every thread of share running on your server network, but at a sharply decreasing rate.
 
 **Signature:**
 

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -26,7 +26,6 @@ export async function main(ns) {
  await ns.hack('n00dles');
 }
 ```
-[ns2 in-game docs](https://bitburner-official.readthedocs.io/en/latest/netscript/netscriptjs.html) <hr> For (deprecated) .script usage, see: [ns1 in-game docs](https://bitburner-official.readthedocs.io/en/latest/netscript/netscript1.html) <hr>
 
 ## Properties
 
@@ -108,7 +107,7 @@ export async function main(ns) {
 |  [getServerRequiredHackingLevel(host)](./bitburner.ns.getserverrequiredhackinglevel.md) | Returns the required hacking level of the target server. |
 |  [getServerSecurityLevel(host)](./bitburner.ns.getserversecuritylevel.md) | Get server security level. |
 |  [getServerUsedRam(host)](./bitburner.ns.getserverusedram.md) | Get the used RAM on a server. |
-|  [getSharePower()](./bitburner.ns.getsharepower.md) | Calculate your share power. Based on all the active share calls. |
+|  [getSharePower()](./bitburner.ns.getsharepower.md) | Share Power has a multiplicative effect on rep/second while doing work for a faction. Share Power increases incrementally for every thread of share running on your server network, but at a sharply decreasing rate. |
 |  [getTimeSinceLastAug()](./bitburner.ns.gettimesincelastaug.md) | Returns the amount of time in milliseconds that have passed since you last installed Augmentations. |
 |  [getTotalScriptExpGain()](./bitburner.ns.gettotalscriptexpgain.md) | Get the exp gain of all scripts. |
 |  [getTotalScriptIncome()](./bitburner.ns.gettotalscriptincome.md) | Get the income of all scripts. |

--- a/markdown/bitburner.ns.share.md
+++ b/markdown/bitburner.ns.share.md
@@ -19,5 +19,5 @@ Promise&lt;void&gt;
 
 RAM cost: 2.4 GB
 
-Increases your rep gain of all faction work types while share is called. Scales with thread count.
+Increases rep/second for all faction work while share is running. Each cycle of ns.share() is 10 seconds. Scales with thread count, but at a sharply decreasing rate.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6678,13 +6678,14 @@ export interface NS {
    * @remarks
    * RAM cost: 2.4 GB
    *
-   * Increases your rep gain of all faction work types while share is called.
-   * Scales with thread count.
+   * Increases rep/second for all faction work while share is running. Each cycle of ns.share() is 10 seconds.
+   * Scales with thread count, but at a sharply decreasing rate.
    */
   share(): Promise<void>;
 
   /**
-   * Calculate your share power. Based on all the active share calls.
+   * Share Power has a multiplicative effect on rep/second while doing work for a faction.
+   * Share Power increases incrementally for every thread of share running on your server network, but at a sharply decreasing rate.
    * @remarks
    * RAM cost: 0.2 GB
    */


### PR DESCRIPTION
Follow up to close #607 
updating player-facing definitions to add context to the returned getSharePower "number" and expectations of the share() method. I wrote the edits in `src/ScriptEditor/NetscriptDefinitions.d.ts` and the rest are automated updates.



ns.share() in editor message
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/4b741a48-1427-4456-9862-28b22be678c3)
and in docs 
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/9c09a873-1d50-4ae1-9a2d-e36c5d86b310)


ns.getSharePower() in editor
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/82ebc291-6e00-41c8-be0c-fcbcc8e65dd2)
and in docs 
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/08b7c5d6-c6de-4a2d-aa83-9397bbcc1866)

