### PR TITLE
FORMULAS: Removing the possible exception when gymGains/universityGains is called

### DIFF
--- a/src/Work/Formulas.ts
+++ b/src/Work/Formulas.ts
@@ -85,7 +85,7 @@ export function calculateFactionExp(person: IPerson, type: FactionWorkType): Wor
 export function calculateCost(classs: Class, location: Location): number {
   const serverMeta = serverMetadata.find((s) => s.specialName === location.name);
   const server = GetServer(serverMeta ? serverMeta.hostname : "");
-  const discount = (server as Server)?.backdoorInstalled ?? false ? 0.9 : 1;
+  const discount = (server as Server)?.backdoorInstalled ? 0.9 : 1;
   return classs.earnings.money * location.costMult * discount;
 }
 

--- a/src/Work/Formulas.ts
+++ b/src/Work/Formulas.ts
@@ -85,7 +85,7 @@ export function calculateFactionExp(person: IPerson, type: FactionWorkType): Wor
 export function calculateCost(classs: Class, location: Location): number {
   const serverMeta = serverMetadata.find((s) => s.specialName === location.name);
   const server = GetServer(serverMeta ? serverMeta.hostname : "");
-  const discount = (server as Server).backdoorInstalled ? 0.9 : 1;
+  const discount = (server as Server)?.backdoorInstalled ?? false ? 0.9 : 1;
   return classs.earnings.money * location.costMult * discount;
 }
 


### PR DESCRIPTION
For locations without a corresponding server, calling `ns.formulas.work.gymGains()` or `ns.formulas.work.universityGains()` in NetScript will raise the "reading properties of null" exception.

As GetServer() in line 87 returns `null` for these locations, trying to access its `backdoorInstalled` causes the issue above. Change the operator to `?.` and deal with possible `undefined` should fix it.

This makes the two forementioned NetScript functions treat all locations uniformly regardless of they have a backdoorable server or not.