### PR TITLE
BUGFIX: Update SleeveCrimeWork.ts to work through all cyclesWorked if its greater than cyclesNeeded

### DIFF
--- a/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
@@ -38,7 +38,7 @@ export class SleeveCrimeWork extends SleeveWorkClass {
     this.cyclesWorked += cycles;
     if (this.cyclesWorked < this.cyclesNeeded()) return;
 
-     while (this.cyclesWorked > this.cyclesNeeded()) {
+    while (this.cyclesWorked > this.cyclesNeeded()) {
       const crime = this.getCrime();
       const gains = this.getExp(sleeve);
       const success = Math.random() < crime.successRate(sleeve);

--- a/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
@@ -38,15 +38,17 @@ export class SleeveCrimeWork extends SleeveWorkClass {
     this.cyclesWorked += cycles;
     if (this.cyclesWorked < this.cyclesNeeded()) return;
 
-    const crime = this.getCrime();
-    const gains = this.getExp(sleeve);
-    const success = Math.random() < crime.successRate(sleeve);
-    if (success) {
-      Player.karma -= crime.karma * sleeve.syncBonus();
-      Player.numPeopleKilled += crime.kills;
-    } else gains.money = 0;
-    applySleeveGains(sleeve, gains, success ? 1 : 0.25);
-    this.cyclesWorked -= this.cyclesNeeded();
+     while (this.cyclesWorked > this.cyclesNeeded()) {
+      const crime = this.getCrime();
+      const gains = this.getExp(sleeve);
+      const success = Math.random() < crime.successRate(sleeve);
+      if (success) {
+        Player.karma -= crime.karma * sleeve.syncBonus();
+        Player.numPeopleKilled += crime.kills;
+      } else gains.money = 0;
+      applySleeveGains(sleeve, gains, success ? 1 : 0.25);
+      this.cyclesWorked -= this.cyclesNeeded();
+    }
   }
 
   APICopy() {


### PR DESCRIPTION
CATEGORY: BUGFIX

Work through all stored cycles possible.
1. This will actually use all of the stored cycles for Shoplift
2. This will fix the UI progress indication noted in the submitted issue

# Linked issues

fixes https://github.com/bitburner-official/bitburner-src/issues/876


# Bug fix

Reproduced issue Dev environment
Issue is that the cycles needed for Shoplift are less than the cycles worked in an Overclocked Sleeve
So when the process hits
`this.cyclesWorked -= this.cyclesNeeded()`

There are still cyclesWorked left over that are actually greater than the number of cycles that would be need to complete the task again.  The progress bar is just a display of cycles worked.  Since every overclock cycle adds more cyclesWorked than removed by the Shoplift task, it grows forever.

Throwing in a loop to work through all remaining cycles until it's actually less than the needed cycles allows Sleeves to achieve their full potential for overclocked shoplifting and it fixes the UI issue.


