### PR TITLE
BUGFIX: rm doesn't remove the correct contract from the array

### DIFF
--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -202,7 +202,7 @@ export abstract class BaseServer implements IServer {
       return { res: true };
     }
     if (path.endsWith(".cct")) {
-      const contractIndex = this.contracts.findIndex((program) => program);
+      const contractIndex = this.contracts.findIndex((contracts) => contracts.fn === path);
       if (contractIndex === -1) return { res: false, msg: `Contract file ${path} does not exist` };
       this.contracts.splice(contractIndex, 1);
       return { res: true };


### PR DESCRIPTION
Fix .cct delete

BUGFIX

# Linked issues

Fixes https://github.com/bitburner-official/bitburner-src/issues/879

# Bug fix

Was able to reproduce the issue.  Looking at the code, it appears it was checking the programs array and not the contracts array.  Somehow it always returned 0.  Changed the lookup to actually check the contract array filename and to match it with the passed in path.
Before fix: would always delete array index 0
After fix: finds the actual array number that matches the filename passed in

