### PR TITLE
UI: bladeburner.getactionrepgain() signature includes more type and default details

### DIFF
--- a/markdown/bitburner.bladeburner.getactionrepgain.md
+++ b/markdown/bitburner.bladeburner.getactionrepgain.md
@@ -18,7 +18,7 @@ getActionRepGain(type: string, name: string, level: number): number;
 |  --- | --- | --- |
 |  type | string | Type of action. |
 |  name | string | Name of action. Must be an exact match. |
-|  level | number | Optional action level at which to calculate the gain |
+|  level | number | Optional number. Action level at which to calculate the gain. Will be the action's current level if not given. |
 
 **Returns:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2901,7 +2901,7 @@ export interface Bladeburner {
    *
    * @param type - Type of action.
    * @param name - Name of action. Must be an exact match.
-   * @param level - Optional action level at which to calculate the gain
+   * @param level - Optional number. Action level at which to calculate the gain. Will be the action's current level if not given.
    * @returns Average Bladeburner reputation gain for successfully completing the specified action.
    */
   getActionRepGain(type: string, name: string, level: number): number;


### PR DESCRIPTION


closes #65

# Bug fix

#65 said "the current implementation requires a level value to be passed in, and will throw an exception if one is not." and more specifically "I believe it doesn't let null/NaN through"

![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/e3ad09fb-a54a-4b1c-8a3d-439c7fb18f7a)

I tested some values and yes `null` and `NaN` throw exception, but a level value is not required. For my understanding of null, it seems like the behavior is correct (not acting as a number), so I don't suggest that change.
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/1f7de681-cb28-461a-a2fb-c37b36706a7b)

I did add a minor update to signature so level type and default might be more clear.

![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/11bb45a3-1e38-4f88-9a9c-628e9d1f13f7)


