### PR TITLE
BUGFIX: Stop -1 contracts

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1663,10 +1663,12 @@ export class Bladeburner {
     if (!this.action) {
       throw new Error("Bladeburner.action is not an ActionIdentifier Object");
     }
-
-    const remainingActions = this.contracts[this.action.name].count;
-    if (remainingActions < 1) {
-      return this.resetAction();
+    //Check to see if action is a contract, and then to verify a sleeve didn't finish it first
+    if (this.action.type === 2) {
+      const remainingActions = this.contracts[this.action.name].count;
+      if (remainingActions < 1) {
+        return this.resetAction();
+      }
     }
     // If the previous action went past its completion time, add to the next action
     // This is not added immediately in case the automation changes the action

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1664,6 +1664,10 @@ export class Bladeburner {
       throw new Error("Bladeburner.action is not an ActionIdentifier Object");
     }
 
+    const remainingActions = this.contracts[this.action.name].count;
+    if (remainingActions < 1) {
+      return this.resetAction();
+    }
     // If the previous action went past its completion time, add to the next action
     // This is not added immediately in case the automation changes the action
     this.actionTimeCurrent += seconds + this.actionTimeOverflow;

--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -40,14 +40,14 @@ export class SleeveBladeburnerWork extends SleeveWorkClass {
     if (this.actionType === "Contracts") {
       const action = Player.bladeburner.getActionObject(actionIdent);
       if (!action) throw new Error(`Error getting ${this.actionName} action object`);
-      if (action.count <= 0) return sleeve.stopWork();
+      if (action.count < 1) return sleeve.stopWork();
     }
 
     while (this.cyclesWorked > this.cyclesNeeded(sleeve)) {
       if (this.actionType === "Contracts") {
         const action = Player.bladeburner.getActionObject(actionIdent);
         if (!action) throw new Error(`Error getting ${this.actionName} action object`);
-        if (action.count <= 0) return sleeve.stopWork();
+        if (action.count < 1) return sleeve.stopWork();
       }
       const retValue = Player.bladeburner.completeAction(sleeve, actionIdent, false);
       if (this.actionType === "General") {


### PR DESCRIPTION
Changed the sleeve and player blade burner action to stop/not process the success if the remaining actions is 0

Fixes https://github.com/bitburner-official/bitburner-src/issues/613

# Bug fix

I fixed the race condition issue by just silently failing the contract action if, on completion, the amount of remaining actions is less than 1.

However, I found a different issue with the Sleeve logic.  I was able to reproduce the issue by just having a single sleeve do contracts.  It looks like the previous code would only stop if the remaining count was less than or equal to 0.  Looking at the object, 'count' is not a whole number, so the sleeve would have continued an action if count was 0.01.  After completion count would be -.99 hence the -1 count in the UI.  I changed it to <1 to account for the fractional counts possible.

Before fix every time I had a sleeve with bonus time run contracts I would get it to -1.
No longer happens after fix.

Verified Operations and BlackOps still work with my player changes.
