### PR TITLE
CORPORATION: Remove cooldown from "Sell CEO Position"

### DIFF
--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -21,9 +21,10 @@ import { createEnumKeyedRecord, getRecordValues } from "../Types/Record";
 
 export const CorporationResolvers: ((prevState: CorpStateName) => void)[] = [];
 
-interface IParams {
+interface ICorporationParams {
   name?: string;
   seedFunded?: boolean;
+  shareSaleCooldown?: number;
 }
 
 export class Corporation {
@@ -70,9 +71,10 @@ export class Corporation {
 
   state = new CorporationState();
 
-  constructor(params: IParams = {}) {
+  constructor(params: ICorporationParams = {}) {
     this.name = params.name || "The Corporation";
     this.seedFunded = params.seedFunded ?? false;
+    this.shareSaleCooldown = params.shareSaleCooldown ?? 0;
   }
 
   addFunds(amt: number): void {

--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -319,22 +319,13 @@ function SellDivisionButton(): React.ReactElement {
 function RestartButton(): React.ReactElement {
   const [open, setOpen] = useState(false);
 
-  const corp = useCorporation();
-  const sellSharesOnCd = corp.shareSaleCooldown > 0;
-
   function restart(): void {
     setOpen(true);
   }
 
   return (
     <>
-      <ButtonWithTooltip
-        normalTooltip={"Sell corporation and start over"}
-        disabledTooltip={
-          sellSharesOnCd ? "Sell corporation and start over. Cannot do this while Sell Shares is on cooldown." : ""
-        }
-        onClick={restart}
-      >
+      <ButtonWithTooltip normalTooltip={"Sell corporation and start over"} onClick={restart}>
         Sell CEO position
       </ButtonWithTooltip>
       <SellCorporationModal open={open} onClose={() => setOpen(false)} />

--- a/src/Corporation/ui/modals/SellSharesModal.tsx
+++ b/src/Corporation/ui/modals/SellSharesModal.tsx
@@ -61,7 +61,7 @@ export function SellSharesModal(props: IProps): React.ReactElement {
           <li>Selling shares will cause stock price to fall due to market forces.</li>
           <li>The money from selling your shares will go directly to you (NOT your Corporation).</li>
           <li>
-            You will not be able to sell shares again (or dissolve the corporation) for{" "}
+            You will not be able to sell shares again for{" "}
             <b>{corp.convertCooldownToString(corpConstants.sellSharesCooldown)}</b>.
           </li>
         </ul>

--- a/src/PersonObjects/Player/PlayerObjectCorporationMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectCorporationMethods.ts
@@ -12,6 +12,7 @@ export function startCorporation(this: PlayerObject, corpName: string, seedFunde
   this.corporation = new Corporation({
     name: corpName,
     seedFunded: seedFunded,
+    shareSaleCooldown: this.corporation?.shareSaleCooldown,
   });
   //reset the research tree in case the corporation was restarted
   resetIndustryResearchTrees();


### PR DESCRIPTION
Selling corporation shares for player money has a 1 hour cooldown. The primary gameplay benefit of this cooldown is to limit the rate of augmentation prestiges with huge money available right away. There is also some gameplay in selecting the best time to sell shares.

In #782 I blocked restarting the corp while this cooldown was active, to prevent a loop of accumulating money without interacting with the corp mechanic:
- take seed funding
- go public
- sell all shares but 1
- restart the corp

Which resulted in optimal strategy for BitNode 3 of:
- take seed funding
- go public
- sell all shares but 1
- buy 1TB RAM to run corp scripts
- wait 1 hour (considered to be poor gameplay)
- restart the corp so that scripts can take private investment offers

This PR removes the cooldown from restarting, while passing on the sell-shares cooldown to the new corporation. This way the loop is prevented on the second iteration instead of the first. And there is never a period where the player has nothing constructive to do.