### PR TITLE
MISC: Nerf Noodle Bar

### DIFF
--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -116,7 +116,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
       }
 
       if (Player.corporation) {
-        Player.corporation.funds += Player.corporation.revenue * 0.01;
+        Player.corporation.addNonIncomeFunds(Player.corporation.revenue * 0.01);
       }
     }
 


### PR DESCRIPTION
Recent Corporation anti-fraud accounting did not account for money laundering through Noodle Bar.

It was possible to exploit previous fraud strategies by eating noodles 10 times per second.