### PR TITLE
CORPORATION: UI to display production and sales multipliers

### DIFF
--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -29,7 +29,6 @@ import { TableCell } from "../../ui/React/Table";
 import { Box } from "@mui/material";
 import { StatsTable } from "../../ui/React/StatsTable";
 
-
 interface OfficeProps {
   office: OfficeSpace;
   rerender: () => void;
@@ -138,7 +137,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
 
   // Sale multipliers
   const businessFactor = division.getBusinessFactor(props.office); //Business employee productivity
-  const [adsTotal, adsAwareness, adsPopularity] = division.getAdvertisingFactors(); //Awareness + popularity
+  const [adsTotal] = division.getAdvertisingFactors(); //Awareness + popularity
   const salesResearch = division.getSalesMultiplier();
   const totalSaleMultiplier = businessFactor * adsTotal * salesResearch * corp.getSalesMult();
   const salesBreakdown = (
@@ -146,8 +145,6 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
       rows={[
         ["Business Employees:", formatCorpMultiplier(businessFactor)],
         ["Advertisement:", formatCorpMultiplier(adsTotal)],
-        [<>&nbsp;&nbsp;&nbsp;Popularity factor:</>, formatCorpStat(adsPopularity)],
-        [<>&nbsp;&nbsp;&nbsp;Awareness factor:</>, formatCorpStat(adsAwareness)],
         ["Sales Research:", formatCorpMultiplier(salesResearch)],
         [`${CorpUpgradeName.ABCSalesBots}:`, formatCorpMultiplier(corp.getSalesMult())],
         [<b key={1}>Total Sales Multiplier:</b>, <b key={2}>{formatCorpMultiplier(totalSaleMultiplier)}</b>],
@@ -255,7 +252,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                       <br />
                       It is based on your Business employees and your advertising.
                       <br />
-                      This will be further modified by demand and competition for each product.
+                      This will be further modified by demand and competition for each item.
                     </Typography>
                   }
                 >

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -114,7 +114,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
         ["Smart Factories:", formatPercent(corp.getProductionMultiplier())],
         ["Boosting Materials:", formatPercent(division.productionMult)],
         ["Production Research:", formatPercent(division.getProductionMultiplier())],
-        [<b>Total Production:</b>, <b>{formatCorpStat(totalMaterialProduction)}</b>],
+        [<b key={1}>Total Production:</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
       ]}
     />
   );
@@ -136,7 +136,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
         ["Boosting Materials:", formatPercent(division.productionMult)],
         ["Production Research:", formatPercent(division.getProductionMultiplier())],
         ["Product Production Research:", formatPercent(division.getProductProductionMultiplier())],
-        [<b>Total Production:</b>, <b>{formatCorpStat(totalProductProduction)}</b>],
+        [<b key={1}>Total Production:</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
       ]}
     />
   );

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -222,28 +222,30 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                 </Tooltip>
               </TableCell>
             </TableRow>
-            <TableRow>
-              <TableCell>
-                <Tooltip
-                  title={
-                    <Typography component="div">
-                      The amount of any given Product this office can produce.
-                      <br />
-                      This value is based off the productivity of your
-                      <br />
-                      Operations, Engineering, and Management employees.
-                    </Typography>
-                  }
-                >
-                  <Typography>Product Production:</Typography>
-                </Tooltip>
-              </TableCell>
-              <TableCell>
-                <Tooltip title={productBreakdown}>
-                  <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
-                </Tooltip>
-              </TableCell>
-            </TableRow>
+            {division.makesProducts ? (
+              <TableRow>
+                <TableCell>
+                  <Tooltip
+                    title={
+                      <Typography component="div">
+                        The amount of any given Product this office can produce.
+                        <br />
+                        This value is based off the productivity of your
+                        <br />
+                        Operations, Engineering, and Management employees.
+                      </Typography>
+                    }
+                  >
+                    <Typography>Product Production:</Typography>
+                  </Tooltip>
+                </TableCell>
+                <TableCell>
+                  <Tooltip title={productBreakdown}>
+                    <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            ) : null}
             <TableRow>
               <TableCell>
                 <Tooltip

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -138,15 +138,16 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
   // Sale multipliers
   const businessFactor = division.getBusinessFactor(props.office); //Business employee productivity
   const [adsTotal] = division.getAdvertisingFactors(); //Awareness + popularity
-  const salesResearch = division.getSalesMultiplier();
-  const totalSaleMultiplier = businessFactor * adsTotal * salesResearch * corp.getSalesMult();
+  const researchMult = division.getSalesMultiplier();
+  const upgradeMult = corp.getSalesMult();
+  const totalSaleMultiplier = businessFactor * adsTotal * researchMult * upgradeMult;
   const salesBreakdown = (
     <StatsTable
       rows={[
         ["Business Employees:", formatCorpMultiplier(businessFactor)],
         ["Advertising:", formatCorpMultiplier(adsTotal)],
-        ["Sales Research:", formatCorpMultiplier(salesResearch)],
-        [`${CorpUpgradeName.ABCSalesBots}:`, formatCorpMultiplier(corp.getSalesMult())],
+        researchMult !== 1 ? ["Research:", formatCorpMultiplier(researchMult)] : [],
+        [`${CorpUpgradeName.ABCSalesBots}:`, formatCorpMultiplier(upgradeMult)],
         [<b key={1}>Total Sales Multiplier:</b>, <b key={2}>{formatCorpMultiplier(totalSaleMultiplier)}</b>],
       ]}
     />

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 
 import { OfficeSpace } from "../OfficeSpace";
-import { CorpUnlockName, CorpEmployeeJob } from "@enums";
+import { CorpUnlockName, CorpEmployeeJob, CorpUpgradeName } from "@enums";
 import { BuyTea } from "../Actions";
 
 import { MoneyCost } from "./MoneyCost";
@@ -111,10 +111,10 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
           "Base Production from Employees:",
           formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: false })),
         ],
-        ["Smart Factories:", formatPercent(corp.getProductionMultiplier())],
         ["Boosting Materials:", formatPercent(division.productionMult)],
         ["Production Research:", formatPercent(division.getProductionMultiplier())],
-        [<b key={1}>Total Production:</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
+        [`${CorpUpgradeName.SmartFactories}:`, formatPercent(corp.getProductionMultiplier())],
+        [<b key={1}>Total Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
       ]}
     />
   );
@@ -132,11 +132,30 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
           "Base Production from Employees:",
           formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true })),
         ],
-        ["Smart Factories:", formatPercent(corp.getProductionMultiplier())],
         ["Boosting Materials:", formatPercent(division.productionMult)],
         ["Production Research:", formatPercent(division.getProductionMultiplier())],
         ["Product Production Research:", formatPercent(division.getProductProductionMultiplier())],
-        [<b key={1}>Total Production:</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
+        [`${CorpUpgradeName.SmartFactories}:`, formatPercent(corp.getProductionMultiplier())],
+        [<b key={1}>Total Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
+      ]}
+    />
+  );
+
+  // Sale multipliers
+  const businessFactor = division.getBusinessFactor(props.office); //Business employee productivity
+  const [adsTotal, adsAwareness, adsPopularity] = division.getAdvertisingFactors(); //Awareness + popularity
+  const salesResearch = division.getSalesMultiplier();
+  const totalSaleMultiplier = businessFactor * adsTotal * salesResearch * corp.getSalesMult();
+  const salesBreakdown = (
+    <StatsTable
+      rows={[
+        ["Business Employees:", formatPercent(businessFactor)],
+        ["Advertisement:", formatPercent(adsTotal)],
+        [<>&nbsp;&nbsp;&nbsp;Awareness factor:</>, formatCorpStat(adsAwareness)],
+        [<>&nbsp;&nbsp;&nbsp;Popularity factor:</>, formatCorpStat(adsPopularity)],
+        ["Sales Research:", formatPercent(salesResearch)],
+        [`${CorpUpgradeName.ABCSalesBots}:`, formatPercent(corp.getSalesMult())],
+        [<b key={1}>Total Sales Multiplier:&nbsp;</b>, <b key={2}>{formatPercent(totalSaleMultiplier)}</b>],
       ]}
     />
   );
@@ -237,13 +256,24 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
             <TableRow>
               <TableCell>
                 <Tooltip
-                  title={<Typography>The effect this office's 'Business' employees has on boosting sales</Typography>}
+                  title={
+                    <Typography>
+                      This office's sales effectivity for all materials and products.
+                      <br />
+                      It is based on your Business employees and your advertising.
+                      <br />
+                      This will be further modified by demand and competition for each product.
+                      <br />
+                      <br />
+                      {salesBreakdown}
+                    </Typography>
+                  }
                 >
-                  <Typography> Business Multiplier:</Typography>
+                  <Typography>Sales Multiplier:</Typography>
                 </Tooltip>
               </TableCell>
               <TableCell align="right">
-                <Typography>x{formatCorpStat(division.getBusinessFactor(props.office))}</Typography>
+                <Typography>{formatPercent(totalSaleMultiplier)}</Typography>
               </TableCell>
             </TableRow>
           </>

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 
 import { OfficeSpace } from "../OfficeSpace";
-import { CorpUnlockName, CorpEmployeeJob, CorpUpgradeName } from "@enums";
+import { CorpUnlockName, CorpEmployeeJob, CorpUpgradeName, CorpProductResearchName } from "@enums";
 import { BuyTea } from "../Actions";
 
 import { MoneyCost } from "./MoneyCost";
@@ -109,7 +109,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
       rows={[
         ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: false }))],
         ["Boosting Materials:", formatCorpMultiplier(division.productionMult)],
-        ["Production Research:", formatCorpMultiplier(division.getProductionMultiplier())],
+        ["Research:", formatCorpMultiplier(division.getProductionMultiplier())],
         [`${CorpUpgradeName.SmartFactories}:`, formatCorpMultiplier(corp.getProductionMultiplier())],
         [<b key={1}>Total Material Production:</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
       ]}
@@ -127,8 +127,8 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
       rows={[
         ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true }))],
         ["Boosting Materials:", formatCorpMultiplier(division.productionMult)],
-        ["Production Research:", formatCorpMultiplier(division.getProductionMultiplier())],
-        ["Product Production Research:", formatCorpMultiplier(division.getProductProductionMultiplier())],
+        ["Research:", formatCorpMultiplier(division.getProductionMultiplier())],
+        [`${CorpProductResearchName.Fulcrum}:`, formatCorpMultiplier(division.getProductProductionMultiplier())],
         [`${CorpUpgradeName.SmartFactories}:`, formatCorpMultiplier(corp.getProductionMultiplier())],
         [<b key={1}>Total Product Production:</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
       ]}

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -7,7 +7,7 @@ import { CorpUnlockName, CorpEmployeeJob, CorpUpgradeName } from "@enums";
 import { BuyTea } from "../Actions";
 
 import { MoneyCost } from "./MoneyCost";
-import { formatBigNumber, formatCorpStat, formatPercent } from "../../ui/formatNumber";
+import { formatBigNumber, formatCorpStat } from "../../ui/formatNumber";
 
 import { UpgradeOfficeSizeModal } from "./modals/UpgradeOfficeSizeModal";
 import { ThrowPartyModal } from "./modals/ThrowPartyModal";
@@ -108,9 +108,9 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
     <StatsTable
       rows={[
         ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: false }))],
-        ["Boosting Materials:", formatPercent(division.productionMult)],
-        ["Production Research:", formatPercent(division.getProductionMultiplier())],
-        [`${CorpUpgradeName.SmartFactories}:`, formatPercent(corp.getProductionMultiplier())],
+        ["Boosting Materials:", "×" + formatCorpStat(division.productionMult)],
+        ["Production Research:", "×" + formatCorpStat(division.getProductionMultiplier())],
+        [`${CorpUpgradeName.SmartFactories}:`, "×" + formatCorpStat(corp.getProductionMultiplier())],
         [<b key={1}>Total Material Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
       ]}
     />
@@ -126,10 +126,10 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
     <StatsTable
       rows={[
         ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true }))],
-        ["Boosting Materials:", formatPercent(division.productionMult)],
-        ["Production Research:", formatPercent(division.getProductionMultiplier())],
-        ["Product Research:", formatPercent(division.getProductProductionMultiplier())],
-        [`${CorpUpgradeName.SmartFactories}:`, formatPercent(corp.getProductionMultiplier())],
+        ["Boosting Materials:", "×" + formatCorpStat(division.productionMult)],
+        ["Production Research:", "×" + formatCorpStat(division.getProductionMultiplier())],
+        ["Product Research:", "×" + formatCorpStat(division.getProductProductionMultiplier())],
+        [`${CorpUpgradeName.SmartFactories}:`, "×" + formatCorpStat(corp.getProductionMultiplier())],
         [<b key={1}>Total Product Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
       ]}
     />
@@ -143,13 +143,13 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
   const salesBreakdown = (
     <StatsTable
       rows={[
-        ["Business Employees:", formatPercent(businessFactor)],
-        ["Advertisement:", formatPercent(adsTotal)],
+        ["Business Employees:", "×" + formatCorpStat(businessFactor)],
+        ["Advertisement:", "×" + formatCorpStat(adsTotal)],
         [<>&nbsp;&nbsp;&nbsp;Awareness factor:</>, formatCorpStat(adsAwareness)],
         [<>&nbsp;&nbsp;&nbsp;Popularity factor:</>, formatCorpStat(adsPopularity)],
-        ["Sales Research:", formatPercent(salesResearch)],
-        [`${CorpUpgradeName.ABCSalesBots}:`, formatPercent(corp.getSalesMult())],
-        [<b key={1}>Total Sales Multiplier:&nbsp;</b>, <b key={2}>{formatPercent(totalSaleMultiplier)}</b>],
+        ["Sales Research:", "×" + formatCorpStat(salesResearch)],
+        [`${CorpUpgradeName.ABCSalesBots}:`, "×" + formatCorpStat(corp.getSalesMult())],
+        [<b key={1}>Total Sales Multiplier:&nbsp;</b>, <b key={2}>{"×" + formatCorpStat(totalSaleMultiplier)}</b>],
       ]}
     />
   );
@@ -263,7 +263,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
               </TableCell>
               <TableCell align="right">
                 <Tooltip title={salesBreakdown}>
-                  <Typography>{formatPercent(totalSaleMultiplier)}</Typography>
+                  <Typography>×{formatCorpStat(totalSaleMultiplier)}</Typography>
                 </Tooltip>
               </TableCell>
             </TableRow>

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -7,7 +7,7 @@ import { CorpUnlockName, CorpEmployeeJob, CorpUpgradeName } from "@enums";
 import { BuyTea } from "../Actions";
 
 import { MoneyCost } from "./MoneyCost";
-import { formatBigNumber, formatCorpStat } from "../../ui/formatNumber";
+import { formatBigNumber, formatCorpStat, formatCorpMultiplier } from "../../ui/formatNumber";
 
 import { UpgradeOfficeSizeModal } from "./modals/UpgradeOfficeSizeModal";
 import { ThrowPartyModal } from "./modals/ThrowPartyModal";
@@ -28,6 +28,7 @@ import TableRow from "@mui/material/TableRow";
 import { TableCell } from "../../ui/React/Table";
 import { Box } from "@mui/material";
 import { StatsTable } from "../../ui/React/StatsTable";
+
 
 interface OfficeProps {
   office: OfficeSpace;
@@ -108,9 +109,9 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
     <StatsTable
       rows={[
         ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: false }))],
-        ["Boosting Materials:", "×" + formatCorpStat(division.productionMult)],
-        ["Production Research:", "×" + formatCorpStat(division.getProductionMultiplier())],
-        [`${CorpUpgradeName.SmartFactories}:`, "×" + formatCorpStat(corp.getProductionMultiplier())],
+        ["Boosting Materials:", formatCorpMultiplier(division.productionMult)],
+        ["Production Research:", formatCorpMultiplier(division.getProductionMultiplier())],
+        [`${CorpUpgradeName.SmartFactories}:`, formatCorpMultiplier(corp.getProductionMultiplier())],
         [<b key={1}>Total Material Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
       ]}
     />
@@ -126,10 +127,10 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
     <StatsTable
       rows={[
         ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true }))],
-        ["Boosting Materials:", "×" + formatCorpStat(division.productionMult)],
-        ["Production Research:", "×" + formatCorpStat(division.getProductionMultiplier())],
-        ["Product Research:", "×" + formatCorpStat(division.getProductProductionMultiplier())],
-        [`${CorpUpgradeName.SmartFactories}:`, "×" + formatCorpStat(corp.getProductionMultiplier())],
+        ["Boosting Materials:", formatCorpMultiplier(division.productionMult)],
+        ["Production Research:", formatCorpMultiplier(division.getProductionMultiplier())],
+        ["Product Research:", formatCorpMultiplier(division.getProductProductionMultiplier())],
+        [`${CorpUpgradeName.SmartFactories}:`, formatCorpMultiplier(corp.getProductionMultiplier())],
         [<b key={1}>Total Product Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
       ]}
     />
@@ -143,13 +144,13 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
   const salesBreakdown = (
     <StatsTable
       rows={[
-        ["Business Employees:", "×" + formatCorpStat(businessFactor)],
-        ["Advertisement:", "×" + formatCorpStat(adsTotal)],
-        [<>&nbsp;&nbsp;&nbsp;Awareness factor:</>, formatCorpStat(adsAwareness)],
+        ["Business Employees:", formatCorpMultiplier(businessFactor)],
+        ["Advertisement:", formatCorpMultiplier(adsTotal)],
         [<>&nbsp;&nbsp;&nbsp;Popularity factor:</>, formatCorpStat(adsPopularity)],
-        ["Sales Research:", "×" + formatCorpStat(salesResearch)],
-        [`${CorpUpgradeName.ABCSalesBots}:`, "×" + formatCorpStat(corp.getSalesMult())],
-        [<b key={1}>Total Sales Multiplier:&nbsp;</b>, <b key={2}>{"×" + formatCorpStat(totalSaleMultiplier)}</b>],
+        [<>&nbsp;&nbsp;&nbsp;Awareness factor:</>, formatCorpStat(adsAwareness)],
+        ["Sales Research:", formatCorpMultiplier(salesResearch)],
+        [`${CorpUpgradeName.ABCSalesBots}:`, formatCorpMultiplier(corp.getSalesMult())],
+        [<b key={1}>Total Sales Multiplier:&nbsp;</b>, <b key={2}>{formatCorpMultiplier(totalSaleMultiplier)}</b>],
       ]}
     />
   );
@@ -263,7 +264,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
               </TableCell>
               <TableCell align="right">
                 <Tooltip title={salesBreakdown}>
-                  <Typography>×{formatCorpStat(totalSaleMultiplier)}</Typography>
+                  <Typography>{formatCorpMultiplier(totalSaleMultiplier)}</Typography>
                 </Tooltip>
               </TableCell>
             </TableRow>

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -186,69 +186,68 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
             </Typography>
           </TableCell>
         </TableRow>
-        {corp.unlocks.has(CorpUnlockName.VeChain) ||
-          (true && (
-            <>
-              <TableRow>
-                <TableCell>
-                  <Tooltip
-                    title={
-                      <Typography component="div">
-                        The amount of material this office can produce.
-                        <br />
-                        This value is based off the productivity of your
-                        <br />
-                        Operations, Engineering, and Management employees.
-                        <br />
-                        <br />
-                        {materialBreakdown}
-                      </Typography>
-                    }
-                  >
-                    <Typography>Material Production:</Typography>
-                  </Tooltip>
-                </TableCell>
-                <TableCell>
-                  <Typography align="right">{formatCorpStat(totalMaterialProduction)}</Typography>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>
-                  <Tooltip
-                    title={
-                      <Typography component="div">
-                        The amount of any given Product this office can produce.
-                        <br />
-                        This value is based off the productivity of your
-                        <br />
-                        Operations, Engineering, and Management employees.
-                        <br />
-                        <br />
-                        {productBreakdown}
-                      </Typography>
-                    }
-                  >
-                    <Typography>Product Production:</Typography>
-                  </Tooltip>
-                </TableCell>
-                <TableCell>
-                  <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>
-                  <Tooltip
-                    title={<Typography>The effect this office's 'Business' employees has on boosting sales</Typography>}
-                  >
-                    <Typography> Business Multiplier:</Typography>
-                  </Tooltip>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography>x{formatCorpStat(division.getBusinessFactor(props.office))}</Typography>
-                </TableCell>
-              </TableRow>
-            </>
-          ))}
+        {corp.unlocks.has(CorpUnlockName.VeChain) && (
+          <>
+            <TableRow>
+              <TableCell>
+                <Tooltip
+                  title={
+                    <Typography component="div">
+                      The amount of material this office can produce.
+                      <br />
+                      This value is based off the productivity of your
+                      <br />
+                      Operations, Engineering, and Management employees.
+                      <br />
+                      <br />
+                      {materialBreakdown}
+                    </Typography>
+                  }
+                >
+                  <Typography>Material Production:</Typography>
+                </Tooltip>
+              </TableCell>
+              <TableCell>
+                <Typography align="right">{formatCorpStat(totalMaterialProduction)}</Typography>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <Tooltip
+                  title={
+                    <Typography component="div">
+                      The amount of any given Product this office can produce.
+                      <br />
+                      This value is based off the productivity of your
+                      <br />
+                      Operations, Engineering, and Management employees.
+                      <br />
+                      <br />
+                      {productBreakdown}
+                    </Typography>
+                  }
+                >
+                  <Typography>Product Production:</Typography>
+                </Tooltip>
+              </TableCell>
+              <TableCell>
+                <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <Tooltip
+                  title={<Typography>The effect this office's 'Business' employees has on boosting sales</Typography>}
+                >
+                  <Typography> Business Multiplier:</Typography>
+                </Tooltip>
+              </TableCell>
+              <TableCell align="right">
+                <Typography>x{formatCorpStat(division.getBusinessFactor(props.office))}</Typography>
+              </TableCell>
+            </TableRow>
+          </>
+        )}
         <AutoAssignJob
           rerender={props.rerender}
           office={props.office}

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -107,14 +107,11 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
   const materialBreakdown = (
     <StatsTable
       rows={[
-        [
-          "Base Production from Employees:",
-          formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: false })),
-        ],
+        ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: false }))],
         ["Boosting Materials:", formatPercent(division.productionMult)],
         ["Production Research:", formatPercent(division.getProductionMultiplier())],
         [`${CorpUpgradeName.SmartFactories}:`, formatPercent(corp.getProductionMultiplier())],
-        [<b key={1}>Total Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
+        [<b key={1}>Total Material Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
       ]}
     />
   );
@@ -128,15 +125,12 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
   const productBreakdown = (
     <StatsTable
       rows={[
-        [
-          "Base Production from Employees:",
-          formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true })),
-        ],
+        ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true }))],
         ["Boosting Materials:", formatPercent(division.productionMult)],
         ["Production Research:", formatPercent(division.getProductionMultiplier())],
-        ["Product Production Research:", formatPercent(division.getProductProductionMultiplier())],
+        ["Product Research:", formatPercent(division.getProductProductionMultiplier())],
         [`${CorpUpgradeName.SmartFactories}:`, formatPercent(corp.getProductionMultiplier())],
-        [<b key={1}>Total Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
+        [<b key={1}>Total Product Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
       ]}
     />
   );
@@ -217,9 +211,6 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                       This value is based off the productivity of your
                       <br />
                       Operations, Engineering, and Management employees.
-                      <br />
-                      <br />
-                      {materialBreakdown}
                     </Typography>
                   }
                 >
@@ -227,7 +218,9 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                 </Tooltip>
               </TableCell>
               <TableCell>
-                <Typography align="right">{formatCorpStat(totalMaterialProduction)}</Typography>
+                <Tooltip title={materialBreakdown}>
+                  <Typography align="right">{formatCorpStat(totalMaterialProduction)}</Typography>
+                </Tooltip>
               </TableCell>
             </TableRow>
             <TableRow>
@@ -240,9 +233,6 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                       This value is based off the productivity of your
                       <br />
                       Operations, Engineering, and Management employees.
-                      <br />
-                      <br />
-                      {productBreakdown}
                     </Typography>
                   }
                 >
@@ -250,7 +240,9 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                 </Tooltip>
               </TableCell>
               <TableCell>
-                <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
+                <Tooltip title={productBreakdown}>
+                  <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
+                </Tooltip>
               </TableCell>
             </TableRow>
             <TableRow>
@@ -263,9 +255,6 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                       It is based on your Business employees and your advertising.
                       <br />
                       This will be further modified by demand and competition for each product.
-                      <br />
-                      <br />
-                      {salesBreakdown}
                     </Typography>
                   }
                 >
@@ -273,7 +262,9 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
                 </Tooltip>
               </TableCell>
               <TableCell align="right">
-                <Typography>{formatPercent(totalSaleMultiplier)}</Typography>
+                <Tooltip title={salesBreakdown}>
+                  <Typography>{formatPercent(totalSaleMultiplier)}</Typography>
+                </Tooltip>
               </TableCell>
             </TableRow>
           </>

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -7,7 +7,7 @@ import { CorpUnlockName, CorpEmployeeJob } from "@enums";
 import { BuyTea } from "../Actions";
 
 import { MoneyCost } from "./MoneyCost";
-import { formatCorpStat } from "../../ui/formatNumber";
+import { formatBigNumber, formatCorpStat, formatPercent } from "../../ui/formatNumber";
 
 import { UpgradeOfficeSizeModal } from "./modals/UpgradeOfficeSizeModal";
 import { ThrowPartyModal } from "./modals/ThrowPartyModal";
@@ -27,6 +27,7 @@ import TableBody from "@mui/material/TableBody";
 import TableRow from "@mui/material/TableRow";
 import { TableCell } from "../../ui/React/Table";
 import { Box } from "@mui/material";
+import { StatsTable } from "../../ui/React/StatsTable";
 
 interface OfficeProps {
   office: OfficeSpace;
@@ -98,6 +99,48 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
   const currUna = props.office.employeeJobs[CorpEmployeeJob.Unassigned];
   const nextUna = props.office.employeeNextJobs[CorpEmployeeJob.Unassigned];
 
+  const totalMaterialProduction =
+    division.getOfficeProductivity(props.office) *
+    corp.getProductionMultiplier() *
+    division.productionMult *
+    division.getProductionMultiplier();
+  const materialBreakdown = (
+    <StatsTable
+      rows={[
+        [
+          "Base Production from Employees:",
+          formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: false })),
+        ],
+        ["Smart Factories:", formatPercent(corp.getProductionMultiplier())],
+        ["Boosting Materials:", formatPercent(division.productionMult)],
+        ["Production Research:", formatPercent(division.getProductionMultiplier())],
+        [<b>Total Production:</b>, <b>{formatCorpStat(totalMaterialProduction)}</b>],
+      ]}
+    />
+  );
+
+  const totalProductProduction =
+    division.getOfficeProductivity(props.office, { forProduct: true }) *
+    corp.getProductionMultiplier() *
+    division.productionMult *
+    division.getProductionMultiplier() *
+    division.getProductProductionMultiplier();
+  const productBreakdown = (
+    <StatsTable
+      rows={[
+        [
+          "Base Production from Employees:",
+          formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true })),
+        ],
+        ["Smart Factories:", formatPercent(corp.getProductionMultiplier())],
+        ["Boosting Materials:", formatPercent(division.productionMult)],
+        ["Production Research:", formatPercent(division.getProductionMultiplier())],
+        ["Product Production Research:", formatPercent(division.getProductProductionMultiplier())],
+        [<b>Total Production:</b>, <b>{formatCorpStat(totalProductProduction)}</b>],
+      ]}
+    />
+  );
+
   return (
     <Table padding="none">
       <TableBody>
@@ -143,60 +186,69 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
             </Typography>
           </TableCell>
         </TableRow>
-        {corp.unlocks.has(CorpUnlockName.VeChain) && (
-          <>
-            <TableRow>
-              <TableCell>
-                <Tooltip
-                  title={
-                    <Typography>
-                      The base amount of material this office can produce. Does not include production multipliers from
-                      upgrades and materials. This value is based off the productivity of your Operations, Engineering,
-                      and Management employees
-                    </Typography>
-                  }
-                >
-                  <Typography>Material Production:</Typography>
-                </Tooltip>
-              </TableCell>
-              <TableCell>
-                <Typography align="right">{formatCorpStat(division.getOfficeProductivity(props.office))}</Typography>
-              </TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell>
-                <Tooltip
-                  title={
-                    <Typography>
-                      The base amount of any given Product this office can produce. Does not include production
-                      multipliers from upgrades and materials. This value is based off the productivity of your
-                      Operations, Engineering, and Management employees
-                    </Typography>
-                  }
-                >
-                  <Typography>Product Production:</Typography>
-                </Tooltip>
-              </TableCell>
-              <TableCell>
-                <Typography align="right">
-                  {formatCorpStat(division.getOfficeProductivity(props.office, { forProduct: true }))}
-                </Typography>
-              </TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell>
-                <Tooltip
-                  title={<Typography>The effect this office's 'Business' employees has on boosting sales</Typography>}
-                >
-                  <Typography> Business Multiplier:</Typography>
-                </Tooltip>
-              </TableCell>
-              <TableCell align="right">
-                <Typography>x{formatCorpStat(division.getBusinessFactor(props.office))}</Typography>
-              </TableCell>
-            </TableRow>
-          </>
-        )}
+        {corp.unlocks.has(CorpUnlockName.VeChain) ||
+          (true && (
+            <>
+              <TableRow>
+                <TableCell>
+                  <Tooltip
+                    title={
+                      <Typography component="div">
+                        The amount of material this office can produce.
+                        <br />
+                        This value is based off the productivity of your
+                        <br />
+                        Operations, Engineering, and Management employees.
+                        <br />
+                        <br />
+                        {materialBreakdown}
+                      </Typography>
+                    }
+                  >
+                    <Typography>Material Production:</Typography>
+                  </Tooltip>
+                </TableCell>
+                <TableCell>
+                  <Typography align="right">{formatCorpStat(totalMaterialProduction)}</Typography>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>
+                  <Tooltip
+                    title={
+                      <Typography component="div">
+                        The amount of any given Product this office can produce.
+                        <br />
+                        This value is based off the productivity of your
+                        <br />
+                        Operations, Engineering, and Management employees.
+                        <br />
+                        <br />
+                        {productBreakdown}
+                      </Typography>
+                    }
+                  >
+                    <Typography>Product Production:</Typography>
+                  </Tooltip>
+                </TableCell>
+                <TableCell>
+                  <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>
+                  <Tooltip
+                    title={<Typography>The effect this office's 'Business' employees has on boosting sales</Typography>}
+                  >
+                    <Typography> Business Multiplier:</Typography>
+                  </Tooltip>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography>x{formatCorpStat(division.getBusinessFactor(props.office))}</Typography>
+                </TableCell>
+              </TableRow>
+            </>
+          ))}
         <AutoAssignJob
           rerender={props.rerender}
           office={props.office}

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -112,7 +112,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
         ["Boosting Materials:", formatCorpMultiplier(division.productionMult)],
         ["Production Research:", formatCorpMultiplier(division.getProductionMultiplier())],
         [`${CorpUpgradeName.SmartFactories}:`, formatCorpMultiplier(corp.getProductionMultiplier())],
-        [<b key={1}>Total Material Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
+        [<b key={1}>Total Material Production:</b>, <b key={2}>{formatCorpStat(totalMaterialProduction)}</b>],
       ]}
     />
   );
@@ -131,7 +131,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
         ["Production Research:", formatCorpMultiplier(division.getProductionMultiplier())],
         ["Product Research:", formatCorpMultiplier(division.getProductProductionMultiplier())],
         [`${CorpUpgradeName.SmartFactories}:`, formatCorpMultiplier(corp.getProductionMultiplier())],
-        [<b key={1}>Total Product Production:&nbsp;</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
+        [<b key={1}>Total Product Production:</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
       ]}
     />
   );
@@ -150,7 +150,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
         [<>&nbsp;&nbsp;&nbsp;Awareness factor:</>, formatCorpStat(adsAwareness)],
         ["Sales Research:", formatCorpMultiplier(salesResearch)],
         [`${CorpUpgradeName.ABCSalesBots}:`, formatCorpMultiplier(corp.getSalesMult())],
-        [<b key={1}>Total Sales Multiplier:&nbsp;</b>, <b key={2}>{formatCorpMultiplier(totalSaleMultiplier)}</b>],
+        [<b key={1}>Total Sales Multiplier:</b>, <b key={2}>{formatCorpMultiplier(totalSaleMultiplier)}</b>],
       ]}
     />
   );

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -128,7 +128,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
         ["Employee Production:", formatBigNumber(division.getOfficeProductivity(props.office, { forProduct: true }))],
         ["Boosting Materials:", formatCorpMultiplier(division.productionMult)],
         ["Production Research:", formatCorpMultiplier(division.getProductionMultiplier())],
-        ["Product Research:", formatCorpMultiplier(division.getProductProductionMultiplier())],
+        ["Product Production Research:", formatCorpMultiplier(division.getProductProductionMultiplier())],
         [`${CorpUpgradeName.SmartFactories}:`, formatCorpMultiplier(corp.getProductionMultiplier())],
         [<b key={1}>Total Product Production:</b>, <b key={2}>{formatCorpStat(totalProductProduction)}</b>],
       ]}
@@ -144,7 +144,7 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
     <StatsTable
       rows={[
         ["Business Employees:", formatCorpMultiplier(businessFactor)],
-        ["Advertisement:", formatCorpMultiplier(adsTotal)],
+        ["Advertising:", formatCorpMultiplier(adsTotal)],
         ["Sales Research:", formatCorpMultiplier(salesResearch)],
         [`${CorpUpgradeName.ABCSalesBots}:`, formatCorpMultiplier(corp.getSalesMult())],
         [<b key={1}>Total Sales Multiplier:</b>, <b key={2}>{formatCorpMultiplier(totalSaleMultiplier)}</b>],

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -220,8 +220,8 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
             <>
               Hire <b>AdVert.Inc</b> to advertise your company. Each level of this upgrade grants your company a static
               increase of 3 and 1 to its awareness and popularity, respectively. It will then increase your company's
-              awareness by 0.5%, and its popularity by a random percentage between 0.5% and 1.5%. These effects are increased
-              by other upgrades that increase the power of your advertising.
+              awareness by 0.5%, and its popularity by a random percentage between 0.5% and 1.5%. These effects are
+              increased by other upgrades that increase the power of your advertising.
             </>
           }
           disabledTooltip={division.getAdVertCost() > corp.funds ? "Insufficient corporation funds" : ""}

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -1,6 +1,7 @@
 // React Component for displaying an Division's overview information
 // (top-left panel in the Division UI)
 import React, { useState } from "react";
+import { MathJax } from "better-react-mathjax";
 
 import { CorpUnlockName, IndustryType } from "@enums";
 import { HireAdVert } from "../Actions";
@@ -135,10 +136,11 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
           title={
             <>
               <Typography>
-                Multiplier for this industry's sales
-                <br />
-                due to its awareness and popularity.
+                Multiplier for this industry's sales due to its awareness and popularity.
               </Typography>
+              <MathJax>{`\\(\\text{${division.type} Industry: }\\alpha = ${division.advertisingFactor}\\)`}</MathJax>
+              <MathJax>{`\\(\\text{multiplier} = \\left((\\text{awareness}+1)^{\\alpha} \\times (\\text{popularity}+1)^{\\alpha} \\times \\frac{\\text{popularity}+0.001}{\\text{awareness}}\\right)^{0.85}\\)`}</MathJax>
+              <br />
               <StatsTable
                 rows={[
                   ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -134,12 +134,17 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
         <Tooltip
           title={
             <>
-              <Typography>Total multiplier for this industry's sales due to its awareness and popularity</Typography>
+              <Typography>
+                Total multiplier for this industry's sales
+                <br />
+                due to its awareness and popularity.
+              </Typography>
               <StatsTable
                 rows={[
                   ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
                   ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
                   ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
+                  [<b>Total:</b>, <b>{formatCorpMultiplier(totalAdvertisingFac)}</b>],
                 ]}
               />
             </>

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -133,21 +133,22 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
       {advertisingInfo && (
         <Tooltip
           title={
-            <>
-              <Typography>
-                Total multiplier for this industry's sales
-                <br />
-                due to its awareness and popularity.
-              </Typography>
-              <StatsTable
-                rows={[
-                  ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
-                  ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
-                  ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
-                  [<b>Total:</b>, <b>{formatCorpMultiplier(totalAdvertisingFac)}</b>],
-                ]}
-              />
-            </>
+            <StatsTable
+              centered={true}
+              title={
+                <>
+                  Multiplier for this industry's sales
+                  <br />
+                  due to its awareness and popularity.
+                </>
+              }
+              rows={[
+                ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
+                ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
+                ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
+                [<b key={1}>Total:</b>, <b key={2}>{formatCorpMultiplier(totalAdvertisingFac)}</b>],
+              ]}
+            />
           }
         >
           <Typography>Advertising Multiplier: {formatCorpMultiplier(totalAdvertisingFac)}</Typography>

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -136,6 +136,7 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
           title={
             <>
               <Typography>Multiplier for this industry's sales due to its awareness and popularity.</Typography>
+              <br />
               <MathJax>{`\\(\\text{${division.type} Industry: }\\alpha = ${division.advertisingFactor}\\)`}</MathJax>
               <MathJax>{`\\(\\text{multiplier} = \\left((\\text{awareness}+1)^{\\alpha} \\times (\\text{popularity}+1)^{\\alpha} \\times \\frac{\\text{popularity}+0.001}{\\text{awareness}}\\right)^{0.85}\\)`}</MathJax>
               <br />
@@ -218,8 +219,8 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
           normalTooltip={
             <>
               Hire <b>AdVert.Inc</b> to advertise your company. Each level of this upgrade grants your company a static
-              increase of 3 and 1 to its awareness and popularity, respectively. It will then increase your company's" +
-              awareness by 1%, and its popularity by a random percentage between 1% and 3%. These effects are increased
+              increase of 3 and 1 to its awareness and popularity, respectively. It will then increase your company's
+              awareness by 0.5%, and its popularity by a random percentage between 0.5% and 1.5%. These effects are increased
               by other upgrades that increase the power of your advertising.
             </>
           }

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 
 import { CorpUnlockName, IndustryType } from "@enums";
 import { HireAdVert } from "../Actions";
-import { formatBigNumber } from "../../ui/formatNumber";
+import { formatBigNumber, formatCorpMultiplier } from "../../ui/formatNumber";
 import { createProgressBarText } from "../../utils/helpers/createProgressBarText";
 import { MakeProductModal } from "./modals/MakeProductModal";
 import { ResearchModal } from "./modals/ResearchModal";
@@ -137,15 +137,15 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
               <Typography>Total multiplier for this industry's sales due to its awareness and popularity</Typography>
               <StatsTable
                 rows={[
-                  ["Awareness Bonus:", "x" + formatBigNumber(Math.pow(awarenessFac, 0.85))],
-                  ["Popularity Bonus:", "x" + formatBigNumber(Math.pow(popularityFac, 0.85))],
-                  ["Ratio Multiplier:", "x" + formatBigNumber(Math.pow(ratioFac, 0.85))],
+                  ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
+                  ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
+                  ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
                 ]}
               />
             </>
           }
         >
-          <Typography>Advertising Multiplier: x{formatBigNumber(totalAdvertisingFac)}</Typography>
+          <Typography>Advertising Multiplier: {formatCorpMultiplier(totalAdvertisingFac)}</Typography>
         </Tooltip>
       )}
       <br />
@@ -161,12 +161,13 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
         <Tooltip
           title={
             <>
-              Production gain from owning production-boosting materials such as hardware, Robots, AI Cores, and Real
-              Estate.
+              Production gain from owning production-boosting materials such as
+              <br />
+              hardware, Robots, AI Cores, and Real Estate.
             </>
           }
         >
-          <Typography>Production Multiplier: {formatBigNumber(division.productionMult)}</Typography>
+          <Typography>Production Multiplier: {formatCorpMultiplier(division.productionMult)}</Typography>
         </Tooltip>
         <IconButton onClick={() => setHelpOpen(true)}>
           <HelpIcon />
@@ -211,7 +212,7 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
         <ButtonWithTooltip
           normalTooltip={
             <>
-              Hire AdVert.Inc to advertise your company. Each level of this upgrade grants your company a static
+              Hire <b>AdVert.Inc</b> to advertise your company. Each level of this upgrade grants your company a static
               increase of 3 and 1 to its awareness and popularity, respectively. It will then increase your company's" +
               awareness by 1%, and its popularity by a random percentage between 1% and 3%. These effects are increased
               by other upgrades that increase the power of your advertising.

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -135,9 +135,7 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
         <Tooltip
           title={
             <>
-              <Typography>
-                Multiplier for this industry's sales due to its awareness and popularity.
-              </Typography>
+              <Typography>Multiplier for this industry's sales due to its awareness and popularity.</Typography>
               <MathJax>{`\\(\\text{${division.type} Industry: }\\alpha = ${division.advertisingFactor}\\)`}</MathJax>
               <MathJax>{`\\(\\text{multiplier} = \\left((\\text{awareness}+1)^{\\alpha} \\times (\\text{popularity}+1)^{\\alpha} \\times \\frac{\\text{popularity}+0.001}{\\text{awareness}}\\right)^{0.85}\\)`}</MathJax>
               <br />

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -133,22 +133,21 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
       {advertisingInfo && (
         <Tooltip
           title={
-            <StatsTable
-              centered={true}
-              title={
-                <>
-                  Multiplier for this industry's sales
-                  <br />
-                  due to its awareness and popularity.
-                </>
-              }
-              rows={[
-                ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
-                ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
-                ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
-                [<b key={1}>Total:</b>, <b key={2}>{formatCorpMultiplier(totalAdvertisingFac)}</b>],
-              ]}
-            />
+            <>
+              <Typography>
+                Multiplier for this industry's sales
+                <br />
+                due to its awareness and popularity.
+              </Typography>
+              <StatsTable
+                rows={[
+                  ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
+                  ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
+                  ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
+                  [<b key={1}>Total:</b>, <b key={2}>{formatCorpMultiplier(totalAdvertisingFac)}</b>],
+                ]}
+              />
+            </>
           }
         >
           <Typography>Advertising Multiplier: {formatCorpMultiplier(totalAdvertisingFac)}</Typography>

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -83,24 +83,16 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
   // Material Gain details
   const gainBreakdown = [
     ["Buy:", mat.buyAmount >= 1e33 ? mat.buyAmount.toExponential(3) : formatBigNumber(mat.buyAmount)],
-    ["Prod:", formatBigNumber(mat.productionAmount)],
-    ["Sell:", formatBigNumber(mat.actualSellAmount)],
-    ["Export:", formatBigNumber(mat.exportedLastCycle)],
-    ["Import:", formatBigNumber(mat.importAmount)]
+    ["Production:", formatBigNumber(mat.productionAmount)],
+    ["Sell:", formatBigNumber(-mat.actualSellAmount)],
+    ["Export:", formatBigNumber(-mat.exportedLastCycle)],
+    ["Import:", formatBigNumber(mat.importAmount)],
   ];
   if (corp.unlocks.has(CorpUnlockName.MarketResearchDemand)) {
     gainBreakdown.push(["Demand:", formatCorpStat(mat.demand)]);
   }
   if (corp.unlocks.has(CorpUnlockName.MarketDataCompetition)) {
     gainBreakdown.push(["Competition:", formatCorpStat(mat.competition)]);
-  }
-  if (division.producedMaterials.includes(mat.name)) {
-    gainBreakdown.push(
-      ["Employee Production:", formatBigNumber(division.getOfficeProductivity(office, { forProduct: true }))],
-      ["Smart Factories:", formatPercent(corp.getProductionMultiplier())],
-      ["Boosting Materials:", formatPercent(division.productionMult)],
-      ["Research:", formatPercent(division.getProductionMultiplier())],
-    );
   }
 
   return (

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -84,9 +84,9 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
   const gainBreakdown = [
     ["Buy:", mat.buyAmount >= 1e33 ? mat.buyAmount.toExponential(3) : formatBigNumber(mat.buyAmount)],
     ["Prod:", formatBigNumber(mat.productionAmount)],
-    ["Sell:", formatBigNumber(-mat.actualSellAmount)],
-    ["Export:", formatBigNumber(-mat.exportedLastCycle)],
     ["Import:", formatBigNumber(mat.importAmount)],
+    ["Export:", formatBigNumber(-mat.exportedLastCycle)],
+    ["Sell:", formatBigNumber(-mat.actualSellAmount)],
   ];
   if (corp.unlocks.has(CorpUnlockName.MarketResearchDemand)) {
     gainBreakdown.push(["Demand:", formatCorpStat(mat.demand)]);

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -8,7 +8,7 @@ import { Warehouse } from "../Warehouse";
 import { ExportModal } from "./modals/ExportModal";
 import { SellMaterialModal } from "./modals/SellMaterialModal";
 import { PurchaseMaterialModal } from "./modals/PurchaseMaterialModal";
-import { formatBigNumber, formatCorpStat, formatPercent, formatQuality } from "../../ui/formatNumber";
+import { formatBigNumber, formatCorpStat, formatQuality } from "../../ui/formatNumber";
 import { isString } from "../../utils/helpers/string";
 import { Money } from "../../ui/React/Money";
 import { useCorporation, useDivision } from "./Context";
@@ -83,7 +83,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
   // Material Gain details
   const gainBreakdown = [
     ["Buy:", mat.buyAmount >= 1e33 ? mat.buyAmount.toExponential(3) : formatBigNumber(mat.buyAmount)],
-    ["Production:", formatBigNumber(mat.productionAmount)],
+    ["Prod:", formatBigNumber(mat.productionAmount)],
     ["Sell:", formatBigNumber(-mat.actualSellAmount)],
     ["Export:", formatBigNumber(-mat.exportedLastCycle)],
     ["Import:", formatBigNumber(mat.importAmount)],

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -8,7 +8,7 @@ import { Warehouse } from "../Warehouse";
 import { ExportModal } from "./modals/ExportModal";
 import { SellMaterialModal } from "./modals/SellMaterialModal";
 import { PurchaseMaterialModal } from "./modals/PurchaseMaterialModal";
-import { formatBigNumber, formatCorpStat, formatQuality } from "../../ui/formatNumber";
+import { formatBigNumber, formatCorpStat, formatPercent, formatQuality } from "../../ui/formatNumber";
 import { isString } from "../../utils/helpers/string";
 import { Money } from "../../ui/React/Money";
 import { useCorporation, useDivision } from "./Context";
@@ -93,6 +93,14 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
   }
   if (corp.unlocks.has(CorpUnlockName.MarketDataCompetition)) {
     gainBreakdown.push(["Competition:", formatCorpStat(mat.competition)]);
+  }
+  if (division.producedMaterials.includes(mat.name)) {
+    gainBreakdown.push(
+      ["Employee Production:", formatBigNumber(division.getOfficeProductivity(office, { forProduct: true }))],
+      ["Smart Factories:", formatPercent(corp.getProductionMultiplier())],
+      ["Boosting Materials:", formatPercent(division.productionMult)],
+      ["Research:", formatPercent(division.getProductionMultiplier())],
+    );
   }
 
   return (

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -85,8 +85,8 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
     ["Buy:", mat.buyAmount >= 1e33 ? mat.buyAmount.toExponential(3) : formatBigNumber(mat.buyAmount)],
     ["Prod:", formatBigNumber(mat.productionAmount)],
     ["Import:", formatBigNumber(mat.importAmount)],
-    ["Export:", formatBigNumber(-mat.exportedLastCycle)],
-    ["Sell:", formatBigNumber(-mat.actualSellAmount)],
+    ["Export:", formatBigNumber(-mat.exportedLastCycle || 0)],
+    ["Sell:", formatBigNumber(-mat.actualSellAmount || 0)],
   ];
   if (corp.unlocks.has(CorpUnlockName.MarketResearchDemand)) {
     gainBreakdown.push(["Demand:", formatCorpStat(mat.demand)]);

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -13,6 +13,7 @@ import { isString } from "../../utils/helpers/string";
 import { Money } from "../../ui/React/Money";
 import { useCorporation, useDivision } from "./Context";
 import { LimitMaterialProductionModal } from "./modals/LimitMaterialProductionModal";
+import { StatsTable } from "../../ui/React/StatsTable";
 
 interface IMaterialProps {
   warehouse: Warehouse;
@@ -79,33 +80,26 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
     limitMaterialButtonText += " (" + formatCorpStat(mat.productionLimit) + ")";
   }
 
+  // Material Gain details
+  const gainBreakdown = [
+    ["Buy:", mat.buyAmount >= 1e33 ? mat.buyAmount.toExponential(3) : formatBigNumber(mat.buyAmount)],
+    ["Prod:", formatBigNumber(mat.productionAmount)],
+    ["Sell:", formatBigNumber(mat.actualSellAmount)],
+    ["Export:", formatBigNumber(mat.exportedLastCycle)],
+    ["Import:", formatBigNumber(mat.importAmount)]
+  ];
+  if (corp.unlocks.has(CorpUnlockName.MarketResearchDemand)) {
+    gainBreakdown.push(["Demand:", formatCorpStat(mat.demand)]);
+  }
+  if (corp.unlocks.has(CorpUnlockName.MarketDataCompetition)) {
+    gainBreakdown.push(["Competition:", formatCorpStat(mat.competition)]);
+  }
+
   return (
     <Paper>
       <Box sx={{ display: "grid", gridTemplateColumns: "2fr 1fr", m: "5px" }}>
         <Box>
-          <Tooltip
-            title={
-              <Typography>
-                Buy: {mat.buyAmount >= 1e33 ? mat.buyAmount.toExponential(3) : formatBigNumber(mat.buyAmount)} <br />
-                Prod: {formatBigNumber(mat.productionAmount)} <br />
-                Sell: {formatBigNumber(mat.actualSellAmount)} <br />
-                Export: {formatBigNumber(mat.exportedLastCycle)} <br />
-                Import: {formatBigNumber(mat.importAmount)}
-                {corp.unlocks.has(CorpUnlockName.MarketResearchDemand) && (
-                  <>
-                    <br />
-                    Demand: {formatCorpStat(mat.demand)}
-                  </>
-                )}
-                {corp.unlocks.has(CorpUnlockName.MarketDataCompetition) && (
-                  <>
-                    <br />
-                    Competition: {formatCorpStat(mat.competition)}
-                  </>
-                )}
-              </Typography>
-            }
-          >
+          <Tooltip title={<StatsTable rows={gainBreakdown} />}>
             <Typography>
               {mat.name}: {formatBigNumber(mat.stored)} (
               {totalGain >= 1e33 ? totalGain.toExponential(3) : formatBigNumber(totalGain)}/s)

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -79,18 +79,18 @@ export function Overview({ rerender }: IProps): React.ReactElement {
               rows={[
                 [
                   "Owned Stock Shares:",
-                  <>&nbsp;{formatShares(corp.numShares)}&nbsp;</>,
-                  <>({formatPercent(corp.numShares / corp.totalShares)})</>,
+                  formatShares(corp.numShares),
+                  `(${formatPercent(corp.numShares / corp.totalShares)})`,
                 ],
                 [
                   "Outstanding Shares:",
-                  <>&nbsp;{formatShares(corp.issuedShares)}&nbsp;</>,
-                  <>({formatPercent(corp.issuedShares / corp.totalShares)})</>,
+                  formatShares(corp.issuedShares),
+                  `(${formatPercent(corp.issuedShares / corp.totalShares)})`,
                 ],
                 [
                   "Private Shares:",
-                  <>&nbsp;{formatShares(corp.investorShares)}&nbsp;</>,
-                  <>({formatPercent(corp.investorShares / corp.totalShares)})</>,
+                  formatShares(corp.investorShares),
+                  `(${formatPercent(corp.investorShares / corp.totalShares)})`,
                 ],
               ]}
             />

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -15,7 +15,7 @@ import * as corpConstants from "../data/Constants";
 import { CorpUnlocks } from "../data/CorporationUnlocks";
 
 import { CONSTANTS } from "../../Constants";
-import { formatCorpStat, formatPercent, formatShares } from "../../ui/formatNumber";
+import { formatCorpMultiplier, formatPercent, formatShares } from "../../ui/formatNumber";
 import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFunctions";
 import { Money } from "../../ui/React/Money";
 import { MoneyRate } from "../../ui/React/MoneyRate";
@@ -45,7 +45,7 @@ export function Overview({ rerender }: IProps): React.ReactElement {
   const multRows: string[][] = [];
   function appendMult(name: string, value: number): void {
     if (value === 1) return;
-    multRows.push([name, formatCorpStat(value)]);
+    multRows.push([name, formatCorpMultiplier(value)]);
   }
   appendMult("Production Multiplier: ", corp.getProductionMultiplier());
   appendMult("Storage Multiplier: ", corp.getStorageMultiplier());

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -93,7 +93,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
                 <StatsTable
                   rows={[
                     ["Prod:", formatBigNumber(product.cityData[city].productionAmount)],
-                    ["Sell:", formatBigNumber(product.cityData[city].actualSellAmount)],
+                    ["Sell:", formatBigNumber(-product.cityData[city].actualSellAmount)],
                   ]}
                 />
               }

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -93,7 +93,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
                 <StatsTable
                   rows={[
                     ["Prod:", formatBigNumber(product.cityData[city].productionAmount)],
-                    ["Sell:", formatBigNumber(-product.cityData[city].actualSellAmount)],
+                    ["Sell:", formatBigNumber(-product.cityData[city].actualSellAmount || 0)],
                   ]}
                 />
               }

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -13,6 +13,7 @@ import { formatBigNumber, formatPercent } from "../../ui/formatNumber";
 import { isString } from "../../utils/helpers/string";
 import { Money } from "../../ui/React/Money";
 import { useCorporation, useDivision } from "./Context";
+import { StatsTable } from "../../ui/React/StatsTable";
 
 interface IProductProps {
   city: CityName;
@@ -89,11 +90,12 @@ export function ProductElem(props: IProductProps): React.ReactElement {
           <Box display="flex">
             <Tooltip
               title={
-                <Typography>
-                  Prod: {formatBigNumber(product.cityData[city].productionAmount)}/s
-                  <br />
-                  Sell: {formatBigNumber(product.cityData[city].actualSellAmount)} /s
-                </Typography>
+                <StatsTable
+                  rows={[
+                    ["Prod:", formatBigNumber(product.cityData[city].productionAmount)],
+                    ["Sell:", formatBigNumber(product.cityData[city].actualSellAmount)],
+                  ]}
+                />
               }
             >
               <Typography>

--- a/src/Corporation/ui/modals/ResearchModal.tsx
+++ b/src/Corporation/ui/modals/ResearchModal.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from "react";
 import { Modal } from "../../../ui/React/Modal";
+import { StatsTable } from "../../../ui/React/StatsTable";
+import { dialogBoxCreate } from "../../../ui/React/DialogBox";
+import { formatCorpMultiplier } from "../../../ui/formatNumber";
 import { IndustryResearchTrees } from "../../data/IndustryData";
 import * as corpConstants from "../../data/Constants";
 import { Division } from "../../Division";
@@ -7,7 +10,7 @@ import { Research } from "../../Actions";
 import { Node } from "../../ResearchTree";
 import { ResearchMap } from "../../ResearchMap";
 import { Settings } from "../../../Settings/Settings";
-import { dialogBoxCreate } from "../../../ui/React/DialogBox";
+
 import Typography from "@mui/material/Typography";
 import Tooltip from "@mui/material/Tooltip";
 import Button from "@mui/material/Button";
@@ -144,15 +147,17 @@ export function ResearchModal(props: IProps): React.ReactElement {
         Research points: {props.industry.researchPoints.toFixed(3)}
         <br />
         Multipliers from research:
-        <br />* Advertising Multiplier: x{researchTree.getAdvertisingMultiplier()}
-        <br />* Employee Charisma Multiplier: x{researchTree.getEmployeeChaMultiplier()}
-        <br />* Employee Creativity Multiplier: x{researchTree.getEmployeeCreMultiplier()}
-        <br />* Employee Efficiency Multiplier: x{researchTree.getEmployeeEffMultiplier()}
-        <br />* Employee Intelligence Multiplier: x{researchTree.getEmployeeIntMultiplier()}
-        <br />* Production Multiplier: x{researchTree.getProductionMultiplier()}
-        <br />* Sales Multiplier: x{researchTree.getSalesMultiplier()}
-        <br />* Scientific Research Multiplier: x{researchTree.getScientificResearchMultiplier()}
-        <br />* Storage Multiplier: x{researchTree.getStorageMultiplier()}
+        <StatsTable rows={[
+          ['Advertising Multiplier:', formatCorpMultiplier(researchTree.getAdvertisingMultiplier())],
+          ['Employee Charisma Multiplier:', formatCorpMultiplier(researchTree.getEmployeeChaMultiplier())],
+          ['Employee Creativity Multiplier:', formatCorpMultiplier(researchTree.getEmployeeCreMultiplier())],
+          ['Employee Efficiency Multiplier:', formatCorpMultiplier(researchTree.getEmployeeEffMultiplier())],
+          ['Employee Intelligence Multiplier:', formatCorpMultiplier(researchTree.getEmployeeIntMultiplier())],
+          ['Production Multiplier:', formatCorpMultiplier(researchTree.getProductionMultiplier())],
+          ['Sales Multiplier:', formatCorpMultiplier(researchTree.getSalesMultiplier())],
+          ['Scientific Research Multiplier:', formatCorpMultiplier(researchTree.getScientificResearchMultiplier())],
+          ['Storage Multiplier:', formatCorpMultiplier(researchTree.getStorageMultiplier())]
+        ]} />
       </Typography>
     </Modal>
   );

--- a/src/Corporation/ui/modals/ResearchModal.tsx
+++ b/src/Corporation/ui/modals/ResearchModal.tsx
@@ -147,17 +147,19 @@ export function ResearchModal(props: IProps): React.ReactElement {
         Research points: {props.industry.researchPoints.toFixed(3)}
         <br />
         Multipliers from research:
-        <StatsTable rows={[
-          ['Advertising Multiplier:', formatCorpMultiplier(researchTree.getAdvertisingMultiplier())],
-          ['Employee Charisma Multiplier:', formatCorpMultiplier(researchTree.getEmployeeChaMultiplier())],
-          ['Employee Creativity Multiplier:', formatCorpMultiplier(researchTree.getEmployeeCreMultiplier())],
-          ['Employee Efficiency Multiplier:', formatCorpMultiplier(researchTree.getEmployeeEffMultiplier())],
-          ['Employee Intelligence Multiplier:', formatCorpMultiplier(researchTree.getEmployeeIntMultiplier())],
-          ['Production Multiplier:', formatCorpMultiplier(researchTree.getProductionMultiplier())],
-          ['Sales Multiplier:', formatCorpMultiplier(researchTree.getSalesMultiplier())],
-          ['Scientific Research Multiplier:', formatCorpMultiplier(researchTree.getScientificResearchMultiplier())],
-          ['Storage Multiplier:', formatCorpMultiplier(researchTree.getStorageMultiplier())]
-        ]} />
+        <StatsTable
+          rows={[
+            ["Advertising Multiplier:", formatCorpMultiplier(researchTree.getAdvertisingMultiplier())],
+            ["Employee Charisma Multiplier:", formatCorpMultiplier(researchTree.getEmployeeChaMultiplier())],
+            ["Employee Creativity Multiplier:", formatCorpMultiplier(researchTree.getEmployeeCreMultiplier())],
+            ["Employee Efficiency Multiplier:", formatCorpMultiplier(researchTree.getEmployeeEffMultiplier())],
+            ["Employee Intelligence Multiplier:", formatCorpMultiplier(researchTree.getEmployeeIntMultiplier())],
+            ["Production Multiplier:", formatCorpMultiplier(researchTree.getProductionMultiplier())],
+            ["Sales Multiplier:", formatCorpMultiplier(researchTree.getSalesMultiplier())],
+            ["Scientific Research Multiplier:", formatCorpMultiplier(researchTree.getScientificResearchMultiplier())],
+            ["Storage Multiplier:", formatCorpMultiplier(researchTree.getStorageMultiplier())],
+          ]}
+        />
       </Typography>
     </Modal>
   );

--- a/src/ui/React/StatsTable.tsx
+++ b/src/ui/React/StatsTable.tsx
@@ -1,29 +1,33 @@
-import React from "react";
+import React, { ReactNode, ReactElement } from "react";
 
 import { Table, TableCell } from "./Table";
-import TableBody from "@mui/material/TableBody";
-import { Table as MuiTable } from "@mui/material";
-import TableRow from "@mui/material/TableRow";
-import Typography from "@mui/material/Typography";
+import { TableBody, TableRow, Table as MuiTable, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 
-interface IProps {
-  rows: React.ReactNode[][];
+interface StatsTableProps {
+  rows: ReactNode[][];
   title?: string;
   wide?: boolean;
 }
 
-export function StatsTable({ rows, title, wide }: IProps): React.ReactElement {
+const useStyles = makeStyles({
+  firstCell: { textAlign: "left" },
+  nonFirstCell: { textAlign: "right", paddingLeft: "0.5em" },
+});
+
+export function StatsTable({ rows, title, wide }: StatsTableProps): ReactElement {
   const T = wide ? MuiTable : Table;
+  const classes = useStyles();
   return (
     <>
       {title && <Typography>{title}</Typography>}
       <T size="small" padding="none">
         <TableBody>
-          {rows.map((row: React.ReactNode[], i: number) => (
-            <TableRow key={i}>
-              {row.map((elem: React.ReactNode, i: number) => (
-                <TableCell key={i} align={i !== 0 ? "right" : "left"}>
-                  <Typography noWrap>{elem}</Typography>
+          {rows.map((row, rowIndex) => (
+            <TableRow key={rowIndex}>
+              {row.map((cell, cellIndex) => (
+                <TableCell key={cellIndex} className={cellIndex === 0 ? classes.firstCell : classes.nonFirstCell}>
+                  <Typography noWrap>{cell}</Typography>
                 </TableCell>
               ))}
             </TableRow>

--- a/src/ui/React/StatsTable.tsx
+++ b/src/ui/React/StatsTable.tsx
@@ -8,16 +8,17 @@ import Typography from "@mui/material/Typography";
 
 interface IProps {
   rows: React.ReactNode[][];
-  title?: string;
+  title?: React.ReactNode;
   wide?: boolean;
+  centered?: boolean;
 }
 
-export function StatsTable({ rows, title, wide }: IProps): React.ReactElement {
+export function StatsTable({ rows, title, wide, centered }: IProps): React.ReactElement {
   const T = wide ? MuiTable : Table;
   return (
     <>
       {title && <Typography>{title}</Typography>}
-      <T size="small" padding="none">
+      <T size="small" padding="none" sx={centered ? { margin: "auto" } : {}}>
         <TableBody>
           {rows.map((row: React.ReactNode[], i: number) => (
             <TableRow key={i}>

--- a/src/ui/React/StatsTable.tsx
+++ b/src/ui/React/StatsTable.tsx
@@ -8,22 +8,21 @@ import Typography from "@mui/material/Typography";
 
 interface IProps {
   rows: React.ReactNode[][];
-  title?: React.ReactNode;
+  title?: string;
   wide?: boolean;
-  centered?: boolean;
 }
 
-export function StatsTable({ rows, title, wide, centered }: IProps): React.ReactElement {
+export function StatsTable({ rows, title, wide }: IProps): React.ReactElement {
   const T = wide ? MuiTable : Table;
   return (
     <>
       {title && <Typography>{title}</Typography>}
-      <T size="small" padding="none" sx={centered ? { margin: "auto" } : {}}>
+      <T size="small" padding="none">
         <TableBody>
           {rows.map((row: React.ReactNode[], i: number) => (
             <TableRow key={i}>
               {row.map((elem: React.ReactNode, i: number) => (
-                <TableCell key={i} align={i !== 0 ? "right" : "left"} sx={i !== 0 ? { paddingLeft: "0.5em" } : {}}>
+                <TableCell key={i} align={i !== 0 ? "right" : "left"}>
                   <Typography noWrap>{elem}</Typography>
                 </TableCell>
               ))}

--- a/src/ui/React/StatsTable.tsx
+++ b/src/ui/React/StatsTable.tsx
@@ -22,7 +22,7 @@ export function StatsTable({ rows, title, wide }: IProps): React.ReactElement {
           {rows.map((row: React.ReactNode[], i: number) => (
             <TableRow key={i}>
               {row.map((elem: React.ReactNode, i: number) => (
-                <TableCell key={i} align={i !== 0 ? "right" : "left"}>
+                <TableCell key={i} align={i !== 0 ? "right" : "left"} sx={i !== 0 ? { paddingLeft: "0.5em" } : {}}>
                   <Typography noWrap>{elem}</Typography>
                 </TableCell>
               ))}

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -151,6 +151,7 @@ export const formatPopulation = formatBigNumber;
 export const formatSecurity = formatBigNumber;
 export const formatStamina = formatBigNumber;
 export const formatStaneksGiftCharge = formatBigNumber;
+export const formatCorpMultiplier = (n: number) => "×" + formatBigNumber(n);
 
 /** Format a number with suffixes starting at 1000 and 2 fractional digits */
 export const formatQuality = (n: number) => formatNumber(n, 2);
@@ -187,7 +188,6 @@ export const formatMatPurchaseAmount = formatMultiplier;
 export const formatSleeveShock = (n: number) => formatNumberNoSuffix(n, 3);
 export const formatSleeveSynchro = formatSleeveShock;
 export const formatCorpStat = formatSleeveShock;
-export const formatCorpMultiplier = (n: number) => "×" + formatCorpStat(n);
 
 /** Parsing numbers does not use the locale as this causes complications. */
 export function parseBigNumber(str: string): number {

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -187,6 +187,7 @@ export const formatMatPurchaseAmount = formatMultiplier;
 export const formatSleeveShock = (n: number) => formatNumberNoSuffix(n, 3);
 export const formatSleeveSynchro = formatSleeveShock;
 export const formatCorpStat = formatSleeveShock;
+export const formatCorpMultiplier = (n: number) => "×" + formatCorpStat(n);
 
 /** Parsing numbers does not use the locale as this causes complications. */
 export function parseBigNumber(str: string): number {


### PR DESCRIPTION
This PR collects production and sales multipliers in tooltips on the office stats screen. These values were already available to players but difficult to work with due to being in different formats on different pages.

### Summary of changes

- Tooltip for material/product buy/sell/prod/export amounts: re-ordered according to game cycles, positive/negative sign of values changed to always be relative to local warehouse space
- Tooltip for Office material/product production amount: reviewed wording and added breakdown of factors
- Tooltip for Office sales multiplier: reviewed wording and added breakdown of factors
- Tooltip for Division advertising factors - added formula, updated table formatting
- Created a new formatter function for Corporation multipliers, to look good right-aligned with formatted Corp stats but include "x", applied it throughout Corp UIs


<img width="605" alt="material breakdown" src="https://github.com/bitburner-official/bitburner-src/assets/208776/1d233fd5-e394-4a18-8d70-22206e00f8d0"><img width="588" alt="product breakdown" src="https://github.com/bitburner-official/bitburner-src/assets/208776/45635b29-917e-4592-84b5-ffeaa2d14603">
<img width="589" alt="sales breakdown" src="https://github.com/bitburner-official/bitburner-src/assets/208776/fb910b3b-2297-4b38-b234-cbf3b63c4b49">
<img width="749" alt="Screenshot 2023-10-02 at 10 44 24 AM" src="https://github.com/bitburner-official/bitburner-src/assets/208776/e4c9bda0-4dfc-4f76-acb4-1f93bea7efba">




---


DarkTechnomancer:
> IMO the biggest help for the lowest effort would be exposing the mechanics in-game. Make VeChain free for a start, but then the somewhat more complicated fix would be moving the multipliers to the places where they apply rather than just showing them in a vacuum. Seeing that you have a x14 Business multiplier and a x0.74 advertising multiplier isn't really useful if you don't know what those mean.
> 
> For example, I think it would be better if you could hover over the number on material production and get a tooltip that breaks it down like 1.4 (Employee Production) * 128 (Warehouse Production Bonus) * 1.1 (Research) * 1 (Morale) = 197.12
