### PR TITLE
UI: For active scripts page, home always on top, then purchased servers, then the rest

### DIFF
--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -86,14 +86,34 @@ export function ServerAccordions(props: IProps): React.ReactElement {
     }
     return false;
   });
-  // Ordering scripts: Home, Purchased/Hacknet (alphabetically), All Other Servers
+  // Ordering scripts: Home, Purchased (alphabetically), Hacknet(alphabetically), All Other Servers
   let finalResponse = [];
   const home = SpecialServers.Home;
-  const homeScripts = filtered.filter((x) => x?.server?.hostname == home && x?.server?.purchasedByPlayer == true);
-  let purchasedScripts = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == true);
-  const other = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == false);
-  purchasedScripts = purchasedScripts.sort((a, b) => a?.server.hostname.localeCompare(b?.server.hostname));
-  finalResponse = homeScripts.concat(purchasedScripts, other);
+  const homeScripts = filtered.filter((x) => x.server.hostname == home && x.server.purchasedByPlayer == true);
+  let hacknetScripts0_9 = filtered.filter(
+    (x) =>
+      x.server.hostname != home &&
+      x.server.purchasedByPlayer == true &&
+      x.server.hostname.substring(0, 7) == "hacknet" &&
+      x.server.hostname.length == 16,
+  );
+  hacknetScripts0_9 = hacknetScripts0_9.sort((a, b) => a.server.hostname.localeCompare(b.server.hostname));
+  let hacknetScripts10_19 = filtered.filter(
+    (x) =>
+      x.server.hostname != home &&
+      x.server.purchasedByPlayer == true &&
+      x.server.hostname.substring(0, 7) == "hacknet" &&
+      x.server.hostname.length == 17,
+  );
+  hacknetScripts10_19 = hacknetScripts10_19.sort((a, b) => a.server.hostname.localeCompare(b.server.hostname));
+  let purchasedScripts = filtered.filter(
+    (x) =>
+      x.server.hostname != home && x.server.purchasedByPlayer == true && x.server.hostname.substring(0, 7) != "hacknet",
+  );
+  const other = filtered.filter((x) => x.server.hostname != home && x.server.purchasedByPlayer == false);
+  purchasedScripts = purchasedScripts.sort((a, b) => a.server.hostname.localeCompare(b.server.hostname));
+  finalResponse = homeScripts.concat(purchasedScripts, hacknetScripts0_9, hacknetScripts10_19, other);
+
   return (
     <>
       <Grid container>

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from "react";
 
 import { ServerAccordion } from "./ServerAccordion";
-
+import {SpecialServers} from "../../Server/data/SpecialServers"
 import TextField from "@mui/material/TextField";
 import List from "@mui/material/List";
 import TablePagination from "@mui/material/TablePagination";
@@ -88,9 +88,10 @@ export function ServerAccordions(props: IProps): React.ReactElement {
   });
   // Ordering scripts: Home, Purchased/Hacknet (alphabetically), All Other Servers
   let finalResponse = [];
-  const homeScripts = filtered.filter((x) => x?.server?.hostname == "home" && x?.server?.purchasedByPlayer == true);
-  let purchasedScripts = filtered.filter((x) => x?.server?.hostname != "home" && x?.server?.purchasedByPlayer == true);
-  const other = filtered.filter((x) => x?.server?.hostname != "home" && x?.server?.purchasedByPlayer == false);
+  const home = SpecialServers.Home
+  const homeScripts = filtered.filter((x) => x?.server?.hostname == home && x?.server?.purchasedByPlayer == true);
+  let purchasedScripts = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == true);
+  const other = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == false);
   purchasedScripts = purchasedScripts.sort((a, b) => a?.server.hostname.localeCompare(b?.server.hostname));
   const tempResponse = homeScripts.concat(purchasedScripts);
   finalResponse = tempResponse.concat(other);

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from "react";
 
 import { ServerAccordion } from "./ServerAccordion";
-import {SpecialServers} from "../../Server/data/SpecialServers"
+import { SpecialServers } from "../../Server/data/SpecialServers";
 import TextField from "@mui/material/TextField";
 import List from "@mui/material/List";
 import TablePagination from "@mui/material/TablePagination";
@@ -88,7 +88,7 @@ export function ServerAccordions(props: IProps): React.ReactElement {
   });
   // Ordering scripts: Home, Purchased/Hacknet (alphabetically), All Other Servers
   let finalResponse = [];
-  const home = SpecialServers.Home
+  const home = SpecialServers.Home;
   const homeScripts = filtered.filter((x) => x?.server?.hostname == home && x?.server?.purchasedByPlayer == true);
   let purchasedScripts = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == true);
   const other = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == false);

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -86,6 +86,14 @@ export function ServerAccordions(props: IProps): React.ReactElement {
     }
     return false;
   });
+  // Pushing a script from home to the start of the array to always display on top
+  if (filtered.find((x) => x?.server?.hostname === "home")) {
+    const index = filtered.findIndex((x) => x?.server?.hostname === "home");
+    if (index != 0) {
+      filtered.unshift(filtered[index]);
+      filtered.splice(index + 1);
+    }
+  }
 
   return (
     <>

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -93,8 +93,8 @@ export function ServerAccordions(props: IProps): React.ReactElement {
   let purchasedScripts = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == true);
   const other = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == false);
   purchasedScripts = purchasedScripts.sort((a, b) => a?.server.hostname.localeCompare(b?.server.hostname));
-  const tempResponse = homeScripts.concat(purchasedScripts);
-  finalResponse = tempResponse.concat(other);
+  //const tempResponse = homeScripts.concat(purchasedScripts,other);
+  finalResponse = homeScripts.concat(purchasedScripts, other); //tempResponse.concat(other);
   return (
     <>
       <Grid container>

--- a/src/ui/ActiveScripts/ServerAccordions.tsx
+++ b/src/ui/ActiveScripts/ServerAccordions.tsx
@@ -93,8 +93,7 @@ export function ServerAccordions(props: IProps): React.ReactElement {
   let purchasedScripts = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == true);
   const other = filtered.filter((x) => x?.server?.hostname != home && x?.server?.purchasedByPlayer == false);
   purchasedScripts = purchasedScripts.sort((a, b) => a?.server.hostname.localeCompare(b?.server.hostname));
-  //const tempResponse = homeScripts.concat(purchasedScripts,other);
-  finalResponse = homeScripts.concat(purchasedScripts, other); //tempResponse.concat(other);
+  finalResponse = homeScripts.concat(purchasedScripts, other);
   return (
     <>
       <Grid container>


### PR DESCRIPTION
Took the list of servers, which is derived from the workerscript objects based on pid value, and filtered it.

Placed home first, then any player purchased server, then any remaining.

Purchased servers are alphabetical

![OrderedServers](https://github.com/bitburner-official/bitburner-src/assets/147098375/085ca562-beaa-4180-840b-9b6f6c21effe)

Tested locally.  The array that I'm filtering is just the current servers running scripts, and not the scripts themselves.  Max size shouldn't exceed 100.  Didn't notice any performance hit when running 3000 scripts on 16 servers.