### PR TITLE
FACTIONS: Fix for faction names staying scrambled after joining

### DIFF
--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -3,7 +3,7 @@ import type { Faction } from "./Faction";
 
 import { Augmentations } from "../Augmentation/Augmentations";
 import { PlayerOwnedAugmentation } from "../Augmentation/PlayerOwnedAugmentation";
-import { AugmentationName } from "@enums";
+import { AugmentationName, FactionDiscovery } from "@enums";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 
 import { Player } from "@player";
@@ -26,6 +26,7 @@ export function inviteToFaction(faction: Faction): void {
   if (faction.alreadyInvited || faction.isMember) return;
   Player.receiveInvite(faction.name);
   faction.alreadyInvited = true;
+  faction.discovery = FactionDiscovery.known;
   if (!Settings.SuppressFactionInvites) {
     InvitationEvent.emit(faction);
   }
@@ -34,6 +35,9 @@ export function inviteToFaction(faction: Faction): void {
 export function joinFaction(faction: Faction): void {
   if (faction.isMember) return;
   faction.isMember = true;
+  faction.alreadyInvited = true;
+  faction.discovery = FactionDiscovery.known;
+
   // Add this faction to player's faction list, keeping it in standard order
   Player.factions = getRecordKeys(Factions).filter((facName) => Factions[facName].isMember);
 

--- a/src/Message/MessageHelpers.tsx
+++ b/src/Message/MessageHelpers.tsx
@@ -124,7 +124,7 @@ const Messages: Record<MessageFilename, Message> = {
     MessageFilename.Jumper2,
     "Do not try to save the world. There is no world to save. If " +
       "you want to find the truth, worry only about yourself. Ethics and " +
-      `morals will get you killed. \n\nWatch out for a hacking group known as ${FactionName.NiteSec}.` +
+      `morals will get you killed. \n\nKeep an eye out for a hacking group known as ${FactionName.NiteSec}.` +
       "\n\n-jump3R",
     FactionName.NiteSec,
   ),

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -308,7 +308,7 @@ exports[`Check Save File Continuity FactionsSave continuity 1`] = `
   "Bladeburners": {
     "ctor": "Faction",
     "data": {
-      "discovery": "unknown",
+      "discovery": "known",
       "favor": 0,
       "playerReputation": 4000,
     },
@@ -340,7 +340,7 @@ exports[`Check Save File Continuity FactionsSave continuity 1`] = `
   "CyberSec": {
     "ctor": "Faction",
     "data": {
-      "discovery": "unknown",
+      "discovery": "known",
       "favor": 20,
       "playerReputation": 1000000,
     },
@@ -476,7 +476,7 @@ exports[`Check Save File Continuity FactionsSave continuity 1`] = `
   "Slum Snakes": {
     "ctor": "Faction",
     "data": {
-      "discovery": "unknown",
+      "discovery": "known",
       "favor": 0,
       "playerReputation": 0,
     },


### PR DESCRIPTION
@Krate8 and @Danger_Mouse report that some faction names stay scrambled after joining. Special factions such as Church of the Machine God bypass the usual invite process and don't get unscrambled when receiving an invite.

The intended behavior is that each faction is meant to get permanently unscrambled the first time you join it, so you can see its checklist of requirements in future prestiges instead of going to out-of-game documentation.

This PR sets `faction.discovery = known` during `joinFaction()` so that it unscrambles even when there has been no invite.