### PR TITLE
UI: Remove unused code in OfficeSpace

### DIFF
--- a/src/Corporation/OfficeSpace.ts
+++ b/src/Corporation/OfficeSpace.ts
@@ -177,7 +177,6 @@ export class OfficeSpace {
 
   hireRandomEmployee(position: CorpEmployeeJob): boolean {
     if (this.atCapacity()) return false;
-    if (document.getElementById("cmpy-mgmt-hire-employee-popup") != null) return false;
 
     this.totalExperience += getRandomInt(50, 100);
 


### PR DESCRIPTION
In src\Corporation\OfficeSpace.ts, there is a reference to "cmpy-mgmt-hire-employee-popup". It is the identifier of a popup which has been removed in commit 5cce1c255ca9542647abb4470dc19fcc267b1575. It is not used in our current code.

