### PR TITLE
MISC: Switch port.nextWrite() from LIFO to FIFO

### DIFF
--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -42,7 +42,7 @@ export function writePort(n: PortNumber, value: unknown): PortData | null {
       `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
     );
   }
-  let { data, resolvers } = getPort(n);
+  const { data, resolvers } = getPort(n);
   data.push(value);
   for (const res of resolvers.splice(0, resolvers.length)) res();
   if (data.length > Settings.MaxPortCapacity) return data.shift() as PortData;
@@ -55,7 +55,7 @@ export function tryWritePort(n: PortNumber, value: unknown): boolean {
       `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
     );
   }
-  let { data, resolvers } = getPort(n);
+  const { data, resolvers } = getPort(n);
   if (data.length >= Settings.MaxPortCapacity) return false;
   data.push(value);
   for (const res of resolvers.splice(0, resolvers.length)) res();

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -42,7 +42,7 @@ export function writePort(n: PortNumber, value: unknown): PortData | null {
       `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
     );
   }
-  const { data, resolvers } = getPort(n);
+  let { data, resolvers } = getPort(n);
   data.push(value);
   for (const res of resolvers) res();
   resolvers = [];
@@ -56,7 +56,7 @@ export function tryWritePort(n: PortNumber, value: unknown): boolean {
       `port.write: Tried to write type ${typeof value}. Only string and number types may be written to ports.`,
     );
   }
-  const { data, resolvers } = getPort(n);
+  let { data, resolvers } = getPort(n);
   if (data.length >= Settings.MaxPortCapacity) return false;
   data.push(value);
   for (const res of resolvers) res();

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -44,8 +44,7 @@ export function writePort(n: PortNumber, value: unknown): PortData | null {
   }
   let { data, resolvers } = getPort(n);
   data.push(value);
-  for (const res of resolvers) res();
-  resolvers = [];
+  for (const res of resolvers.splice(0, resolvers.length)) res();
   if (data.length > Settings.MaxPortCapacity) return data.shift() as PortData;
   return null;
 }
@@ -59,8 +58,7 @@ export function tryWritePort(n: PortNumber, value: unknown): boolean {
   let { data, resolvers } = getPort(n);
   if (data.length >= Settings.MaxPortCapacity) return false;
   data.push(value);
-  for (const res of resolvers) res();
-  resolvers = [];
+  for (const res of resolvers.splice(0, resolvers.length)) res();
   return true;
 }
 

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -44,7 +44,8 @@ export function writePort(n: PortNumber, value: unknown): PortData | null {
   }
   const { data, resolvers } = getPort(n);
   data.push(value);
-  while (resolvers.length > 0) resolvers.pop()?.();
+  for (const res of resolvers) res();
+  resolvers = [];
   if (data.length > Settings.MaxPortCapacity) return data.shift() as PortData;
   return null;
 }
@@ -58,7 +59,8 @@ export function tryWritePort(n: PortNumber, value: unknown): boolean {
   const { data, resolvers } = getPort(n);
   if (data.length >= Settings.MaxPortCapacity) return false;
   data.push(value);
-  while (resolvers.length > 0) resolvers.pop()?.();
+  for (const res of resolvers) res();
+  resolvers = [];
   return true;
 }
 


### PR DESCRIPTION
This has been discussed on Discord already and the consensus is that FIFO behavior makes more sense and is worth changing to. This is a breaking change but there's no evidence of anyone actually using multiple nextWrites on the same port, and those who are considering it would need FIFO behavior for what they want to do.

This should be trivial to test but I can't do so on mobile.