### PR TITLE
STANEK: Re-apply stanek boosts when applying entropy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:dev
       - uses: actions/upload-pages-artifact@v1
         with:
           path: ".app"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-      - run: npm run build:dev
+      - run: npm run build
       - uses: actions/upload-pages-artifact@v1
         with:
           path: ".app"

--- a/src/CotMG/StaneksGift.ts
+++ b/src/CotMG/StaneksGift.ts
@@ -58,7 +58,7 @@ export class StaneksGift extends BaseGift {
     this.storedCycles = Math.max(0, this.storedCycles - usedCycles);
     // Only update multipliers (slow) if there was charging done since last process tick.
     if (this.justCharged) {
-      this.updateMults();
+      Player.applyEntropy(Player.entropy);
       this.justCharged = false;
     }
     StaneksGiftEvents.emit();
@@ -210,9 +210,6 @@ export class StaneksGift extends BaseGift {
   }
 
   updateMults(): void {
-    // applyEntropy also reapplies all augmentations and source files
-    // This wraps up the reset nicely
-    Player.applyEntropy(Player.entropy);
     const mults = this.calculateMults();
     Player.mults = mergeMultipliers(Player.mults, mults);
     Player.updateSkillLevels();

--- a/src/DevMenu/ui/StanekDev.tsx
+++ b/src/DevMenu/ui/StanekDev.tsx
@@ -29,12 +29,14 @@ export function StanekDev(): React.ReactElement {
     staneksGift.fragments.forEach((f) => {
       f.highestCharge = 1e21;
       f.numCharge = 1e21;
+      Player.applyEntropy(Player.entropy);
     });
   }
 
   function modCharge(modify: number): (x: number) => void {
     return function (cycles: number): void {
       staneksGift.fragments.forEach((f) => (f.highestCharge += cycles * modify));
+      Player.applyEntropy(Player.entropy);
     };
   }
 

--- a/src/DevMenu/ui/StanekDev.tsx
+++ b/src/DevMenu/ui/StanekDev.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { staneksGift } from "../../CotMG/Helper";
-import { Player } from "@Player";
+import { Player } from "@player";
 
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";

--- a/src/DevMenu/ui/StanekDev.tsx
+++ b/src/DevMenu/ui/StanekDev.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { staneksGift } from "../../CotMG/Helper";
+import { Player } from "@Player";
 
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";

--- a/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
@@ -1,5 +1,6 @@
 /** Augmentation-related methods for the Player class (PlayerObject) */
 import { calculateEntropy } from "../Grafting/EntropyAccumulation";
+import { staneksGift } from "../../CotMG/Helper";
 
 import type { PlayerObject } from "./PlayerObject";
 
@@ -9,4 +10,5 @@ export function applyEntropy(this: PlayerObject, stacks = 1): void {
   this.reapplyAllSourceFiles();
 
   this.mults = calculateEntropy(stacks);
+  staneksGift.updateMults();
 }

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -229,8 +229,6 @@ const Engine: {
     if (loadGame(saveString)) {
       FormatsNeedToChange.emit();
       initBitNodeMultipliers();
-      Player.reapplyAllAugmentations();
-      Player.reapplyAllSourceFiles();
       if (Player.hasWseAccount) {
         initSymbolToStockMap();
       }


### PR DESCRIPTION
Demo at https://yichizhng.github.io/bitburner-src/

Try doing the following (using the dev menu) and observe how stats change:

- Give yourself SF-13
- Add some stats
- Accept Stanek's gift
- Place some stat boost pieces
- Charge the pieces
- Apply some entropy

Also fixes a dev menu issue - adding stanek charge doesn't apply the new boosts.