### PR TITLE
REMOTE: Added possibility to change target IP of remote API

### DIFF
--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -37,7 +37,7 @@ export const RemoteAPIPage = (): React.ReactElement => {
       <Tooltip
         title={
           <Typography>
-            This address is used to connect to a Remote API port, please ensure that it matches with your Remote API
+            This address is used to connect to a Remote API, please ensure that it matches with your Remote API
             address. Default localhost.
           </Typography>
         }
@@ -50,13 +50,14 @@ export const RemoteAPIPage = (): React.ReactElement => {
           value={remoteFileApiAddress}
           onChange={handleRemoteFileApiAddressChange}
           placeholder="localhost"
+          size={"medium"}
         />
       </Tooltip>
       <br />
       <Tooltip
         title={
           <Typography>
-            This port number is used to connect to a Remote API port, please ensure that it matches with your Remote API
+            This port number is used to connect to a Remote API, please ensure that it matches with your Remote API
             server port. Set to 0 to disable the feature.
           </Typography>
         }
@@ -73,6 +74,7 @@ export const RemoteAPIPage = (): React.ReactElement => {
           value={remoteFileApiPort}
           onChange={handleRemoteFileApiPortChange}
           placeholder="12525"
+          size={"medium"}
         />
       </Tooltip>
       <br />

--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -37,8 +37,8 @@ export const RemoteAPIPage = (): React.ReactElement => {
       <Tooltip
         title={
           <Typography>
-            This address is used to connect to a Remote API, please ensure that it matches with your Remote API
-            address. Default localhost.
+            This address is used to connect to a Remote API, please ensure that it matches with your Remote API address.
+            Default localhost.
           </Typography>
         }
       >

--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -7,10 +7,16 @@ import { isRemoteFileApiConnectionLive, newRemoteFileApiConnection } from "../..
 
 export const RemoteAPIPage = (): React.ReactElement => {
   const [remoteFileApiPort, setRemoteFileApiPort] = useState(Settings.RemoteFileApiPort);
+  const [remoteFileApiAddress, setRemoteFileApiAddress] = useState(Settings.RemoteFileApiAddress);
 
   function handleRemoteFileApiPortChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setRemoteFileApiPort(Number(event.target.value));
     Settings.RemoteFileApiPort = Number(event.target.value);
+  }
+
+  function handleRemoteFileApiAddressChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    setRemoteFileApiAddress(String(event.target.value));
+    Settings.RemoteFileApiAddress = String(event.target.value);
   }
 
   return (
@@ -31,6 +37,25 @@ export const RemoteAPIPage = (): React.ReactElement => {
       <Tooltip
         title={
           <Typography>
+            This address is used to connect to a Remote API port, please ensure that it matches with your Remote API
+            address. Default localhost.
+          </Typography>
+        }
+      >
+        <TextField
+          key={"remoteAPIAddress"}
+          InputProps={{
+            startAdornment: <Typography>Address:&nbsp;</Typography>,
+          }}
+          value={remoteFileApiAddress}
+          onChange={handleRemoteFileApiAddressChange}
+          placeholder="localhost"
+        />
+      </Tooltip>
+      <br />
+      <Tooltip
+        title={
+          <Typography>
             This port number is used to connect to a Remote API port, please ensure that it matches with your Remote API
             server port. Set to 0 to disable the feature.
           </Typography>
@@ -44,13 +69,14 @@ export const RemoteAPIPage = (): React.ReactElement => {
                 Port:&nbsp;
               </Typography>
             ),
-            endAdornment: <Button onClick={newRemoteFileApiConnection}>Connect</Button>,
           }}
           value={remoteFileApiPort}
           onChange={handleRemoteFileApiPortChange}
           placeholder="12525"
         />
       </Tooltip>
+      <br />
+      <Button onClick={newRemoteFileApiConnection}>Connect</Button>
     </GameOptionsPage>
   );
 };

--- a/src/RemoteFileAPI/RemoteFileAPI.ts
+++ b/src/RemoteFileAPI/RemoteFileAPI.ts
@@ -5,9 +5,8 @@ let server: Remote;
 
 export function newRemoteFileApiConnection(): void {
   if (server) server.stopConnection();
-  if (Settings.RemoteFileApiAddress === "") Settings.RemoteFileApiAddress = "localhost";
   if (Settings.RemoteFileApiPort === 0 || Settings.RemoteFileApiPort > 65535) return;
-  server = new Remote(Settings.RemoteFileApiAddress, Settings.RemoteFileApiPort);
+  server = new Remote(Settings.RemoteFileApiAddress == "" ? "localhost" : Settings.RemoteFileApiAddress, Settings.RemoteFileApiPort);
   server.startConnection();
 }
 

--- a/src/RemoteFileAPI/RemoteFileAPI.ts
+++ b/src/RemoteFileAPI/RemoteFileAPI.ts
@@ -6,7 +6,10 @@ let server: Remote;
 export function newRemoteFileApiConnection(): void {
   if (server) server.stopConnection();
   if (Settings.RemoteFileApiPort === 0 || Settings.RemoteFileApiPort > 65535) return;
-  server = new Remote(Settings.RemoteFileApiAddress == "" ? "localhost" : Settings.RemoteFileApiAddress, Settings.RemoteFileApiPort);
+  server = new Remote(
+    Settings.RemoteFileApiAddress === "" ? "localhost" : Settings.RemoteFileApiAddress,
+    Settings.RemoteFileApiPort,
+  );
   server.startConnection();
 }
 

--- a/src/RemoteFileAPI/RemoteFileAPI.ts
+++ b/src/RemoteFileAPI/RemoteFileAPI.ts
@@ -5,8 +5,9 @@ let server: Remote;
 
 export function newRemoteFileApiConnection(): void {
   if (server) server.stopConnection();
-  if (Settings.RemoteFileApiPort === 0) return;
-  server = new Remote("localhost", Settings.RemoteFileApiPort);
+  if (Settings.RemoteFileApiAddress === "") Settings.RemoteFileApiAddress = "localhost";
+  if (Settings.RemoteFileApiPort === 0 || Settings.RemoteFileApiPort > 65535) return;
+  server = new Remote(Settings.RemoteFileApiAddress, Settings.RemoteFileApiPort);
   server.startConnection();
 }
 

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -40,6 +40,8 @@ export const Settings = {
   MaxPortCapacity: 50,
   /** Limit the number of entries in the terminal. */
   MaxTerminalCapacity: 500,
+  /** IP address the Remote File API client will try to connect to. Default localhost . */
+  RemoteFileApiAddress: "localhost",
   /** Port the Remote File API client will try to connect to. 0 to disable. */
   RemoteFileApiPort: 0,
   /** Whether to save the game when the player saves any file. */


### PR DESCRIPTION
#  Description 
Added possibility to change target of the Remote API to allow development of scripts on other device than where game is running.

It is a niche situation but with Steam Deck gaining popularity and being a good device for idlers, I think giving this possibility for the more savvy would be great.

## Possible usage
- Game running on different device(Steam Deck, laptop, vm)
- File synchronization utility([Viteburner](https://github.com/Tanimodori/viteburner-template),[bitburner-filesync](https://github.com/bitburner-official/bitburner-filesync)) on main device(main pc, work pc)

# Features
- possibility to change target IP of the Remote API

![image](https://github.com/bitburner-official/bitburner-src/assets/42799650/8b9ccdff-0be6-4f4f-8aba-889a3cf20a92)
![image](https://github.com/bitburner-official/bitburner-src/assets/42799650/ef8c2d8f-9a90-405a-9b5e-be8a2ad38f5d)
