### PR TITLE
BUGFIX: Fix array of strings parsing for coding contracts

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -1162,7 +1162,7 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
       const sanitizedPlayerAns: string = removeBracketsFromArrayString(ans);
       const sanitizedPlayerAnsArr: string[] = sanitizedPlayerAns.split(",");
       for (let i = 0; i < sanitizedPlayerAnsArr.length; ++i) {
-        sanitizedPlayerAnsArr[i] = removeQuotesFromString(sanitizedPlayerAnsArr[i]).replace(/\s/g, "");
+        sanitizedPlayerAnsArr[i] = removeQuotesFromString(sanitizedPlayerAnsArr[i].replace(/\s/g, ""));
       }
 
       if (sanitizedPlayerAnsArr.length !== res.length) {
@@ -1264,7 +1264,7 @@ export const codingContractTypesMetadata: ICodingContractTypeMetadata[] = [
       // Don't include any "" entries in the parsed array
       const sanitizedPlayerAnsArr: string[] = filterTruthy(sanitizedPlayerAns.split(","));
       for (let i = 0; i < sanitizedPlayerAnsArr.length; ++i) {
-        sanitizedPlayerAnsArr[i] = removeQuotesFromString(sanitizedPlayerAnsArr[i]).replace(/\s/g, "");
+        sanitizedPlayerAnsArr[i] = removeQuotesFromString(sanitizedPlayerAnsArr[i].replace(/\s/g, ""));
       }
 
       if (num == null || num.length === 0) {


### PR DESCRIPTION
When a contract expects an array of strings, and the user manually submits it, parsing fails for arrays with spaces after the commas

e.g:
```
["()()()", "(())()"]
          ^
```

This is problematic because the examples for the coding contract show the strings formatted in this way:

![image](https://github.com/bitburner-official/bitburner-src/assets/26750130/722c350b-b2c1-49b9-88e5-e48f63ce17e4)

Most common scripting languages will also by default format arrays in this way, so this error will happen to anyone directly  pasting from them


The issue is that `removeQuotesFromString` will only remove quotes if they are either the first or last char in the string, so if there is whitespace at the start of the string before a quote, it will not remove it.

https://github.com/bitburner-official/bitburner-src/blob/ae8f26f03bfa8d58b73460f32c346fb2e6e7d989/src/data/codingcontracttypes.ts#L40-L50


The current flow for answer validation is:
`split on ','` -> `remove quote at start and/or end` -> `remove whitespace`


This PR swaps the order to: 

`split on ','` -> `remove whitespace` -> `remove quote at start and/or end`


This fixes the array spacing issue without any major refactor to  `removeQuotesFromString`


Video of built app running with the fixed validation:

https://github.com/bitburner-official/bitburner-src/assets/26750130/e13da075-8949-442d-bb66-b2278c989ff2

closes #616 

- [x] `npm run format` 
- [x] `npm run lint`


