### PR TITLE
CORPORATION: Fix wrong additive value in office party result message

### DIFF
--- a/src/Corporation/OfficeSpace.ts
+++ b/src/Corporation/OfficeSpace.ts
@@ -96,7 +96,7 @@ export class OfficeSpace {
       if (this.autoParty) {
         this.avgMorale = this.maxMorale;
       } else {
-        // Each 5% multiplier gives an extra flat +1 to morale to make recovering from low morale easier.
+        // Each 10% multiplier gives an extra flat +1 to morale to make recovering from low morale easier.
         const increase = this.partyMult > 1 ? (this.partyMult - 1) * 10 : 0;
         this.avgMorale = ((this.avgMorale - reduction * Math.random()) * perfMult + increase) * this.partyMult;
       }

--- a/src/Corporation/ui/modals/ThrowPartyModal.tsx
+++ b/src/Corporation/ui/modals/ThrowPartyModal.tsx
@@ -38,8 +38,8 @@ export function ThrowPartyModal(props: IProps): React.ReactElement {
       dialogBoxCreate("You don't have enough company funds to throw a party!");
     } else {
       const mult = ThrowParty(corp, props.office, cost);
-      // Each 5% multiplier gives an extra flat +1 to morale to make recovering from low morale easier.
-      const increase = mult > 1 ? (mult - 1) * 0.2 : 0;
+      // Each 10% multiplier gives an extra flat +1 to morale to make recovering from low morale easier.
+      const increase = mult > 1 ? (mult - 1) * 0.1 : 0;
 
       if (mult > 0) {
         dialogBoxCreate(


### PR DESCRIPTION
The additive morale value in the message about the effects of an office party was double the actual value used in the formula. I also corrected two comments referring to the wrong value, but I'm not 100 % sure the comments are wrong and not the formula.

Either way, I changed the message and the comments to match the code. See attached images for an example. Before, the message would have said "increased by 20.00%," which, if it were true, would yield a morale of about 96.5.

closes #793

![fix-party-before](https://github.com/bitburner-official/bitburner-src/assets/26329811/441991d6-0b50-4e42-a354-6b837df09f08)
![fix-party-result](https://github.com/bitburner-official/bitburner-src/assets/26329811/5f9ce14a-d10f-44a5-9611-fd1d0ce9ec21)
![fix-party-after](https://github.com/bitburner-official/bitburner-src/assets/26329811/9042388d-7438-4767-a1cb-05092a6ccff0)
