### PR TITLE
CORPORATION: Fix warehouse not updating after product sale

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -946,6 +946,7 @@ export class Division {
           console.error(`Invalid State: ${state}`);
           break;
       } //End switch(this.state)
+      this.updateWarehouseSizeUsed(warehouse);
     }
     return totalProfit;
   }


### PR DESCRIPTION
Currently, the warehouse updates its used space after materials are processed, but doesn't do it after products are processed. As a result, products that are sold still occupy the warehouse until the next purchase tick updates it.

I made it recalculate warehouse after processing products too. Tested and working.