### PR TITLE
FIX: update white-space style to function on electron app

### DIFF
--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
       bottom: "5px",
       opacity: "0.75",
       maxWidth: "100%",
-      "white-space": "nowrap break-spaces",
+      whiteSpace: "pre",
       overflow: "hidden",
       pointerEvents: "none",
     },


### PR DESCRIPTION
The electron version of the app did not respect the previously-existing white-space style, unlike Chrome where it was initially tested. This caused the ghosted suggestion in the terminal to overlap with the prompt.

This change resolves the issue to both preserve multiple spaces for layout, as well as preventing word wrap to avoid the suggestions from overflowing. 

I have tested this fix on electron for windows 32 and 64, as well as Chrome, Firefox, and Edge, and all of them have the text indent correctly with no overlaps.