### PR TITLE
CORPORATION: fix "Use same 'Sell Amount' for all cities" 

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -166,6 +166,8 @@ export function SellMaterial(material: Material, amount: string, price: string):
 
 export function SellProduct(product: Product, city: CityName, amt: string, price: string, all: boolean): void {
   //Parse price
+  // initliaze newPrice with oldPrice as default
+  let newPrice = product.cityData[city].desiredSellPrice;
   if (price.includes("MP")) {
     //Dynamically evaluated quantity. First test to make sure its valid
     //Sanitize input, then replace dynamic variables with arbitrary numbers
@@ -181,17 +183,19 @@ export function SellProduct(product: Product, city: CityName, amt: string, price
     if (temp == null || isNaN(parseFloat(temp))) {
       throw new Error("Invalid value or expression for sell price field.");
     }
-    product.cityData[city].desiredSellPrice = price; //Use sanitized price
+    newPrice = price; //Use sanitized price
   } else {
     const cost = parseFloat(price);
     if (isNaN(cost)) {
       throw new Error("Invalid value for sell price field");
     }
-    product.cityData[city].desiredSellPrice = cost;
+    newPrice = cost;
   }
 
   // Parse quantity
   amt = amt.toUpperCase();
+  //initialize newAmount with old as default
+  let newAmount = product.cityData[city].desiredSellAmount;
   if (amt.includes("MAX") || amt.includes("PROD") || amt.includes("INV")) {
     //Dynamically evaluated quantity. First test to make sure its valid
     let qty = amt.replace(/\s+/g, "");
@@ -208,14 +212,7 @@ export function SellProduct(product: Product, city: CityName, amt: string, price
     if (temp == null || isNaN(parseFloat(temp))) {
       throw new Error("Invalid value or expression for sell quantity field");
     }
-
-    if (all) {
-      for (const cityName of Object.values(CityName)) {
-        product.cityData[cityName].desiredSellAmount = qty; //Use sanitized input
-      }
-    } else {
-      product.cityData[city].desiredSellAmount = qty; //Use sanitized input
-    }
+    newAmount = qty; //Use sanitized input
   } else if (isNaN(parseFloat(amt)) || parseFloat(amt) < 0) {
     throw new Error("Invalid value for sell quantity field! Must be numeric or 'PROD' or 'MAX'");
   } else {
@@ -223,21 +220,17 @@ export function SellProduct(product: Product, city: CityName, amt: string, price
     if (isNaN(qty)) {
       qty = 0;
     }
-    if (qty === 0) {
-      if (all) {
-        for (const cityName of Object.values(CityName)) {
-          product.cityData[cityName].desiredSellAmount = 0;
-        }
-      } else {
-        product.cityData[city].desiredSellAmount = 0;
-      }
-    } else if (all) {
-      for (const cityName of Object.values(CityName)) {
-        product.cityData[cityName].desiredSellAmount = qty;
-      }
-    } else {
-      product.cityData[city].desiredSellAmount = qty;
+    newAmount = qty;
+  }
+  //apply new price and amount to all or just current
+  if (all) {
+    for (const cityName of Object.values(CityName)) {
+      product.cityData[cityName].desiredSellAmount = newAmount;
+      product.cityData[cityName].desiredSellPrice = newPrice;
     }
+  } else {
+    product.cityData[city].desiredSellAmount = newAmount;
+    product.cityData[city].desiredSellPrice = newPrice;
   }
 }
 

--- a/src/Corporation/ui/modals/SellProductModal.tsx
+++ b/src/Corporation/ui/modals/SellProductModal.tsx
@@ -97,7 +97,7 @@ export function SellProductModal(props: IProps): React.ReactElement {
       <Button onClick={sellProduct}>Confirm</Button>
       <FormControlLabel
         control={<Switch checked={checked} onChange={onCheckedChange} />}
-        label={<Typography>Use same 'Sell Amount' for all cities</Typography>}
+        label={<Typography>Set same 'sell amount and price' for all cities</Typography>}
       />
     </Modal>
   );

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7089,7 +7089,7 @@ export interface WarehouseAPI {
    * @param productName - Name of the product
    * @param amt - Amount to sell, can be "MAX"
    * @param price - Price to sell, can be "MP"
-   * @param all - Sell in all city
+   * @param all - Set sell amount and price in all cities
    */
   sellProduct(
     divisionName: string,


### PR DESCRIPTION
extracting the applying of the parsed inputs out of the parsing section into their own section
removes some code dups
fixes #561
