### PR TITLE
BUGFIX: Include script offline production in Active Scripts

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -9,6 +9,7 @@ export const CONSTANTS: {
   VersionNumber: number;
   MaxSkillLevel: number;
   MilliPerCycle: number;
+  OfflineHackingIncome: number;
   CorpFactionRepRequirement: number;
   BaseFocusBonus: number;
   BaseCostFor1GBOfRamHome: number;
@@ -95,6 +96,9 @@ export const CONSTANTS: {
 
   // Milliseconds per game cycle
   MilliPerCycle: 200,
+
+  // Multiplier for hacking income earned from offline scripts
+  OfflineHackingIncome: 0.75,
 
   // How much reputation is needed to join a megacorporation's faction
   CorpFactionRepRequirement: 400e3,

--- a/src/Script/ScriptHelpers.ts
+++ b/src/Script/ScriptHelpers.ts
@@ -54,9 +54,15 @@ export function scriptCalculateOfflineProduction(runningScript: RunningScript): 
   const expGain = confidence * (runningScript.onlineExpGained / runningScript.onlineRunningTime) * timePassed;
   Player.gainHackingExp(expGain);
 
+  const moneyGain =
+    (runningScript.onlineMoneyMade / runningScript.onlineRunningTime) * timePassed * CONSTANTS.OfflineHackingIncome;
+  // money is given to player during engine load
+  Player.scriptProdSinceLastAug += moneyGain;
+
   // Update script stats
   runningScript.offlineRunningTime += timePassed;
   runningScript.offlineExpGained += expGain;
+  runningScript.offlineMoneyMade += moneyGain;
 
   // Weaken
   for (const hostname of Object.keys(runningScript.dataMap)) {

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -262,7 +262,8 @@ const Engine: {
       }
 
       let offlineReputation = 0;
-      const offlineHackingIncome = (Player.moneySourceA.hacking / Player.playtimeSinceLastAug) * timeOffline * 0.75;
+      const offlineHackingIncome =
+        (Player.moneySourceA.hacking / Player.playtimeSinceLastAug) * timeOffline * CONSTANTS.OfflineHackingIncome;
       Player.gainMoney(offlineHackingIncome, "hacking");
       // Process offline progress
 


### PR DESCRIPTION
Offline script production isn't calculated for display under Active Scripts in either the `Total production since last Augment Installation` up top or in the individual scripts details themselves. This PR calculates the offline production for scripts in these areas.

Notes:
* `getTotalScriptIncome()` 's second return value uses `Player.scriptProdSinceLastAug` which now tracks offline script production. Usage of this API will see the second return value much larger than previously used.

closes #802

## Changes
* Add a constant the offline hacking income factor (`CONSTANTS.OfflineHackingIncome`)
* Calculate offline income per script in `scriptCalculateOfflineProduction` the same way as `engine.js` does. This function is only called once when the game is loaded. Offline hacking exp is also calculated here. This will show the offline production for each individual active script.
* Add offline income to `Player.scriptProdSinceLastAug`. This will update the top counter in Active Scripts.

## Screenshots
Some screenshots of relevant areas. Note I only show one script but it's the only relevant money making script in this particular save. The rest of the scripts combined amount to a couple of `b` out of several `T`. Differences in hacking total and 'Total since last aug install' are due to a delay between grabbing screenshots.


### Bugged
![offline_prod_bugged](https://github.com/bitburner-official/bitburner-src/assets/7016138/124cc7d4-84a4-4f36-8adc-b6708de7b031)
### Fixed
![offline_prod_fixed](https://github.com/bitburner-official/bitburner-src/assets/7016138/13571ca7-cb04-4c3b-a2f3-4de070ba812a)
