### PR TITLE
MISC: Change import declaration of arg library

### DIFF
--- a/src/Terminal/commands/ps.ts
+++ b/src/Terminal/commands/ps.ts
@@ -1,7 +1,7 @@
 import { Terminal } from "../../Terminal";
 import { BaseServer } from "../../Server/BaseServer";
 import { matchScriptPathUnanchored } from "../../utils/helpers/scriptKey";
-import * as libarg from "arg";
+import libarg from "arg";
 
 export function ps(args: (string | number | boolean)[], server: BaseServer): void {
   let flags;

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -3,7 +3,7 @@ import { BaseServer } from "../../Server/BaseServer";
 import { LogBoxEvents } from "../../ui/React/LogBoxManager";
 import { startWorkerScript } from "../../NetscriptWorker";
 import { RunningScript } from "../../Script/RunningScript";
-import * as libarg from "arg";
+import libarg from "arg";
 import { formatRam } from "../../ui/formatNumber";
 import { ScriptArg } from "@nsdefs";
 import { isPositiveInteger } from "../../types";

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -7,7 +7,7 @@ import { HelpTexts } from "./HelpText";
 import { compile } from "../NetscriptJSEvaluator";
 import { Flags } from "../NetscriptFunctions/Flags";
 import { AutocompleteData } from "@nsdefs";
-import * as libarg from "arg";
+import libarg from "arg";
 import { getAllDirectories, resolveDirectory, root } from "../Paths/Directory";
 import { resolveScriptFilePath } from "../Paths/ScriptFilePath";
 


### PR DESCRIPTION
When we import "arg" library, there are 2 forms of import declarations:
- Namespace import:
  - src\Terminal\commands\ps.ts
  - src\Terminal\commands\runScript.ts
  - src\Terminal\getTabCompletionPossibilities.ts
- Default import:
  - src\NetscriptFunctions\Flags.ts
  - src\Terminal\commands\ls.tsx

This pull request changes those namespace import declarations to default import declarations.
When we use "arg", we usually write code like this:
```js
const flags = libarg(params);
```
This is not how we are supposed to use [namespace object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#module_namespace_object). Webpack can deal with it and generate proper JavaScript code. However, we should use proper form of import declaration in this case (Default import).
Reference: https://www.typescriptlang.org/tsconfig#esModuleInterop
