### PR TITLE
UI: 'Disable Text Effects' setting applies to "corrupted text"

### DIFF
--- a/src/Achievements/AchievementList.tsx
+++ b/src/Achievements/AchievementList.tsx
@@ -118,7 +118,7 @@ export function AchievementList({ achievements, playerAchievements }: IProps): J
               <Typography color="secondary" sx={{ mt: 1 }}>
                 {secret.map((item) => (
                   <span key={`secret_${item.achievement.ID}`}>
-                    <CorruptableText content={item.achievement.ID}></CorruptableText>
+                    <CorruptableText content={item.achievement.ID} spoiler={true}></CorruptableText>
                     <br />
                   </span>
                 ))}

--- a/src/Bladeburner/ui/BlackOpPage.tsx
+++ b/src/Bladeburner/ui/BlackOpPage.tsx
@@ -30,7 +30,7 @@ export function BlackOpPage(props: IProps): React.ReactElement {
       </Typography>
       {props.bladeburner.blackops[BlackOperationName.OperationDaedalus] ? (
         <Button sx={{ my: 1, p: 1 }} onClick={() => Router.toPage(Page.BitVerse, { flume: false, quick: false })}>
-          <CorruptableText content="Destroy w0rld_d34mon"></CorruptableText>
+          <CorruptableText content="Destroy w0rld_d34mon" spoiler={false}></CorruptableText>
         </Button>
       ) : (
         <BlackOpList bladeburner={props.bladeburner} />

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -136,7 +136,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
             ) : (
               <Tooltip title={"Rumored Faction"}>
                 <span style={{ overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
-                  <CorruptableText content={props.faction.name} />
+                  <CorruptableText content={props.faction.name} spoiler={false} />
                 </span>
               </Tooltip>
             )}

--- a/src/Locations/ui/GenericLocation.tsx
+++ b/src/Locations/ui/GenericLocation.tsx
@@ -21,8 +21,6 @@ import { CasinoLocation } from "./CasinoLocation";
 import { Location } from "../Location";
 import { LocationType } from "@enums";
 
-import { Settings } from "../../Settings/Settings";
-
 import { isBackdoorInstalled } from "../../Server/ServerHelpers";
 import { GetServer } from "../../Server/AllServers";
 
@@ -97,10 +95,10 @@ export function GenericLocation({ loc }: IProps): React.ReactElement {
     <>
       <Button onClick={() => Router.toPage(Page.City)}>Return to World</Button>
       <Typography variant="h4" sx={{ mt: 1 }}>
-        {backdoorInstalled && !Settings.DisableTextEffects ? (
+        {backdoorInstalled ? (
           <Tooltip title={`Backdoor installed on ${loc.name}.`}>
             <span>
-              <CorruptableText content={loc.name} />
+              <CorruptableText content={loc.name} spoiler={false} />
             </span>
           </Tooltip>
         ) : (

--- a/src/Locations/ui/GenericLocation.tsx
+++ b/src/Locations/ui/GenericLocation.tsx
@@ -96,7 +96,7 @@ export function GenericLocation({ loc }: IProps): React.ReactElement {
       <Button onClick={() => Router.toPage(Page.City)}>Return to World</Button>
       <Typography variant="h4" sx={{ mt: 1 }}>
         {backdoorInstalled ? (
-          <Tooltip title={`Backdoor installed on ${loc.name}.`}>
+          <Tooltip title={`Backdoor installed on ${serverMeta.hostname}.`}>
             <span>
               <CorruptableText content={loc.name} spoiler={false} />
             </span>

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -303,7 +303,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
     return (
       <>
         <Typography>
-          <CorruptableText content={"An eerie aura surrounds this area. You feel you should leave."} />
+          <CorruptableText content={"An eerie aura surrounds this area. You feel you should leave."} spoiler={false} />
         </Typography>
       </>
     );

--- a/src/ui/MD/a.tsx
+++ b/src/ui/MD/a.tsx
@@ -28,7 +28,7 @@ export const A = (props: React.PropsWithChildren<{ href?: string }>): React.Reac
           cursor: "pointer",
         }}
       >
-        <CorruptableText content={props.children + ""} />
+        <CorruptableText content={props.children + ""} spoiler={true} />
       </span>
     );
   return (

--- a/src/ui/React/CorruptableText.tsx
+++ b/src/ui/React/CorruptableText.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Settings } from "../../Settings/Settings";
 
 function replace(str: string, i: number, char: string): string {
   return str.substring(0, i) + char + str.substring(i + 1);
@@ -6,12 +7,17 @@ function replace(str: string, i: number, char: string): string {
 
 interface CorruptableTextProps {
   content: string;
+  spoiler: boolean;
 }
 
-function randomize(char: string): string {
+function randomize(char: string, obfuscate: boolean): string {
   const randFrom = (str: string): string => str[Math.floor(Math.random() * str.length)];
   const classes = ["abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "1234567890", " _", "()[]{}<>"];
   const other = `!@#$%^&*()_+|\\';"/.,?\`~`;
+
+  if (obfuscate && Math.random() < 0.75) {
+    return randFrom(other);
+  }
 
   for (const c of classes) {
     if (c.includes(char)) return randFrom(c);
@@ -24,6 +30,10 @@ export function CorruptableText(props: CorruptableTextProps): JSX.Element {
   const [content, setContent] = useState(props.content);
 
   useEffect(() => {
+    if (Settings.DisableTextEffects) {
+      return;
+    }
+
     let counter = 5;
     const timers: number[] = [];
     const intervalId = setInterval(() => {
@@ -32,7 +42,7 @@ export function CorruptableText(props: CorruptableTextProps): JSX.Element {
       counter = Math.random() * 5;
       const index = Math.random() * props.content.length;
       const letter = props.content.charAt(index);
-      setContent((content) => replace(content, index, randomize(letter)));
+      setContent((content) => replace(content, index, randomize(letter, false)));
       timers.push(
         window.setTimeout(() => {
           setContent((content) => replace(content, index, letter));
@@ -45,6 +55,11 @@ export function CorruptableText(props: CorruptableTextProps): JSX.Element {
       timers.forEach((timerId) => clearTimeout(timerId));
     };
   }, [props.content]);
+
+  if (Settings.DisableTextEffects) {
+    const spoileredContent = content.replaceAll(/./g, (c) => randomize(c, true));
+    return <span>{props.spoiler ? spoileredContent : content}</span>;
+  }
 
   return <span>{content}</span>;
 }


### PR DESCRIPTION
Adds "spoiler" boolean property to CorruptableText; text will be corrupted and unreadable if true, else text will have zero effects
All changes only apply while 'Disable Text Effects' is toggled ON in settings, otherwise everything appears as usual.

Closes #892

Old:
![old_corruptabletext](https://github.com/bitburner-official/bitburner-src/assets/90784553/93c042b0-dcf8-44d5-9880-a21c092edc8a)
New:
![new_corruptabletext](https://github.com/bitburner-official/bitburner-src/assets/90784553/a19d72dc-a63a-4e94-9475-0f6cbd848a9c)
