### PR TITLE
UI: More helpful server purchase cost errors

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1161,7 +1161,11 @@ export const ns: InternalAPI<NSFull> = {
 
     const cost = getPurchaseServerCost(ram);
     if (cost === Infinity) {
-      helpers.log(ctx, () => `Invalid argument: ram='${ram}'`);
+      if (ram > getPurchaseServerMaxRam()) {
+        helpers.log(ctx, () => `Invalid argument: ram='${ram}' must not be greater than getPurchaseServerMaxRam`);
+      } else {
+        helpers.log(ctx, () => `Invalid argument: ram='${ram}' must be a positive power of 2`);
+      }
       return Infinity;
     }
 


### PR DESCRIPTION
Update `getPurchasedServerCost` to have feedback for invalid server sizes, the same as the feedback given with `purchaseServer`, to make it easier for players to understand why a specific cost query is failing. 

Note that the documentation for `getPurchasedServerUpgradeCost` and `purchaseServer` say that the maximum value is 2^20 even on bitnodes where this is not true; if desired I can also update those NetscriptDefinitions entries.