### PR TITLE
UI: Issue 53 augs suppressed affects soft reset menu button

### DIFF
--- a/src/Augmentation/ui/AugmentationsRoot.tsx
+++ b/src/Augmentation/ui/AugmentationsRoot.tsx
@@ -163,8 +163,7 @@ export function AugmentationsRoot(props: IProps): React.ReactElement {
                 <br />- home ram and cores
                 <br />
                 <br />
-                It is recommended to install several Augmentations at once. Preferably everything from any faction of
-                your choosing.
+                It is recommended to install several Augmentations at once.
               </>
             }
           />

--- a/src/GameOptions/ui/GameOptionsSidebar.tsx
+++ b/src/GameOptions/ui/GameOptionsSidebar.tsx
@@ -3,7 +3,6 @@ import { Box, Button, List, ListItemButton, Paper, Tooltip, Typography } from "@
 import { default as React, useRef, useState } from "react";
 import { FileDiagnosticModal } from "../../Diagnostic/FileDiagnosticModal";
 import { ImportData, saveObject } from "../../SaveObject";
-import { Settings } from "../../Settings/Settings";
 import { StyleEditorButton } from "../../Themes/ui/StyleEditorButton";
 import { ThemeEditorButton } from "../../Themes/ui/ThemeEditorButton";
 import { ConfirmationModal } from "../../ui/React/ConfirmationModal";
@@ -196,10 +195,7 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
           </Button>
         </Tooltip>
         <Box sx={{ gridArea: "reset", "& .MuiButton-root": { height: "100%", width: "100%" } }}>
-          <SoftResetButton
-            noConfirmation={Settings.SuppressBuyAugmentationConfirmation}
-            onTriggered={props.softReset}
-          />
+          <SoftResetButton onTriggered={props.softReset} />
         </Box>
         <Tooltip
           title={
@@ -267,7 +263,8 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
         open={confirmResetOpen}
         onClose={() => setConfirmResetOpen(false)}
         onConfirm={props.reactivateTutorial}
-        confirmationText={"This will reset all your stats to 1 and money to 1k. Are you sure?"}
+        confirmationText={"Reset your stats and money to start the tutorial? Home scripts will not be reset."}
+        additionalButton={<Button onClick={() => setConfirmResetOpen(false)}>Cancel</Button>}
       />
     </Box>
   );

--- a/src/Locations/ui/TravelAgencyRoot.tsx
+++ b/src/Locations/ui/TravelAgencyRoot.tsx
@@ -31,7 +31,7 @@ function travel(to: CityName): void {
 
   Player.loseMoney(cost, "other");
   Player.travel(to);
-  dialogBoxCreate(`You are now in ${to}!`);
+  if (!Settings.SuppressTravelConfirmation) dialogBoxCreate(`You are now in ${to}!`);
   Router.toPage(Page.City);
 }
 

--- a/src/Locations/ui/TravelConfirmationModal.tsx
+++ b/src/Locations/ui/TravelConfirmationModal.tsx
@@ -29,6 +29,7 @@ export function TravelConfirmationModal(props: IProps): React.ReactElement {
       <Button onClick={travel}>
         <Typography>Travel</Typography>
       </Button>
+      <Button onClick={() => props.onClose()}>Cancel</Button>
     </Modal>
   );
 }

--- a/src/ui/React/DeleteGameButton.tsx
+++ b/src/ui/React/DeleteGameButton.tsx
@@ -34,6 +34,7 @@ export function DeleteGameButton({ color = "primary" }: IProps): React.ReactElem
         open={modalOpened}
         onClose={() => setModalOpened(false)}
         confirmationText={"Really delete your game? (It's permanent!)"}
+        additionalButton={<Button onClick={() => setModalOpened(false)}>Cancel</Button>}
       />
     </>
   );

--- a/src/ui/React/SoftResetButton.tsx
+++ b/src/ui/React/SoftResetButton.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import { ConfirmationModal } from "./ConfirmationModal";
 import Button from "@mui/material/Button";
-import { Tooltip } from "@mui/material";
+import { Tooltip, Typography } from "@mui/material";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 
 interface IProps {
@@ -26,9 +26,22 @@ export function SoftResetButton({
     }
   }
 
+  const confirmationMessage = `Soft Reset will:
+
+  - Reset basic stats and money
+  - Accumulate Favor for companies and factions
+  - Install Augmentations if you have any purchased
+  - Reset servers, programs, recent scripts and terminal 
+  - Scripts on your home server will stop, but aren't deleted
+  - Stop some special mechanics like Bladeburner tasks
+  - You will not lose overall progress or access to special mechanics
+
+Are you sure? 
+  `;
+
   return (
     <>
-      <Tooltip title="Perform a soft reset. Resets everything as if you had just installed Augmentations without installing them.">
+      <Tooltip title="Perform a Soft Reset - similar to installing Augmentations, even if you have none.">
         <Button startIcon={<RestartAltIcon />} color={color} onClick={handleButtonClick}>
           Soft Reset
         </Button>
@@ -37,7 +50,8 @@ export function SoftResetButton({
         onConfirm={onTriggered}
         open={modalOpened}
         onClose={() => setModalOpened(false)}
-        confirmationText={"This will perform the same action as installing Augmentations, are you sure?"}
+        confirmationText={<Typography style={{ whiteSpace: "pre-wrap" }}>{confirmationMessage}</Typography>}
+        additionalButton={<Button onClick={() => setModalOpened(false)}>Cancel</Button>}
       />
     </>
   );


### PR DESCRIPTION

closes #53

# Bug fix

"When Suppress augmentation confirmation is enabled, Soft Reset won't give a confirmation [modal]" => removed that feature. Soft Reset relates to augmentations abstractly, but a confirmation modal would be appropriate and shouldn't tie to suppressing augmentation messages.

The previous tooltip was completely inaccurate, given that Soft Reset _does_ install augmentations if any are purchased.
OLD:
![SR toolt](https://github.com/bitburner-official/bitburner-src/assets/141260118/daf05bb4-f386-4e5c-a43b-f0e639d6e6bd)

 Augmentation install is similar and fine as a "short hand," but now more accurate
NEW:
![SR tool NEW](https://github.com/bitburner-official/bitburner-src/assets/141260118/b7c8dd92-5e04-4533-8edd-a851927c73c9)

Modal has room to be verbose, so the Soft Reset process is now distinctly de-coupled from augmentation language

OLD:
![sr modal](https://github.com/bitburner-official/bitburner-src/assets/141260118/56d06601-7d87-4687-9cd6-e4a2aca17129)

NEW:
![SR NEW](https://github.com/bitburner-official/bitburner-src/assets/141260118/ec6e2f3f-1689-4d12-b074-7bd7537d61f8)


# Additional changes

- Travel agency, Delete Game and Restart Tutorial modals add a cancel button
- Arrival message can be suppressed 
- Removed Augmentations page arbitrary advice to preferentially buy "everything from any faction of your choosing."
- Tutorial modal text edit

