### PR TITLE
HACKNET: Fix spendHashes ignoring count for Company Favor upgrade

### DIFF
--- a/src/Hacknet/HacknetHelpers.tsx
+++ b/src/Hacknet/HacknetHelpers.tsx
@@ -569,7 +569,7 @@ export function purchaseHashUpgrade(upgName: string, upgTarget: string, count = 
           console.error(`Invalid target specified in purchaseHashUpgrade(): ${upgTarget}`);
           throw new Error(`'${upgTarget}' is not a company.`);
         }
-        Companies[upgTarget].favor += 5;
+        Companies[upgTarget].favor += 5 * count;
         break;
       }
       default:


### PR DESCRIPTION
spendHashes() ignored the count parameter for the "Company Favor" upgrade which allowed free upgrades (level == 0) or wasted hashes (level > 1).

closes #791