### PR TITLE
UI: Basic Map and Set support in ns.print/tprint

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -220,15 +220,20 @@ function argsToString(args: unknown[]): string {
     const nativeArg = toNative(arg);
 
     // Handle Map formatting, since it does not JSON stringify or toString in a helpful way
-    // output is  "< key1 => value1, key2 => value2, >"
+    // output is  "< Map: key1 => value1; key2 => value2 >"
     if (nativeArg instanceof Map && [...nativeArg].length) {
-      out += "<";
-      nativeArg.forEach((key, value) => (out += ` ${key} => ${value},`));
-      return (out += " >");
+      const formattedMap = [...nativeArg]
+        .map((m) => {
+          const key = argsToString([m[0]]);
+          const value = argsToString([m[1]]);
+          return `${key} => ${value}`;
+        })
+        .join("; ");
+      return (out += `< Map: ${formattedMap} >`);
     }
     // Handle Set formatting, since it does not JSON stringify or toString in a helpful way
     if (nativeArg instanceof Set) {
-      return (out += `${[...nativeArg]}`);
+      return (out += `< Set: ${[...nativeArg].join("; ")} >`);
     }
     if (typeof nativeArg === "object") {
       return (out += JSON.stringify(nativeArg));

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -224,9 +224,7 @@ function argsToString(args: unknown[]): string {
     if (nativeArg instanceof Map && [...nativeArg].length) {
       const formattedMap = [...nativeArg]
         .map((m) => {
-          const key = argsToString([m[0]]);
-          const value = argsToString([m[1]]);
-          return `${key} => ${value}`;
+          return `${m[0]} => ${m[1]}`;
         })
         .join("; ");
       return (out += `< Map: ${formattedMap} >`);

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -234,7 +234,7 @@ function argsToString(args: unknown[]): string {
       return (out += JSON.stringify(nativeArg));
     }
 
-    return out;
+    return (out += `${nativeArg}`);
   }, "") as string;
 }
 

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -209,21 +209,33 @@ function runOptions(ctx: NetscriptContext, threadOrOption: unknown): CompleteRun
 
 /** Convert multiple arguments for tprint or print into a single string. */
 function argsToString(args: unknown[]): string {
-  let out = "";
-  for (let arg of args) {
+  // Reduce array of args into a single output string
+  return args.reduce((out, arg) => {
     if (arg === null) {
-      out += "null";
-      continue;
+      return (out += "null");
     }
     if (arg === undefined) {
-      out += "undefined";
-      continue;
+      return (out += "undefined");
     }
-    arg = toNative(arg);
-    out += typeof arg === "object" ? JSON.stringify(arg) : `${arg}`;
-  }
+    const nativeArg = toNative(arg);
 
-  return out;
+    // Handle Map formatting, since it does not JSON stringify or toString in a helpful way
+    // output is  "< key1 => value1, key2 => value2, >"
+    if (nativeArg instanceof Map && [...nativeArg].length) {
+      out += "<";
+      nativeArg.forEach((key, value) => (out += ` ${key} => ${value},`));
+      return (out += " >");
+    }
+    // Handle Set formatting, since it does not JSON stringify or toString in a helpful way
+    if (nativeArg instanceof Set) {
+      return (out += `${[...nativeArg]}`);
+    }
+    if (typeof nativeArg === "object") {
+      return (out += JSON.stringify(nativeArg));
+    }
+
+    return out;
+  }, "") as string;
 }
 
 /** Creates an error message string containing hostname, scriptname, and the error message msg */


### PR DESCRIPTION
Added basic support for printing maps and sets via print and tprint.
Note that the formatting I chose for maps clearly indicates they are not an object with object keys, but rather are entries with a key => value relationship. I am open to suggestions for different formatting styles, as well, since there isn't exactly a standard for the string representation AFAIK.

![image](https://github.com/bitburner-official/bitburner-src/assets/1338468/bedb1296-bd73-49ef-8c88-aaece65859b3)
