### PR TITLE
FIX: #896 - Establish a base growth in Bladeburner

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -894,6 +894,9 @@ export class Bladeburner {
     const count = Math.round(sourceCity.pop * percentage);
     sourceCity.pop -= count;
     destCity.pop += count;
+    if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+      destCity.pop += BladeburnerConstants.BasePopGrowth;
+    }
   }
 
   triggerPotentialMigration(sourceCityName: CityName, chance: number): void {
@@ -926,6 +929,9 @@ export class Bladeburner {
       const percentage = getRandomInt(10, 20) / 100;
       const count = Math.round(sourceCity.pop * percentage);
       sourceCity.pop += count;
+      if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+        sourceCity.pop += BladeburnerConstants.BasePopGrowth;
+      }
       if (this.logging.events) {
         this.log("Intelligence indicates that a new Synthoid community was formed in a city");
       }
@@ -937,6 +943,9 @@ export class Bladeburner {
         const percentage = getRandomInt(10, 20) / 100;
         const count = Math.round(sourceCity.pop * percentage);
         sourceCity.pop += count;
+        if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+          sourceCity.pop += BladeburnerConstants.BasePopGrowth;
+        }
         if (this.logging.events) {
           this.log("Intelligence indicates that a new Synthoid community was formed in a city");
         }
@@ -949,7 +958,9 @@ export class Bladeburner {
         const count = Math.round(sourceCity.pop * percentage);
         sourceCity.pop -= count;
         destCity.pop += count;
-
+        if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+          destCity.pop += BladeburnerConstants.BasePopGrowth;
+        }
         if (this.logging.events) {
           this.log(
             "Intelligence indicates that a Synthoid community migrated from " + sourceCityName + " to some other city",
@@ -961,6 +972,9 @@ export class Bladeburner {
       const percentage = getRandomInt(8, 24) / 100;
       const count = Math.round(sourceCity.pop * percentage);
       sourceCity.pop += count;
+      if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
+        sourceCity.pop += BladeburnerConstants.BasePopGrowth;
+      }
       if (this.logging.events) {
         this.log(
           "Intelligence indicates that the Synthoid population of " + sourceCityName + " just changed significantly",

--- a/src/Bladeburner/data/Constants.ts
+++ b/src/Bladeburner/data/Constants.ts
@@ -33,6 +33,9 @@ export const BladeburnerConstants = {
   BaseStatGain: 1, // Base stat gain per second
   BaseIntGain: 0.003, // Base intelligence stat gain
 
+  BasePopGrowth: 100, // Base amount a population will grow by
+  PopGrowthCeiling: 1.5e9, // Amount of population a city can have before BasePopGrowth does not apply
+
   ActionCountGrowthPeriod: 480, // Time (s) it takes for action count to grow by its specified value
 
   RankToFactionRepFactor: 2, // Delta Faction Rep = this * Delta Rank


### PR DESCRIPTION
Established a base grow for population in Bladeburner.  It will kick in when the city that is growing's population is below a certain threshold.

Tested by killing EVERYONE, and waiting for an update.  Population increased by the base amount in 1 city.
