### PR TITLE
INFILTRATION: Change hermes AUG to instead show the next characters

### DIFF
--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -1781,7 +1781,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       repCost: 1e4,
       moneyCost: 1e6,
       info: "Penta-dynamo-neurovascular-valve inserted in the carpal ligament, enhances dexterity.",
-      stats: "This augmentation makes the Cheat Code minigame easier by allowing the opposite character.",
+      stats: "This augmentation makes the Cheat Code minigame easier by showing what character will come next.",
       isSpecial: true,
       factions: [FactionName.ShadowsOfAnarchy],
     },

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -1,16 +1,9 @@
 import { Paper, Typography } from "@mui/material";
 import React, { useState } from "react";
 import { AugmentationName } from "@enums";
+import { Settings } from "../../Settings/Settings";
 import { Player } from "@player";
-import {
-  downArrowSymbol,
-  getArrow,
-  getInverseArrow,
-  leftArrowSymbol,
-  random,
-  rightArrowSymbol,
-  upArrowSymbol,
-} from "../utils";
+import { downArrowSymbol, getArrow, leftArrowSymbol, random, rightArrowSymbol, upArrowSymbol } from "../utils";
 import { interpolate } from "./Difficulty";
 import { GameTimer } from "./GameTimer";
 import { IMinigameProps } from "./IMinigameProps";
@@ -43,9 +36,12 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
   const [index, setIndex] = useState(0);
   const hasAugment = Player.hasAugmentation(AugmentationName.TrickeryOfHermes, true);
 
+  const focusColor = Settings.theme.primary;
+  const hintColor = Settings.theme.disabled;
+
   function press(this: Document, event: KeyboardEvent): void {
     event.preventDefault();
-    if (code[index] !== getArrow(event) && (!hasAugment || code[index] !== getInverseArrow(event))) {
+    if (code[index] !== getArrow(event)) {
       props.onFailure();
       return;
     }
@@ -58,7 +54,18 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
       <GameTimer millis={timer} onExpire={props.onFailure} />
       <Paper sx={{ display: "grid", justifyItems: "center" }}>
         <Typography variant="h4">Enter the Code!</Typography>
-        <Typography variant="h4">{code[index]}</Typography>
+        <Typography variant="h4">
+          {hasAugment && (
+            <>
+              <span style={{ color: hintColor }}>{index > 1 ? code[index - 2] : "\u00a0"}&nbsp;</span>
+              <span style={{ color: hintColor }}>{index > 0 ? code[index - 1] : "\u00a0"}&nbsp;</span>
+              <span style={{ color: focusColor }}>{code[index]}</span>
+              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 1 ? code[index + 1] : "\u00a0"}</span>
+              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 2 ? code[index + 2] : "\u00a0"}</span>
+            </>
+          )}
+          {!hasAugment && <span style={{ color: focusColor }}>{code[index]}</span>}
+        </Typography>
         <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
       </Paper>
     </>

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -3,7 +3,17 @@ import React, { useState } from "react";
 import { AugmentationName } from "@enums";
 import { Settings } from "../../Settings/Settings";
 import { Player } from "@player";
-import { downArrowSymbol, getArrow, leftArrowSymbol, random, rightArrowSymbol, upArrowSymbol } from "../utils";
+import {
+  downArrowSymbol,
+  getArrow,
+  leftArrowSymbol,
+  random,
+  rightArrowSymbol,
+  upArrowSymbol,
+  leftDashedArrowSymbol,
+  rightDashedArrowSymbol,
+  toDashedArrow,
+} from "../utils";
 import { interpolate } from "./Difficulty";
 import { GameTimer } from "./GameTimer";
 import { IMinigameProps } from "./IMinigameProps";
@@ -49,6 +59,8 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
     if (index + 1 >= code.length) props.onSuccess();
   }
 
+  // Hidden arrows are to force a consistent column width for the grid layout,
+  // based on the widest character (left and right dashed arrows)
   return (
     <>
       <GameTimer millis={timer} onExpire={props.onFailure} />
@@ -56,13 +68,15 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
         <Typography variant="h4">Enter the Code!</Typography>
         <Typography variant="h4">
           {hasAugment && (
-            <>
-              <span style={{ color: hintColor }}>{index > 1 ? code[index - 2] : "\u00a0"}&nbsp;</span>
-              <span style={{ color: hintColor }}>{index > 0 ? code[index - 1] : "\u00a0"}&nbsp;</span>
+            <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(7, 1fr)", textAlign: "center" }}>
+              <span style={{ visibility: "hidden" }}>{leftDashedArrowSymbol}</span>
+              <span style={{ color: hintColor }}>{index > 1 && toDashedArrow(code[index - 2])}</span>
+              <span style={{ color: hintColor }}>{index > 0 && toDashedArrow(code[index - 1])}</span>
               <span style={{ color: focusColor }}>{code[index]}</span>
-              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 1 ? code[index + 1] : "\u00a0"}</span>
-              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 2 ? code[index + 2] : "\u00a0"}</span>
-            </>
+              <span style={{ color: hintColor }}>{index < code.length - 1 && toDashedArrow(code[index + 1])}</span>
+              <span style={{ color: hintColor }}>{index < code.length - 2 && toDashedArrow(code[index + 2])}</span>
+              <span style={{ visibility: "hidden" }}>{rightDashedArrowSymbol}</span>
+            </div>
           )}
           {!hasAugment && <span style={{ color: focusColor }}>{code[index]}</span>}
         </Typography>

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -68,7 +68,7 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
         <Typography variant="h4">Enter the Code!</Typography>
         <Typography variant="h4">
           {hasAugment && (
-            <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(7, 1fr)", textAlign: "center" }}>
+            <div style={{ display: "grid", gap: "2rem", gridTemplateColumns: "repeat(7, 1fr)", textAlign: "center" }}>
               <span style={{ visibility: "hidden" }}>{leftDashedArrowSymbol}</span>
               <span style={{ color: hintColor }}>{index > 1 && toDashedArrow(code[index - 2])}</span>
               <span style={{ color: hintColor }}>{index > 0 && toDashedArrow(code[index - 1])}</span>

--- a/src/Infiltration/utils.ts
+++ b/src/Infiltration/utils.ts
@@ -9,6 +9,11 @@ export const downArrowSymbol = "↓";
 export const leftArrowSymbol = "←";
 export const rightArrowSymbol = "→";
 
+export const leftDashedArrowSymbol = "\u21e0";
+export const upDashedArrowSymbol = "\u21e1";
+export const rightDashedArrowSymbol = "\u21e2";
+export const downDashedArrowSymbol = "\u21e3";
+
 export function getArrow(event: KeyboardEvent): string {
   switch (event.key) {
     case KEY.UP_ARROW:
@@ -41,6 +46,20 @@ export function getInverseArrow(event: KeyboardEvent): string {
     case KEY.LEFT_ARROW:
     case KEY.A:
       return rightArrowSymbol;
+  }
+  return "";
+}
+
+export function toDashedArrow(arrow: string): string {
+  switch (arrow) {
+    case downArrowSymbol:
+      return downDashedArrowSymbol;
+    case rightArrowSymbol:
+      return rightDashedArrowSymbol;
+    case upArrowSymbol:
+      return upDashedArrowSymbol;
+    case leftArrowSymbol:
+      return leftDashedArrowSymbol;
   }
   return "";
 }


### PR DESCRIPTION
This is a _suggested_ change to how the Shadows of Anarchy Hermes augmentation (for the Cheat Code infiltration) works.

I've found the Hermes aug to be the worst of all the SoA augs and barely helpful. Most SoA augs are at least desirable. This changes the aug to instead show what characters are going to come next. The opposite character functionality is removed.

Through play-testing this, I found you needed to also show the previous characters for the augmentation to not simply be more confusing. It's difficulty with the augmentation is now about on par with the Ares/Slash minigame; you'll probably succeed but if you slack off a bit you'll lose.

The flavour text could possibly be updated to reflect the new behavour but if you mentally squint, it can still makes sense.

### Two Arrows
Here's a gif with two arrows before and two arrows after the "real" arrow. This is what is implemented in the PR.
![arrows_new](https://github.com/bitburner-official/bitburner-src/assets/7016138/8da7eec8-0086-45ae-bdf5-199b49c04d3b)
