### PR TITLE
MISC: Tweak HacknetServer's upgradeRam function

### DIFF
--- a/src/Hacknet/HacknetServer.ts
+++ b/src/Hacknet/HacknetServer.ts
@@ -104,9 +104,7 @@ export class HacknetServer extends BaseServer implements IHacknetNode {
   }
 
   upgradeRam(levels: number, prodMult: number): boolean {
-    for (let i = 0; i < levels; ++i) {
-      this.maxRam *= 2;
-    }
+    this.maxRam *= Math.pow(2, levels);
     this.maxRam = Math.min(HacknetServerConstants.MaxRam, Math.round(this.maxRam));
     this.updateHashRate(prodMult);
 


### PR DESCRIPTION
Replace the for-loop repeating multiply by two with a single multiply by Math.pow().

Built and ran in dev mode and was able to upgrade ram multiple times in multiple nodes.

closes #749 