### PR TITLE
CORPORATION: Align columns in warehouse storage breakdown

### DIFF
--- a/src/Corporation/ui/DivisionWarehouse.tsx
+++ b/src/Corporation/ui/DivisionWarehouse.tsx
@@ -22,6 +22,7 @@ import { purchaseWarehouse } from "../Actions";
 import { useCorporation, useDivision } from "./Context";
 import { gameCyclesPerCorpStateCycle } from "../data/Constants";
 import { ButtonWithTooltip } from "../../ui/Components/ButtonWithTooltip";
+import { StatsTable } from "../../ui/React/StatsTable";
 
 interface WarehouseProps {
   corp: Corporation;
@@ -95,25 +96,21 @@ function WarehouseRoot(props: WarehouseProps): React.ReactElement {
     }
   }
 
-  const breakdownItems: string[] = [];
+  const breakdownItems: string[][] = [];
   for (const matName of corpConstants.materialNames) {
     const mat = props.warehouse.materials[matName];
     if (mat.stored === 0) continue;
-    breakdownItems.push(`${matName}: ${formatMaterialSize(mat.stored * MaterialInfo[matName].size)}`);
+    breakdownItems.push([`${matName}:`, `${formatMaterialSize(mat.stored * MaterialInfo[matName].size)}`]);
   }
 
   for (const [prodName, product] of division.products) {
-    breakdownItems.push(
-      `${prodName}: ${formatMaterialSize(product.cityData[props.currentCity].stored * product.size)}`,
-    );
+    breakdownItems.push([
+      `${prodName}:`,
+      `${formatMaterialSize(product.cityData[props.currentCity].stored * product.size)}`,
+    ]);
   }
 
-  let breakdown;
-  if (breakdownItems.length > 0) {
-    breakdown = breakdownItems.map((item, i) => <p key={i}>{item}</p>);
-  } else {
-    breakdown = <>No items in storage.</>;
-  }
+  const breakdown = breakdownItems.length > 0 ? <StatsTable rows={breakdownItems} /> : <>No items in storage.</>;
 
   return (
     <Paper>


### PR DESCRIPTION
Minor UI cleanup

Before:
![corp-warehouse-breakdown-before](https://github.com/bitburner-official/bitburner-src/assets/208776/a4782169-0f01-45b9-a90a-ad4faeabab57)

After:
<img width="317" alt="corp-warehouse-breakdown-after" src="https://github.com/bitburner-official/bitburner-src/assets/208776/87432310-b2bb-4d06-a1b2-3db022351222">
