### PR TITLE
CORPORATION: fix division state display

### DIFF
--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -115,7 +115,7 @@ export class Corporation {
         ind.resetImports(state);
       }
       for (const ind of this.divisions.values()) {
-        ind.process(marketCycles, state, this);
+        ind.process(marketCycles, this);
       }
 
       // Process cooldowns

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -73,7 +73,6 @@ export class Division {
   thisCycleRevenue = 0;
   thisCycleExpenses = 0;
 
-  
   newInd = true;
 
   // Sector 12 office and warehouse are added by default, these entries are added in the constructor.
@@ -142,8 +141,8 @@ export class Division {
     }
   }
 
-  process(marketCycles = 1,  corporation: Corporation): void {
-    const state = corporation.state.getState()
+  process(marketCycles = 1, corporation: Corporation): void {
+    const state = corporation.state.getState();
     //At the start of a cycle, store and reset revenue/expenses
     //Then calculate salaries and process the markets
     if (state === "START") {
@@ -265,7 +264,7 @@ export class Division {
 
   //Process production, purchase, and import/export of materials
   processMaterials(marketCycles = 1, corporation: Corporation): [number, number] {
-    const state = corporation.state.getState()
+    const state = corporation.state.getState();
     let revenue = 0;
     let expenses = 0;
     this.calculateProductionFactors();
@@ -718,7 +717,7 @@ export class Division {
 
   /** Process product development and production/sale */
   processProducts(marketCycles = 1, corporation: Corporation): [number, number] {
-    const state = corporation.state.getState()
+    const state = corporation.state.getState();
     let revenue = 0;
     const expenses = 0;
 
@@ -747,7 +746,7 @@ export class Division {
 
   //Processes FINISHED products
   processProduct(marketCycles = 1, product: Product, corporation: Corporation): number {
-    const state = corporation.state.getState()
+    const state = corporation.state.getState();
     let totalProfit = 0;
     for (const [city, office] of getRecordEntries(this.offices)) {
       const warehouse = this.warehouses[city];
@@ -951,7 +950,7 @@ export class Division {
     return totalProfit;
   }
 
-  resetImports(state: string): void {
+  resetImports(state: CorpStateName): void {
     //At the start of the export state, set the imports of everything to 0
     if (state === "EXPORT") {
       for (const warehouse of getRecordValues(this.warehouses)) {

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -73,7 +73,7 @@ export class Division {
   thisCycleRevenue = 0;
   thisCycleExpenses = 0;
 
-  state: CorpStateName = "START";
+  
   newInd = true;
 
   // Sector 12 office and warehouse are added by default, these entries are added in the constructor.
@@ -142,9 +142,8 @@ export class Division {
     }
   }
 
-  process(marketCycles = 1, state: CorpStateName, corporation: Corporation): void {
-    this.state = state;
-
+  process(marketCycles = 1,  corporation: Corporation): void {
+    const state = corporation.state.getState()
     //At the start of a cycle, store and reset revenue/expenses
     //Then calculate salaries and process the markets
     if (state === "START") {
@@ -266,6 +265,7 @@ export class Division {
 
   //Process production, purchase, and import/export of materials
   processMaterials(marketCycles = 1, corporation: Corporation): [number, number] {
+    const state = corporation.state.getState()
     let revenue = 0;
     let expenses = 0;
     this.calculateProductionFactors();
@@ -285,7 +285,7 @@ export class Division {
       const warehouse = this.warehouses[city];
       if (!warehouse) continue;
 
-      switch (this.state) {
+      switch (state) {
         case "PURCHASE": {
           const smartBuy: PartialRecord<CorpMaterialName, [buyAmt: number, reqMat: number]> = {};
 
@@ -708,7 +708,7 @@ export class Division {
         case "START":
           break;
         default:
-          console.error(`Invalid state: ${this.state}`);
+          console.error(`Invalid state: ${state}`);
           break;
       } //End switch(this.state)
       this.updateWarehouseSizeUsed(warehouse);
@@ -718,6 +718,7 @@ export class Division {
 
   /** Process product development and production/sale */
   processProducts(marketCycles = 1, corporation: Corporation): [number, number] {
+    const state = corporation.state.getState()
     let revenue = 0;
     const expenses = 0;
 
@@ -725,7 +726,7 @@ export class Division {
     for (const [name, product] of this.products) {
       if (!product.finished) {
         // Product still under development
-        if (this.state !== "PRODUCTION") continue;
+        if (state !== "PRODUCTION") continue;
         const city = product.creationCity;
         const office = this.offices[city];
         if (!office) {
@@ -746,11 +747,12 @@ export class Division {
 
   //Processes FINISHED products
   processProduct(marketCycles = 1, product: Product, corporation: Corporation): number {
+    const state = corporation.state.getState()
     let totalProfit = 0;
     for (const [city, office] of getRecordEntries(this.offices)) {
       const warehouse = this.warehouses[city];
       if (!warehouse) continue;
-      switch (this.state) {
+      switch (state) {
         case "PRODUCTION": {
           //Calculate the maximum production of this material based
           //on the office's productivity
@@ -942,7 +944,7 @@ export class Division {
         case "EXPORT":
           break;
         default:
-          console.error(`Invalid State: ${this.state}`);
+          console.error(`Invalid State: ${state}`);
           break;
       } //End switch(this.state)
     }

--- a/src/Corporation/ui/DivisionWarehouse.tsx
+++ b/src/Corporation/ui/DivisionWarehouse.tsx
@@ -59,8 +59,9 @@ function WarehouseRoot(props: WarehouseProps): React.ReactElement {
   }
 
   // Next state which will be processed:
+  const state = corp.state.getState()
   let stateText;
-  switch (division.state) {
+  switch (state) {
     case "START":
       stateText = "Next state: Preparing";
       break;
@@ -77,7 +78,7 @@ function WarehouseRoot(props: WarehouseProps): React.ReactElement {
       stateText = "Next state: Exporting materials and/or products";
       break;
     default:
-      console.error(`Invalid state: ${division.state}`);
+      console.error(`Invalid state: ${state}`);
       break;
   }
 

--- a/src/Corporation/ui/DivisionWarehouse.tsx
+++ b/src/Corporation/ui/DivisionWarehouse.tsx
@@ -59,7 +59,7 @@ function WarehouseRoot(props: WarehouseProps): React.ReactElement {
   }
 
   // Next state which will be processed:
-  const state = corp.state.getState()
+  const state = corp.state.getState();
   let stateText;
   switch (state) {
     case "START":


### PR DESCRIPTION
remove this.state from division class
changing the calls to it to be based on corporation.state.getState to make sure the correct state variable is used
fixing a bug that the division ui shows the past state instead of the next state 
and bring it in line with how the ui text is worded and what the api returns (getCorporation().state)
