### PR TITLE
UI: mirror StatsOverviews skill formatting for Skills in Stats page

### DIFF
--- a/src/ui/React/StatsRow.tsx
+++ b/src/ui/React/StatsRow.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Typography, TableCell, TableRow } from "@mui/material";
 
-import { formatExp, formatNumberNoSuffix } from "../formatNumber";
+import { formatExp, formatSkill } from "../formatNumber";
 import { useStyles } from "./CharacterOverview";
 
 interface ITableRowData {
@@ -26,9 +26,9 @@ export const StatsRow = ({ name, color, children, data }: IProps): React.ReactEl
     if (data.content !== undefined) {
       content = data.content;
     } else if (data.level !== undefined && data.exp !== undefined) {
-      content = `${formatNumberNoSuffix(data.level, 0)} (${formatExp(data.exp)} exp)`;
+      content = `${formatSkill(data.level)} (${formatExp(data.exp)} exp)`;
     } else if (data.level !== undefined && data.exp === undefined) {
-      content = `${formatNumberNoSuffix(data.level, 0)}`;
+      content = `${formatSkill(data.level)}`;
     }
   }
 


### PR DESCRIPTION
uses the same formatting in Stats Skills like the Skills in Overview 


closes #631