### PR TITLE
UI: Clarify wording in Corporation

### DIFF
--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -246,7 +246,7 @@ function PublicButtons({ rerender }: IPublicButtonsProps): React.ReactElement {
       </ButtonWithTooltip>
       <SellSharesModal open={sellSharesOpen} onClose={() => setSellSharesOpen(false)} rerender={rerender} />
       <ButtonWithTooltip
-        normalTooltip={"Buy back shares you that previously issued or sold on the market"}
+        normalTooltip={"Buy back outstanding shares that you previously issued or sold on the market"}
         disabledTooltip={corp.issuedShares < 1 ? "No shares available to buy back" : ""}
         onClick={() => setBuybackSharesOpen(true)}
       >

--- a/src/Corporation/ui/modals/BuybackSharesModal.tsx
+++ b/src/Corporation/ui/modals/BuybackSharesModal.tsx
@@ -89,7 +89,7 @@ export function BuybackSharesModal(props: IProps): React.ReactElement {
           disabledText
         ) : (
           <>
-            <b>{corp.name}</b>'s stock price will rise to <Money money={sharePrice} /> per share.
+            <b>{corp.name}</b>'s stock price will settle at <Money money={sharePrice} /> per share.
           </>
         )}
       </Typography>

--- a/src/Corporation/ui/modals/SellSharesModal.tsx
+++ b/src/Corporation/ui/modals/SellSharesModal.tsx
@@ -88,7 +88,7 @@ export function SellSharesModal(props: IProps): React.ReactElement {
           <>
             You will receive <Money money={profit} />.
             <br />
-            <b>{corp.name}</b>'s stock price will fall to <Money money={sharePrice} /> per share.
+            <b>{corp.name}</b>'s stock price will settle at <Money money={sharePrice} /> per share.
           </>
         )}
       </Typography>


### PR DESCRIPTION
A few UIs changed in #782 had unclear wording reported in Discord:

"stock price will rise/fall" used incorrectly in common edge cases:
<img width="613" alt="image" src="https://github.com/bitburner-official/bitburner-src/assets/208776/aafbbc75-c47d-4e53-858a-9dc4a7a3e07e">

typo in "buyback shares" tooltip
![image](https://github.com/bitburner-official/bitburner-src/assets/208776/d37131fe-8571-41df-b0d0-b4abe02b75d9)

