### PR TITLE
TERMINAL: Updated Alias/Unalias

### DIFF
--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -99,6 +99,7 @@ export const HelpTexts: Record<string, string[]> = {
     "'alias NAME=VALUE' on the Terminal. ",
     " ",
     "The 'unalias' command can be used to remove aliases.",
+    "NOTE:  The -all alias is reserved for removal.",
     " ",
   ],
   analyze: [
@@ -443,8 +444,10 @@ export const HelpTexts: Record<string, string[]> = {
   ],
   unalias: [
     "Usage: unalias [alias name]",
+    "Usage: unalias -all",
     " ",
     "Deletes the specified alias. Note that the double quotation marks are required. ",
+    "The -all command will remove ALL aliases that you have set.",
     " ",
     "As an example, if an alias was declared using:",
     " ",

--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -99,7 +99,7 @@ export const HelpTexts: Record<string, string[]> = {
     "'alias NAME=VALUE' on the Terminal. ",
     " ",
     "The 'unalias' command can be used to remove aliases.",
-    "NOTE:  The -all alias is reserved for removal.",
+    "NOTE:  The --all alias is reserved for removal.",
     " ",
   ],
   analyze: [
@@ -447,7 +447,7 @@ export const HelpTexts: Record<string, string[]> = {
     "Usage: unalias -all",
     " ",
     "Deletes the specified alias. Note that the double quotation marks are required. ",
-    "The -all command will remove ALL aliases that you have set.",
+    "The --all command will remove ALL aliases that you have set.",
     " ",
     "As an example, if an alias was declared using:",
     " ",

--- a/src/Terminal/commands/alias.ts
+++ b/src/Terminal/commands/alias.ts
@@ -6,8 +6,8 @@ export function alias(args: (string | number | boolean)[]): void {
     printAliases();
     return;
   }
-  if (args[0] === "-all") {
-    Terminal.print(`-all is reserved for removal`);
+  if (args[0] === "--all") {
+    Terminal.print(`--all is reserved for removal`);
     return;
   }
   if (args.length === 1) {

--- a/src/Terminal/commands/alias.ts
+++ b/src/Terminal/commands/alias.ts
@@ -7,7 +7,7 @@ export function alias(args: (string | number | boolean)[]): void {
     return;
   }
   if (args[0] === "--all") {
-    Terminal.print(`--all is reserved for removal`);
+    Terminal.error(`--all is reserved for removal`);
     return;
   }
   if (args.length === 1) {

--- a/src/Terminal/commands/alias.ts
+++ b/src/Terminal/commands/alias.ts
@@ -6,6 +6,10 @@ export function alias(args: (string | number | boolean)[]): void {
     printAliases();
     return;
   }
+  if (args[0] === "-all") {
+    Terminal.print(`-all is reserved for removal`);
+    return;
+  }
   if (args.length === 1) {
     if (parseAliasDeclaration(args[0] + "")) {
       Terminal.print(`Set alias ${args[0]}`);

--- a/src/Terminal/commands/unalias.ts
+++ b/src/Terminal/commands/unalias.ts
@@ -3,7 +3,7 @@ import { removeAlias, Aliases, GlobalAliases } from "../../Alias";
 
 export function unalias(args: (string | number | boolean)[]): void {
   if (args.length !== 1) {
-    Terminal.error("Incorrect usage of unalias name. Usage: unalias [alias] or unalias -all");
+    Terminal.error("Incorrect usage of unalias name. Usage: unalias [alias] or unalias --all");
     return;
   } else if (args[0] === "--all") {
     for (const alias of Aliases) {

--- a/src/Terminal/commands/unalias.ts
+++ b/src/Terminal/commands/unalias.ts
@@ -1,10 +1,21 @@
 import { Terminal } from "../../Terminal";
-import { removeAlias } from "../../Alias";
+import { removeAlias, Aliases, GlobalAliases } from "../../Alias";
 
 export function unalias(args: (string | number | boolean)[]): void {
   if (args.length !== 1) {
-    Terminal.error("Incorrect usage of unalias name. Usage: unalias [alias]");
+    Terminal.error("Incorrect usage of unalias name. Usage: unalias [alias] or unalias -all");
     return;
+  } else if (args[0] === "-all") {
+    for (const alias of Aliases) {
+      if (removeAlias(alias[0] + "")) {
+        Terminal.print(`Removed alias ${alias[0]}`);
+      }
+    }
+    for (const alias of GlobalAliases) {
+      if (removeAlias(alias[0] + "")) {
+        Terminal.print(`Removed alias ${alias[0]}`);
+      }
+    }
   } else if (removeAlias(args[0] + "")) {
     Terminal.print(`Removed alias ${args[0]}`);
   } else {

--- a/src/Terminal/commands/unalias.ts
+++ b/src/Terminal/commands/unalias.ts
@@ -5,7 +5,7 @@ export function unalias(args: (string | number | boolean)[]): void {
   if (args.length !== 1) {
     Terminal.error("Incorrect usage of unalias name. Usage: unalias [alias] or unalias -all");
     return;
-  } else if (args[0] === "-all") {
+  } else if (args[0] === "--all") {
     for (const alias of Aliases) {
       if (removeAlias(alias[0] + "")) {
         Terminal.print(`Removed alias ${alias[0]}`);


### PR DESCRIPTION
Reserved the -all from Alias as a remove command.
Added -all to unalias to remove all aliases set.
Updated help files and descriptions when alias/unalias are entered with nothing else

Tested by trying to set an alias to -all, showed error message that it's reserved.
Tested with unalias.  Shows all aliases removed.  Only works if it's the first command, so unalias -g *x* will still work for specifics global aliases.