### PR TITLE
MISC: Add configuration to eslintrc to fix the warning thrown when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,9 +35,9 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "off",
     "react/no-unescaped-entities": "off",
   },
-  "settings": {
-    "react": {
-      "version": "detect"
-    }
-  }
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,4 +35,9 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "off",
     "react/no-unescaped-entities": "off",
   },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
 };


### PR DESCRIPTION
This fixes the `Warning: React version not specified` warning thrown every time lint is run.