### PR TITLE
FUNCTION: Allow user to disable the disable log message

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -505,20 +505,25 @@ export const ns: InternalAPI<NSFull> = {
   clearLog: (ctx) => () => {
     ctx.workerScript.scriptRef.clearLog();
   },
-  disableLog: (ctx) => (_fn) => {
-    const fn = helpers.string(ctx, "fn", _fn);
-    if (fn === "ALL") {
-      for (const fn of Object.keys(possibleLogs)) {
+  disableLog:
+    (ctx) =>
+    (_fn, _suppress = false) => {
+      const fn = helpers.string(ctx, "fn", _fn);
+      const suppress = _suppress;
+      if (fn === "ALL") {
+        for (const fn of Object.keys(possibleLogs)) {
+          ctx.workerScript.disableLogs[fn] = true;
+        }
+        helpers.log(ctx, () => `Disabled logging for all functions`);
+      } else if (possibleLogs[fn] === undefined) {
+        throw helpers.makeRuntimeErrorMsg(ctx, `Invalid argument: ${fn}.`);
+      } else {
         ctx.workerScript.disableLogs[fn] = true;
+        if (suppress == false) {
+          helpers.log(ctx, () => `Disabled logging for ${fn}`);
+        }
       }
-      helpers.log(ctx, () => `Disabled logging for all functions`);
-    } else if (possibleLogs[fn] === undefined) {
-      throw helpers.makeRuntimeErrorMsg(ctx, `Invalid argument: ${fn}.`);
-    } else {
-      ctx.workerScript.disableLogs[fn] = true;
-      helpers.log(ctx, () => `Disabled logging for ${fn}`);
-    }
-  },
+    },
   enableLog: (ctx) => (_fn) => {
     const fn = helpers.string(ctx, "fn", _fn);
     if (fn === "ALL") {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -514,7 +514,9 @@ export const ns: InternalAPI<NSFull> = {
         for (const fn of Object.keys(possibleLogs)) {
           ctx.workerScript.disableLogs[fn] = true;
         }
-        helpers.log(ctx, () => `Disabled logging for all functions`);
+        if (suppress == false) {
+          helpers.log(ctx, () => `Disabled logging for all functions`);
+        }
       } else if (possibleLogs[fn] === undefined) {
         throw helpers.makeRuntimeErrorMsg(ctx, `Invalid argument: ${fn}.`);
       } else {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5240,8 +5240,9 @@ export interface NS {
    * Logging can be disabled for all functions by passing `ALL` as the argument.
    *
    * @param fn - Name of function for which to disable logging.
+   * @param suppress - If true, disables the log message declaring function logging was disabled. Defaults to false.
    */
-  disableLog(fn: string): void;
+  disableLog(fn: string, suppress: boolean): void;
 
   /**
    * Enable logging for a certain function.
@@ -5252,6 +5253,7 @@ export interface NS {
    * function as an argument, then it will revert the effects of disableLog(`ALL`).
    *
    * @param fn - Name of function for which to enable logging.
+   
    */
   enableLog(fn: string): void;
 


### PR DESCRIPTION
calling the disableLog function traces out in the log that the function was disabled.  When calling this function from within a function, will still get displayed.  Added an option to suppress this log message.

Example of the previous behavior for disabling 'sleep' on top, and the new parameter being set to 'true' on the bottom

![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/1c771419-14fb-4413-b4b7-c4fe7ac8381d)
