### PR TITLE
HACKNET: Fix inconsistent numbers of cpu cores for the bonus Hacknet Server granted by BN-9/SF-9.3

### DIFF
--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -290,6 +290,7 @@ export function prestigeSourceFile(isFlume: boolean): void {
 
     hserver.level = 100;
     hserver.cores = 10;
+    hserver.cpuCores = 10;
     hserver.cache = 5;
     hserver.updateHashRate(Player.mults.hacknet_node_money);
     hserver.updateHashCapacity();


### PR DESCRIPTION
### The problem this PR wishes to solve
#### Step to reproduce:
1. Enter BN-9
OR
Enter any bitnode while Source-File 9.3 is owned
2. Check the displayed Cores of the "highly-upgraded Hacknet Server" in Hacknet UI tab
3. Check the Cores by either:
3.1. Running NS function `ns.getServer('hacknet-server-0').cpuCores`
3.2. Connecting to the server and run terminal command `lscpu`

#### Result:
Step 2 indicates the server has 10 cores.
Step 3 indicates the server has 1 core only.

#### Other info:
- The cost of upgrading cores is calculated as it has 10 cores.
- Running some of hacking related NS functions (namely `grow()` and `weaken()`) on this server uses 1 as the `cores` factor.
- Upgrading its core to 11 or more eliminates the inconsistency.

#### Version
Bitburner v2.5.0 (b87b8b4be)

### Into the code
[Lines 288~297 of the file Prestige.ts](https://github.com/bitburner-official/bitburner-src/blob/dev/src/Prestige.ts#L288-L297) are responsible for the initial stats of the bonus Hacknet Server. However, the property `cpuCores` is left unset and thus will inherit from `BaseServer` in [Server/BaseServer.ts](https://github.com/bitburner-official/bitburner-src/blob/dev/src/Server/BaseServer.ts#L48), which is 1.
By upgrading its core, `cpuCores` will be set equals to `cores`. This happens in [line 98 of Hacknet/HacknetServer.ts](https://github.com/bitburner-official/bitburner-src/blob/dev/src/Hacknet/HacknetServer.ts#L98). The two properties keeps equal from then on.
Set the initial value of property `cpuCores` to 10 should fix the problem.