### PR TITLE
SLEEVE: Add task counter to Crimes and BladeBurner

### DIFF
--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -17,6 +17,7 @@ export const isSleeveBladeburnerWork = (w: SleeveWorkClass | null): w is SleeveB
 
 export class SleeveBladeburnerWork extends SleeveWorkClass {
   type: SleeveWorkType.BLADEBURNER = SleeveWorkType.BLADEBURNER;
+  tasksCompleted = 0;
   cyclesWorked = 0;
   actionType: "General" | "Contracts";
   actionName: string;
@@ -69,6 +70,7 @@ export class SleeveBladeburnerWork extends SleeveWorkClass {
       if (this.actionType === "Contracts") {
         applySleeveGains(sleeve, scaleWorkStats(retValue, sleeve.shockBonus(), false));
       }
+      this.tasksCompleted++;
       this.cyclesWorked -= this.cyclesNeeded(sleeve);
       // Resolve and reset nextCompletion promise
       const resolver = this.signalCompletion;
@@ -82,6 +84,7 @@ export class SleeveBladeburnerWork extends SleeveWorkClass {
       type: SleeveWorkType.BLADEBURNER as "BLADEBURNER",
       actionType: this.actionType,
       actionName: this.actionName,
+      tasksCompleted: this.tasksCompleted,
       cyclesWorked: this.cyclesWorked,
       cyclesNeeded: this.cyclesNeeded(sleeve),
       nextCompletion: this.nextCompletion,

--- a/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveCrimeWork.ts
@@ -16,6 +16,7 @@ export const isSleeveCrimeWork = (w: SleeveWorkClass | null): w is SleeveCrimeWo
 export class SleeveCrimeWork extends SleeveWorkClass {
   type: SleeveWorkType.CRIME = SleeveWorkType.CRIME;
   crimeType: CrimeType;
+  tasksCompleted = 0;
   cyclesWorked = 0;
   constructor(crimeType?: CrimeType) {
     super();
@@ -47,6 +48,7 @@ export class SleeveCrimeWork extends SleeveWorkClass {
         Player.numPeopleKilled += crime.kills;
       } else gains.money = 0;
       applySleeveGains(sleeve, gains, success ? 1 : 0.25);
+      this.tasksCompleted++;
       this.cyclesWorked -= this.cyclesNeeded();
     }
   }
@@ -55,6 +57,7 @@ export class SleeveCrimeWork extends SleeveWorkClass {
     return {
       type: SleeveWorkType.CRIME as "CRIME",
       crimeType: this.crimeType,
+      tasksCompleted: this.tasksCompleted,
       cyclesWorked: this.cyclesWorked,
       cyclesNeeded: this.cyclesNeeded(),
     };

--- a/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { CrimeType, FactionWorkType } from "@enums";
 import { CONSTANTS } from "../../../Constants";
 import { Player } from "@player";
-import { formatPercent, formatNumber } from "../../../ui/formatNumber";
+import { formatPercent, formatInt } from "../../../ui/formatNumber";
 import { ProgressBar } from "../../../ui/React/Progress";
 import { Sleeve } from "../Sleeve";
 import { MoreStatsModal } from "./MoreStatsModal";
@@ -31,7 +31,7 @@ function getWorkDescription(sleeve: Sleeve, progress: number): string {
       return "This sleeve is currently set to synchronize with the original consciousness. This causes the Sleeve's synchronization to increase.";
     case SleeveWorkType.BLADEBURNER:
       return (
-        `This sleeve is currently attempting to perform ${work.actionName}.\n\nTasks Completed: ${formatNumber(
+        `This sleeve is currently attempting to perform ${work.actionName}.\n\nTasks Completed: ${formatInt(
           work.tasksCompleted,
         )}\n \n` + `Progress: ${formatPercent(progress)}`
       );
@@ -40,7 +40,7 @@ function getWorkDescription(sleeve: Sleeve, progress: number): string {
       return (
         `This sleeve is currently attempting ${crime.workName} (Success Rate: ${formatPercent(
           crime.successRate(sleeve),
-        )}).\n\nTasks Completed: ${formatNumber(work.tasksCompleted)} 
+        )}).\n\nTasks Completed: ${formatInt(work.tasksCompleted)} 
 		\n` + `Progress: ${formatPercent(progress)}`
       );
     }

--- a/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
@@ -31,16 +31,16 @@ function getWorkDescription(sleeve: Sleeve, progress: number): string {
       return "This sleeve is currently set to synchronize with the original consciousness. This causes the Sleeve's synchronization to increase.";
     case SleeveWorkType.BLADEBURNER:
       return (
-        `This sleeve is currently attempting to perform ${work.actionName}.\nTasks Completed: ${formatNumber(
+        `This sleeve is currently attempting to perform ${work.actionName}.\n\nTasks Completed: ${formatNumber(
           work.tasksCompleted,
-        )} \n` + `Progress: ${formatPercent(progress)}`
+        )}\n \n` + `Progress: ${formatPercent(progress)}`
       );
     case SleeveWorkType.CRIME: {
       const crime = work.getCrime();
       return (
         `This sleeve is currently attempting ${crime.workName} (Success Rate: ${formatPercent(
           crime.successRate(sleeve),
-        )}).\nTasks Completed: ${formatNumber(work.tasksCompleted)} 
+        )}).\n\nTasks Completed: ${formatNumber(work.tasksCompleted)} 
 		\n` + `Progress: ${formatPercent(progress)}`
       );
     }

--- a/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { CrimeType, FactionWorkType } from "@enums";
 import { CONSTANTS } from "../../../Constants";
 import { Player } from "@player";
-import { formatPercent } from "../../../ui/formatNumber";
+import { formatPercent, formatNumber } from "../../../ui/formatNumber";
 import { ProgressBar } from "../../../ui/React/Progress";
 import { Sleeve } from "../Sleeve";
 import { MoreStatsModal } from "./MoreStatsModal";
@@ -31,15 +31,17 @@ function getWorkDescription(sleeve: Sleeve, progress: number): string {
       return "This sleeve is currently set to synchronize with the original consciousness. This causes the Sleeve's synchronization to increase.";
     case SleeveWorkType.BLADEBURNER:
       return (
-        `This sleeve is currently attempting to perform ${work.actionName}.\n\n` +
-        `Progress: ${formatPercent(progress)}`
+        `This sleeve is currently attempting to perform ${work.actionName}.\nTasks Completed: ${formatNumber(
+          work.tasksCompleted,
+        )} \n` + `Progress: ${formatPercent(progress)}`
       );
     case SleeveWorkType.CRIME: {
       const crime = work.getCrime();
       return (
         `This sleeve is currently attempting ${crime.workName} (Success Rate: ${formatPercent(
           crime.successRate(sleeve),
-        )}).\n\n` + `Progress: ${formatPercent(progress)}`
+        )}).\nTasks Completed: ${formatNumber(work.tasksCompleted)} 
+		\n` + `Progress: ${formatPercent(progress)}`
       );
     }
     case SleeveWorkType.FACTION: {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -987,6 +987,7 @@ type SleeveBladeburnerTask = {
   cyclesWorked: number;
   cyclesNeeded: number;
   nextCompletion: Promise<void>;
+  tasksCompleted: number;
 };
 
 /** @public */
@@ -1005,6 +1006,7 @@ type SleeveCrimeTask = {
   crimeType: CrimeType | `${CrimeType}`;
   cyclesWorked: number;
   cyclesNeeded: number;
+  tasksCompleted: number;
 };
 
 /** @public */

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -1347,6 +1347,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "data": {
               "crimeType": "Homicide",
               "cyclesWorked": 0,
+              "tasksCompleted": 0,
               "type": "CRIME",
             },
           },


### PR DESCRIPTION
Added a counter on sleeve tasks.  This is for when a sleeve is in Overclock mode.  The progress bar doesn't reflect the actual completions, and on some tasks will just appear to be stuck, even though the Sleeve is doing work.

I just added an attribute to the SleeveWork object, and increment it by one when a task is finished.

![SleeveTasksCounter](https://github.com/bitburner-official/bitburner-src/assets/147098375/eba5863a-4f6f-4fb6-8b03-923bab250358)
