### PR TITLE
UI: Modals no longer update while closing

### DIFF
--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -69,7 +69,11 @@ export const Modal = ({ open, onClose, children, sx }: ModalProps): React.ReactE
       sx={sx}
     >
       <Fade in={open}>
-        <div className={classes.paper} style={{ pointerEvents: open ? "auto" : "none" }}>
+        <div
+          className={classes.paper}
+          //@ts-expect-error inert is not supported by react types yet, this is a workaround until then. https://github.com/facebook/react/pull/24730
+          inert={open ? null : ""}
+        >
           <IconButton className={classes.closeButton} onClick={onClose}>
             <CloseIcon />
           </IconButton>

--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -41,14 +41,14 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-interface IProps {
+interface ModalProps {
   open: boolean;
   onClose: () => void;
   children: React.ReactNode;
   sx?: SxProps<Theme>;
 }
 
-export const Modal = (props: IProps): React.ReactElement => {
+export const Modal = ({ open, onClose, children, sx }: ModalProps): React.ReactElement => {
   const classes = useStyles();
   return (
     <M
@@ -56,18 +56,18 @@ export const Modal = (props: IProps): React.ReactElement => {
       disableScrollLock
       disableEnforceFocus
       disableAutoFocus
-      open={props.open}
-      onClose={props.onClose}
+      open={open}
+      onClose={onClose}
       closeAfterTransition
       className={classes.modal}
-      sx={props.sx}
+      sx={sx}
     >
-      <Fade in={props.open}>
+      <Fade in={open}>
         <div className={classes.paper}>
-          <IconButton className={classes.closeButton} onClick={props.onClose}>
+          <IconButton className={classes.closeButton} onClick={onClose}>
             <CloseIcon />
           </IconButton>
-          <Box sx={{ m: 2 }}>{props.children}</Box>
+          <Box sx={{ m: 2 }}>{children}</Box>
         </div>
       </Fade>
     </M>

--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Theme } from "@mui/material";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
@@ -50,6 +50,12 @@ interface ModalProps {
 
 export const Modal = ({ open, onClose, children, sx }: ModalProps): React.ReactElement => {
   const classes = useStyles();
+  const [content, setContent] = useState(children);
+  useEffect(() => {
+    if (!open) return;
+    setContent(children);
+  }, [children, open]);
+
   return (
     <M
       disableRestoreFocus
@@ -67,7 +73,7 @@ export const Modal = ({ open, onClose, children, sx }: ModalProps): React.ReactE
           <IconButton className={classes.closeButton} onClick={onClose}>
             <CloseIcon />
           </IconButton>
-          <Box sx={{ m: 2 }}>{children}</Box>
+          <Box sx={{ m: 2 }}>{content}</Box>
         </div>
       </Fade>
     </M>

--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -69,7 +69,7 @@ export const Modal = ({ open, onClose, children, sx }: ModalProps): React.ReactE
       sx={sx}
     >
       <Fade in={open}>
-        <div className={classes.paper}>
+        <div className={classes.paper} style={{ pointerEvents: open ? "auto" : "none" }}>
           <IconButton className={classes.closeButton} onClick={onClose}>
             <CloseIcon />
           </IconButton>


### PR DESCRIPTION
Modals were previously updating their contents and were still interactive during the closing animation, allowing e.g. a button that closes the modal to be pressed twice. This PR should fix both of these issues across all modals.

Tested alongside #782 which has some good example modals where it's clear the content is changing after the closing animation starts.

I temporarily set the transition time to 2 full seconds for this test, so it is more clear that the content does not update while the modal is closing. I also removed the special code from that PR that was instant-closing the modal.

Modal transitions were not actually changed to be this slow, the slowness was just a temporary change to make it easier to see that this was working properly.

https://github.com/bitburner-official/bitburner-src/assets/84951833/2c2fc9ec-3338-4a40-b226-ec682e3c8848