### PR TITLE
UI: clear search suggestions on clearall modification

### DIFF
--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -102,11 +102,6 @@ export function TerminalInput(): React.ReactElement {
     return Array(prefixLength).fill(" ");
   }
 
-  function resetSearchSuggestions() {
-    setSearchResults([]);
-    setSearchResultsIndex(0);
-  }
-
   function modifyInput(mod: Modification): void {
     const ref = terminalInput.current;
     if (!ref) return;
@@ -155,7 +150,7 @@ export function TerminalInput(): React.ReactElement {
         break;
       case "clearall": // Deletes everything in the input
         saveValue("");
-        resetSearchSuggestions();
+        resetSearch();
         break;
     }
   }

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -102,7 +102,12 @@ export function TerminalInput(): React.ReactElement {
     return Array(prefixLength).fill(" ");
   }
 
-  function modifyInput(mod: string): void {
+  function resetSearchSuggestions() {
+    setSearchResults([]);
+    setSearchResultsIndex(0);
+  }
+
+  function modifyInput(mod: Modification): void {
     const ref = terminalInput.current;
     if (!ref) return;
     const inputLength = value.length;
@@ -110,7 +115,7 @@ export function TerminalInput(): React.ReactElement {
     if (start === null) return;
     const inputText = ref.value;
 
-    switch (mod.toLowerCase()) {
+    switch (mod) {
       case "backspace":
         if (start > 0 && start <= inputLength + 1) {
           saveValue(inputText.substr(0, start - 1) + inputText.substr(start));
@@ -150,18 +155,19 @@ export function TerminalInput(): React.ReactElement {
         break;
       case "clearall": // Deletes everything in the input
         saveValue("");
+        resetSearchSuggestions();
         break;
     }
   }
 
-  function moveTextCursor(loc: string): void {
+  function moveTextCursor(loc: Location): void {
     const ref = terminalInput.current;
     if (!ref) return;
     const inputLength = value.length;
     const start = ref.selectionStart;
     if (start === null) return;
 
-    switch (loc.toLowerCase()) {
+    switch (loc) {
       case "home":
         ref.setSelectionRange(0, 0);
         break;
@@ -461,3 +467,18 @@ export function TerminalInput(): React.ReactElement {
     </>
   );
 }
+
+type Modification =
+  | "clearall"
+  | "home"
+  | "end"
+  | "prevchar"
+  | "prevword"
+  | "nextword"
+  | "backspace"
+  | "deletewordbefore"
+  | "deletewordafter"
+  | "clearbefore"
+  | "clearafter";
+
+type Location = "home" | "end" | "prevchar" | "nextchar" | "prevword" | "nextword";


### PR DESCRIPTION
# UI: clear search suggestions on "clearall" terminal modification

(this also adds types for `modifyInput()` and `moveTextCursor()` functions)

## Testing steps
- turn on settings (Misc » Bash & Misc » Terminal History)
- type several commands in the terminal with same prefix ( ie "run")
- clear terminal
- type prefix
- hit up arrow & see suggestions
- hit ctrl + c
- notice that the suggestion is still present

## GIFs
### Prod
![bb-clr-trmnl-prod](https://github.com/bitburner-official/bitburner-src/assets/38120002/0ab4291f-f068-449a-b314-da183b4385bb)

### Dev
![bb-clr-trmnl-dev](https://github.com/bitburner-official/bitburner-src/assets/38120002/2aff228a-b2c3-46d8-99cb-3fd80b1aa440)

