### PR TITLE
DOCS: Add type of return for 3 formulas functions.

### DIFF
--- a/markdown/bitburner.hackingformulas.growtime.md
+++ b/markdown/bitburner.hackingformulas.growtime.md
@@ -23,5 +23,5 @@ growTime(server: Server, player: Person): number;
 
 number
 
-The calculated grow time.
+The calculated grow time, in milliseconds.
 

--- a/markdown/bitburner.hackingformulas.hacktime.md
+++ b/markdown/bitburner.hackingformulas.hacktime.md
@@ -23,5 +23,5 @@ hackTime(server: Server, player: Person): number;
 
 number
 
-The calculated hack time.
+The calculated hack time, in milliseconds.
 

--- a/markdown/bitburner.hackingformulas.weakentime.md
+++ b/markdown/bitburner.hackingformulas.weakentime.md
@@ -23,5 +23,5 @@ weakenTime(server: Server, player: Person): number;
 
 number
 
-The calculated weaken time.
+The calculated weaken time, in milliseconds.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4241,21 +4241,21 @@ interface HackingFormulas {
    * Calculate hack time.
    * @param server - Server info, typically from {@link NS.getServer | getServer}
    * @param player - Player info, typically from {@link NS.getPlayer | getPlayer}
-   * @returns The calculated hack time.
+   * @returns The calculated hack time, in milliseconds.
    */
   hackTime(server: Server, player: Person): number;
   /**
    * Calculate grow time.
    * @param server - Server info, typically from {@link NS.getServer | getServer}
    * @param player - Player info, typically from {@link NS.getPlayer | getPlayer}
-   * @returns The calculated grow time.
+   * @returns The calculated grow time, in milliseconds.
    */
   growTime(server: Server, player: Person): number;
   /**
    * Calculate weaken time.
    * @param server - Server info, typically from {@link NS.getServer | getServer}
    * @param player - Player info, typically from {@link NS.getPlayer | getPlayer}
-   * @returns The calculated weaken time.
+   * @returns The calculated weaken time, in milliseconds.
    */
   weakenTime(server: Server, player: Person): number;
 }


### PR DESCRIPTION
I checked the whole API, these were the only ones missing a distinction between seconds/milliseconds.

Doc-only change.

