### PR TITLE
CORPORATION: fix production limitation

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -379,9 +379,11 @@ export class Division {
           /* Process production of materials */
           if (this.producedMaterials.length > 0) {
             //ugly section to find limits
-            const limits = this.producedMaterials.map((matName) => warehouse.materials[matName].productionLimit)
+            const limits = this.producedMaterials.map((matName) => warehouse.materials[matName].productionLimit);
             //if any limit is null then we dont use any limit, if all limits are set we find the highest and limit the overall prod based on it
-            const globalLimit: number = limits.some((lim)=> !isDefined(lim)) ? -1 : Math.max(...limits.filter(isDefined));
+            const globalLimit: number = limits.some((lim) => !isDefined(lim))
+              ? -1
+              : Math.max(...limits.filter(isDefined));
             //Calculate the maximum production of this material based
             //on the office's productivity
             const maxProd =

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -381,9 +381,7 @@ export class Division {
             //ugly section to find limits
             const limits = this.producedMaterials.map((matName) => warehouse.materials[matName].productionLimit);
             //if any limit is null then we dont use any limit, if all limits are set we find the highest and limit the overall prod based on it
-            const globalLimit: number = limits.some((lim) => !isDefined(lim))
-              ? -1
-              : Math.max(...limits.filter(isDefined));
+            const divLimit: number = limits.some((lim) => !isDefined(lim)) ? -1 : Math.max(...limits.filter(isDefined));
             //Calculate the maximum production of this material based
             //on the office's productivity
             const maxProd =
@@ -394,7 +392,7 @@ export class Division {
             let prod;
 
             // If there is a limit set on production, apply the limit
-            prod = globalLimit === -1 ? maxProd : Math.min(maxProd, globalLimit);
+            prod = divLimit === -1 ? maxProd : Math.min(maxProd, divLimit);
 
             prod *= corpConstants.secondsPerMarketCycle * marketCycles; //Convert production from per second to per market cycle
 

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -378,7 +378,7 @@ export class Division {
           /* Process production of materials */
           if (this.producedMaterials.length > 0) {
             //if any limit is null then we use Number.MaxValue, if all limits are set we find the highest and limit the overall prod based on it
-            const divLimit = Math.max(
+            const cityLimit = Math.max(
               ...this.producedMaterials.map(
                 (matName) => warehouse.materials[matName].productionLimit ?? Number.MAX_VALUE,
               ),
@@ -393,7 +393,7 @@ export class Division {
               this.getProductionMultiplier(); // Multiplier from Research
 
             // If there is a limit set on production, apply the limit and convert production from per second to per market cycle
-            let prod = Math.min(maxProd, divLimit) * corpConstants.secondsPerMarketCycle * marketCycles;
+            let prod = Math.min(maxProd, cityLimit) * corpConstants.secondsPerMarketCycle * marketCycles;
 
             // Calculate net change in warehouse storage making the produced materials will cost
             let totalMatSize = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ export type PositiveInteger = Integer & PositiveNumber;
 // Numeric typechecking functions - these should be moved somewhere else
 export const isInteger = (n: unknown): n is Integer => Number.isInteger(n);
 export const isPositiveInteger = (n: unknown): n is PositiveInteger => isInteger(n) && n > 0;
+//type guard for null
+export const isDefined = <T>(t: T | null | undefined): t is T => t != null;
 
 /** Utility type for typechecking objects. Makes all keys optional and sets values to unknown,
  * making it safe to assert a shape for the variable once it's known to be a non-null object */

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,6 @@ export type PositiveInteger = Integer & PositiveNumber;
 // Numeric typechecking functions - these should be moved somewhere else
 export const isInteger = (n: unknown): n is Integer => Number.isInteger(n);
 export const isPositiveInteger = (n: unknown): n is PositiveInteger => isInteger(n) && n > 0;
-//type guard for null
-export const isDefined = <T>(t: T | null | undefined): t is T => t != null;
 
 /** Utility type for typechecking objects. Makes all keys optional and sets values to unknown,
  * making it safe to assert a shape for the variable once it's known to be a non-null object */


### PR DESCRIPTION
needs testing


this aims on fixing the bug that only the first material that a division produces limit gets used and others get ignored
this also tries to limit the actual production on the highest limit 
if a div produces 2 materials a and b 
and a is limited to 100 and b to 1000 but it could produce 2000 
then it should only buy stuff for 1000 and 900 a would be voided