### PR TITLE
MISC: Fix check for "True Recursion" achievement

### DIFF
--- a/src/Arcade/ui/BBCabinet.tsx
+++ b/src/Arcade/ui/BBCabinet.tsx
@@ -14,7 +14,7 @@ const style = {
 export function BBCabinetRoot(): React.ReactElement {
   useEffect(() => {
     window.addEventListener("message", function (this: Window, ev: MessageEvent<boolean>) {
-      if (ev.isTrusted && ev.origin == "https://bitburner-official.github.io" && ev.data) {
+      if (ev.isTrusted && ev.origin == "https://bitburner-official.github.io" && ev.data === true) {
         Player.giveExploit(Exploit.TrueRecursion);
       }
     });


### PR DESCRIPTION
The `bitburner-legacy` iframe uses `postMessage()` to report achievement status to the main game in its parent window. It sends a message with `{data: false}` when the achievement is not yet unlocked, and `{data: true}` when the achievement is unlocked. `BBCabinet.tsx` receives this message.

When a player has React-Devtools running in their browser, it also uses `postMessage()` to send things like `{data: { source: "react-devtools-bridge", payload: {…} }}` between these frames. This value is truthy and comes from an appropriate origin, so the achievement can be unlocked accidentally for players who took no action.

This PR changes the check to `event.data === true`, which can still be crafted by a player looking for a shortcut, but is unlikely to come from a third-party source accidentally.