### PR TITLE
HACKNET: Rework Netburners

### DIFF
--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -814,7 +814,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
     // === H === //
     [AugmentationName.HacknetNodeCPUUpload]: {
       repCost: 3.75e3,
-      moneyCost: 1.1e7,
+      moneyCost: 11e6,
       info:
         "Uploads the architecture and design details of a Hacknet Node's CPU into " +
         "the brain. This allows the user to engineer custom hardware and software " +
@@ -835,8 +835,8 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       factions: [FactionName.Netburners],
     },
     [AugmentationName.HacknetNodeCoreDNI]: {
-      repCost: 1.25e4,
-      moneyCost: 6e7,
+      repCost: 12.5e3,
+      moneyCost: 60e6,
       info:
         "Installs a Direct-Neural Interface jack into the arm that is capable of connecting " +
         "to a Hacknet Node. This lets the user access and manipulate the Node's processing logic using " +
@@ -846,7 +846,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
     },
     [AugmentationName.HacknetNodeKernelDNI]: {
       repCost: 7.5e3,
-      moneyCost: 4e7,
+      moneyCost: 40e6,
       info:
         "Installs a Direct-Neural Interface jack into the arm that is capable of connecting to a " +
         "Hacknet Node. This lets the user access and manipulate the Node's kernel using " +
@@ -863,6 +863,21 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
         "offers better performance.",
       hacknet_node_money: 1.1,
       hacknet_node_purchase_cost: 0.9,
+      factions: [FactionName.Netburners],
+    },
+    [AugmentationName.HacknetRecoveryKey]: {
+      repCost: 1e6,
+      moneyCost: 1e9, // $24.7b if all 6 augs are bought at once
+      info: "Stores the cryptographic passkey for one Hacknet Node.",
+      stats: "This augmentation lets you keep your highest-level Hacknet Node after installing augmentations.",
+      isSpecial: true,
+      prereqs: [
+        AugmentationName.HacknetNodeCPUUpload,
+        AugmentationName.HacknetNodeCacheUpload,
+        AugmentationName.HacknetNodeCoreDNI,
+        AugmentationName.HacknetNodeKernelDNI,
+        AugmentationName.HacknetNodeNICUpload,
+      ],
       factions: [FactionName.Netburners],
     },
     [AugmentationName.HemoRecirculator]: {

--- a/src/Augmentation/Enums.ts
+++ b/src/Augmentation/Enums.ts
@@ -56,6 +56,7 @@ export enum AugmentationName {
   HacknetNodeNICUpload = "Hacknet Node NIC Architecture Neural-Upload",
   HacknetNodeKernelDNI = "Hacknet Node Kernel Direct-Neural Interface",
   HacknetNodeCoreDNI = "Hacknet Node Core Direct-Neural Interface",
+  HacknetRecoveryKey = "Hacknet Recovery Key",
   Neurotrainer1 = "Neurotrainer I",
   Neurotrainer2 = "Neurotrainer II",
   Neurotrainer3 = "Neurotrainer III",

--- a/src/Faction/FactionInfo.tsx
+++ b/src/Faction/FactionInfo.tsx
@@ -657,11 +657,20 @@ export const FactionInfos: Record<FactionName, FactionInfo> = {
 
   // Early game factions - factions the player will prestige with early on that don't belong in other categories.
   [FactionName.Netburners]: new FactionInfo({
-    infoText: <>{"~~//*>H4CK|\\|3T 8URN3R5**>?>\\~~"}</>,
-    rumorText: <>{"~~//*>H4CK|\\|3T 8URN3R5**>?>\\~~"}</>,
+    infoText: <>{"~~//*>H4CK|\\|3T 8URN3R5**>?>\\\\~~"}</>,
+    rumorText: <>{"~~//*>H4CK|\\|3T 8URN3R5**>?>\\\\~~"}</>,
     inviteReqs: [haveSkill("hacking", 80), totalHacknetRam(8), totalHacknetCores(4), totalHacknetLevels(100)],
     rumorReqs: [totalHacknetLevels(50)],
-    offerHackingWork: true,
+    special: true,
+    assignment: (): React.ReactElement => {
+      return (
+        <Option
+          buttonText={"Open Hacknet"}
+          infoText={`${FactionName.Netburners} reputation can only be gained by operating hacknet nodes.`}
+          onClick={() => Router.toPage(Page.Hacknet)}
+        />
+      );
+    },
   }),
 
   [FactionName.TianDiHui]: new FactionInfo({

--- a/src/Hacknet/HashManager.ts
+++ b/src/Hacknet/HashManager.ts
@@ -10,6 +10,7 @@ import { HashUpgrades } from "./HashUpgrades";
 import { HashUpgrade } from "./HashUpgrade";
 
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, constructorsForReviver } from "../utils/JSONReviver";
+import { updateHashManagerCapacity } from "./HacknetHelpers";
 
 export class HashManager {
   // Max number of hashes this can hold. Equal to the sum of capacities of
@@ -81,8 +82,7 @@ export class HashManager {
     }
     this.hashes = 0;
 
-    // When prestiging, player's hacknet nodes are always reset. So capacity = 0
-    this.updateCapacity(0);
+    updateHashManagerCapacity();
   }
 
   /** Reverts an upgrade and refunds the hashes used to buy it */

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -4,19 +4,27 @@
  * Displays general information about Hacknet Nodes
  */
 import React from "react";
-import Typography from "@mui/material/Typography";
+import { Box, Button, Typography } from "@mui/material";
+
+import { Factions } from "../../Faction/Factions";
+import { FactionName } from "@enums";
+import { Router } from "../../ui/GameRoot";
+import { Page } from "../../ui/Router";
 
 interface IProps {
   hasHacknetServers: boolean;
 }
 
 export function GeneralInfo(props: IProps): React.ReactElement {
+  const faction = Factions[FactionName.Netburners];
+
   return (
     <>
       <Typography>
         The Hacknet is a global, decentralized network of machines. It is used by hackers all around the world to
         anonymously share computing power and perform distributed cyberattacks without the fear of being traced.
       </Typography>
+      <br />
       {!props.hasHacknetServers ? (
         <>
           <Typography>
@@ -45,6 +53,18 @@ export function GeneralInfo(props: IProps): React.ReactElement {
               `scripts.`}
           </Typography>
         </>
+      )}
+      <br />
+      {faction.isMember && (
+        <Box>
+          <Typography>
+            Contributing to the Hacknet network also increases your reputation with {FactionName.Netburners}.
+            <br />
+            <Button onClick={() => Router.toPage(Page.Faction, { faction })}>
+              View {FactionName.Netburners} faction
+            </Button>
+          </Typography>
+        </Box>
       )}
     </>
   );

--- a/src/Hacknet/ui/HacknetNodeElem.tsx
+++ b/src/Hacknet/ui/HacknetNodeElem.tsx
@@ -63,9 +63,9 @@ export function HacknetNodeElem(props: IProps): React.ReactElement {
     upgradeLevelButton = (
       <Tooltip
         title={
-          <Typography>
+          <>
             +<MoneyRate money={increase} />
-          </Typography>
+          </>
         }
       >
         <Button onClick={upgradeLevelOnClick}>
@@ -105,9 +105,9 @@ export function HacknetNodeElem(props: IProps): React.ReactElement {
     upgradeRAMButton = (
       <Tooltip
         title={
-          <Typography>
+          <>
             +<MoneyRate money={increase} />
-          </Typography>
+          </>
         }
       >
         <Button onClick={upgradeRamOnClick}>
@@ -149,9 +149,9 @@ export function HacknetNodeElem(props: IProps): React.ReactElement {
     upgradeCoresButton = (
       <Tooltip
         title={
-          <Typography>
+          <>
             +<MoneyRate money={increase} />
-          </Typography>
+          </>
         }
       >
         <Button onClick={upgradeCoresOnClick}>
@@ -164,7 +164,7 @@ export function HacknetNodeElem(props: IProps): React.ReactElement {
 
   return (
     <Grid item component={Paper} p={1}>
-      <Table size="small">
+      <Table size="small" sx={{ "white-space": "nowrap" }}>
         <TableBody>
           <TableRow>
             <TableCell colSpan={3}>

--- a/src/Hacknet/ui/HacknetRoot.tsx
+++ b/src/Hacknet/ui/HacknetRoot.tsx
@@ -102,13 +102,15 @@ export function HacknetRoot(): React.ReactElement {
       <Typography variant="h4">Hacknet {hasHacknetServers() ? "Servers" : "Nodes"}</Typography>
       <GeneralInfo hasHacknetServers={hasHacknetServers()} />
 
-      <PurchaseButton cost={purchaseCost} multiplier={purchaseMultiplier} onClick={handlePurchaseButtonClick} />
+      <br />
+
+      <PlayerInfo totalProduction={totalProduction} />
 
       <br />
 
       <Grid container spacing={2}>
         <Grid item xs={6}>
-          <PlayerInfo totalProduction={totalProduction} />
+          <PurchaseButton cost={purchaseCost} multiplier={purchaseMultiplier} onClick={handlePurchaseButtonClick} />
         </Grid>
         <Grid item xs={6}>
           <MultiplierButtons onClicks={purchaseMultiplierOnClicks} purchaseMultiplier={purchaseMultiplier} />

--- a/src/Hacknet/ui/HacknetServerElem.tsx
+++ b/src/Hacknet/ui/HacknetServerElem.tsx
@@ -245,10 +245,10 @@ export function HacknetServerElem(props: IProps): React.ReactElement {
 
   return (
     <Grid item component={Paper} p={1}>
-      <Table size="small">
+      <Table size="small" sx={{ "white-space": "nowrap" }}>
         <TableBody>
           <TableRow>
-            <TableCell>
+            <TableCell colSpan={3}>
               <Typography>{node.hostname}</Typography>
             </TableCell>
           </TableRow>

--- a/src/Hacknet/ui/PlayerInfo.tsx
+++ b/src/Hacknet/ui/PlayerInfo.tsx
@@ -12,7 +12,11 @@ import { Money } from "../../ui/React/Money";
 import { MoneyRate } from "../../ui/React/MoneyRate";
 import { HashRate } from "../../ui/React/HashRate";
 import { Hashes } from "../../ui/React/Hashes";
-import Typography from "@mui/material/Typography";
+import { Paper, Typography } from "@mui/material";
+import { StatsTable } from "../../ui/React/StatsTable";
+import { Factions } from "../../Faction/Factions";
+import { FactionName } from "@enums";
+import { ReputationRate } from "../../ui/React/ReputationRate";
 
 interface IProps {
   totalProduction: number;
@@ -20,32 +24,28 @@ interface IProps {
 
 export function PlayerInfo(props: IProps): React.ReactElement {
   const hasServers = hasHacknetServers();
+  const faction = Factions[FactionName.Netburners];
 
-  let prod;
+  const rows: React.ReactNode[][] = [["Money:", <Money key="money" money={Player.money} />]];
   if (hasServers) {
-    prod = <HashRate hashes={props.totalProduction} />;
+    rows.push([
+      "Hashes:",
+      <Typography key={"hashes"}>
+        <Hashes hashes={Player.hashManager.hashes} /> / <Hashes hashes={Player.hashManager.capacity} />
+      </Typography>,
+    ]);
+    rows.push(["Total Hacknet Production:", <HashRate key="prod" hashes={props.totalProduction} />]);
   } else {
-    prod = <MoneyRate money={props.totalProduction} />;
+    rows.push(["Total Hacknet Production:", <MoneyRate key="prod" money={props.totalProduction} />]);
+  }
+  if (faction.isMember) {
+    const repRate = (hasServers ? (props.totalProduction * 1e6) / 4 : props.totalProduction) * 1e-2;
+    rows.push([`${faction.name} reputation gain:`, <ReputationRate key="rep" reputation={repRate} />]);
   }
 
   return (
-    <>
-      <Typography>
-        Money:
-        <Money money={Player.money} />
-      </Typography>
-
-      {hasServers && (
-        <>
-          <Typography>
-            Hashes: <Hashes hashes={Player.hashManager.hashes} /> / <Hashes hashes={Player.hashManager.capacity} />
-          </Typography>
-        </>
-      )}
-
-      <Typography>
-        Total Hacknet {hasServers ? "Server" : "Node"} Production: {prod}
-      </Typography>
-    </>
+    <Paper sx={{ display: "inline-block", padding: 0.5, margin: "0.5em 0" }}>
+      <StatsTable rows={rows} />
+    </Paper>
   );
 }

--- a/src/Hacknet/ui/PlayerInfo.tsx
+++ b/src/Hacknet/ui/PlayerInfo.tsx
@@ -16,7 +16,9 @@ import { Paper, Typography } from "@mui/material";
 import { StatsTable } from "../../ui/React/StatsTable";
 import { Factions } from "../../Faction/Factions";
 import { FactionName } from "@enums";
+import { Reputation } from "../../ui/React/Reputation";
 import { ReputationRate } from "../../ui/React/ReputationRate";
+import Tooltip from "@mui/material/Tooltip";
 
 interface IProps {
   totalProduction: number;
@@ -26,25 +28,47 @@ export function PlayerInfo(props: IProps): React.ReactElement {
   const hasServers = hasHacknetServers();
   const faction = Factions[FactionName.Netburners];
 
-  const rows: React.ReactNode[][] = [["Money:", <Money key="money" money={Player.money} />]];
+  const rows: React.ReactNode[][] = [];
+  rows.push(["Money Spent:", <Money key="money" money={-Player.moneySourceA.hacknet_expenses} />, null]);
+  rows.push([
+    "Money Produced:",
+    <Money key="money" money={Player.moneySourceA.hacknet} />,
+    <span key="moneyRate">
+      (<MoneyRate money={props.totalProduction} />)
+    </span>,
+  ]);
   if (hasServers) {
+    rows[1][2] = (
+      <Tooltip key="moneyRate" title="Value of hashes if sold for money">
+        <>
+          (<MoneyRate money={(props.totalProduction * 1e6) / 4} />)
+        </>
+      </Tooltip>
+    );
     rows.push([
       "Hashes:",
-      <Typography key={"hashes"}>
+      <span key={"hashes"}>
         <Hashes hashes={Player.hashManager.hashes} /> / <Hashes hashes={Player.hashManager.capacity} />
-      </Typography>,
+      </span>,
+      <span key="hashRate">
+        (<HashRate key="hashRate" hashes={props.totalProduction} />)
+      </span>,
     ]);
-    rows.push(["Total Hacknet Production:", <HashRate key="prod" hashes={props.totalProduction} />]);
-  } else {
-    rows.push(["Total Hacknet Production:", <MoneyRate key="prod" money={props.totalProduction} />]);
   }
   if (faction.isMember) {
     const repRate = (hasServers ? (props.totalProduction * 1e6) / 4 : props.totalProduction) * 1e-2;
-    rows.push([`${faction.name} reputation gain:`, <ReputationRate key="rep" reputation={repRate} />]);
+    rows.push([
+      `${faction.name} reputation:`,
+      <Reputation key="rep" reputation={faction.playerReputation} />,
+      <span key="repRate">
+        (<ReputationRate key="repRate" reputation={repRate} />)
+      </span>,
+    ]);
   }
 
   return (
-    <Paper sx={{ display: "inline-block", padding: 0.5, margin: "0.5em 0" }}>
+    <Paper sx={{ display: "inline-block", padding: "0.5em 1em", margin: "0.5em 0" }}>
+      <Typography variant="h6">Hacknet Summary</Typography>
       <StatsTable rows={rows} />
     </Paper>
   );

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -120,7 +120,15 @@ export function prestigeAugmentation(this: PlayerObject): void {
   this.scriptProdSinceLastAug = 0;
   this.moneySourceA.reset();
 
-  this.hacknetNodes.length = 0;
+  if (this.hasAugmentation(AugmentationName.HacknetRecoveryKey, false)) {
+    // TODO:
+    // - select the highest-level one instead of the first one
+    // - apply some reasonable level limits
+    // - ensure server contents are wiped
+    this.hacknetNodes.length = 1;
+  } else {
+    this.hacknetNodes.length = 0;
+  }
   this.hashManager.prestige();
 
   // Reapply augs, re-calculate skills and reset HP


### PR DESCRIPTION
Gain Netburners reputation by operating Hacknet nodes or servers.

This is a work in progress.

### TODO

- [x] Remove active hacking work from Netburners
- [x] Add passive Netburners reputation gain from operating Hacknet nodes or servers
- [x] Explain the above with UIs
- [ ] Balance passive reputation gain rate so that the choice of when to install Netburners augs is meaningful
- [ ] Balance passive money gain rate so that overall time to complete a bitnode is similar to current
- [ ] Update any tutorials that mention Netburners
- [ ] Consider more Netburners-exclusive augmentations such as "Hacknet Recovery Key"

### Screenshots
<img width="692" alt="faction screen" src="https://github.com/bitburner-official/bitburner-src/assets/208776/84901eb4-7832-4f54-80f6-d857173b5c04">
<img width="824" alt="hacknet screen" src="https://github.com/bitburner-official/bitburner-src/assets/208776/442a1655-fdac-4989-9b9c-bad3117e5583">
