### PR TITLE
UI: Support for terminal history search with arrow keys

### DIFF
--- a/src/GameOptions/ui/MiscPage.tsx
+++ b/src/GameOptions/ui/MiscPage.tsx
@@ -36,8 +36,9 @@ export const MiscPage = (): React.ReactElement => {
         text="Enable terminal history search with arrow keys"
         tooltip={
           <>
-            If there is text in the terminal, using the up arrow will search through the terminal history for previous
-            commands that start with the current text.
+            If there is user-entered text in the terminal, using the up arrow will search through the terminal history
+            for previous commands that start with the current text, instead of navigating to the most recent history
+            item. Search results can be executed immediately via 'enter', or autofilled into the terminal with 'tab'.
           </>
         }
       />

--- a/src/GameOptions/ui/MiscPage.tsx
+++ b/src/GameOptions/ui/MiscPage.tsx
@@ -30,6 +30,17 @@ export const MiscPage = (): React.ReactElement => {
           </>
         }
       />
+      <OptionSwitch
+        checked={Settings.EnableHistorySearch}
+        onChange={(newValue) => (Settings.EnableHistorySearch = newValue)}
+        text="Enable terminal history search with arrow keys"
+        tooltip={
+          <>
+            If there is text in the terminal, using the up arrow will search through the terminal history for
+            previous commands that start with the current text.
+          </>
+        }
+      />
     </GameOptionsPage>
   );
 };

--- a/src/GameOptions/ui/MiscPage.tsx
+++ b/src/GameOptions/ui/MiscPage.tsx
@@ -36,8 +36,8 @@ export const MiscPage = (): React.ReactElement => {
         text="Enable terminal history search with arrow keys"
         tooltip={
           <>
-            If there is text in the terminal, using the up arrow will search through the terminal history for
-            previous commands that start with the current text.
+            If there is text in the terminal, using the up arrow will search through the terminal history for previous
+            commands that start with the current text.
           </>
         }
       />

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -27,7 +27,7 @@ export const Settings = {
   /** Whether to enable bash hotkeys */
   EnableBashHotkeys: false,
   /** Whether to enable terminal history search */
-  EnableHistorySearch: true,
+  EnableHistorySearch: false,
   /** Timestamps format string */
   TimestampsFormat: "",
   /** Locale used for display numbers. */

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -26,6 +26,8 @@ export const Settings = {
   DisableOverviewProgressBars: false,
   /** Whether to enable bash hotkeys */
   EnableBashHotkeys: false,
+  /** Whether to enable terminal history search */
+  EnableHistorySearch: true,
   /** Timestamps format string */
   TimestampsFormat: "",
   /** Locale used for display numbers. */

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -37,9 +37,10 @@ const useStyles = makeStyles((theme: Theme) =>
       position: "absolute",
       bottom: "5px",
       opacity: "0.5",
-      "max-width": "100%",
-      "white-space": "nowrap",
+      maxWidth: "100%",
+      whiteSpace: "nowrap",
       overflow: "hidden",
+      pointerEvents: "none",
     },
   }),
 );
@@ -54,7 +55,7 @@ export function TerminalInput(): React.ReactElement {
   const [postUpdateValue, setPostUpdateValue] = useState<{ postUpdate: () => void } | null>();
   const [possibilities, setPossibilities] = useState<string[]>([]);
   const [searchResults, setSearchResults] = useState<string[]>([]);
-  const [autofilledValue, setAutofilledValue] = useState<boolean>(false);
+  const [autofilledValue, setAutofilledValue] = useState(false);
   const classes = useStyles();
 
   // If we have no data in the current terminal history, let's initialize it from the player save
@@ -268,7 +269,7 @@ export function TerminalInput(): React.ReactElement {
 
       // If there is a partial command in the terminal, hitting "up" will filter the history
       if (value && !autofilledValue && Settings.EnableHistorySearch) {
-        if (searchResults.length > 1) {
+        if (searchResults.length > 0) {
           const results = [...searchResults];
           results.push(results.shift() ?? "");
           setSearchResults(results);
@@ -276,11 +277,7 @@ export function TerminalInput(): React.ReactElement {
         }
         const newResults = [...new Set(Terminal.commandHistory.filter((item) => item?.startsWith(value)).reverse())];
 
-        // If there is only one result, simply make that the value in the terminal
-        if (newResults.length === 1) {
-          saveValue(newResults[0]);
-          return;
-        } else if (newResults.length) {
+        if (newResults.length) {
           setSearchResults(newResults);
           return;
         }
@@ -308,7 +305,7 @@ export function TerminalInput(): React.ReactElement {
       if (Settings.EnableBashHotkeys) {
         event.preventDefault();
       }
-      if (searchResults.length > 1) {
+      if (searchResults.length > 0) {
         const results = [...searchResults];
         results.unshift(results.pop() ?? "");
         setSearchResults(results);

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -36,9 +36,9 @@ const useStyles = makeStyles((theme: Theme) =>
       margin: theme.spacing(0),
       position: "absolute",
       bottom: "5px",
-      opacity: "0.5",
+      opacity: "0.75",
       maxWidth: "100%",
-      whiteSpace: "nowrap",
+      "white-space": "nowrap break-spaces",
       overflow: "hidden",
       pointerEvents: "none",
     },
@@ -94,6 +94,12 @@ export function TerminalInput(): React.ReactElement {
     setSearchResults([]);
     setAutofilledValue(isAutofilled);
     setSearchResultsIndex(0);
+  }
+
+  function getSearchSuggestionPrespace() {
+    const currentPrefix = `[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> `;
+    const prefixLength = `${currentPrefix}${value}`.length;
+    return Array(prefixLength).fill(" ");
   }
 
   function modifyInput(mod: string): void {
@@ -218,13 +224,12 @@ export function TerminalInput(): React.ReactElement {
     // Run command or insert newline
     if (event.key === KEY.ENTER) {
       event.preventDefault();
-      Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
-      if (searchResults.length) {
-        Terminal.executeCommands(searchResults[searchResultsIndex]);
+      const command = searchResults.length ? searchResults[searchResultsIndex] : value;
+      Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${command}`);
+      if (command) {
+        Terminal.executeCommands(command);
         saveValue("");
-      } else if (value) {
-        Terminal.executeCommands(value);
-        saveValue("");
+        resetSearch();
       }
       return;
     }
@@ -332,6 +337,10 @@ export function TerminalInput(): React.ReactElement {
         saveValue(prevCommand);
         resetSearch(true);
       }
+    }
+
+    if (event.key === KEY.ESC && searchResults.length) {
+      resetSearch();
     }
 
     // Extra Bash Emulation Hotkeys, must be enabled through options
@@ -443,8 +452,9 @@ export function TerminalInput(): React.ReactElement {
           </Typography>
         </Paper>
       </Popper>
-      <Typography classes={{ root: classes.absolute }} color={"secondary"} paragraph={false}>
-        [{Player.getCurrentServer().hostname}&nbsp;/{Terminal.cwd()}]&gt;&nbsp;{searchResults[searchResultsIndex]}
+      <Typography classes={{ root: classes.absolute }} color={"primary"} paragraph={false}>
+        {getSearchSuggestionPrespace()}
+        {(searchResults[searchResultsIndex] ?? "").substring(value.length)}
       </Typography>
     </>
   );

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -284,8 +284,10 @@ export function TerminalInput(): React.ReactElement {
 
         if (newResults.length) {
           setSearchResults(newResults);
-          return;
         }
+        // Prevent moving through the history when the user has a search term even if there are
+        // no search results, to be consistent with zsh-type terminal behavior
+        return;
       }
 
       if (i < 0 || i > len) {

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -32,6 +32,15 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(0),
       height: "100%",
     },
+    absolute: {
+      margin: theme.spacing(0),
+      position: "absolute",
+      bottom: "5px",
+      opacity: "0.5",
+      "max-width": "100%",
+      "white-space": "nowrap",
+      overflow: "hidden",
+    },
   }),
 );
 
@@ -207,7 +216,10 @@ export function TerminalInput(): React.ReactElement {
     if (event.key === KEY.ENTER) {
       event.preventDefault();
       Terminal.print(`[${Player.getCurrentServer().hostname} /${Terminal.cwd()}]> ${value}`);
-      if (value) {
+      if (searchResults.length) {
+        Terminal.executeCommands(searchResults[0]);
+        saveValue("");
+      } else if (value) {
         Terminal.executeCommands(value);
         saveValue("");
       }
@@ -416,7 +428,7 @@ export function TerminalInput(): React.ReactElement {
           spellCheck: false,
           onBlur: () => {
             setPossibilities([]);
-            resetSearch();
+            //resetSearch(); TODO: re-add this
           },
           onKeyDown: onKeyDown,
         }}
@@ -436,21 +448,9 @@ export function TerminalInput(): React.ReactElement {
           </Typography>
         </Paper>
       </Popper>
-      <Popper
-        open={!!searchResults.length && possibilities.length === 0}
-        anchorEl={terminalInput.current}
-        placement={"top"}
-        sx={{ maxWidth: "75%" }}
-      >
-        <Paper sx={{ m: 1, p: 2 }}>
-          <Typography classes={{ root: classes.preformatted }} color={"secondary"} paragraph={false}>
-            Search result:
-          </Typography>
-          <Typography classes={{ root: classes.preformatted }} color={"primary"} paragraph={false}>
-            {`>  ${searchResults[0]}`}
-          </Typography>
-        </Paper>
-      </Popper>
+      <Typography classes={{ root: classes.absolute }} color={"secondary"} paragraph={false}>
+        [{Player.getCurrentServer().hostname}&nbsp;/{Terminal.cwd()}]&gt;&nbsp;{searchResults[0]}
+      </Typography>
     </>
   );
 }


### PR DESCRIPTION
Adds support for using the up and down arrow keys to search through your terminal history based on current text, similar to how the [feature works on zsh](https://coderwall.com/p/jpj_6q/zsh-better-history-searching-with-arrow-keys)

For example, typing "ru" and then hitting up arrow will cycle through previous commands you have entered starting with "ru" such as `run n00dles.js` and `run Nuke.exe` until you find the one you want, and hitting "tab" will then fill in that command from the history.  Hitting "enter" will execute the suggestion as a command.

Up and down arrow on an empty terminal is unchanged, and maintains the current functionality of cycling through recent terminal history sorted by time entered.

This feature can be disabled under the "misc" settings if desired by the user.

In the below example, `connect foodnstuff` is the first search result. Even though there are other commands that were entered after "connect foodnstuff"  (such as "home") , they are skipped because the user was searching for commands starting with "co" 



![Capture3](https://github.com/bitburner-official/bitburner-src/assets/1338468/017833e0-ffae-42ee-9cc3-3e33ee300113)
