### PR TITLE
MISC: Readthedocs configuration that redirects to this repo

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,34 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+# -- Project information -----------------------------------------------------
+
+project = 'Bitburner'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+              ]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['*']
+exclude_patterns = ['doc/index.rst']
+
+# -- Options for HTML output -------------------------------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,5 @@
+.. meta::
+   :http-equiv=Refresh: 0; url='https://github.com/bitburner-official/bitburner-src/blob/dev/src/Documentation/doc/index.md'
+
+This link is outdated as documentation for Bitburner has been migrated to an in-game menu, this page should have redirected you to the new location.
+You can also click `here to go to the game's documentation <https://github.com/bitburner-official/bitburner-src/blob/dev/src/Documentation/doc/index.md/>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
 .. meta::
-   :http-equiv=Refresh: 0; url='https://github.com/bitburner-official/bitburner-src/blob/dev/src/Documentation/doc/index.md'
+   :http-equiv=Refresh: 0; url='https://github.com/bitburner-official/bitburner-src/blob/stable/src/Documentation/doc/index.md'
 
 This link is outdated as documentation for Bitburner has been migrated to an in-game menu, this page should have redirected you to the new location.
-You can also click `here to go to the game's documentation <https://github.com/bitburner-official/bitburner-src/blob/dev/src/Documentation/doc/index.md/>`_.
+You can also click `here to go to the game's documentation <https://github.com/bitburner-official/bitburner-src/blob/stable/src/Documentation/doc/index.md/>`_.


### PR DESCRIPTION
This PR reintroduces a ReadTheDocs configuration, that in combination with some tweaks on the ReadTheDocs side (which I will make once this merges, but have tested with my own fork) redirects people from ReadTheDocs to the documentation available at https://github.com/bitburner-official/bitburner-src/blob/dev/src/Documentation/doc/index.md.

It:
- closes #824
- stops the e-mails the ReadTheDocs admins have been getting (finally!!)
- redirects people to up-to-date documentation, what more do you want?
