### PR TITLE
API: Singularity API - check for purchased program before enough money

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -452,14 +452,14 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         return false;
       }
 
-      if (Player.money < item.price) {
-        helpers.log(ctx, () => `Not enough money to purchase '${item.program}'. Need ${formatMoney(item.price)}`);
-        return false;
-      }
-
       if (Player.hasProgram(item.program)) {
         helpers.log(ctx, () => `You already have the '${item.program}' program`);
         return true;
+      }
+
+      if (Player.money < item.price) {
+        helpers.log(ctx, () => `Not enough money to purchase '${item.program}'. Need ${formatMoney(item.price)}`);
+        return false;
       }
 
       Player.getHomeComputer().pushProgram(item.program);


### PR DESCRIPTION
# Singularity: check if a program has been purchased before determining whether the user has enough money. 

# Bug fix

The function is set to return `true` if the user has either 
- already purchased the program 
- successfully purchased the program. 

By swapping these logic statements, we check to see if the program has been purchased before determining if the user has enough money. This way, if I don't have enough money to purchase the program again, the function will return `true` as expected. 

