### PR TITLE
UI: General devmenu followup changes

### DIFF
--- a/src/DevMenu/ui/General.tsx
+++ b/src/DevMenu/ui/General.tsx
@@ -131,10 +131,10 @@ export function General(): React.ReactElement {
         <NumberInput placeholder={"$$$"} onChange={setDevMoney} />
         <Button onClick={addCustomMoney}>Give Money</Button>
         <Button onClick={setMoney(0)}>Clear Money</Button>
-        <br />
-        <br />
         {Player.hashManager.capacity > 0 && (
           <>
+            <br />
+            <br />
             <Typography>
               Hashes (current: <Hashes hashes={Player.hashManager.hashes} /> /&nbsp;
               <Hashes hashes={Player.hashManager.capacity} />)


### PR DESCRIPTION
Following up on changes from #835

* Got rid of fixed width buttons
* Section headings more clearly defined with vertical space
* Page shows current money / hashes / Max Home RAM. Section periodically rerenders to keep this displayed info updated.
* No more super tall money buttons
* Hashes section only shows up if hash capacity is greater than 0.
* Ram section display updates based on the formatting options player has selected (GiB vs GB).

Visual comparison:
![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/af20d6b2-e9ee-4add-b706-f6371e9abcd2)