### PR TITLE
MISC: Format time in ns.sleep log messages

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -236,7 +236,7 @@ export const ns: InternalAPI<NSFull> = {
     (ctx) =>
     (_time = 0) => {
       const time = helpers.number(ctx, "time", _time);
-      helpers.log(ctx, () => `Sleeping for ${time} milliseconds`);
+      helpers.log(ctx, () => `Sleeping for ${convertTimeMsToTimeElapsedString(time, true)}.`);
       return helpers.netscriptDelay(ctx, time).then(function () {
         return Promise.resolve(true);
       });
@@ -245,7 +245,7 @@ export const ns: InternalAPI<NSFull> = {
     (ctx) =>
     (_time = 0) => {
       const time = helpers.number(ctx, "time", _time);
-      helpers.log(ctx, () => `Sleeping for ${time} milliseconds`);
+      helpers.log(ctx, () => `Sleeping for ${convertTimeMsToTimeElapsedString(time, true)}.`);
       return new Promise((resolve) => setTimeout(() => resolve(true), time));
     },
   grow:


### PR DESCRIPTION
Use `convertTimeMsToTimeElapsedString()` in `ns.sleep(ms)` and `ns.asleep(ms)` log messages.

Before:

```
asleep: Sleeping for 3600000 milliseconds
```

After:

```
asleep: Sleeping for 1 hour
```
