### PR TITLE
UI: fix ActiveScripts Page map scripts with same arguments correctly

### DIFF
--- a/src/ui/ActiveScripts/ServerAccordionContent.tsx
+++ b/src/ui/ActiveScripts/ServerAccordionContent.tsx
@@ -27,7 +27,7 @@ export function ServerAccordionContent(props: IProps): React.ReactElement {
     <>
       <List dense disablePadding>
         {props.workerScripts.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((ws) => (
-          <WorkerScriptAccordion key={`${ws.name}_${ws.args}`} workerScript={ws} />
+          <WorkerScriptAccordion key={`${ws.pid}`} workerScript={ws} />
         ))}
       </List>
       <TablePagination


### PR DESCRIPTION
# Bug fix

- For active script, currently could run multiple scripts with the same arguments simultaneously, thus this React `key` setting is not correct.
- For previous code, you could reproduce the bug by running multiple scripts with the same arguments, and click kill script in the `ActiveScripts` Page, it will render more script in the list as it should be. 
- fix tested locally.