### PR TITLE
UI: Add filter to faction augmentation purchase page

### DIFF
--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { Box, Button, Tooltip, Typography, Paper, Container, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 
@@ -23,19 +23,23 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
   const rerender = useRerender(400);
   const [filterText, setFilterText] = useState("");
 
-  function getAugs(): AugmentationName[] {
-    return getFactionAugmentationsFiltered(faction).filter(
-      (aug: AugmentationName) =>
-        !filterText ||
-        matches(Augmentations[aug].name, filterText) ||
-        matches(Augmentations[aug].info, filterText) ||
-        matches(Augmentations[aug].stats, filterText),
-    );
-  }
+  const matches = (s1: string, s2: string) => s1.toLowerCase().includes(s2.toLowerCase());
+  const factionAugs = useMemo(() => getFactionAugmentationsFiltered(faction), [faction]);
+  const filteredFactionAugs = useMemo(
+    () =>
+      factionAugs.filter(
+        (aug: AugmentationName) =>
+          !filterText ||
+          matches(Augmentations[aug].name, filterText) ||
+          matches(Augmentations[aug].info, filterText) ||
+          matches(Augmentations[aug].stats, filterText),
+      ),
+    [filterText, factionAugs],
+  );
 
-  const matches = (s1: string, s2: string) => {
-    return s1.toLowerCase().includes(s2.toLowerCase());
-  };
+  function getAugs(): AugmentationName[] {
+    return filteredFactionAugs;
+  }
 
   function getAugsSorted(): AugmentationName[] {
     switch (Settings.PurchaseAugmentationsOrder) {

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { Box, Button, Tooltip, Typography, Paper, Container } from "@mui/material";
+import React, { useState } from "react";
+import { Box, Button, Tooltip, Typography, Paper, Container, TextField } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
 
 import { Augmentations } from "../../Augmentation/Augmentations";
 import { getAugCost, getGenericAugmentationPriceMultiplier } from "../../Augmentation/AugmentationHelpers";
@@ -20,10 +21,21 @@ import { useRerender } from "../../ui/React/hooks";
 /** Root React Component for displaying a faction's "Purchase Augmentations" page */
 export function AugmentationsPage({ faction }: { faction: Faction }): React.ReactElement {
   const rerender = useRerender(400);
+  const [filterText, setFilterText] = useState("");
 
   function getAugs(): AugmentationName[] {
-    return getFactionAugmentationsFiltered(faction);
+    return getFactionAugmentationsFiltered(faction).filter(
+      (aug: AugmentationName) =>
+        !filterText ||
+        matches(Augmentations[aug].name, filterText) ||
+        matches(Augmentations[aug].info, filterText) ||
+        matches(Augmentations[aug].stats, filterText),
+    );
   }
+
+  const matches = (s1: string, s2: string) => {
+    return s1.toLowerCase().indexOf(s2.toLowerCase()) !== -1;
+  };
 
   function getAugsSorted(): AugmentationName[] {
     switch (Settings.PurchaseAugmentationsOrder) {
@@ -111,6 +123,10 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
   function switchSortOrder(newOrder: PurchaseAugmentationsOrderSetting): void {
     Settings.PurchaseAugmentationsOrder = newOrder;
     rerender();
+  }
+
+  function handleFilterChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    setFilterText(event.target.value);
   }
 
   const augs = getAugsSorted();
@@ -202,6 +218,19 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
               Sort by Purchasable
             </Button>
           </Box>
+          <TextField
+            value={filterText}
+            onChange={handleFilterChange}
+            autoFocus
+            placeholder="Filter augmentations"
+            InputProps={{
+              startAdornment: <SearchIcon />,
+              spellCheck: false,
+            }}
+            style={{
+              paddingTop: "8px",
+            }}
+          />
         </Paper>
       </Container>
 

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -34,7 +34,7 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
   }
 
   const matches = (s1: string, s2: string) => {
-    return s1.toLowerCase().indexOf(s2.toLowerCase()) !== -1;
+    return s1.toLowerCase().includes(s2.toLowerCase());
   };
 
   function getAugsSorted(): AugmentationName[] {

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -227,9 +227,7 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
               startAdornment: <SearchIcon />,
               spellCheck: false,
             }}
-            style={{
-              paddingTop: "8px",
-            }}
+            sx={{ pt: 1 }}
           />
         </Paper>
       </Container>


### PR DESCRIPTION
Currently, the only way to identify which augmentations are helpful for your current goal (e.g. gain hacking level) is to slowly mouse over each one to see its stats and description. This can become VERY tedious, especially once you are dealing with a gang with dozens and dozens of augments on offer, and when you only need certain stats in the current bitnode.

This change adds a filter box to the augmentation purchase screen for factions, allowing users to narrow down the displayed augmentations to only the ones they are looking for. This feature works with the sort options; you can sort your filtered result by cost, rep, etc. The filter is cleared upon exiting the faction aug purchase screen, preventing it from getting "stuck" and hiding important augs from the player if they forgot about it or accidentally added some filter text.

Note that this allows the users to also filter for text that is only present in the description, in addition to text in the name and stats; in some cases this may clutter the results, but I wanted the feature to be as flexible as possible.


For example, this filters the very large list down to a manageable few that help with crime success rates:
![Screenshot 2023-09-06 143403](https://github.com/bitburner-official/bitburner-src/assets/1338468/2a4d4dc8-7d3e-4a1e-9bdf-4397c220a363)


Placeholder text gives the user a hint as to what it does when empty:
![image](https://github.com/bitburner-official/bitburner-src/assets/1338468/bb870789-5dfe-44b4-a5d2-3fc647eb37e7)

