### PR TITLE
BUGFIX: Properly apply entropy to hacknet multiplers

### DIFF
--- a/src/PersonObjects/Grafting/EntropyAccumulation.ts
+++ b/src/PersonObjects/Grafting/EntropyAccumulation.ts
@@ -31,7 +31,7 @@ export const calculateEntropy = (stacks = 1): Multipliers => {
     crime_money: Player.mults.crime_money * nerf,
     crime_success: Player.mults.crime_success * nerf,
 
-    hacknet_node_money: Player.mults.hacknet_node_money / nerf,
+    hacknet_node_money: Player.mults.hacknet_node_money * nerf,
     hacknet_node_purchase_cost: Player.mults.hacknet_node_purchase_cost / nerf,
     hacknet_node_ram_cost: Player.mults.hacknet_node_ram_cost / nerf,
     hacknet_node_core_cost: Player.mults.hacknet_node_core_cost / nerf,

--- a/src/PersonObjects/Grafting/EntropyAccumulation.ts
+++ b/src/PersonObjects/Grafting/EntropyAccumulation.ts
@@ -31,11 +31,11 @@ export const calculateEntropy = (stacks = 1): Multipliers => {
     crime_money: Player.mults.crime_money * nerf,
     crime_success: Player.mults.crime_success * nerf,
 
-    hacknet_node_money: Player.mults.hacknet_node_money * nerf,
-    hacknet_node_purchase_cost: Player.mults.hacknet_node_purchase_cost * nerf,
-    hacknet_node_ram_cost: Player.mults.hacknet_node_ram_cost * nerf,
-    hacknet_node_core_cost: Player.mults.hacknet_node_core_cost * nerf,
-    hacknet_node_level_cost: Player.mults.hacknet_node_level_cost * nerf,
+    hacknet_node_money: Player.mults.hacknet_node_money / nerf,
+    hacknet_node_purchase_cost: Player.mults.hacknet_node_purchase_cost / nerf,
+    hacknet_node_ram_cost: Player.mults.hacknet_node_ram_cost / nerf,
+    hacknet_node_core_cost: Player.mults.hacknet_node_core_cost / nerf,
+    hacknet_node_level_cost: Player.mults.hacknet_node_level_cost / nerf,
 
     work_money: Player.mults.work_money * nerf,
 


### PR DESCRIPTION
Entropy is supposed to be a negative effect applied to the player when grafting augments.  Current implementation of entropy actually reduces the costs of hacknet instead of increasing the cost.

Changed the calculation to divide by entropy instead of multiply

199 Entropy before:
![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/a1a39ee9-c339-40e0-aff1-9747f1586008)

199 Entropy after:
![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/a5253f77-0c50-440b-bec7-191c3ed3d083)
