### PR TITLE
UI: Changed message when buying tor router to not be misleading

### DIFF
--- a/src/Locations/ui/TorButton.tsx
+++ b/src/Locations/ui/TorButton.tsx
@@ -32,7 +32,7 @@ export function purchaseTorRouter(): void {
   dialogBoxCreate(
     "You have purchased a TOR router!\n" +
       "You now have access to the dark web from your home computer.\n" +
-      "Use the scan/scan-analyze commands to search for the dark web connection.",
+      "Use the buy command in the terminal to purchase programs.",
   );
 }
 


### PR DESCRIPTION
Currently the message implies you need to connect to darkweb to buy programs, which is not the case.

I've changed it to tell you to use the buy command.