### PR TITLE
UI: Clean up typesetting of Corp ingredient formulas

### DIFF
--- a/src/Corporation/ui/IndustryProductEquation.tsx
+++ b/src/Corporation/ui/IndustryProductEquation.tsx
@@ -15,7 +15,7 @@ export function IndustryProductEquation(props: IProps): React.ReactElement {
   }
   const prod = props.division.producedMaterials.map((p) => `1\\text{ ${p}}`);
   if (props.division.makesProducts) {
-    prod.push("\text{Products}");
+    prod.push("\\text{Products}");
   }
 
   return <MathJax>{"\\(" + reqs.join("+") + `\\Rightarrow ` + prod.join("+") + "\\)"}</MathJax>;

--- a/src/Corporation/ui/IndustryProductEquation.tsx
+++ b/src/Corporation/ui/IndustryProductEquation.tsx
@@ -11,11 +11,11 @@ export function IndustryProductEquation(props: IProps): React.ReactElement {
   const reqs = [];
   for (const [reqMat, reqAmt] of getRecordEntries(props.division.requiredMaterials)) {
     if (!reqAmt) continue;
-    reqs.push(String.raw`${reqAmt}\text{ }${reqMat}`);
+    reqs.push(String.raw`${reqAmt} \text{${reqMat}}`);
   }
-  const prod = props.division.producedMaterials.map((p) => `1\\text{ }${p}`);
+  const prod = props.division.producedMaterials.map((p) => `1 \\text{${p}}`);
   if (props.division.makesProducts) {
-    prod.push("Products");
+    prod.push("\text{Products}");
   }
 
   return <MathJax>{"\\(" + reqs.join("+") + `\\Rightarrow ` + prod.join("+") + "\\)"}</MathJax>;

--- a/src/Corporation/ui/IndustryProductEquation.tsx
+++ b/src/Corporation/ui/IndustryProductEquation.tsx
@@ -11,9 +11,9 @@ export function IndustryProductEquation(props: IProps): React.ReactElement {
   const reqs = [];
   for (const [reqMat, reqAmt] of getRecordEntries(props.division.requiredMaterials)) {
     if (!reqAmt) continue;
-    reqs.push(String.raw`${reqAmt} \text{${reqMat}}`);
+    reqs.push(String.raw`${reqAmt}\text{ ${reqMat}}`);
   }
-  const prod = props.division.producedMaterials.map((p) => `1 \\text{${p}}`);
+  const prod = props.division.producedMaterials.map((p) => `1\\text{ ${p}}`);
   if (props.division.makesProducts) {
     prod.push("\text{Products}");
   }

--- a/src/Corporation/ui/IndustryProductEquation.tsx
+++ b/src/Corporation/ui/IndustryProductEquation.tsx
@@ -11,9 +11,9 @@ export function IndustryProductEquation(props: IProps): React.ReactElement {
   const reqs = [];
   for (const [reqMat, reqAmt] of getRecordEntries(props.division.requiredMaterials)) {
     if (!reqAmt) continue;
-    reqs.push(String.raw`${reqAmt}\text{ ${reqMat}}`);
+    reqs.push(String.raw`${reqAmt}\;\text{${reqMat}}`);
   }
-  const prod = props.division.producedMaterials.map((p) => `1\\text{ ${p}}`);
+  const prod = props.division.producedMaterials.map((p) => `1\\;\\text{${p}}`);
   if (props.division.makesProducts) {
     prod.push("\\text{Products}");
   }

--- a/src/Corporation/ui/IndustryProductEquation.tsx
+++ b/src/Corporation/ui/IndustryProductEquation.tsx
@@ -11,11 +11,11 @@ export function IndustryProductEquation(props: IProps): React.ReactElement {
   const reqs = [];
   for (const [reqMat, reqAmt] of getRecordEntries(props.division.requiredMaterials)) {
     if (!reqAmt) continue;
-    reqs.push(String.raw`${reqAmt}\;\text{${reqMat}}`);
+    reqs.push(String.raw`${reqAmt}\;\textit{${reqMat}}`);
   }
-  const prod = props.division.producedMaterials.map((p) => `1\\;\\text{${p}}`);
+  const prod = props.division.producedMaterials.map((p) => `1\\;\\textit{${p}}`);
   if (props.division.makesProducts) {
-    prod.push("\\text{Products}");
+    prod.push("\\textit{Products}");
   }
 
   return <MathJax>{"\\(" + reqs.join("+") + `\\Rightarrow ` + prod.join("+") + "\\)"}</MathJax>;


### PR DESCRIPTION
Corporation production formulas use some confusing typesetting syntax. Cleaning it up also allows us to make the symbol names clearer for accessibility, matching other formulas already in the game.

before:

$$
0.5\text{ }Water+0.2\text{ }Chemicals\Rightarrow 1\text{ }Plants+1\text{ }Food
$$

after:

$$
0.5\\;\textit{Water}+0.2\\;\textit{Chemicals}\Rightarrow 1\\;\textit{Plants}+1\\;\textit{Food}
$$