### PR TITLE
UI: Prevent recursive aliases from being resolved. Fixes bitburner-official#630

### DIFF
--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -66,10 +66,9 @@ export function removeAlias(name: string): boolean {
  * Returns the original string with any aliases substituted in.
  * Aliases are only applied to "whole words", one level deep
  * @param origCommand the original command string
- * @param maxDepth the maximum depth that alias chains are permitted (default 10)
  */
-export function substituteAliases(origCommand: string, maxDepth = 10): string {
-  return applyAliases(origCommand, maxDepth);
+export function substituteAliases(origCommand: string): string {
+  return applyAliases(origCommand);
 }
 
 /**
@@ -77,13 +76,11 @@ export function substituteAliases(origCommand: string, maxDepth = 10): string {
  * unless there are any reference loops or the reference chain is too deep
  * @param origCommand the original command string
  * @param depth the current recursion depth
- * @param maxDepth the maximum depth that alias chains are permitted
  * @param currentlyProcessingAliases any aliases that have been applied in the recursive evaluation leading to this point
  * @return { string } the provided command with all of its referenced aliases evaluated
  */
-function applyAliases(origCommand: string, maxDepth = 10, depth = 0, currentlyProcessingAliases: string[] = []) {
-  // Prevent extremely deep alias chains
-  if (depth >= maxDepth || !origCommand) {
+function applyAliases(origCommand: string, depth = 0, currentlyProcessingAliases: string[] = []) {
+  if (!origCommand) {
     return origCommand;
   }
   const commandArray = origCommand.split(" ");
@@ -97,7 +94,7 @@ function applyAliases(origCommand: string, maxDepth = 10, depth = 0, currentlyPr
   // (unless there are any reference loops or the reference chain is too deep)
   const localAlias = Aliases.get(commandArray[0]);
   if (localAlias && !currentlyProcessingAliases.includes(localAlias)) {
-    const appliedAlias = applyAliases(localAlias, maxDepth, depth + 1, [
+    const appliedAlias = applyAliases(localAlias, depth + 1, [
       commandArray[0],
       ...currentlyProcessingAliases,
     ]);
@@ -108,7 +105,7 @@ function applyAliases(origCommand: string, maxDepth = 10, depth = 0, currentlyPr
   const processedCommands = commandArray.reduce((resolvedCommandArray: string[], command) => {
     const globalAlias = GlobalAliases.get(command);
     if (globalAlias && !currentlyProcessingAliases.includes(globalAlias)) {
-      const appliedAlias = applyAliases(globalAlias, maxDepth, depth + 1, [command, ...currentlyProcessingAliases]);
+      const appliedAlias = applyAliases(globalAlias, depth + 1, [command, ...currentlyProcessingAliases]);
       resolvedCommandArray.push(appliedAlias);
     } else {
       // If there is no alias, or if the alias has a circular reference, leave the command as-is

--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -94,10 +94,7 @@ function applyAliases(origCommand: string, depth = 0, currentlyProcessingAliases
   // (unless there are any reference loops or the reference chain is too deep)
   const localAlias = Aliases.get(commandArray[0]);
   if (localAlias && !currentlyProcessingAliases.includes(localAlias)) {
-    const appliedAlias = applyAliases(localAlias, depth + 1, [
-      commandArray[0],
-      ...currentlyProcessingAliases,
-    ]);
+    const appliedAlias = applyAliases(localAlias, depth + 1, [commandArray[0], ...currentlyProcessingAliases]);
     commandArray.splice(0, 1, ...appliedAlias.split(" "));
   }
 

--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -65,39 +65,54 @@ export function removeAlias(name: string): boolean {
 /**
  * Returns the original string with any aliases substituted in.
  * Aliases are only applied to "whole words", one level deep
+ * @param origCommand the original command string
+ * @param maxDepth the maximum depth that alias chains are permitted (default 10)
  */
-export function substituteAliases(origCommand: string): string {
-  const commandArray = origCommand.split(" ");
-  if (commandArray.length > 0) {
-    // For the alias and unalias commands, don't substitute
-    if (commandArray[0] === "unalias" || commandArray[0] === "alias") {
-      return commandArray.join(" ");
-    }
+export function substituteAliases(origCommand: string, maxDepth = 10): string {
+  return applyAliases(origCommand, maxDepth);
+}
 
-    let somethingSubstituted = true;
-    let depth = 0;
-    let lastAlias;
-
-    while (somethingSubstituted && depth < 10) {
-      depth++;
-      somethingSubstituted = false;
-      const alias = Aliases.get(commandArray[0])?.split(" ");
-      if (alias !== undefined) {
-        somethingSubstituted = true;
-        commandArray.splice(0, 1, ...alias);
-        //commandArray[0] = alias;
-      }
-      for (let i = 0; i < commandArray.length; ++i) {
-        const alias = GlobalAliases.get(commandArray[i])?.split(" ");
-        if (alias !== undefined && (commandArray[i] != lastAlias || somethingSubstituted)) {
-          somethingSubstituted = true;
-          lastAlias = commandArray[i];
-          commandArray.splice(i, 1, ...alias);
-          i += alias.length - 1;
-          //commandArray[i] = alias;
-        }
-      }
-    }
+/**
+ * Recursively evaluates aliases and applies them to the command string,
+ * unless there are any reference loops or the reference chain is too deep
+ * @param origCommand the original command string
+ * @param depth the current recursion depth
+ * @param maxDepth the maximum depth that alias chains are permitted
+ * @param currentlyProcessingAliases any aliases that have been applied in the recursive evaluation leading to this point
+ * @return { string } the provided command with all of its referenced aliases evaluated
+ */
+function applyAliases(origCommand: string, maxDepth = 10, depth = 0, currentlyProcessingAliases: string[] = []) {
+  // Prevent extremely deep alias chains
+  if (depth >= maxDepth || !origCommand) {
+    return origCommand;
   }
-  return commandArray.join(" ");
+  const commandArray = origCommand.split(" ");
+
+  // Do not apply aliases when defining a new alias
+  if (commandArray[0] === "unalias" || commandArray[0] === "alias") {
+    return commandArray.join(" ");
+  }
+
+  // First get non-global aliases, and recursively apply them
+  // (unless there are any reference loops or the reference chain is too deep)
+  const localAlias = Aliases.get(commandArray[0]);
+  if (localAlias && !currentlyProcessingAliases.includes(localAlias)) {
+    const appliedAlias = applyAliases(localAlias, maxDepth, depth + 1, [localAlias, ...currentlyProcessingAliases]);
+    commandArray.splice(0, 1, ...appliedAlias.split(" "));
+  }
+
+  // Once local aliasing is complete (or if none are present) handle any global aliases
+  const processedCommands = commandArray.reduce((resolvedCommandArray: string[], command) => {
+    const globalAlias = GlobalAliases.get(command);
+    if (globalAlias && !currentlyProcessingAliases.includes(globalAlias)) {
+      const appliedAlias = applyAliases(globalAlias, maxDepth, depth + 1, [globalAlias, ...currentlyProcessingAliases]);
+      resolvedCommandArray.push(appliedAlias);
+    } else {
+      // If there is no alias, or if the alias has a circular reference, leave the command as-is
+      resolvedCommandArray.push(command);
+    }
+    return resolvedCommandArray;
+  }, []);
+
+  return processedCommands.join(" ");
 }

--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -97,7 +97,10 @@ function applyAliases(origCommand: string, maxDepth = 10, depth = 0, currentlyPr
   // (unless there are any reference loops or the reference chain is too deep)
   const localAlias = Aliases.get(commandArray[0]);
   if (localAlias && !currentlyProcessingAliases.includes(localAlias)) {
-    const appliedAlias = applyAliases(localAlias, maxDepth, depth + 1, [localAlias, ...currentlyProcessingAliases]);
+    const appliedAlias = applyAliases(localAlias, maxDepth, depth + 1, [
+      commandArray[0],
+      ...currentlyProcessingAliases,
+    ]);
     commandArray.splice(0, 1, ...appliedAlias.split(" "));
   }
 
@@ -105,7 +108,7 @@ function applyAliases(origCommand: string, maxDepth = 10, depth = 0, currentlyPr
   const processedCommands = commandArray.reduce((resolvedCommandArray: string[], command) => {
     const globalAlias = GlobalAliases.get(command);
     if (globalAlias && !currentlyProcessingAliases.includes(globalAlias)) {
-      const appliedAlias = applyAliases(globalAlias, maxDepth, depth + 1, [globalAlias, ...currentlyProcessingAliases]);
+      const appliedAlias = applyAliases(globalAlias, maxDepth, depth + 1, [command, ...currentlyProcessingAliases]);
       resolvedCommandArray.push(appliedAlias);
     } else {
       // If there is no alias, or if the alias has a circular reference, leave the command as-is

--- a/test/jest/Alias/Alias.test.ts
+++ b/test/jest/Alias/Alias.test.ts
@@ -7,17 +7,27 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=recursiveAlias");
 
     const result = substituteAliases("recursiveAlias");
-    expect(result).toEqual("recursiveAlias");
+    expect(result).toEqual("d");
+  });
+
+  it("Should only change local aliases if they are the start of the command", () => {
+    parseAliasDeclaration("a=b");
+    parseAliasDeclaration("b=c");
+    parseAliasDeclaration("c=d");
+    parseAliasDeclaration("d=e");
+
+    const result = substituteAliases("a b c d");
+    expect(result).toEqual("e b c d");
   });
 
   it("Should gracefully handle recursive global aliases", () => {
-    parseAliasDeclaration("recursiveAlias=b", true);
+    parseAliasDeclaration("a=b", true);
     parseAliasDeclaration("b=c", true);
     parseAliasDeclaration("c=d", true);
-    parseAliasDeclaration("d=recursiveAlias", true);
+    parseAliasDeclaration("d=a", true);
 
-    const result = substituteAliases("recursiveAlias");
-    expect(result).toEqual("recursiveAlias");
+    const result = substituteAliases("a b c d");
+    expect(result).toEqual("d a b c");
   });
 
   it("Should gracefully handle recursive mixed local and global aliases", () => {
@@ -27,7 +37,7 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=recursiveAlias", false);
 
     const result = substituteAliases("recursiveAlias");
-    expect(result).toEqual("recursiveAlias");
+    expect(result).toEqual("d");
   });
 
   it("Should replace chained aliases", () => {
@@ -46,7 +56,7 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("c=d", true);
     parseAliasDeclaration("d=e", true);
 
-    const result = substituteAliases("a", 2);
-    expect(result).toEqual("c");
+    const result = substituteAliases("a b c d", 2);
+    expect(result).toEqual("c d e e");
   });
 });

--- a/test/jest/Alias/Alias.test.ts
+++ b/test/jest/Alias/Alias.test.ts
@@ -1,0 +1,52 @@
+import { substituteAliases, parseAliasDeclaration } from "../../../src/Alias";
+describe("substituteAliases Tests", () => {
+  it("Should gracefully handle recursive local aliases", () => {
+    parseAliasDeclaration("recursiveAlias=b");
+    parseAliasDeclaration("b=c");
+    parseAliasDeclaration("c=d");
+    parseAliasDeclaration("d=recursiveAlias");
+
+    const result = substituteAliases("recursiveAlias");
+    expect(result).toEqual("recursiveAlias");
+  });
+
+  it("Should gracefully handle recursive global aliases", () => {
+    parseAliasDeclaration("recursiveAlias=b", true);
+    parseAliasDeclaration("b=c", true);
+    parseAliasDeclaration("c=d", true);
+    parseAliasDeclaration("d=recursiveAlias", true);
+
+    const result = substituteAliases("recursiveAlias");
+    expect(result).toEqual("recursiveAlias");
+  });
+
+  it("Should gracefully handle recursive mixed local and global aliases", () => {
+    parseAliasDeclaration("recursiveAlias=b", true);
+    parseAliasDeclaration("b=c", false);
+    parseAliasDeclaration("c=d", true);
+    parseAliasDeclaration("d=recursiveAlias", false);
+
+    const result = substituteAliases("recursiveAlias");
+    expect(result).toEqual("recursiveAlias");
+  });
+
+  it("Should replace chained aliases", () => {
+    parseAliasDeclaration("a=b", true);
+    parseAliasDeclaration("b=c", true);
+    parseAliasDeclaration("c=d", true);
+    parseAliasDeclaration("d=e", true);
+
+    const result = substituteAliases("a");
+    expect(result).toEqual("e");
+  });
+
+  it("Should replace chained aliases only up to the maxDepth", () => {
+    parseAliasDeclaration("a=b", true);
+    parseAliasDeclaration("b=c", true);
+    parseAliasDeclaration("c=d", true);
+    parseAliasDeclaration("d=e", true);
+
+    const result = substituteAliases("a", 2);
+    expect(result).toEqual("c");
+  });
+});

--- a/test/jest/Alias/Alias.test.ts
+++ b/test/jest/Alias/Alias.test.ts
@@ -49,14 +49,4 @@ describe("substituteAliases Tests", () => {
     const result = substituteAliases("a");
     expect(result).toEqual("e");
   });
-
-  it("Should replace chained aliases only up to the maxDepth", () => {
-    parseAliasDeclaration("a=b", true);
-    parseAliasDeclaration("b=c", true);
-    parseAliasDeclaration("c=d", true);
-    parseAliasDeclaration("d=e", true);
-
-    const result = substituteAliases("a b c d", 2);
-    expect(result).toEqual("c d e e");
-  });
 });


### PR DESCRIPTION
Refactor alias processing: when resolving an alias, look at the tracked list of previously-processed aliases that led to the current one, and do not resolve any ~~aliaii~~ aliases already present in it. This ensures there are no loops in the alias reference tree in a given command, and replaces the current only-one-alias-lookback solution.

closes bitburner-official#630