### PR TITLE
BUGFIX: Patch a minor hole in RAM calculation

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -385,7 +385,9 @@ function updateDynamicRam(ctx: NetscriptContext, ramCost: number): void {
   ws.dynamicLoadedFns[fnName] = true;
 
   ws.dynamicRamUsage = Math.min(ws.dynamicRamUsage + ramCost, RamCostConstants.Max);
-  if (ws.dynamicRamUsage > 1.01 * ws.scriptRef.ramUsage) {
+  // This constant is just a handful of ULPs, and gives protection against
+  // rounding issues without exposing rounding exploits in ramUsage.
+  if (ws.dynamicRamUsage > 1.00000000000001 * ws.scriptRef.ramUsage) {
     log(ctx, () => "Insufficient static ram available.");
     const err = makeRuntimeErrorMsg(
       ctx,


### PR DESCRIPTION
Using the `ramOverride` option, a worker script could be set to 1.73266GB (1.75/1.01) and then 1% more workers fit into available RAM.

Did some basic smoke tests that launching scripts works when it should and is denied when it should be.