### PR TITLE
IMPROVEMENT: Apply core bonus for share and stanek

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -35,6 +35,7 @@ import {
   numCycleForGrowthCorrected,
   processSingleServerGrowth,
   safelyCreateUniqueServer,
+  getCoreBonus,
 } from "./Server/ServerHelpers";
 import {
   getPurchasedServerUpgradeCost,
@@ -397,7 +398,8 @@ export const ns: InternalAPI<NSFull> = {
           helpers.log(ctx, () => "Server is null, did it die?");
           return Promise.resolve(0);
         }
-        const coreBonus = 1 + (host.cpuCores - 1) / 16;
+        const cores = helpers.getServer(ctx, ctx.workerScript.hostname).cpuCores;
+        const coreBonus = getCoreBonus(cores);
         const weakenAmt = CONSTANTS.ServerWeakenAmount * threads * coreBonus;
         server.weaken(weakenAmt);
         ctx.workerScript.scriptRef.recordWeaken(server.hostname, threads);
@@ -420,15 +422,12 @@ export const ns: InternalAPI<NSFull> = {
     (_threads, _cores = 1) => {
       const threads = helpers.number(ctx, "threads", _threads);
       const cores = helpers.number(ctx, "cores", _cores);
-      const coreBonus = 1 + (cores - 1) / 16;
+      const coreBonus = getCoreBonus(cores);
       return CONSTANTS.ServerWeakenAmount * threads * coreBonus * currentNodeMults.ServerWeakenRate;
     },
   share: (ctx) => () => {
-    const cores = GetServer(ctx.workerScript.hostname)?.cpuCores;
-    let coreBonus = 1;
-    if (cores) {
-      coreBonus = 1 + (cores - 1) / 16;
-    }
+    const cores = helpers.getServer(ctx, ctx.workerScript.hostname).cpuCores;
+    const coreBonus = getCoreBonus(cores);
     helpers.log(ctx, () => "Sharing this computer.");
     const end = StartSharing(
       ctx.workerScript.scriptRef.threads * calculateIntelligenceBonus(Player.skills.intelligence, 2) * coreBonus,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -424,9 +424,14 @@ export const ns: InternalAPI<NSFull> = {
       return CONSTANTS.ServerWeakenAmount * threads * coreBonus * currentNodeMults.ServerWeakenRate;
     },
   share: (ctx) => () => {
+    const cores = GetServer(ctx.workerScript.hostname)?.cpuCores;
+    let coreBonus = 1;
+    if (cores) {
+      coreBonus = 1 + (cores - 1) / 16;
+    }
     helpers.log(ctx, () => "Sharing this computer.");
     const end = StartSharing(
-      ctx.workerScript.scriptRef.threads * calculateIntelligenceBonus(Player.skills.intelligence, 2),
+      ctx.workerScript.scriptRef.threads * calculateIntelligenceBonus(Player.skills.intelligence, 2) * coreBonus,
     );
     return helpers.netscriptDelay(ctx, 10000).finally(function () {
       helpers.log(ctx, () => "Finished sharing this computer.");

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -43,11 +43,16 @@ export function NetscriptStanek(): InternalAPI<IStanek> {
         );
       }
       //Charge the fragment
+      const cores = helpers.getServer(ctx, ctx.workerScript.hostname)?.cpuCores;
+      let coreBonus = 1;
+      if (cores) {
+        coreBonus = 1 + (cores - 1) / 16;
+      }
       const inBonus = staneksGift.inBonus();
       const time = inBonus ? 200 : 1000;
       if (inBonus) staneksGift.isBonusCharging = true;
       return helpers.netscriptDelay(ctx, time).then(function () {
-        staneksGift.charge(fragment, ctx.workerScript.scriptRef.threads);
+        staneksGift.charge(fragment, ctx.workerScript.scriptRef.threads * coreBonus);
         helpers.log(ctx, () => `Charged fragment with ${ctx.workerScript.scriptRef.threads} threads.`);
         return Promise.resolve();
       });

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -11,6 +11,7 @@ import { applyAugmentation } from "../Augmentation/AugmentationHelpers";
 import { joinFaction } from "../Faction/FactionHelpers";
 import { Factions } from "../Faction/Factions";
 import { helpers } from "../Netscript/NetscriptHelpers";
+import { getCoreBonus } from "../Server/ServerHelpers";
 
 export function NetscriptStanek(): InternalAPI<IStanek> {
   function checkStanekAPIAccess(ctx: NetscriptContext): void {
@@ -43,11 +44,8 @@ export function NetscriptStanek(): InternalAPI<IStanek> {
         );
       }
       //Charge the fragment
-      const cores = helpers.getServer(ctx, ctx.workerScript.hostname)?.cpuCores;
-      let coreBonus = 1;
-      if (cores) {
-        coreBonus = 1 + (cores - 1) / 16;
-      }
+      const cores = helpers.getServer(ctx, ctx.workerScript.hostname).cpuCores;
+      const coreBonus = getCoreBonus(cores);
       const inBonus = staneksGift.inBonus();
       const time = inBonus ? 200 : 1000;
       if (inBonus) staneksGift.isBonusCharging = true;

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -60,7 +60,7 @@ export function numCycleForGrowth(server: IServer, growth: number, cores = 1): n
 
   const serverGrowthPercentage = server.serverGrowth / 100;
 
-  const coreBonus = 1 + (cores - 1) / 16;
+  const coreBonus = getCoreBonus(cores);
   const cycles =
     Math.log(growth) /
     (Math.log(ajdGrowthRate) *
@@ -103,7 +103,7 @@ export function numCycleForGrowthCorrected(
 
   // total of all grow thread multipliers
   const serverGrowthPercentage = server.serverGrowth / 100.0;
-  const coreMultiplier = 1 + (cores - 1) / 16;
+  const coreMultiplier = getCoreBonus(cores);
   const threadMultiplier =
     serverGrowthPercentage * person.mults.hacking_grow * coreMultiplier * currentNodeMults.ServerGrowthRate;
 
@@ -294,4 +294,9 @@ export function isBackdoorInstalled(server: BaseServer): boolean {
     return server.backdoorInstalled;
   }
   return false;
+}
+
+export function getCoreBonus(cores = 1): number {
+  const coreBonus = 1 + (cores - 1) / 16;
+  return coreBonus;
 }


### PR DESCRIPTION
Currently cores don't add a bonus for running share or charging stanek fragments.  I'm not sure why not, and it doesn't seem game breaking (share core bonus only gives ~1% increase) so I decided to add it in.

Tested locally, verified share/charge work, and used dev tools to make sure the thread count was increased.