### PR TITLE
DOCUMENT: ns.getScriptLog update to use "FilenameOrPID" and related ns.tail change

### DIFF
--- a/markdown/bitburner.ns.getscriptlogs.md
+++ b/markdown/bitburner.ns.getscriptlogs.md
@@ -9,14 +9,14 @@ Get all the logs of a script.
 **Signature:**
 
 ```typescript
-getScriptLogs(fn?: string, host?: string, ...args: (string | number | boolean)[]): string[];
+getScriptLogs(fn?: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): string[];
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  fn | string | _(Optional)_ Optional. Filename of script to get logs from. |
+|  fn | [FilenameOrPID](./bitburner.filenameorpid.md) | _(Optional)_ Optional. Filename or PID of script to get logs from. |
 |  host | string | _(Optional)_ Optional. Hostname of the server that the script is on. |
 |  args | (string \| number \| boolean)\[\] | Arguments to identify which scripts to get logs for. |
 
@@ -32,7 +32,7 @@ RAM cost: 0 GB
 
 Returns a script’s logs. The logs are returned as an array, where each line is an element in the array. The most recently logged line is at the end of the array. Note that there is a maximum number of lines that a script stores in its logs. This is configurable in the game’s options. If the function is called with no arguments, it will return the current script’s logs.
 
-Otherwise, the fn, hostname/ip, and args… arguments can be used to get the logs from another script. Remember that scripts are uniquely identified by both their names and arguments.
+Otherwise, the PID or filename, hostname/ip, and args… arguments can be used to get logs from another script. Remember that scripts are uniquely identified by both their names and arguments.
 
 ## Example
 

--- a/markdown/bitburner.ns.tail.md
+++ b/markdown/bitburner.ns.tail.md
@@ -32,7 +32,7 @@ Opens a script’s logs. This is functionally the same as the tail Terminal comm
 
 If the function is called with no arguments, it will open the current script’s logs.
 
-Otherwise, the fn, hostname/ip, and args… arguments can be used to get the logs from another script. Remember that scripts are uniquely identified by both their names and arguments.
+Otherwise, the PID or filename, hostname/ip, and args… arguments can be used to get the logs from another script. Remember that scripts are uniquely identified by both their names and arguments.
 
 ## Example
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5101,7 +5101,7 @@ export interface NS {
    * Note that there is a maximum number of lines that a script stores in its logs. This is configurable in the game’s options.
    * If the function is called with no arguments, it will return the current script’s logs.
    *
-   * Otherwise, the fn, hostname/ip, and args… arguments can be used to get the logs from another script.
+   * Otherwise, the PID or filename, hostname/ip, and args… arguments can be used to get logs from another script.
    * Remember that scripts are uniquely identified by both their names and arguments.
    *
    * @example
@@ -5115,12 +5115,12 @@ export interface NS {
    * //Open logs from foo.js on the foodnstuff server that was run with the arguments [1, "test"]
    * ns.getScriptLogs("foo.js", "foodnstuff", 1, "test");
    * ```
-   * @param fn - Optional. Filename of script to get logs from.
+   * @param fn - Optional. Filename or PID of script to get logs from.
    * @param host - Optional. Hostname of the server that the script is on.
    * @param args - Arguments to identify which scripts to get logs for.
    * @returns Returns a string array, where each line is an element in the array. The most recently logged line is at the end of the array.
    */
-  getScriptLogs(fn?: string, host?: string, ...args: (string | number | boolean)[]): string[];
+  getScriptLogs(fn?: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): string[];
 
   /**
    * Get an array of recently killed scripts across all servers.
@@ -5152,7 +5152,7 @@ export interface NS {
    *
    * If the function is called with no arguments, it will open the current script’s logs.
    *
-   * Otherwise, the fn, hostname/ip, and args… arguments can be used to get the logs from another script.
+   * Otherwise, the PID or filename, hostname/ip, and args… arguments can be used to get the logs from another script.
    * Remember that scripts are uniquely identified by both their names and arguments.
    *
    * @example


### PR DESCRIPTION
closes #714

# Bug fix

- Updates ns.getScriptLog description to mention PID
- "" fn argument type from "string" to "filenameOrPID"
- updates ns.tail() to use the same language in description, i.e.  `the PID or filename` replaces `the fn`

script for testing attached. Save as  .js and run. nukes n00dles, writes and exes a script, fetches the PID and demonstrates use of either PID or filename and host to get the same results with both ns.getScriptLog and ns.tail()

[getScriptLogs PID update test.txt](https://github.com/bitburner-official/bitburner-src/files/12448850/getScriptLogs.PID.update.test.txt)


