### PR TITLE
SINGULARITY: Added getOwnedNFGAugmentations

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -193,6 +193,7 @@ const singularity = {
   getCrimeChance: SF4Cost(RamCostConstants.SingularityFn3),
   getCrimeStats: SF4Cost(RamCostConstants.SingularityFn3),
   getOwnedAugmentations: SF4Cost(RamCostConstants.SingularityFn3),
+  getOwnedNFGAugmentations: SF4Cost(RamCostConstants.SingularityFn3),
   getOwnedSourceFiles: SF4Cost(RamCostConstants.SingularityFn3),
   getAugmentationFactions: SF4Cost(RamCostConstants.SingularityFn3),
   getAugmentationsFromFaction: SF4Cost(RamCostConstants.SingularityFn3),

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -93,6 +93,24 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       }
       return res;
     },
+    getOwnedNFGAugmentations: (ctx) => (_purchased) => {
+      helpers.checkSingularityAccess(ctx);
+      const purchased = !!_purchased;
+      let res = 0;
+      for (let i = 0; i < Player.augmentations.length; ++i) {
+        if (Player.augmentations[i].name === "NeuroFlux Governor") {
+          res += Player.augmentations[i].level;
+        }
+      }
+      if (purchased) {
+        for (let i = 0; i < Player.queuedAugmentations.length; ++i) {
+          if (Player.queuedAugmentations[i].name === "NeuroFlux Governor") {
+            res++;
+          }
+        }
+      }
+      return res;
+    },
     getOwnedSourceFiles: () => () => [...Player.sourceFiles].map(([n, lvl]) => ({ n, lvl })),
     getAugmentationFactions: (ctx) => (_augName) => {
       helpers.checkSingularityAccess(ctx);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2145,6 +2145,21 @@ export interface Singularity {
   getOwnedAugmentations(purchased?: boolean): string[];
 
   /**
+   * Get a list of owned NFG augmentations.
+   * @remarks
+   * RAM cost: 5 GB * 16/4/1
+   *
+   *
+   * This function returns the number of NFG augmentations you have.
+   *
+   * @param purchased - Specifies whether the returned number should include Augmentations you have purchased but not
+   *   yet installed. By default, this argument is false which means that the return value will NOT have the purchased
+   *   Augmentations.
+   * @returns Array containing the number of all NFG Augmentations you have.
+   */
+  getOwnedNFGAugmentations(purchased?: boolean): number;
+
+  /**
    * Get a list of acquired Source-Files.
    * @remarks
    * RAM cost: 5 GB


### PR DESCRIPTION
Add the ability to get installed/owned/queued NFG augmentation totals.
New command:  ns.singularity.getOwnedNFGAugmentations(?true/false)

Imported my game.  Tested outputs, showed correct for Total Installed and Queued installs.  Tested OK after install as well.