### PR TITLE
UI: Rename gang territory task to avoid confusion with other similarly-named mechanics

### DIFF
--- a/src/Documentation/doc/advanced/gang.md
+++ b/src/Documentation/doc/advanced/gang.md
@@ -6,7 +6,7 @@ Seen by most of the population as nihilistic, murderous and vile, occassional ru
 
 ## Starting and Recruiting
 
-Outside of [BitNode-2](bitnodes.md) gangs require much more crime and heartbreak to create, but can still be a great help. Creating a Gang in other [BitNodes](bitnodes.md) will offer more [Augmentations](../basic/augmentations.md) than other [Factions](factions.md), but they will not be a way to destroy the [BitNode](bitnodes.md) alone.
+Outside of [BitNode-2](bitnodes.md) gangs require much more crime and heartbreak to create, but can still be a great help. Creating a Gang in other [BitNodes](bitnodes.md) will offer more [Augmentations](../basic/augmentations.md) than other [Factions](../basic/factions.md), but they will not be a way to destroy the [BitNode](bitnodes.md) alone.
 
 After creating a gang, you will be able to start recruiting, adding members to your gang as you gain Respect. While in a BitNode, your gang and gang member stats will not reset if you install augmentations.
 
@@ -30,6 +30,6 @@ Active gang members earn stats, respect and money based on their current stats, 
 
 Your gang's "Wanted Level" can make tasks much less productive, and is affected by the tasks assigned to gang members. "Ethical Hacking" or "Vigilante Justice" tasks can lower Wanted Level.
 
-"Territory Warfare" is a special task that builds Power for your gang. If "Territory Battles" is enabled [see the Territory subpage of your Gang page], members have a chance to win or lose territory by clashing with other gangs. The % of Territory you control affects most aspects of your gang productivity.
+"Territory Warfare" is a special task that builds Power for your gang. If "Territory Clashes" is enabled [see the Territory subpage of your Gang page], members have a chance to win or lose territory by clashing with other gangs. The % of Territory you control affects most aspects of your gang productivity.
 
 Note that gang members can die during clashes, even if your gang wins.

--- a/src/Documentation/doc/advanced/gang.md
+++ b/src/Documentation/doc/advanced/gang.md
@@ -30,6 +30,6 @@ Active gang members earn stats, respect and money based on their current stats, 
 
 Your gang's "Wanted Level" can make tasks much less productive, and is affected by the tasks assigned to gang members. "Ethical Hacking" or "Vigilante Justice" tasks can lower Wanted Level.
 
-"Territory Warfare" is a special task that builds Power for your gang. If "Territory Warfare" is enabled [see the Territory subpage of your Gang page], members have a chance to win or lose territory by clashing with other gangs. The % of Territory you control affects most aspects of your gang productivity.
+"Territory Warfare" is a special task that builds Power for your gang. If "Territory Battles" is enabled [see the Territory subpage of your Gang page], members have a chance to win or lose territory by clashing with other gangs. The % of Territory you control affects most aspects of your gang productivity.
 
 Note that gang members can die during clashes, even if your gang wins.

--- a/src/Documentation/doc/advanced/gang.md
+++ b/src/Documentation/doc/advanced/gang.md
@@ -30,6 +30,6 @@ Active gang members earn stats, respect and money based on their current stats, 
 
 Your gang's "Wanted Level" can make tasks much less productive, and is affected by the tasks assigned to gang members. "Ethical Hacking" or "Vigilante Justice" tasks can lower Wanted Level.
 
-"Territory Warfare" is a special task that builds Power for your gang. If "Territory Clashes" is enabled [see the Territory subpage of your Gang page], members have a chance to win or lose territory by clashing with other gangs. The % of Territory you control affects most aspects of your gang productivity.
+"Territory Warfare" is a special task that builds Power for your gang. If "Territory Clashes" are enabled [see the Territory subpage of your Gang page], members have a chance to win or lose territory by clashing with other gangs. The % of Territory you control affects most aspects of your gang productivity.
 
 Note that gang members can die during clashes, even if your gang wins.

--- a/src/Gang/data/tasks.ts
+++ b/src/Gang/data/tasks.ts
@@ -379,7 +379,7 @@ export const gangMemberTasksMetadata: IGangMemberTaskMetadata[] = [
     params: { chaWeight: 100, difficulty: 8 },
   },
   {
-    desc: "Members assigned to this task increase your gang's power. They will also fight for territory if 'Territory Clashes' is engaged.<br><br>Note that gang members can be killed while assigned this task during clashes.",
+    desc: "Members assigned to this task increase your gang's power. They will also fight for territory if 'Territory Clashes' are enabled.<br /><br />Gang members performing this task can be killed during clashes.",
     isCombat: true,
     isHacking: true,
     name: "Territory Warfare",

--- a/src/Gang/data/tasks.ts
+++ b/src/Gang/data/tasks.ts
@@ -379,7 +379,7 @@ export const gangMemberTasksMetadata: IGangMemberTaskMetadata[] = [
     params: { chaWeight: 100, difficulty: 8 },
   },
   {
-    desc: "Members assigned to this task increase your gang's power and will fight for territory if 'Territory Warfare' is engaged. Note that gang members can be killed while assigned this task.",
+    desc: "Members assigned to this task increase your gang's power, and will fight for territory if 'Territory Battles' is engaged.<br><br>Note that gang members can be killed while assigned this task during clashes.",
     isCombat: true,
     isHacking: true,
     name: "Territory Warfare",

--- a/src/Gang/data/tasks.ts
+++ b/src/Gang/data/tasks.ts
@@ -379,7 +379,7 @@ export const gangMemberTasksMetadata: IGangMemberTaskMetadata[] = [
     params: { chaWeight: 100, difficulty: 8 },
   },
   {
-    desc: "Members assigned to this task increase your gang's power, and will fight for territory if 'Territory Battles' is engaged.<br><br>Note that gang members can be killed while assigned this task during clashes.",
+    desc: "Members assigned to this task increase your gang's power. They will also fight for territory if 'Territory Clashes' is engaged.<br><br>Note that gang members can be killed while assigned this task during clashes.",
     isCombat: true,
     isHacking: true,
     name: "Territory Warfare",

--- a/src/Gang/ui/ManagementSubpage.tsx
+++ b/src/Gang/ui/ManagementSubpage.tsx
@@ -41,12 +41,12 @@ export function ManagementSubpage(): React.ReactElement {
           <Tooltip
             title={
               <Typography>
-                Engaging in Territory Warfare sets your clash chance to 100%. Disengaging will cause your clash chance
+                Engaging in Territory Battles sets your clash chance to 100%. Disengaging will cause your clash chance
                 to gradually decrease until it reaches 0%. See the "Territory" subpage for more information.
               </Typography>
             }
           >
-            <Typography>Engage in Territory Warfare</Typography>
+            <Typography>Engage in Territory Battles</Typography>
           </Tooltip>
         }
       />

--- a/src/Gang/ui/ManagementSubpage.tsx
+++ b/src/Gang/ui/ManagementSubpage.tsx
@@ -41,12 +41,12 @@ export function ManagementSubpage(): React.ReactElement {
           <Tooltip
             title={
               <Typography>
-                Engaging in Territory Battles sets your clash chance to 100%. Disengaging will cause your clash chance
+                Engaging in Territory Clashes sets your clash chance to 100%. Disengaging will cause your clash chance
                 to gradually decrease until it reaches 0%. See the "Territory" subpage for more information.
               </Typography>
             }
           >
-            <Typography>Engage in Territory Battles</Typography>
+            <Typography>Engage in Territory Clashes</Typography>
           </Tooltip>
         }
       />

--- a/src/Gang/ui/TerritoryInfoModal.tsx
+++ b/src/Gang/ui/TerritoryInfoModal.tsx
@@ -34,13 +34,13 @@ export const TerritoryInfoModal = ({ open, onClose }: IProps): React.ReactElemen
           <br />
           <br />
           To increase your chances of winning territory, assign gang members to "Territory Warfare". This will build
-          your gang power. Then, enable "Engage in Territory Battles" to start fighting over territory.
+          your gang power. Then, enable "Engage in Territory Clashes" to start fighting over territory.
         </Typography>
         <br />
         <Typography variant="h4">Territory Clash Chance</Typography>
         <Typography>
           This percentage represents the chance you have of 'clashing' with another gang. If you do not wish to
-          gain/lose territory, then keep this percentage at 0% by not Engaging in Territory Battles.
+          gain/lose territory, then keep this percentage at 0% by not Engaging in Territory Clashes.
         </Typography>
       </>
     </Modal>

--- a/src/Gang/ui/TerritoryInfoModal.tsx
+++ b/src/Gang/ui/TerritoryInfoModal.tsx
@@ -34,13 +34,13 @@ export const TerritoryInfoModal = ({ open, onClose }: IProps): React.ReactElemen
           <br />
           <br />
           To increase your chances of winning territory, assign gang members to "Territory Warfare". This will build
-          your gang power. Then, enable "Engage in Territory Warfare" to start fighting over territory.
+          your gang power. Then, enable "Engage in Territory Battles" to start fighting over territory.
         </Typography>
         <br />
         <Typography variant="h4">Territory Clash Chance</Typography>
         <Typography>
           This percentage represents the chance you have of 'clashing' with another gang. If you do not wish to
-          gain/lose territory, then keep this percentage at 0% by not engaging in territory warfare.
+          gain/lose territory, then keep this percentage at 0% by not Engaging in Territory Battles.
         </Typography>
       </>
     </Modal>

--- a/src/Gang/ui/TerritorySubpage.tsx
+++ b/src/Gang/ui/TerritorySubpage.tsx
@@ -44,12 +44,12 @@ export function TerritorySubpage(): React.ReactElement {
             <Tooltip
               title={
                 <Typography>
-                  Engaging in Territory Battles sets your clash chance to 100%. Disengaging will cause your clash chance
+                  Engaging in Territory Clashes sets your clash chance to 100%. Disengaging will cause your clash chance
                   to gradually decrease until it reaches 0%.
                 </Typography>
               }
             >
-              <Typography>Engage in Territory Battles</Typography>
+              <Typography>Engage in Territory Clashes</Typography>
             </Tooltip>
           }
         />

--- a/src/Gang/ui/TerritorySubpage.tsx
+++ b/src/Gang/ui/TerritorySubpage.tsx
@@ -44,12 +44,12 @@ export function TerritorySubpage(): React.ReactElement {
             <Tooltip
               title={
                 <Typography>
-                  Engaging in Territory Warfare sets your clash chance to 100%. Disengaging will cause your clash chance
+                  Engaging in Territory Battles sets your clash chance to 100%. Disengaging will cause your clash chance
                   to gradually decrease until it reaches 0%.
                 </Typography>
               }
             >
-              <Typography>Engage in Territory Warfare</Typography>
+              <Typography>Engage in Territory Battles</Typography>
             </Tooltip>
           }
         />

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -783,7 +783,7 @@ interface GangGenInfo {
   wantedLevel: number;
   /** Wanted level gained/lost per game cycle (negative for losses) */
   wantedLevelGainRate: number;
-  /** Indicating if territory battles is enabled */
+  /** Indicating if territory clashes is enabled */
   territoryWarfareEngaged: boolean;
   /** Number indicating the current wanted penalty */
   wantedPenalty: number;
@@ -3626,13 +3626,13 @@ export interface Gang {
   getAscensionResult(memberName: string): GangMemberAscension | undefined;
 
   /**
-   * Enable/Disable territory battles.
+   * Enable/Disable territory clashes.
    * @remarks
    * RAM cost: 2 GB
    *
-   * Set whether or not the gang should engage in territory battles
+   * Set whether or not the gang should engage in territory clashes
    *
-   * @param engage - Whether or not to engage in territory battles.
+   * @param engage - Whether or not to engage in territory clashes.
    */
   setTerritoryWarfare(engage: boolean): void;
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -783,7 +783,7 @@ interface GangGenInfo {
   wantedLevel: number;
   /** Wanted level gained/lost per game cycle (negative for losses) */
   wantedLevelGainRate: number;
-  /** Indicating if territory clashes is enabled */
+  /** Indicating if territory clashes are enabled */
   territoryWarfareEngaged: boolean;
   /** Number indicating the current wanted penalty */
   wantedPenalty: number;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -783,7 +783,7 @@ interface GangGenInfo {
   wantedLevel: number;
   /** Wanted level gained/lost per game cycle (negative for losses) */
   wantedLevelGainRate: number;
-  /** Indicating if territory warfare is enabled */
+  /** Indicating if territory battles is enabled */
   territoryWarfareEngaged: boolean;
   /** Number indicating the current wanted penalty */
   wantedPenalty: number;
@@ -3626,13 +3626,13 @@ export interface Gang {
   getAscensionResult(memberName: string): GangMemberAscension | undefined;
 
   /**
-   * Enable/Disable territory warfare.
+   * Enable/Disable territory battles.
    * @remarks
    * RAM cost: 2 GB
    *
-   * Set whether or not the gang should engage in territory warfare
+   * Set whether or not the gang should engage in territory battles
    *
-   * @param engage - Whether or not to engage in territory warfare.
+   * @param engage - Whether or not to engage in territory battles.
    */
   setTerritoryWarfare(engage: boolean): void;
 


### PR DESCRIPTION
The game incentivizes players to make sure their gang members are always engaged (not idle). Currently, one of the things that individual members can be engaged in, is "Territory Warfare". Despite being so engaged, this state is very is different than the "engaged in territory warfare" references in the documents and territory tab. (This caused me quite a lot of Googling on my first gang to try and make sure the greenhorns weren't in danger until I was ready for it!)

To make it more clear that the gang task is distinct (but related) to the state of war the gang can be in, I am proposing to rename the task "Territory Patrol" instead, or some other distinct but clear name. (I welcome input on other wording options!). This gives some association with the territory tab (it is the only task that references "territory") but is also clearly distinct from the clash enabled state.

I have also added some more detail to the task description, to explicitly describe what the task does and how it interacts with warfare.

To make sure this change does not break existing player automation, the gang task API accepts the legacy task name when assigning gang members to this task, to make sure this change does not have detrimental side effects.


![image](https://github.com/bitburner-official/bitburner-src/assets/1338468/9818b028-ff5f-43bf-a8ba-daffb0985759)

