### PR TITLE
BUGFIX: Prevent faction invitations appearing after prestige

### DIFF
--- a/src/Faction/ui/InvitationModal.tsx
+++ b/src/Faction/ui/InvitationModal.tsx
@@ -7,7 +7,7 @@ import { EventEmitter } from "../../utils/EventEmitter";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 
-export const InvitationEvent = new EventEmitter<[Faction]>();
+export const InvitationEvent = new EventEmitter<[Faction | null]>();
 
 export function InvitationModal({ hidden }: { hidden: boolean }): React.ReactElement {
   const [faction, setFaction] = useState<Faction | null>(null);
@@ -17,8 +17,9 @@ export function InvitationModal({ hidden }: { hidden: boolean }): React.ReactEle
     const i = Player.factionInvitations.findIndex((facName) => facName === faction.name);
     if (i === -1) {
       console.error("Could not find faction in Player.factionInvitations");
+    } else {
+      joinFaction(faction);
     }
-    joinFaction(faction);
     setFaction(null);
   }
 

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -26,6 +26,7 @@ import { CONSTANTS } from "../../Constants";
 import { Exploit } from "../../Exploits/Exploit";
 import { Faction } from "../../Faction/Faction";
 import { Factions } from "../../Faction/Factions";
+import { InvitationEvent } from "../../Faction/ui/InvitationModal";
 import { resetGangs } from "../../Gang/AllGangs";
 import { Cities } from "../../Locations/Cities";
 import { Locations } from "../../Locations/Locations";
@@ -104,6 +105,8 @@ export function prestigeAugmentation(this: PlayerObject): void {
 
   this.factions = [];
   this.factionInvitations = [];
+  // Clear any pending invitation modals
+  InvitationEvent.emit(null);
 
   this.queuedAugmentations = [];
 


### PR DESCRIPTION
Reported in discord: https://discord.com/channels/415207508303544321/415213413745164318/1160776780672663592

After hacking the world daemon, the game is still technically running as usual behind the bitflume page.
This means that faction invites can come through without being displayed. If an invite occurs on the bitflume page and suppress invites is off, that invite will appear after selecting a bit node and will allow you to join that faction regardless of requirements.

## Reproduction
1. Start brand new save in dev mode
2. Give a lot of money in the dev console
3. Quickly press "Hack w0r1d_d43mon" in the dev console
4. Wait for a minute in the bitflume screen
5. Click any node
6. Observe a faction invitation for Sector-12 despite only having 1k cash.

### Bugged
![faction_broken](https://github.com/bitburner-official/bitburner-src/assets/7016138/6b236ffd-d0e7-4b5d-92a3-1f8433b9e917)
### Fixed
![faction_fixed](https://github.com/bitburner-official/bitburner-src/assets/7016138/610894fb-aa1d-4ad8-897c-86a48bc5696c)

## Changes
* Faction `InvitationModal` accepts null as an input to close the model through the `EventEmitter`
* `prestigeAugmentation` calls `InvitationEvent.emit(null)` to close any model
* The model `Join` button only actually joins the faction if there's a matching invite present. The invite should always be present with the `emit(null)` change, this is just defensive.

### Testing
* Followed the reproduction steps with the updated code: No faction invite appeared
* Used dev mode to give faction requirements while staying in the bitnode: Faction invitations appeared as per normal and Join worked correctly and dismissing the invite modal still showed it under factions.
