### PR TITLE
DOCS: Tweak Illuminati .lit to provide a join hint

### DIFF
--- a/src/Literature/Literatures.ts
+++ b/src/Literature/Literatures.ts
@@ -380,8 +380,8 @@ export const Literatures: Record<LiteratureName, Literature> = {
       "THE GOVERNMENT DOES NOT EXIST. CORPORATIONS DO NOT RUN SOCIETY<br><br>" +
       `THE ${FactionName.Illuminati.toUpperCase()} ARE THE SECRET RULERS OF THE WORLD!<br><br>` +
       `Yes, the ${FactionName.Illuminati} of legends. The ancient secret society that controls the entire ` +
-      "world from the shadows with their invisible hand. The group of the rich and wealthy " +
-      "that have penetrated every major government, financial agency, and corporation in the last " +
+      "world from the shadows with their invisible hand. With their personal wealth and skills " +
+      "they have penetrated every major government, financial agency, and corporation in the last " +
       "three hundred years.<br><br>" +
       "OPEN YOUR EYES<br><br>" +
       `It was the ${FactionName.Illuminati} that brought an end to democracy in the world. They are the driving force ` +


### PR DESCRIPTION
Some of the more obscure factions are very hard to discover without going out-of-game. The Illuminati have a strong hint of *existence* with this .lit file, but it doesn't tell you what you need to join. This gives more of a hint as to the conditions.