### PR TITLE
UI: Preserve tail window location when hidden

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -398,15 +398,13 @@ export function GameRoot(): React.ReactElement {
                 <Box className={classes.root}>{mainPage}</Box>
               )}
               <Unclickable />
-              {withPopups && (
-                <>
-                  <LogBoxManager />
-                  <AlertManager />
-                  <PromptManager />
-                  <InvitationModal />
-                  <Snackbar />
-                </>
-              )}
+              <div style={{ display: withPopups ? "inherit" : "none", position: "absolute" }}>
+                <LogBoxManager />
+                <AlertManager />
+                <PromptManager />
+                <InvitationModal />
+                <Snackbar />
+              </div>
               <Apr1 />
             </SnackbarProvider>
           </HistoryProvider>


### PR DESCRIPTION
Use display: none instead of un-mounting the tail windows when hidden during screens like Infiltration. This preserves the window locations, and allows users to manually override the css if they want to show these windows during infiltration etc.