### PR TITLE
CODE: Enable es2023 features

### DIFF
--- a/electron/jsconfig.json
+++ b/electron/jsconfig.json
@@ -1,0 +1,3 @@
+{
+  "compilerOptions": { "target": "ESNext" }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "css-loader": "^6.7.3",
         "electron": "^26.2.4",
         "electron-packager": "^17.1.1",
-        "eslint": "^8.43.0",
+        "eslint": "^8.51.0",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "file-loader": "^6.2.0",
@@ -93,7 +93,7 @@
         "source-map": "^0.7.4",
         "start-server-and-test": "^1.15.2",
         "style-loader": "^3.3.1",
-        "typescript": "^4.9.4",
+        "typescript": "^5.2.2",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.11.1"
@@ -2384,9 +2384,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
-      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
+      "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7879,15 +7879,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
-      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
+      "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.50.0",
+        "@eslint/js": "8.51.0",
         "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -17281,16 +17281,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "css-loader": "^6.7.3",
     "electron": "^26.2.4",
     "electron-packager": "^17.1.1",
-    "eslint": "^8.43.0",
+    "eslint": "^8.51.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "file-loader": "^6.2.0",
@@ -94,7 +94,7 @@
     "source-map": "^0.7.4",
     "start-server-and-test": "^1.15.2",
     "style-loader": "^3.3.1",
-    "typescript": "^4.9.4",
+    "typescript": "^5.2.2",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1"

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -25,14 +25,15 @@ export function validateObject<Type extends Record<string, unknown>, Key extends
       } else if (paramValidator.func !== undefined) {
         paramValidator.func(obj, validator, key);
       } else {
-        if (typeof obj[key] !== typeof paramValidator.default) {
+        const objVal = obj[key];
+        if (typeof objVal !== typeof paramValidator.default) {
           obj[key] = paramValidator.default as Type[Key];
         }
-        if (typeof obj[key] === "number" && paramValidator.min !== undefined) {
-          if (obj[key] < paramValidator.min) obj[key] = paramValidator.min as Type[Key];
+        if (typeof objVal === "number" && paramValidator.min !== undefined && objVal < paramValidator.min) {
+          obj[key] = paramValidator.min as Type[Key];
         }
-        if (typeof obj[key] === "number" && paramValidator.max !== undefined) {
-          if (obj[key] > paramValidator.max) obj[key] = paramValidator.max as Type[Key];
+        if (typeof objVal === "number" && paramValidator.max !== undefined && objVal > paramValidator.max) {
+          obj[key] = paramValidator.max as Type[Key];
         }
       }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2022"
+    "target": "ESNext"
   },
   "include": ["src/**/*", "electron/**/*", "node_modules/monaco-editor/monaco.d.ts"]
 }


### PR DESCRIPTION
Fixes #853 

For some reason ES2023 was not accepted as a valid target, even though documentation online says it should be. But selecting ESNext works. Trying to get es2023 to work is why I updated some packages, I don't think that was necessary otherwise.

Not a huge fan of keeping jsconfig.json in the distributed folder with all the electron js files, although package.json is already included so it's not a new issue with this file.