### PR TITLE
UI: added autorerender time to Buy Augment page

### DIFF
--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -19,7 +19,7 @@ import { useRerender } from "../../ui/React/hooks";
 
 /** Root React Component for displaying a faction's "Purchase Augmentations" page */
 export function AugmentationsPage({ faction }: { faction: Faction }): React.ReactElement {
-  const rerender = useRerender();
+  const rerender = useRerender(400);
 
   function getAugs(): AugmentationName[] {
     return getFactionAugmentationsFiltered(faction);


### PR DESCRIPTION
Buy Augment page didnt auto update wich for the most part is fine because there isnt much that changes without player interaction (wich would trigger a rerender) 
but the current reputation with that faction doesnt update so i added a 400ms auto rerender to it
  
 edit.: closes  #695 
