### PR TITLE
SLEEVE API UI UPDATE && FIX ISSUE #896 BB NEEDS BASE GROWTH - Added setToBladeburnerSingleAction and the ability to set sleeves to IDLE from UI and a base growth to BB

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -894,6 +894,9 @@ export class Bladeburner {
     const count = Math.round(sourceCity.pop * percentage);
     sourceCity.pop -= count;
     destCity.pop += count;
+    if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+      destCity.pop += BladeburnerConstants.BasePopGrowth;
+    }
   }
 
   triggerPotentialMigration(sourceCityName: CityName, chance: number): void {
@@ -926,6 +929,9 @@ export class Bladeburner {
       const percentage = getRandomInt(10, 20) / 100;
       const count = Math.round(sourceCity.pop * percentage);
       sourceCity.pop += count;
+      if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+        sourceCity.pop += BladeburnerConstants.BasePopGrowth;
+      }
       if (this.logging.events) {
         this.log("Intelligence indicates that a new Synthoid community was formed in a city");
       }
@@ -937,6 +943,9 @@ export class Bladeburner {
         const percentage = getRandomInt(10, 20) / 100;
         const count = Math.round(sourceCity.pop * percentage);
         sourceCity.pop += count;
+        if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+          sourceCity.pop += BladeburnerConstants.BasePopGrowth;
+        }
         if (this.logging.events) {
           this.log("Intelligence indicates that a new Synthoid community was formed in a city");
         }
@@ -949,7 +958,9 @@ export class Bladeburner {
         const count = Math.round(sourceCity.pop * percentage);
         sourceCity.pop -= count;
         destCity.pop += count;
-
+        if (destCity.pop > BladeburnerConstants.PopGrowthCeiling) {
+          destCity.pop += BladeburnerConstants.BasePopGrowth;
+        }
         if (this.logging.events) {
           this.log(
             "Intelligence indicates that a Synthoid community migrated from " + sourceCityName + " to some other city",
@@ -961,6 +972,9 @@ export class Bladeburner {
       const percentage = getRandomInt(8, 24) / 100;
       const count = Math.round(sourceCity.pop * percentage);
       sourceCity.pop += count;
+      if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+        sourceCity.pop += BladeburnerConstants.BasePopGrowth;
+      }
       if (this.logging.events) {
         this.log(
           "Intelligence indicates that the Synthoid population of " + sourceCityName + " just changed significantly",

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1655,7 +1655,7 @@ export class Bladeburner {
     }
   }
 
-  processAction(seconds: number): void {
+  processAction(seconds: number, person: Person): void {
     if (this.action.type === ActionTypes.Idle) return;
     if (this.actionTimeToComplete <= 0) {
       throw new Error(`Invalid actionTimeToComplete value: ${this.actionTimeToComplete}, type; ${this.action.type}`);
@@ -1678,7 +1678,7 @@ export class Bladeburner {
       if (action == null) {
         throw new Error("Failed to get BlackOperation Object for: " + this.action.name);
       } else if (this.action.type != ActionTypes.BlackOperation && this.action.type != ActionTypes.BlackOp) {
-        this.startAction(this.action); // Repeat action
+          this.startAction(this.action); // Repeat action
       }
     }
   }
@@ -2041,7 +2041,7 @@ export class Bladeburner {
         this.randomEventCounter += getRandomInt(240, 600);
       }
 
-      this.processAction(seconds);
+      this.processAction(seconds, Player);
 
       // Automation
       if (this.automateEnabled) {

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -958,7 +958,7 @@ export class Bladeburner {
         const count = Math.round(sourceCity.pop * percentage);
         sourceCity.pop -= count;
         destCity.pop += count;
-        if (destCity.pop > BladeburnerConstants.PopGrowthCeiling) {
+        if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
           destCity.pop += BladeburnerConstants.BasePopGrowth;
         }
         if (this.logging.events) {

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -1655,7 +1655,7 @@ export class Bladeburner {
     }
   }
 
-  processAction(seconds: number, person: Person): void {
+  processAction(seconds: number): void {
     if (this.action.type === ActionTypes.Idle) return;
     if (this.actionTimeToComplete <= 0) {
       throw new Error(`Invalid actionTimeToComplete value: ${this.actionTimeToComplete}, type; ${this.action.type}`);
@@ -1678,7 +1678,7 @@ export class Bladeburner {
       if (action == null) {
         throw new Error("Failed to get BlackOperation Object for: " + this.action.name);
       } else if (this.action.type != ActionTypes.BlackOperation && this.action.type != ActionTypes.BlackOp) {
-          this.startAction(this.action); // Repeat action
+        this.startAction(this.action); // Repeat action
       }
     }
   }
@@ -2041,7 +2041,7 @@ export class Bladeburner {
         this.randomEventCounter += getRandomInt(240, 600);
       }
 
-      this.processAction(seconds, Player);
+      this.processAction(seconds);
 
       // Automation
       if (this.automateEnabled) {

--- a/src/Bladeburner/data/Constants.ts
+++ b/src/Bladeburner/data/Constants.ts
@@ -33,6 +33,9 @@ export const BladeburnerConstants = {
   BaseStatGain: 1, // Base stat gain per second
   BaseIntGain: 0.003, // Base intelligence stat gain
 
+  BasePopGrowth: 100, // Base amount a population will grow by
+  PopGrowthCeiling: 1.5e9, // Amount of population a city can have before BasePopGrowth does not apply
+
   ActionCountGrowthPeriod: 480, // Time (s) it takes for action count to grow by its specified value
 
   RankToFactionRepFactor: 2, // Delta Faction Rep = this * Delta Rank

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -319,6 +319,7 @@ const sleeve = {
   getSleevePurchasableAugs: RamCostConstants.SleeveBase,
   purchaseSleeveAug: RamCostConstants.SleeveBase,
   setToBladeburnerAction: RamCostConstants.SleeveBase,
+  setToBladeburnerSingleAction: RamCostConstants.SleeveBase,
   getSleeveAugmentationPrice: RamCostConstants.SleeveBase,
   getSleeveAugmentationRepReq: RamCostConstants.SleeveBase,
 } as const;

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -261,6 +261,36 @@ export function NetscriptSleeve(): InternalAPI<NetscriptSleeve> {
 
       return Player.sleeves[sleeveNumber].bladeburner(action, contract);
     },
+    setToBladeburnerSingleAction: (ctx) => (_sleeveNumber, _action, _contract?) => {
+      const sleeveNumber = helpers.number(ctx, "sleeveNumber", _sleeveNumber);
+      const action = helpers.string(ctx, "action", _action);
+      let contract: string;
+      if (typeof _contract === "undefined") {
+        contract = "------";
+      } else {
+        contract = helpers.string(ctx, "contract", _contract);
+      }
+      checkSleeveAPIAccess(ctx);
+      checkSleeveNumber(ctx, sleeveNumber);
+
+      // Cannot Take on Contracts if another sleeve is performing that action
+      if (action === "Take on contracts") {
+        for (let i = 0; i < Player.sleeves.length; ++i) {
+          if (i === sleeveNumber) {
+            continue;
+          }
+          const other = Player.sleeves[i];
+          if (isSleeveBladeburnerWork(other.currentWork) && other.currentWork.actionName === contract) {
+            throw helpers.makeRuntimeErrorMsg(
+              ctx,
+              `Sleeve ${sleeveNumber} cannot take on contracts because Sleeve ${i} is already performing that action.`,
+            );
+          }
+        }
+      }
+
+      return Player.sleeves[sleeveNumber].bladeburnersingle(action, contract);
+    },
   };
 
   // Removed functions

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -431,7 +431,7 @@ export class Sleeve extends Person implements SleevePerson {
   /** Begin a Single bladeburner task */
   bladeburnersingle(action: string, contract: string): boolean {
     if (!Player.bladeburner) return false;
-     this.singleAction = true;
+    this.singleAction = true;
     switch (action) {
       case "Training":
         this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training" }));

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -60,9 +60,6 @@ export class Sleeve extends Person implements SleevePerson {
    */
   shock = 100;
 
-  /* Whether or not we are performing a single action */
-  singleAction = false;
-
   /** Stored number of game "loop" cycles */
   storedCycles = 0;
 
@@ -398,31 +395,33 @@ export class Sleeve extends Person implements SleevePerson {
     if (!Player.bladeburner) return false;
     switch (action) {
       case "Training":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training", singleAction: false }));
         return true;
       case "Field analysis":
       case "Field Analysis":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Field Analysis" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Field Analysis", singleAction: false }));
         return true;
       case "Recruitment":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Recruitment" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Recruitment", singleAction: false }));
         return true;
       case "Diplomacy":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Diplomacy" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Diplomacy", singleAction: false }));
         return true;
       case "Hyperbolic Regeneration Chamber":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Hyperbolic Regeneration Chamber" }));
+        this.startWork(
+          new SleeveBladeburnerWork({ type: "General", name: "Hyperbolic Regeneration Chamber", singleAction: false }),
+        );
         return true;
       case "Infiltrate synthoids":
       case "Infiltrate Synthoids":
-        this.startWork(new SleeveInfiltrateWork());
+        this.startWork(new SleeveInfiltrateWork({ singleAction: false }));
         return true;
       case "Support main sleeve":
         this.startWork(new SleeveSupportWork());
         return true;
       case "Take on contracts":
         if (!Contracts[contract]) return false;
-        this.startWork(new SleeveBladeburnerWork({ type: "Contracts", name: contract }));
+        this.startWork(new SleeveBladeburnerWork({ type: "Contracts", name: contract, singleAction: false }));
         return true;
     }
     return false;
@@ -431,34 +430,35 @@ export class Sleeve extends Person implements SleevePerson {
   /** Begin a Single bladeburner task */
   bladeburnersingle(action: string, contract: string): boolean {
     if (!Player.bladeburner) return false;
-    this.singleAction = true;
     switch (action) {
       case "Training":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training", singleAction: true }));
         return true;
       case "Field analysis":
       case "Field Analysis":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Field Analysis" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Field Analysis", singleAction: true }));
         return true;
       case "Recruitment":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Recruitment" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Recruitment", singleAction: true }));
         return true;
       case "Diplomacy":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Diplomacy" }));
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Diplomacy", singleAction: true }));
         return true;
       case "Hyperbolic Regeneration Chamber":
-        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Hyperbolic Regeneration Chamber" }));
+        this.startWork(
+          new SleeveBladeburnerWork({ type: "General", name: "Hyperbolic Regeneration Chamber", singleAction: true }),
+        );
         return true;
       case "Infiltrate synthoids":
       case "Infiltrate Synthoids":
-        this.startWork(new SleeveInfiltrateWork());
+        this.startWork(new SleeveInfiltrateWork({ singleAction: true }));
         return true;
       case "Support main sleeve":
         this.startWork(new SleeveSupportWork());
         return true;
       case "Take on contracts":
         if (!Contracts[contract]) return false;
-        this.startWork(new SleeveBladeburnerWork({ type: "Contracts", name: contract }));
+        this.startWork(new SleeveBladeburnerWork({ type: "Contracts", name: contract, singleAction: true }));
         return true;
     }
     return false;

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -60,6 +60,9 @@ export class Sleeve extends Person implements SleevePerson {
    */
   shock = 100;
 
+  /* Whether or not we are performing a single action */
+  singleAction = false;
+
   /** Stored number of game "loop" cycles */
   storedCycles = 0;
 
@@ -393,6 +396,42 @@ export class Sleeve extends Person implements SleevePerson {
   /** Begin a bladeburner task */
   bladeburner(action: string, contract: string): boolean {
     if (!Player.bladeburner) return false;
+    switch (action) {
+      case "Training":
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training" }));
+        return true;
+      case "Field analysis":
+      case "Field Analysis":
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Field Analysis" }));
+        return true;
+      case "Recruitment":
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Recruitment" }));
+        return true;
+      case "Diplomacy":
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Diplomacy" }));
+        return true;
+      case "Hyperbolic Regeneration Chamber":
+        this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Hyperbolic Regeneration Chamber" }));
+        return true;
+      case "Infiltrate synthoids":
+      case "Infiltrate Synthoids":
+        this.startWork(new SleeveInfiltrateWork());
+        return true;
+      case "Support main sleeve":
+        this.startWork(new SleeveSupportWork());
+        return true;
+      case "Take on contracts":
+        if (!Contracts[contract]) return false;
+        this.startWork(new SleeveBladeburnerWork({ type: "Contracts", name: contract }));
+        return true;
+    }
+    return false;
+  }
+
+  /** Begin a Single bladeburner task */
+  bladeburnersingle(action: string, contract: string): boolean {
+    if (!Player.bladeburner) return false;
+     this.singleAction = true;
     switch (action) {
       case "Training":
         this.startWork(new SleeveBladeburnerWork({ type: "General", name: "Training" }));

--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -9,6 +9,7 @@ import { scaleWorkStats } from "../../../Work/WorkStats";
 interface SleeveBladeburnerWorkParams {
   type: "General" | "Contracts";
   name: string;
+  singleAction: boolean;
 }
 
 export const isSleeveBladeburnerWork = (w: SleeveWorkClass | null): w is SleeveBladeburnerWork =>
@@ -19,11 +20,13 @@ export class SleeveBladeburnerWork extends SleeveWorkClass {
   cyclesWorked = 0;
   actionType: "General" | "Contracts";
   actionName: string;
+  actionSingleAction: boolean;
 
   constructor(params?: SleeveBladeburnerWorkParams) {
     super();
     this.actionType = params?.type ?? "General";
     this.actionName = params?.name ?? "Field Analysis";
+    this.actionSingleAction = params?.singleAction ?? false;
   }
 
   cyclesNeeded(sleeve: Sleeve): number {
@@ -60,8 +63,7 @@ export class SleeveBladeburnerWork extends SleeveWorkClass {
         applySleeveGains(sleeve, scaleWorkStats(retValue, sleeve.shockBonus(), false));
       }
       this.cyclesWorked -= this.cyclesNeeded(sleeve);
-      if (sleeve.singleAction) {
-        sleeve.singleAction = false;
+      if (this.actionSingleAction) {
         return sleeve.stopWork();
       }
     }

--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -60,6 +60,10 @@ export class SleeveBladeburnerWork extends SleeveWorkClass {
         applySleeveGains(sleeve, scaleWorkStats(retValue, sleeve.shockBonus(), false));
       }
       this.cyclesWorked -= this.cyclesNeeded(sleeve);
+      if (sleeve.singleAction) {
+        sleeve.singleAction = false;
+        return sleeve.stopWork();
+      }
     }
   }
 

--- a/src/PersonObjects/Sleeve/Work/SleeveInfiltrateWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveInfiltrateWork.ts
@@ -9,9 +9,18 @@ const infiltrateCycles = 60000 / CONSTANTS.MilliPerCycle;
 export const isSleeveInfiltrateWork = (w: SleeveWorkClass | null): w is SleeveInfiltrateWork =>
   w !== null && w.type === SleeveWorkType.INFILTRATE;
 
+interface SleeveInfiltrateWorkParams {
+  singleAction: boolean;
+}
+
 export class SleeveInfiltrateWork extends SleeveWorkClass {
   type: SleeveWorkType.INFILTRATE = SleeveWorkType.INFILTRATE;
   cyclesWorked = 0;
+  singleAction: boolean;
+  constructor(params?: SleeveInfiltrateWorkParams) {
+    super();
+    this.singleAction = params?.singleAction ?? false;
+  }
 
   cyclesNeeded(): number {
     return infiltrateCycles;
@@ -23,8 +32,7 @@ export class SleeveInfiltrateWork extends SleeveWorkClass {
     if (this.cyclesWorked > this.cyclesNeeded()) {
       this.cyclesWorked -= this.cyclesNeeded();
       Player.bladeburner.infiltrateSynthoidCommunities();
-      if (sleeve.singleAction) {
-        sleeve.singleAction = false;
+      if (this.singleAction) {
         return sleeve.stopWork();
       }
     }

--- a/src/PersonObjects/Sleeve/Work/SleeveInfiltrateWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveInfiltrateWork.ts
@@ -23,6 +23,10 @@ export class SleeveInfiltrateWork extends SleeveWorkClass {
     if (this.cyclesWorked > this.cyclesNeeded()) {
       this.cyclesWorked -= this.cyclesNeeded();
       Player.bladeburner.infiltrateSynthoidCommunities();
+      if (sleeve.singleAction) {
+        sleeve.singleAction = false;
+        return sleeve.stopWork();
+      }
     }
   }
 

--- a/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
@@ -74,6 +74,7 @@ export function SleeveElem(props: SleeveElemProps): React.ReactElement {
   function setTask(): void {
     switch (abc[0]) {
       case "------":
+        props.sleeve.stopWork();
         break;
       case "Work for Company":
         if (getEnumHelper("CompanyName").isMember(abc[1])) props.sleeve.workForCompany(abc[1]);

--- a/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
@@ -73,7 +73,7 @@ export function SleeveElem(props: SleeveElemProps): React.ReactElement {
 
   function setTask(): void {
     switch (abc[0]) {
-      case "------":
+      case "Idle":
         props.sleeve.stopWork();
         break;
       case "Work for Company":

--- a/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
@@ -74,7 +74,6 @@ export function SleeveElem(props: SleeveElemProps): React.ReactElement {
   function setTask(): void {
     switch (abc[0]) {
       case "------":
-        props.sleeve.stopWork();
         break;
       case "Work for Company":
         if (getEnumHelper("CompanyName").isMember(abc[1])) props.sleeve.workForCompany(abc[1]);

--- a/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
+++ b/src/PersonObjects/Sleeve/ui/TaskSelector.tsx
@@ -113,7 +113,7 @@ function possibleContracts(sleeve: Sleeve): string[] {
 
 const tasks: {
   [key: string]: undefined | ((sleeve: Sleeve) => ITaskDetails);
-  ["------"]: (sleeve: Sleeve) => ITaskDetails;
+  ["Idle"]: (sleeve: Sleeve) => ITaskDetails;
   ["Work for Company"]: (sleeve: Sleeve) => ITaskDetails;
   ["Work for Faction"]: (sleeve: Sleeve) => ITaskDetails;
   ["Commit Crime"]: (sleeve: Sleeve) => ITaskDetails;
@@ -123,8 +123,8 @@ const tasks: {
   ["Shock Recovery"]: (sleeve: Sleeve) => ITaskDetails;
   ["Synchronize"]: (sleeve: Sleeve) => ITaskDetails;
 } = {
-  "------": (): ITaskDetails => {
-    return { first: ["------"], second: () => ["------"] };
+  Idle: (): ITaskDetails => {
+    return { first: ["Idle"], second: () => ["------"] };
   },
   "Work for Company": (sleeve: Sleeve): ITaskDetails => {
     let jobs = possibleJobs(sleeve);
@@ -219,7 +219,7 @@ const tasks: {
 
 const canDo: {
   [key: string]: undefined | ((sleeve: Sleeve) => boolean);
-  ["------"]: (sleeve: Sleeve) => boolean;
+  ["Idle"]: (sleeve: Sleeve) => boolean;
   ["Work for Company"]: (sleeve: Sleeve) => boolean;
   ["Work for Faction"]: (sleeve: Sleeve) => boolean;
   ["Commit Crime"]: (sleeve: Sleeve) => boolean;
@@ -229,7 +229,7 @@ const canDo: {
   ["Shock Recovery"]: (sleeve: Sleeve) => boolean;
   ["Synchronize"]: (sleeve: Sleeve) => boolean;
 } = {
-  "------": () => true,
+  Idle: () => true,
   "Work for Company": (sleeve: Sleeve) => possibleJobs(sleeve).length > 0,
   "Work for Faction": (sleeve: Sleeve) => possibleFactions(sleeve).length > 0,
   "Commit Crime": () => true,
@@ -243,7 +243,7 @@ const canDo: {
 
 function getABC(sleeve: Sleeve): [string, string, string] {
   const work = sleeve.currentWork;
-  if (work === null) return ["------", "------", "------"];
+  if (work === null) return ["Idle", "------", "------"];
   switch (work.type) {
     case SleeveWorkType.COMPANY:
       return ["Work for Company", work.companyName, "------"];

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4007,6 +4007,20 @@ export interface Sleeve {
    * @returns True if the sleeve started the given Bladeburner action, false otherwise.
    */
   setToBladeburnerAction(sleeveNumber: number, action: string, contract?: string): boolean;
+
+  /**
+   * Set a sleeve to perform a single Bladeburner action.
+   * @remarks
+   * RAM cost: 4 GB
+   *
+   * Return a boolean indicating whether or not the sleeve started a Bladeburner action.
+   *
+   * @param sleeveNumber - Index of the sleeve to perform a Bladeburner action.
+   * @param action - Name of the action to be performed.
+   * @param contract - Name of the contract if applicable.
+   * @returns True if the sleeve started the given Bladeburner action, false otherwise.
+   */
+  setToBladeburnerSingleAction(sleeveNumber: number, action: string, contract?: string): boolean;
 }
 
 /**


### PR DESCRIPTION
This updates sleeves with the following abilities:
In the sleeve UI, if you select ------ and set task, your sleeve will go into IDLE mode

New API function call:  ns.sleeve.setToBladeburnerSingleAction
-Identical to it's counterpart, except that your sleeve will stop what they are doing automatically after their action has completed

Tested by running sleeves side by side, half with runonce commands.  All tested ok.

-update: ------ now renamed to Idle
-update: Added a fix for issue #896 
-Tested by killing all the population in every city.  Waited, and my base population was added at the next event.
