### PR TITLE
UI: Make Source-Files devmenu page reactive

### DIFF
--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useState } from "react";
 
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
@@ -14,6 +15,22 @@ import ButtonGroup from "@mui/material/ButtonGroup";
 const validSFN = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 
 export function SourceFilesDev(): React.ReactElement {
+  const [sfData, setSfData] = useState({
+    1: Player.sourceFileLvl(1),
+    2: Player.sourceFileLvl(2),
+    3: Player.sourceFileLvl(3),
+    4: Player.sourceFileLvl(4),
+    5: Player.sourceFileLvl(5),
+    6: Player.sourceFileLvl(6),
+    7: Player.sourceFileLvl(7),
+    8: Player.sourceFileLvl(8),
+    9: Player.sourceFileLvl(9),
+    10: Player.sourceFileLvl(10),
+    11: Player.sourceFileLvl(11),
+    12: Player.sourceFileLvl(12),
+    13: Player.sourceFileLvl(13),
+  });
+
   function setSF(sfN: number, sfLvl: number) {
     return function () {
       if (sfN === 9) {
@@ -21,9 +38,11 @@ export function SourceFilesDev(): React.ReactElement {
       }
       if (sfLvl === 0) {
         Player.sourceFiles.delete(sfN);
+        setSfData({ ...sfData, [sfN]: sfLvl });
         return;
       }
       Player.sourceFiles.set(sfN, sfLvl);
+      setSfData({ ...sfData, [sfN]: sfLvl });
     };
   }
 
@@ -38,6 +57,9 @@ export function SourceFilesDev(): React.ReactElement {
   function clearExploits(): void {
     Player.exploits = [];
   }
+
+  const ownedStyle = { borderColor: "green", background: "" };
+  const notOwnedStyle = { borderColor: "", background: "black" };
 
   return (
     <Accordion TransitionProps={{ unmountOnExit: true }}>
@@ -83,10 +105,18 @@ export function SourceFilesDev(): React.ReactElement {
                 </td>
                 <td>
                   <ButtonGroup>
-                    <Button onClick={setSF(i, 0)}>0</Button>
-                    <Button onClick={setSF(i, 1)}>1</Button>
-                    <Button onClick={setSF(i, 2)}>2</Button>
-                    <Button onClick={setSF(i, 3)}>3</Button>
+                    <Button onClick={setSF(i, 0)} style={Player.sourceFileLvl(i) >= 0 ? ownedStyle : notOwnedStyle}>
+                      0
+                    </Button>
+                    <Button onClick={setSF(i, 1)} style={Player.sourceFileLvl(i) >= 1 ? ownedStyle : notOwnedStyle}>
+                      1
+                    </Button>
+                    <Button onClick={setSF(i, 2)} style={Player.sourceFileLvl(i) >= 2 ? ownedStyle : notOwnedStyle}>
+                      2
+                    </Button>
+                    <Button onClick={setSF(i, 3)} style={Player.sourceFileLvl(i) >= 3 ? ownedStyle : notOwnedStyle}>
+                      3
+                    </Button>
                   </ButtonGroup>
                 </td>
               </tr>

--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -45,8 +45,27 @@ export function SourceFilesDev(): React.ReactElement {
     Player.exploits = [];
   }
 
+  const setallButtonStyle = { borderColor: "", background: "black" };
   const ownedStyle = { borderColor: "green", background: "" };
   const notOwnedStyle = { borderColor: "", background: "black" };
+
+  const devLvls = [0, 1, 2, 3];
+
+  const buttonGroupAll = devLvls.map((lvl) => {
+    return (
+      <Button key={lvl} onClick={setAllSF(lvl)} style={setallButtonStyle}>
+        {lvl}
+      </Button>
+    );
+  });
+  const buttonGroupSF = (i: number) =>
+    devLvls.map((lvl) => {
+      return (
+        <Button key={lvl} onClick={setSF(i, lvl)} style={Player.sourceFileLvl(i) >= lvl ? ownedStyle : notOwnedStyle}>
+          {lvl}
+        </Button>
+      );
+    });
 
   return (
     <Accordion TransitionProps={{ unmountOnExit: true }}>
@@ -69,20 +88,7 @@ export function SourceFilesDev(): React.ReactElement {
                 <Typography>All:</Typography>
               </td>
               <td>
-                <ButtonGroup>
-                  <Button aria-label="all-sf-0" onClick={setAllSF(0)}>
-                    0
-                  </Button>
-                  <Button aria-label="all-sf-1" onClick={setAllSF(1)}>
-                    1
-                  </Button>
-                  <Button aria-label="all-sf-2" onClick={setAllSF(2)}>
-                    2
-                  </Button>
-                  <Button aria-label="all-sf-3" onClick={setAllSF(3)}>
-                    3
-                  </Button>
-                </ButtonGroup>
+                <ButtonGroup>{buttonGroupAll}</ButtonGroup>
               </td>
             </tr>
             {validSFN.map((i) => (
@@ -91,20 +97,7 @@ export function SourceFilesDev(): React.ReactElement {
                   <Typography>SF-{i}:</Typography>
                 </td>
                 <td>
-                  <ButtonGroup>
-                    <Button onClick={setSF(i, 0)} style={Player.sourceFileLvl(i) >= 0 ? ownedStyle : notOwnedStyle}>
-                      0
-                    </Button>
-                    <Button onClick={setSF(i, 1)} style={Player.sourceFileLvl(i) >= 1 ? ownedStyle : notOwnedStyle}>
-                      1
-                    </Button>
-                    <Button onClick={setSF(i, 2)} style={Player.sourceFileLvl(i) >= 2 ? ownedStyle : notOwnedStyle}>
-                      2
-                    </Button>
-                    <Button onClick={setSF(i, 3)} style={Player.sourceFileLvl(i) >= 3 ? ownedStyle : notOwnedStyle}>
-                      3
-                    </Button>
-                  </ButtonGroup>
+                  <ButtonGroup>{buttonGroupSF(i)}</ButtonGroup>
                 </td>
               </tr>
             ))}

--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { useState } from "react";
+import React, { useState } from "react";
 
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";

--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -51,17 +51,14 @@ export function SourceFilesDev(): React.ReactElement {
 
   const devLvls = [0, 1, 2, 3];
 
-  const buttonGroupAll = devLvls.map((lvl) => {
-    return (
-      <Button key={lvl} onClick={setAllSF(lvl)} style={setallButtonStyle}>
-        {lvl}
-      </Button>
-    );
-  });
-  const buttonGroupSF = (i: number) =>
+  const buttonGroup = (sfN?: number) =>
     devLvls.map((lvl) => {
       return (
-        <Button key={lvl} onClick={setSF(i, lvl)} style={Player.sourceFileLvl(i) >= lvl ? ownedStyle : notOwnedStyle}>
+        <Button
+          key={lvl}
+          onClick={sfN === undefined ? setAllSF(lvl) : setSF(sfN, lvl)}
+          style={sfN === undefined ? setallButtonStyle : Player.sourceFileLvl(sfN) >= lvl ? ownedStyle : notOwnedStyle}
+        >
           {lvl}
         </Button>
       );
@@ -88,16 +85,16 @@ export function SourceFilesDev(): React.ReactElement {
                 <Typography>All:</Typography>
               </td>
               <td>
-                <ButtonGroup>{buttonGroupAll}</ButtonGroup>
+                <ButtonGroup>{buttonGroup()}</ButtonGroup>
               </td>
             </tr>
-            {validSFN.map((i) => (
-              <tr key={"sf-" + i}>
+            {validSFN.map((sfN) => (
+              <tr key={"sf-" + sfN}>
                 <td>
-                  <Typography>SF-{i}:</Typography>
+                  <Typography>SF-{sfN}:</Typography>
                 </td>
                 <td>
-                  <ButtonGroup>{buttonGroupSF(i)}</ButtonGroup>
+                  <ButtonGroup>{buttonGroup(sfN)}</ButtonGroup>
                 </td>
               </tr>
             ))}

--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -82,7 +82,7 @@ export function SourceFilesDev(): React.ReactElement {
             </tr>
             <tr key={"sf-all"}>
               <td>
-                <Typography>All:</Typography>
+                <Typography>Set All:</Typography>
               </td>
               <td>
                 <ButtonGroup>{buttonGroup()}</ButtonGroup>

--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -13,23 +13,10 @@ import ButtonGroup from "@mui/material/ButtonGroup";
 
 // Update as additional BitNodes get implemented
 const validSFN = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+const initialState = validSFN.reduce((obj, sfN) => ({ ...obj, [sfN]: "" }), { "": "" });
 
 export function SourceFilesDev(): React.ReactElement {
-  const [sfData, setSfData] = useState({
-    1: Player.sourceFileLvl(1),
-    2: Player.sourceFileLvl(2),
-    3: Player.sourceFileLvl(3),
-    4: Player.sourceFileLvl(4),
-    5: Player.sourceFileLvl(5),
-    6: Player.sourceFileLvl(6),
-    7: Player.sourceFileLvl(7),
-    8: Player.sourceFileLvl(8),
-    9: Player.sourceFileLvl(9),
-    10: Player.sourceFileLvl(10),
-    11: Player.sourceFileLvl(11),
-    12: Player.sourceFileLvl(12),
-    13: Player.sourceFileLvl(13),
-  });
+  const [sfData, setSfData] = useState(initialState);
 
   function setSF(sfN: number, sfLvl: number) {
     return function () {


### PR DESCRIPTION
# Documentation

Source-Files devmenu page now indicates owned SF levels, and updates reactively.

Old:
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/cfc37e50-c8b0-4e83-ba2b-b7e30fa43c87)

=> New:
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/ad431ece-1aa0-4f65-bf0e-5b81d498650e)
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/51f40867-9146-4e97-8cc7-9b5e66195c2d)
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/95e9a7e2-63b4-4346-afdc-0aee49ef62cb)
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/6064da4d-1b11-498a-88ba-3868acdf0df7)
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/6307b521-5758-4ab3-bafa-f050bd4179ba)
![image](https://github.com/bitburner-official/bitburner-src/assets/141260118/69133397-92ed-492a-a421-7a91d0ce03d1)


