### PR TITLE
IMPROVEMENT: Pad purchased and hacknet server numbers

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectServerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectServerMethods.ts
@@ -45,7 +45,7 @@ export function getUpgradeHomeCoresCost(this: PlayerObject): number {
 
 export function createHacknetServer(this: PlayerObject): HacknetServer {
   const numOwned = this.hacknetNodes.length;
-  const name = hasHacknetServers() ? `hacknet-server-${numOwned}` : `hacknet-node-${numOwned}`;
+  const name = hasHacknetServers() ? `hacknet-server-${String(numOwned).padStart(2,'0')}` : `hacknet-node-${String(numOwned).padStart(2,'0')}`;
   const server = new HacknetServer({
     adminRights: true,
     hostname: name,

--- a/src/PersonObjects/Player/PlayerObjectServerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectServerMethods.ts
@@ -45,7 +45,9 @@ export function getUpgradeHomeCoresCost(this: PlayerObject): number {
 
 export function createHacknetServer(this: PlayerObject): HacknetServer {
   const numOwned = this.hacknetNodes.length;
-  const name = hasHacknetServers() ? `hacknet-server-${String(numOwned).padStart(2,'0')}` : `hacknet-node-${String(numOwned).padStart(2,'0')}`;
+  const name = hasHacknetServers()
+    ? `hacknet-server-${String(numOwned).padStart(2, "0")}`
+    : `hacknet-node-${String(numOwned).padStart(2, "0")}`;
   const server = new HacknetServer({
     adminRights: true,
     hostname: name,

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -31,7 +31,7 @@ export function safelyCreateUniqueServer(params: IConstructorParams): Server {
 
     // Use a for loop to ensure that we don't get suck in an infinite loop somehow
     for (let i = 0; i < 200; ++i) {
-      hostname = hostname.replace(/-[0-9]+$/, `-${String(i).padStart(2,'0')}`);
+      hostname = hostname.replace(/-[0-9]+$/, `-${String(i).padStart(2, "0")}`);
       if (GetServer(hostname) == null) {
         break;
       }

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -31,7 +31,7 @@ export function safelyCreateUniqueServer(params: IConstructorParams): Server {
 
     // Use a for loop to ensure that we don't get suck in an infinite loop somehow
     for (let i = 0; i < 200; ++i) {
-      hostname = hostname.replace(/-[0-9]+$/, `-${i}`);
+      hostname = hostname.replace(/-[0-9]+$/, `-${String(i).padStart(2,'0')}`);
       if (GetServer(hostname) == null) {
         break;
       }


### PR DESCRIPTION
Hacknet and purchased servers automatically get incremented numerically, but it's not a padded number.  If you want to sort by server name, 10 will come before 2.

Padded the functions to add a leading 0 for digits 0-9. so the servers would be ordered properly.

Change is mainly to coincide with https://github.com/bitburner-official/bitburner-src/pull/954#issuecomment-1837259330