### PR TITLE
DOCS: add GetMemberInfo object missing descriptions

### DIFF
--- a/markdown/bitburner.gangmemberinfo.agi_asc_points.md
+++ b/markdown/bitburner.gangmemberinfo.agi_asc_points.md
@@ -4,7 +4,7 @@
 
 ## GangMemberInfo.agi\_asc\_points property
 
-Total earned agility experience
+Total Agility Ascension points accumulated
 
 **Signature:**
 

--- a/markdown/bitburner.gangmemberinfo.augmentations.md
+++ b/markdown/bitburner.gangmemberinfo.augmentations.md
@@ -4,6 +4,8 @@
 
 ## GangMemberInfo.augmentations property
 
+List of all Augmentations currently installed on gang member
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.gangmemberinfo.cha_asc_points.md
+++ b/markdown/bitburner.gangmemberinfo.cha_asc_points.md
@@ -4,7 +4,7 @@
 
 ## GangMemberInfo.cha\_asc\_points property
 
-Total earned charisma experience
+Total Charisma Ascension points accumulated
 
 **Signature:**
 

--- a/markdown/bitburner.gangmemberinfo.def_asc_points.md
+++ b/markdown/bitburner.gangmemberinfo.def_asc_points.md
@@ -4,7 +4,7 @@
 
 ## GangMemberInfo.def\_asc\_points property
 
-Total earned defense experience
+Total Defense Ascension points accumulated
 
 **Signature:**
 

--- a/markdown/bitburner.gangmemberinfo.dex_asc_points.md
+++ b/markdown/bitburner.gangmemberinfo.dex_asc_points.md
@@ -4,7 +4,7 @@
 
 ## GangMemberInfo.dex\_asc\_points property
 
-Total earned dexterity experience
+Total Dexterity Ascension points accumulated
 
 **Signature:**
 

--- a/markdown/bitburner.gangmemberinfo.earnedrespect.md
+++ b/markdown/bitburner.gangmemberinfo.earnedrespect.md
@@ -4,6 +4,8 @@
 
 ## GangMemberInfo.earnedRespect property
 
+Amount of Respect earned by member since they last Ascended
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.gangmemberinfo.hack_asc_points.md
+++ b/markdown/bitburner.gangmemberinfo.hack_asc_points.md
@@ -4,7 +4,7 @@
 
 ## GangMemberInfo.hack\_asc\_points property
 
-Total earned hack experience
+Total Hack Ascension points accumulated
 
 **Signature:**
 

--- a/markdown/bitburner.gangmemberinfo.md
+++ b/markdown/bitburner.gangmemberinfo.md
@@ -16,29 +16,29 @@ interface GangMemberInfo
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
 |  [agi\_asc\_mult](./bitburner.gangmemberinfo.agi_asc_mult.md) |  | number | Agility multiplier from ascensions |
-|  [agi\_asc\_points](./bitburner.gangmemberinfo.agi_asc_points.md) |  | number | Total earned agility experience |
+|  [agi\_asc\_points](./bitburner.gangmemberinfo.agi_asc_points.md) |  | number | Total Agility Ascension points accumulated |
 |  [agi\_exp](./bitburner.gangmemberinfo.agi_exp.md) |  | number | Current agility experience |
 |  [agi\_mult](./bitburner.gangmemberinfo.agi_mult.md) |  | number | Agility multiplier from equipment |
 |  [agi](./bitburner.gangmemberinfo.agi.md) |  | number | Agility skill level |
 |  [augmentations](./bitburner.gangmemberinfo.augmentations.md) |  | string\[\] | List of all Augmentations currently installed on gang member |
 |  [cha\_asc\_mult](./bitburner.gangmemberinfo.cha_asc_mult.md) |  | number | Charisma multiplier from ascensions |
-|  [cha\_asc\_points](./bitburner.gangmemberinfo.cha_asc_points.md) |  | number | Total earned charisma experience |
+|  [cha\_asc\_points](./bitburner.gangmemberinfo.cha_asc_points.md) |  | number | Total Charisma Ascension points accumulated |
 |  [cha\_exp](./bitburner.gangmemberinfo.cha_exp.md) |  | number | Current charisma experience |
 |  [cha\_mult](./bitburner.gangmemberinfo.cha_mult.md) |  | number | Charisma multiplier from equipment |
 |  [cha](./bitburner.gangmemberinfo.cha.md) |  | number | Charisma skill level |
 |  [def\_asc\_mult](./bitburner.gangmemberinfo.def_asc_mult.md) |  | number | Defense multiplier from ascensions |
-|  [def\_asc\_points](./bitburner.gangmemberinfo.def_asc_points.md) |  | number | Total earned defense experience |
+|  [def\_asc\_points](./bitburner.gangmemberinfo.def_asc_points.md) |  | number | Total Defense Ascension points accumulated |
 |  [def\_exp](./bitburner.gangmemberinfo.def_exp.md) |  | number | Current defense experience |
 |  [def\_mult](./bitburner.gangmemberinfo.def_mult.md) |  | number | Defense multiplier from equipment |
 |  [def](./bitburner.gangmemberinfo.def.md) |  | number | Defense skill level |
 |  [dex\_asc\_mult](./bitburner.gangmemberinfo.dex_asc_mult.md) |  | number | Dexterity multiplier from ascensions |
-|  [dex\_asc\_points](./bitburner.gangmemberinfo.dex_asc_points.md) |  | number | Total earned dexterity experience |
+|  [dex\_asc\_points](./bitburner.gangmemberinfo.dex_asc_points.md) |  | number | Total Dexterity Ascension points accumulated |
 |  [dex\_exp](./bitburner.gangmemberinfo.dex_exp.md) |  | number | Current dexterity experience |
 |  [dex\_mult](./bitburner.gangmemberinfo.dex_mult.md) |  | number | Dexterity multiplier from equipment |
 |  [dex](./bitburner.gangmemberinfo.dex.md) |  | number | Dexterity skill level |
 |  [earnedRespect](./bitburner.gangmemberinfo.earnedrespect.md) |  | number | Amount of Respect earned by member since they last Ascended |
 |  [hack\_asc\_mult](./bitburner.gangmemberinfo.hack_asc_mult.md) |  | number | Hack multiplier from ascensions |
-|  [hack\_asc\_points](./bitburner.gangmemberinfo.hack_asc_points.md) |  | number | Total earned hack experience |
+|  [hack\_asc\_points](./bitburner.gangmemberinfo.hack_asc_points.md) |  | number | Total Hack Ascension points accumulated |
 |  [hack\_exp](./bitburner.gangmemberinfo.hack_exp.md) |  | number | Current hack experience |
 |  [hack\_mult](./bitburner.gangmemberinfo.hack_mult.md) |  | number | Hack multiplier from equipment |
 |  [hack](./bitburner.gangmemberinfo.hack.md) |  | number | Hack skill level |
@@ -46,7 +46,7 @@ interface GangMemberInfo
 |  [name](./bitburner.gangmemberinfo.name.md) |  | string | Name of the gang member |
 |  [respectGain](./bitburner.gangmemberinfo.respectgain.md) |  | number | Per Cycle Rate this member is currently gaining Respect |
 |  [str\_asc\_mult](./bitburner.gangmemberinfo.str_asc_mult.md) |  | number | Strength multiplier from ascensions |
-|  [str\_asc\_points](./bitburner.gangmemberinfo.str_asc_points.md) |  | number | Total earned strength experience |
+|  [str\_asc\_points](./bitburner.gangmemberinfo.str_asc_points.md) |  | number | Total Strength Ascension points accumulated |
 |  [str\_exp](./bitburner.gangmemberinfo.str_exp.md) |  | number | Current strength experience |
 |  [str\_mult](./bitburner.gangmemberinfo.str_mult.md) |  | number | Strength multiplier from equipment |
 |  [str](./bitburner.gangmemberinfo.str.md) |  | number | Strength skill level |

--- a/markdown/bitburner.gangmemberinfo.md
+++ b/markdown/bitburner.gangmemberinfo.md
@@ -20,7 +20,7 @@ interface GangMemberInfo
 |  [agi\_exp](./bitburner.gangmemberinfo.agi_exp.md) |  | number | Current agility experience |
 |  [agi\_mult](./bitburner.gangmemberinfo.agi_mult.md) |  | number | Agility multiplier from equipment |
 |  [agi](./bitburner.gangmemberinfo.agi.md) |  | number | Agility skill level |
-|  [augmentations](./bitburner.gangmemberinfo.augmentations.md) |  | string\[\] |  |
+|  [augmentations](./bitburner.gangmemberinfo.augmentations.md) |  | string\[\] | List of all Augmentations currently installed on gang member |
 |  [cha\_asc\_mult](./bitburner.gangmemberinfo.cha_asc_mult.md) |  | number | Charisma multiplier from ascensions |
 |  [cha\_asc\_points](./bitburner.gangmemberinfo.cha_asc_points.md) |  | number | Total earned charisma experience |
 |  [cha\_exp](./bitburner.gangmemberinfo.cha_exp.md) |  | number | Current charisma experience |
@@ -36,21 +36,21 @@ interface GangMemberInfo
 |  [dex\_exp](./bitburner.gangmemberinfo.dex_exp.md) |  | number | Current dexterity experience |
 |  [dex\_mult](./bitburner.gangmemberinfo.dex_mult.md) |  | number | Dexterity multiplier from equipment |
 |  [dex](./bitburner.gangmemberinfo.dex.md) |  | number | Dexterity skill level |
-|  [earnedRespect](./bitburner.gangmemberinfo.earnedrespect.md) |  | number |  |
+|  [earnedRespect](./bitburner.gangmemberinfo.earnedrespect.md) |  | number | Amount of Respect earned by member since they last Ascended |
 |  [hack\_asc\_mult](./bitburner.gangmemberinfo.hack_asc_mult.md) |  | number | Hack multiplier from ascensions |
 |  [hack\_asc\_points](./bitburner.gangmemberinfo.hack_asc_points.md) |  | number | Total earned hack experience |
 |  [hack\_exp](./bitburner.gangmemberinfo.hack_exp.md) |  | number | Current hack experience |
 |  [hack\_mult](./bitburner.gangmemberinfo.hack_mult.md) |  | number | Hack multiplier from equipment |
 |  [hack](./bitburner.gangmemberinfo.hack.md) |  | number | Hack skill level |
-|  [moneyGain](./bitburner.gangmemberinfo.moneygain.md) |  | number |  |
+|  [moneyGain](./bitburner.gangmemberinfo.moneygain.md) |  | number | Per Cycle Income for this gang member |
 |  [name](./bitburner.gangmemberinfo.name.md) |  | string | Name of the gang member |
-|  [respectGain](./bitburner.gangmemberinfo.respectgain.md) |  | number |  |
+|  [respectGain](./bitburner.gangmemberinfo.respectgain.md) |  | number | Per Cycle Rate this member is currently gaining Respect |
 |  [str\_asc\_mult](./bitburner.gangmemberinfo.str_asc_mult.md) |  | number | Strength multiplier from ascensions |
 |  [str\_asc\_points](./bitburner.gangmemberinfo.str_asc_points.md) |  | number | Total earned strength experience |
 |  [str\_exp](./bitburner.gangmemberinfo.str_exp.md) |  | number | Current strength experience |
 |  [str\_mult](./bitburner.gangmemberinfo.str_mult.md) |  | number | Strength multiplier from equipment |
 |  [str](./bitburner.gangmemberinfo.str.md) |  | number | Strength skill level |
 |  [task](./bitburner.gangmemberinfo.task.md) |  | string | Currently assigned task |
-|  [upgrades](./bitburner.gangmemberinfo.upgrades.md) |  | string\[\] |  |
-|  [wantedLevelGain](./bitburner.gangmemberinfo.wantedlevelgain.md) |  | number |  |
+|  [upgrades](./bitburner.gangmemberinfo.upgrades.md) |  | string\[\] | List of all non-Augmentation Equipment owned by gang member |
+|  [wantedLevelGain](./bitburner.gangmemberinfo.wantedlevelgain.md) |  | number | Per Cycle Rate by which this gang member is affecting your gang's Wanted Level |
 

--- a/markdown/bitburner.gangmemberinfo.md
+++ b/markdown/bitburner.gangmemberinfo.md
@@ -52,5 +52,5 @@ interface GangMemberInfo
 |  [str](./bitburner.gangmemberinfo.str.md) |  | number | Strength skill level |
 |  [task](./bitburner.gangmemberinfo.task.md) |  | string | Currently assigned task |
 |  [upgrades](./bitburner.gangmemberinfo.upgrades.md) |  | string\[\] | List of all non-Augmentation Equipment owned by gang member |
-|  [wantedLevelGain](./bitburner.gangmemberinfo.wantedlevelgain.md) |  | number | Per Cycle Rate by which this gang member is affecting your gang's Wanted Level |
+|  [wantedLevelGain](./bitburner.gangmemberinfo.wantedlevelgain.md) |  | number | Per Cycle Rate by which this member is affecting your gang's Wanted Level |
 

--- a/markdown/bitburner.gangmemberinfo.moneygain.md
+++ b/markdown/bitburner.gangmemberinfo.moneygain.md
@@ -4,6 +4,8 @@
 
 ## GangMemberInfo.moneyGain property
 
+Per Cycle Income for this gang member
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.gangmemberinfo.respectgain.md
+++ b/markdown/bitburner.gangmemberinfo.respectgain.md
@@ -4,6 +4,8 @@
 
 ## GangMemberInfo.respectGain property
 
+Per Cycle Rate this member is currently gaining Respect
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.gangmemberinfo.str_asc_points.md
+++ b/markdown/bitburner.gangmemberinfo.str_asc_points.md
@@ -4,7 +4,7 @@
 
 ## GangMemberInfo.str\_asc\_points property
 
-Total earned strength experience
+Total Strength Ascension points accumulated
 
 **Signature:**
 

--- a/markdown/bitburner.gangmemberinfo.upgrades.md
+++ b/markdown/bitburner.gangmemberinfo.upgrades.md
@@ -4,6 +4,8 @@
 
 ## GangMemberInfo.upgrades property
 
+List of all non-Augmentation Equipment owned by gang member
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.gangmemberinfo.wantedlevelgain.md
+++ b/markdown/bitburner.gangmemberinfo.wantedlevelgain.md
@@ -4,6 +4,8 @@
 
 ## GangMemberInfo.wantedLevelGain property
 
+Per Cycle Rate by which this gang member is affecting your gang's Wanted Level
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.gangmemberinfo.wantedlevelgain.md
+++ b/markdown/bitburner.gangmemberinfo.wantedlevelgain.md
@@ -4,7 +4,7 @@
 
 ## GangMemberInfo.wantedLevelGain property
 
-Per Cycle Rate by which this gang member is affecting your gang's Wanted Level
+Per Cycle Rate by which this member is affecting your gang's Wanted Level
 
 **Signature:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -870,6 +870,7 @@ interface GangMemberInfo {
   name: string;
   /** Currently assigned task */
   task: string;
+  /** Amount of Respect earned by member since they last Ascended */
   earnedRespect: number;
 
   /** Hack skill level */
@@ -937,11 +938,16 @@ interface GangMemberInfo {
   /** Total earned charisma experience */
   cha_asc_points: number;
 
+  /** List of all non-Augmentation Equipment owned by gang member */
   upgrades: string[];
+  /** List of all Augmentations currently installed on gang member */
   augmentations: string[];
 
+  /** Per Cycle Rate this member is currently gaining Respect */
   respectGain: number;
+  /** Per Cycle Rate by which this gang member is affecting your gang's Wanted Level */
   wantedLevelGain: number;
+  /** Per Cycle Income for this gang member */
   moneyGain: number;
 }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -945,7 +945,7 @@ interface GangMemberInfo {
 
   /** Per Cycle Rate this member is currently gaining Respect */
   respectGain: number;
-  /** Per Cycle Rate by which this gang member is affecting your gang's Wanted Level */
+  /** Per Cycle Rate by which this member is affecting your gang's Wanted Level */
   wantedLevelGain: number;
   /** Per Cycle Income for this gang member */
   moneyGain: number;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -925,17 +925,17 @@ interface GangMemberInfo {
   /** Charisma multiplier from ascensions */
   cha_asc_mult: number;
 
-  /** Total earned hack experience */
+  /** Total Hack Ascension points accumulated */
   hack_asc_points: number;
-  /** Total earned strength experience */
+  /** Total Strength Ascension points accumulated */
   str_asc_points: number;
-  /** Total earned defense experience */
+  /** Total Defense Ascension points accumulated */
   def_asc_points: number;
-  /** Total earned dexterity experience */
+  /** Total Dexterity Ascension points accumulated */
   dex_asc_points: number;
-  /** Total earned agility experience */
+  /** Total Agility Ascension points accumulated */
   agi_asc_points: number;
-  /** Total earned charisma experience */
+  /** Total Charisma Ascension points accumulated */
   cha_asc_points: number;
 
   /** List of all non-Augmentation Equipment owned by gang member */


### PR DESCRIPTION
PR based on player confusion
![Let's change  upgrades to  equipment](https://github.com/bitburner-official/bitburner-src/assets/141260118/19f4182e-d72e-4840-b773-6357c8c4cc36)

In RTD-beta docs the property was `.equipment`, and at some point changed to `.upgrades`. Obviously RTD is not relevant anymore, but most of the in-game text uses "Equipment", so the reason for the change isn't clear to me. However, the "Upgrades" idea is now heavily baked in, and (at first glance) not worth changing. E.g...
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/f7be17d2-f777-4694-83e7-47bb8dd22010)

Instead of renaming anything, I've added missing descriptions, and context that rates are per cycle (ie multiply by 5 or 20 or whatever to match the per second rate shown on GangMemberCard). 

I chose a very vague description for the `asc_points` properties, for example "Total Hack Ascension points accumulated". It's not clear to me what exactly the value represents, but the old descriptions say "Total earned {skill} experience", which is misleading. Open to suggestions.

And no periods because it followed the style of the existing descriptions in that section lol.

Demo : https://github.com/myCatsName/bitburner-src/blob/getMemberInfo-missing-descriptions/markdown/bitburner.gangmemberinfo.md


