### PR TITLE
FACTIONS: Support favor gain over 34,000

### DIFF
--- a/src/Company/Company.ts
+++ b/src/Company/Company.ts
@@ -104,11 +104,17 @@ export class Company {
   }
 
   getFavorGain(): number {
-    if (this.favor == null) this.favor = 0;
-    const storedRep = Math.max(0, favorToRep(this.favor));
+    const storedFavor = Math.max(0, this.favor || 0);
+    const storedRep = Math.max(0, favorToRep(storedFavor));
     const totalRep = storedRep + this.playerReputation;
-    const newFavor = repToFavor(totalRep);
-    return newFavor - this.favor;
+    if (totalRep <= Number.MAX_VALUE) {
+      const newFavor = repToFavor(totalRep);
+      return newFavor - storedFavor;
+    }
+    else {
+      // Above effectively-infinite favor levels, support gaining up to the max amount each prestige.
+      return repToFavor(this.playerReputation);
+    }
   }
 
   /** Serialize the current object to a JSON save state. */

--- a/src/Faction/Faction.ts
+++ b/src/Faction/Faction.ts
@@ -67,15 +67,14 @@ export class Faction {
     this.isBanned = false;
   }
 
-  //Returns an array with [How much favor would be gained, how much rep would be left over]
+  /** Calculate the amount of favor that would be gained in a prestige. */
   getFavorGain(): number {
-    if (this.favor == null) {
-      this.favor = 0;
-    }
-    const storedRep = Math.max(0, favorToRep(this.favor));
-    const totalRep = storedRep + this.playerReputation;
-    const newFavor = repToFavor(totalRep);
-    return newFavor - this.favor;
+    const reducedBase = 1.00002;
+    const storedFavor = Math.max(0, this.favor || 0);
+    const storedRep = favorToRep(storedFavor, reducedBase);
+    const reducedRep = Math.pow(reducedBase, repToFavor(this.playerReputation));
+    const totalRep = storedRep + reducedRep;
+    return repToFavor(totalRep, reducedBase) - storedFavor;
   }
 
   static savedKeys = getKeyList(Faction, {

--- a/src/Faction/Faction.ts
+++ b/src/Faction/Faction.ts
@@ -74,7 +74,15 @@ export class Faction {
     const storedRep = favorToRep(storedFavor, reducedBase);
     const reducedRep = Math.pow(reducedBase, repToFavor(this.playerReputation));
     const totalRep = storedRep + reducedRep;
-    return repToFavor(totalRep, reducedBase) - storedFavor;
+    if (totalRep < Number.MAX_VALUE) {
+      const newFavor = repToFavor(totalRep, reducedBase);
+      return newFavor - storedFavor;
+    }
+    else {
+      // Above effectively-infinite favor levels, support gaining up to the max amount each prestige.
+      const gainedFavor = repToFavor(this.playerReputation);
+      return gainedFavor;
+    }
   }
 
   static savedKeys = getKeyList(Faction, {

--- a/src/Faction/Faction.ts
+++ b/src/Faction/Faction.ts
@@ -69,18 +69,19 @@ export class Faction {
 
   /** Calculate the amount of favor that would be gained in a prestige. */
   getFavorGain(): number {
-    const reducedBase = 1.00002;
     const storedFavor = Math.max(0, this.favor || 0);
+    const gainedFavor = repToFavor(this.playerReputation);
+
+    const reducedBase = 1.00002;
     const storedRep = favorToRep(storedFavor, reducedBase);
-    const reducedRep = Math.pow(reducedBase, repToFavor(this.playerReputation));
-    const totalRep = storedRep + reducedRep;
+    const gainedRep = favorToRep(gainedFavor, reducedBase);
+    const totalRep = storedRep + gainedRep;
     if (totalRep < Number.MAX_VALUE) {
       const newFavor = repToFavor(totalRep, reducedBase);
       return newFavor - storedFavor;
     }
     else {
       // Above effectively-infinite favor levels, support gaining up to the max amount each prestige.
-      const gainedFavor = repToFavor(this.playerReputation);
       return gainedFavor;
     }
   }

--- a/src/Faction/formulas/favor.ts
+++ b/src/Faction/formulas/favor.ts
@@ -2,12 +2,14 @@
 // see https://en.wikipedia.org/wiki/Geometric_series#Closed-form_formula
 // for information on how to calculate this
 
-export function favorToRep(f: number): number {
-  const raw = Math.min(25000 * (Math.pow(1.02, f) - 1, Number.MAX_VALUE / 8));
-  return Math.round(raw * 10000) / 10000; // round to make things easier.
+export function favorToRep(f: number, base: number = 1.02): number {
+  const raw = 25000 * (Math.pow(base, f) - 1);
+  const rounded = Math.round(raw * 10000) / 10000; // round to make things easier.
+  return Math.min(rounded, Number.MAX_VALUE);
 }
 
-export function repToFavor(r: number): number {
-  const raw = Math.log(r / 25000 + 1) / Math.log(1.02);
+export function repToFavor(r: number, base: number = 1.02): number {
+  r = Math.min(r, Number.MAX_VALUE);
+  const raw = Math.log(r / 25000 + 1) / Math.log(base);
   return Math.round(raw * 10000) / 10000; // round to make things easier.
 }

--- a/src/Faction/formulas/favor.ts
+++ b/src/Faction/formulas/favor.ts
@@ -3,7 +3,7 @@
 // for information on how to calculate this
 
 export function favorToRep(f: number): number {
-  const raw = 25000 * (Math.pow(1.02, f) - 1);
+  const raw = Math.min(25000 * (Math.pow(1.02, f) - 1, Number.MAX_VALUE / 8));
   return Math.round(raw * 10000) / 10000; // round to make things easier.
 }
 


### PR DESCRIPTION
Reported on Discord by @Azirale — 12/11/23, 12:00 PM
> Might want a Number.MAX_VALUE guard on this, or something, because after a reset the first tick of working for the faction will give you literally infinite money. It also breaks the favor on the company, because it goes NaN after the next install.
It seems to be once you get past some septillion or octillion rep, something in the favour calculation hits infinite, and it just explodes.

In order to support favor values between 34,867 and Infinity, we can perform calculations in a lower base. Using a base of 1.00002 supports favor values up to about 3.4e7.

It might be better gameplay to support stacking up to the max value each prestige by growing arithmetically instead of logarithmically above level. I will try to graph the difference between these formulas...