### PR TITLE
BUGFIX: Update formatNumber.ts to allow formating 0 with 0 suffix

### DIFF
--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -114,8 +114,8 @@ export function formatNumber(n: number, fractionalDigits = 3, suffixStart = 1000
   // Special handling for Infinities
   if (nAbs === Infinity) return n < 0 ? "-∞" : "∞";
 
-  // Early return for non-suffix
-  if (nAbs < suffixStart) {
+  // Early return for non-suffix or if number and suffix are 0
+  if (nAbs < suffixStart || (nAbs == 0 && suffixStart == 0)) {
     if (isInteger) return basicFormatter.format(n);
     return getFormatter(fractionalDigits).format(n);
   }

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -113,9 +113,12 @@ export function formatNumber(n: number, fractionalDigits = 3, suffixStart = 1000
 
   // Special handling for Infinities
   if (nAbs === Infinity) return n < 0 ? "-∞" : "∞";
+  if (suffixStart < 1000) {
+    throw new Error("suffixStart must be greater than or equal to 1000");
+  }
 
   // Early return for non-suffix or if number and suffix are 0
-  if (nAbs < suffixStart || (nAbs == 0 && suffixStart == 0)) {
+  if (nAbs < suffixStart) {
     if (isInteger) return basicFormatter.format(n);
     return getFormatter(fractionalDigits).format(n);
   }


### PR DESCRIPTION
From the discord Bug Report room.  Player noticed they would get NaN when attempting to call ns.formatNumber

```
ns.tprint("Format 1:       ", ns.formatNumber(1, 0, 0))
ns.tprint("Format 0:       ", ns.formatNumber(0, 0, 0))
ns.tprint("Format 0 (def): ", ns.formatNumber(0))

```
```
test_fm.js: Format 1:       1
test_fm.js: Format 0:       NaNundefined
test_fm.js: Format 0 (def): 0.000
```

It looks like the code to check for non-suffixed numbers doesn't account for 0.  Adding in a check just for 0 allows the correct output in this case.

```
1.js: Format 1:       1
1.js: Format 0:       0
1.js: Format 0 (def): 0.000
```
