### PR TITLE
UI: Fixed padding issue with server page slector and made script page selector static

### DIFF
--- a/src/ui/ActiveScripts/ServerAccordionContent.tsx
+++ b/src/ui/ActiveScripts/ServerAccordionContent.tsx
@@ -25,7 +25,7 @@ export function ServerAccordionContent(props: IProps): React.ReactElement {
 
   return (
     <>
-      {props.workerScripts.length > 10 ? (
+      {props.workerScripts.length > 0 ? (
         <TablePagination
           rowsPerPageOptions={[10, 15, 20, 100]}
           component="div"

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -101,6 +101,7 @@ export function ServerAccordions(props: IProps): React.ReactElement {
             }}
             style={{
               paddingTop: "8px",
+			  paddingBottom: "14px"
             }}
           />
         </Grid>
@@ -121,6 +122,7 @@ export function ServerAccordions(props: IProps): React.ReactElement {
           )}
         </Grid>
       </Grid>
+	  
       <List dense={true}>
         {filtered.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((data) => {
           return (

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -101,7 +101,7 @@ export function ServerAccordions(props: IProps): React.ReactElement {
             }}
             style={{
               paddingTop: "8px",
-			  paddingBottom: "14px"
+              paddingBottom: "14px",
             }}
           />
         </Grid>
@@ -122,7 +122,7 @@ export function ServerAccordions(props: IProps): React.ReactElement {
           )}
         </Grid>
       </Grid>
-	  
+
       <List dense={true}>
         {filtered.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((data) => {
           return (


### PR DESCRIPTION
The server pagination selector is set to only be displayed when there are > 10 servers running scripts.  Whenever it was displayed, it would push the whole table of scripts down.  When it would hide, the table would move up.  I added padding to stop its appearance and disappearance from causing the whole table to shift.

The script pagination selector causes a much greater jump in the UI anytime its displayed/hide which gets worse as certain script execution times get lower.

![JumpingScripts](https://github.com/bitburner-official/bitburner-src/assets/147098375/707b3282-9274-453f-bb2a-923118b7a252)

I changed the behavior to always show the page selector as I couldn't think of a better solution, aside from maybe making it an option to hide or always show.