### PR TITLE
TERMINAL: Fix autocompletion when running scripts with the "./" command

### DIFF
--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -277,12 +277,18 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
       return possibilities;
 
     default:
+      if (!onCommand) {
+        const options = await scriptAutocomplete();
+        if (options) {
+          addGeneric({ iterable: options, usePathing: false });
+        }
+      }
       return possibilities;
   }
 
   async function scriptAutocomplete(): Promise<string[] | undefined> {
     let inputCopy = commandArray.join(" ");
-    if (commandLength === 1) inputCopy = "run " + inputCopy;
+    if (commandLength >= 1 && commandArray[0] !== "run") inputCopy = "run " + inputCopy;
     const commands = parseCommands(inputCopy);
     if (commands.length === 0) return;
     const command = parseCommand(commands[commands.length - 1]);

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -233,6 +233,9 @@ export function TerminalInput(): React.ReactElement {
 
     // Autocomplete
     if (event.key === KEY.TAB) {
+      if (event.altKey || event.ctrlKey) {
+        return;
+      }
       event.preventDefault();
       if (searchResults.length) {
         saveValue(searchResults[searchResultsIndex]);


### PR DESCRIPTION
# fixes #549: completion is broken for scripts called without `run`

CATEGORY: UI

# Linked issues

fixes #549

# Bug fix

Before the patch, for a file `x.js` that declares a `AutocompleteData.servers` autocompletion:
```
./x.js w<tab>
./x.js w
```

After the patch:
```
./x.js w<tab>
./x.js w0r1d_d43m0n
```

I included another minor fix for autocompletion: *tab* will no longer launch an autocompletion when the user pressed alt-tab or ctrl-tab.

Sidenote : The "CONTRIBUTING" document does mention `npm run lint` but forgets `format`. In my case, the command didn't request any change. It would have been annoying to amend the commits at this step (PR message). Please keep  the documentation in sync with the PR template.