### PR TITLE
UI: change Stats Skill formatting to mirror StatsOverview

### DIFF
--- a/src/ui/React/StatsRow.tsx
+++ b/src/ui/React/StatsRow.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Typography, TableCell, TableRow } from "@mui/material";
 
-import { formatExp, formatNumberNoSuffix } from "../formatNumber";
+import { formatExp, formatSkill } from "../formatNumber";
 import { useStyles } from "./CharacterOverview";
 
 interface ITableRowData {
@@ -26,9 +26,9 @@ export const StatsRow = ({ name, color, children, data }: IProps): React.ReactEl
     if (data.content !== undefined) {
       content = data.content;
     } else if (data.level !== undefined && data.exp !== undefined) {
-      content = `${formatNumberNoSuffix(data.level, 0)} (${formatExp(data.exp)} exp)`;
+      content = `${formatSkill(data.level)} (${formatExp(data.exp)} exp)`;
     } else if (data.level !== undefined && data.exp === undefined) {
-      content = `${formatNumberNoSuffix(data.level, 0)}`;
+      content = `${formatSkill(data.level)}`;
     }
   }
 


### PR DESCRIPTION
uses formatSkill in Stats Skills to make it the same as in the Overview
closes #631

Before:
![image](https://github.com/bitburner-official/bitburner-src/assets/115591472/f20a0b07-3800-42fd-8d9a-dfbe97777ee6)

After:
![image](https://github.com/bitburner-official/bitburner-src/assets/115591472/dd048d7a-3c53-47d3-950e-d09ce1334786)

