### PR TITLE
MISC: Update Electron to 26.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "babel-jest": "^29.3.1",
         "babel-loader": "^9.1.2",
         "css-loader": "^6.7.3",
-        "electron": "^22.2.1",
+        "electron": "^26.2.4",
         "electron-packager": "^17.1.1",
         "eslint": "^8.43.0",
         "eslint-plugin-react": "^7.32.2",
@@ -4320,9 +4320,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+      "version": "18.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
+      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
       "dev": true
     },
     "node_modules/@types/numeral": {
@@ -7117,14 +7117,14 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "22.3.25",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.25.tgz",
-      "integrity": "sha512-AjrP7bebMs/IPsgmyowptbA7jycTkrJC7jLZTb5JoH30PkBC6pZx/7XQ0aDok82SsmSiF4UJDOg+HoLrEBiqmg==",
+      "version": "26.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.4.tgz",
+      "integrity": "sha512-weMUSMyDho5E0DPQ3breba3D96IxwNvtYHjMd/4/wNN3BdI5s3+0orNnPVGJFcLhSvKoxuKUqdVonUocBPwlQA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -20964,9 +20964,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+      "version": "18.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
+      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
       "dev": true
     },
     "@types/numeral": {
@@ -23098,13 +23098,13 @@
       "dev": true
     },
     "electron": {
-      "version": "22.3.25",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.25.tgz",
-      "integrity": "sha512-AjrP7bebMs/IPsgmyowptbA7jycTkrJC7jLZTb5JoH30PkBC6pZx/7XQ0aDok82SsmSiF4UJDOg+HoLrEBiqmg==",
+      "version": "26.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.4.tgz",
+      "integrity": "sha512-weMUSMyDho5E0DPQ3breba3D96IxwNvtYHjMd/4/wNN3BdI5s3+0orNnPVGJFcLhSvKoxuKUqdVonUocBPwlQA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-jest": "^29.3.1",
     "babel-loader": "^9.1.2",
     "css-loader": "^6.7.3",
-    "electron": "^22.2.1",
+    "electron": "^26.2.4",
     "electron-packager": "^17.1.1",
     "eslint": "^8.43.0",
     "eslint-plugin-react": "^7.32.2",


### PR DESCRIPTION
The version of Electron should be updated to address these vulnerabilities:

- [CVE-2023-4863](https://nvd.nist.gov/vuln/detail/CVE-2023-4863)
- [CVE-2023-5217](https://nvd.nist.gov/vuln/detail/CVE-2023-5217)

It is unlikely for a Bitburner player to try to display .webp or .vp8 media, but it is technically possible.