### PR TITLE
CORPORATION: move product productionCost into cityData

### DIFF
--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -232,7 +232,7 @@ export class Corporation {
           assets += mat.stored * mat.averagePrice;
         }
         for (const prod of ind.products.values()) {
-          assets += prod.cityData[warehouse.city].stored * prod.productionCost;
+          assets += prod.cityData[warehouse.city].stored * prod.cityData[warehouse.city].productionCost;
         }
       }
     });

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -823,13 +823,13 @@ export class Division {
         }
         case "SALE": {
           //Process sale of Products
-          product.productionCost = 0; //Estimated production cost
+          product.cityData[city].productionCost = 0; //Estimated production cost
           for (const [reqMatName, reqQty] of getRecordEntries(product.requiredMaterials)) {
-            product.productionCost += reqQty * warehouse.materials[reqMatName].marketPrice;
+            product.cityData[city].productionCost += reqQty * warehouse.materials[reqMatName].marketPrice;
           }
 
           // Since its a product, its production cost is increased for labor
-          product.productionCost *= corpConstants.baseProductProfitMult;
+          product.cityData[city].productionCost *= corpConstants.baseProductProfitMult;
 
           // Sale multipliers
           const businessFactor = this.getBusinessFactor(office); //Business employee productivity
@@ -887,33 +887,33 @@ export class Division {
               if (sqrtNumerator === 0) {
                 optimalPrice = 0; // Nothing to sell
               } else {
-                optimalPrice = product.productionCost + markupLimit;
+                optimalPrice = product.cityData[city].productionCost + markupLimit;
                 console.warn(`In Corporation, found illegal 0s when trying to calculate MarketTA2 sale cost`);
               }
             } else {
-              optimalPrice = numerator / denominator + product.productionCost;
+              optimalPrice = numerator / denominator + product.cityData[city].productionCost;
             }
 
             // Store this "optimal Price" in a property so we don't have to re-calculate for UI
             sCost = optimalPrice;
           } else if (product.marketTa1) {
-            sCost = product.productionCost + markupLimit;
+            sCost = product.cityData[city].productionCost + markupLimit;
           } else if (isString(sellPrice)) {
             let sCostString = sellPrice;
             if (product.markup === 0) {
               console.error(`mku is zero, reverting to 1 to avoid Infinity`);
               product.markup = 1;
             }
-            sCostString = sCostString.replace(/MP/g, product.productionCost.toString());
-            sCost = Math.max(product.productionCost, eval(sCostString));
+            sCostString = sCostString.replace(/MP/g, product.cityData[city].productionCost.toString());
+            sCost = Math.max(product.cityData[city].productionCost, eval(sCostString));
           } else {
             sCost = sellPrice;
           }
           product.uiMarketPrice[city] = sCost;
           let markup = 1;
-          if (sCost > product.productionCost) {
-            if (sCost - product.productionCost > markupLimit) {
-              markup = markupLimit / (sCost - product.productionCost);
+          if (sCost > product.cityData[city].productionCost) {
+            if (sCost - product.cityData[city].productionCost > markupLimit) {
+              markup = markupLimit / (sCost - product.cityData[city].productionCost);
             }
           }
 

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -31,9 +31,6 @@ export class Product {
   without suffering a loss in the # of sales */
   markup = 0;
 
-  /** Cost of producing this product if buying its component materials at market price */
-  productionCost = 0;
-
   /** Whether the development for this product is finished yet */
   finished = false;
   developmentProgress = 0; // Creation progress - A number between 0-100 representing percentage
@@ -82,6 +79,8 @@ export class Product {
     desiredSellAmount: 0 as number | string,
     /** Player input sell price e.g. "MP * 5" */
     desiredSellPrice: "" as string | number,
+    /** Cost of producing this product if buying its component materials at market price */
+    productionCost: 0,
   }));
 
   /** How much warehouse space is occupied per unit of this product */

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -137,7 +137,8 @@ export function ProductElem(props: IProductProps): React.ReactElement {
           <Box display="flex">
             <Tooltip title={<Typography>An estimate of the material cost it takes to create this Product.</Typography>}>
               <Typography>
-                Est. Production Cost: <Money money={product.productionCost / corpConstants.baseProductProfitMult} />
+                Est. Production Cost:{" "}
+                <Money money={product.cityData[city].productionCost / corpConstants.baseProductProfitMult} />
               </Typography>
             </Tooltip>
           </Box>
@@ -151,7 +152,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
               }
             >
               <Typography>
-                Est. Market Price: <Money money={product.productionCost} />
+                Est. Market Price: <Money money={product.cityData[city].productionCost} />
               </Typography>
             </Tooltip>
           </Box>

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -31,26 +31,26 @@ export function ProductElem(props: IProductProps): React.ReactElement {
   const [cancelOpen, setCancelOpen] = useState(false);
   const city = props.city;
   const product = props.product;
-
+  const cityData = product.cityData[city];
   const hasUpgradeDashboard = division.hasResearch("uPgrade: Dashboard");
 
   // Total product gain = production - sale
-  const totalGain = product.cityData[city].productionAmount - product.cityData[city].actualSellAmount;
+  const totalGain = cityData.productionAmount - cityData.actualSellAmount;
 
   // Sell button
   let sellButtonText: JSX.Element;
-  const desiredSellAmount = product.cityData[city].desiredSellAmount;
+  const desiredSellAmount = cityData.desiredSellAmount;
   if (desiredSellAmount !== null) {
     if (isString(desiredSellAmount)) {
       sellButtonText = (
         <>
-          Sell ({formatBigNumber(product.cityData[city].actualSellAmount)}/{desiredSellAmount})
+          Sell ({formatBigNumber(cityData.actualSellAmount)}/{desiredSellAmount})
         </>
       );
     } else {
       sellButtonText = (
         <>
-          Sell ({formatBigNumber(product.cityData[city].actualSellAmount)}/{formatBigNumber(desiredSellAmount)})
+          Sell ({formatBigNumber(cityData.actualSellAmount)}/{formatBigNumber(desiredSellAmount)})
         </>
       );
     }
@@ -64,7 +64,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
     </>
   );
   // Limit Production button
-  const productionLimit = product.cityData[city].productionLimit;
+  const productionLimit = cityData.productionLimit;
   const limitProductionButtonText =
     "Limit Production" + (productionLimit !== null ? " (" + formatBigNumber(productionLimit) + ")" : "");
 
@@ -92,14 +92,14 @@ export function ProductElem(props: IProductProps): React.ReactElement {
               title={
                 <StatsTable
                   rows={[
-                    ["Prod:", formatBigNumber(product.cityData[city].productionAmount)],
-                    ["Sell:", formatBigNumber(-product.cityData[city].actualSellAmount || 0)],
+                    ["Prod:", formatBigNumber(cityData.productionAmount)],
+                    ["Sell:", formatBigNumber(-cityData.actualSellAmount || 0)],
                   ]}
                 />
               }
             >
               <Typography>
-                {product.name}: {formatBigNumber(product.cityData[city].stored)} ({formatBigNumber(totalGain)}
+                {product.name}: {formatBigNumber(cityData.stored)} ({formatBigNumber(totalGain)}
                 /s)
               </Typography>
             </Tooltip>
@@ -131,14 +131,13 @@ export function ProductElem(props: IProductProps): React.ReactElement {
                 </Typography>
               }
             >
-              <Typography>Effective rating: {formatBigNumber(product.cityData[city].effectiveRating)}</Typography>
+              <Typography>Effective rating: {formatBigNumber(cityData.effectiveRating)}</Typography>
             </Tooltip>
           </Box>
           <Box display="flex">
             <Tooltip title={<Typography>An estimate of the material cost it takes to create this Product.</Typography>}>
               <Typography>
-                Est. Production Cost:{" "}
-                <Money money={product.cityData[city].productionCost / corpConstants.baseProductProfitMult} />
+                Est. Production Cost: <Money money={cityData.productionCost / corpConstants.baseProductProfitMult} />
               </Typography>
             </Tooltip>
           </Box>
@@ -152,7 +151,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
               }
             >
               <Typography>
-                Est. Market Price: <Money money={product.cityData[city].productionCost} />
+                Est. Market Price: <Money money={cityData.productionCost} />
               </Typography>
             </Tooltip>
           </Box>

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -278,7 +278,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
         rating: product.rating,
         effectiveRating: cityData.effectiveRating,
         stats: cloneDeep(product.stats),
-        productionCost: product.productionCost,
+        productionCost: cityData.productionCost,
         desiredSellPrice: cityData.desiredSellPrice,
         desiredSellAmount: cityData.desiredSellAmount,
         stored: cityData.stored,


### PR DESCRIPTION
> When products are sold, their production cost is updated every time (https://github.com/bitburner-official/bitburner-src/blob/dev/src/Corporation/Division.ts#L826), it's the cost of all input materials multiplied by 5. Since material price changes, product.productionCost also changes. This updated value is what's shown in the corp UI and returned by ns.corporation.getProduct().productionCost. However, it is not city-specific, but material prices are different in different cities. So as a result, that number is only accurate for the city that was processed last.
https://discord.com/channels/415207508303544321/415213413745164318/1165999223989342280

Moved Product productionCost into cityData to save the individual productionCost
this might make it easier to "fraud" by moving items from a city with low production Cost into a city with high production cost to sell there
but i think good information are more important than preventing that