### PR TITLE
CORPORATION: expose product size in getProduct 

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -287,6 +287,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
         developmentProgress: product.developmentProgress,
         advertisingInvestment: product.advertisingInvestment,
         designInvestment: product.designInvestment,
+        size: product.size,
       };
     },
     purchaseWarehouse: (ctx) => (_divisionName, _cityName) => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7900,6 +7900,8 @@ interface Product {
   advertisingInvestment: number;
   /** Funds that were spent on designing the product */
   designInvestment: number;
+  /** How much warehouse space is occupied per unit of this product */
+  size: number;
 }
 
 /**


### PR DESCRIPTION
tiny qol change
just added size to getProduct so people dont have to look up the size calculation in the source