### PR TITLE
CORPORATION: Account for CapEx and Cap Gains differently

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -74,7 +74,7 @@ export function purchaseOffice(corporation: Corporation, division: Division, cit
   if (division.offices[city]) {
     throw new Error(`You have already expanded into ${city} for ${division.name}`);
   }
-  corporation.loseFunds(corpConstants.officeInitialCost, "office");
+  corporation.loseFunds(corpConstants.officeInitialCost, "division");
   division.offices[city] = new OfficeSpace({
     city: city,
     size: corpConstants.officeInitialSize,
@@ -391,7 +391,7 @@ export function ThrowParty(corp: Corporation, office: OfficeSpace, costPerEmploy
 export function purchaseWarehouse(corp: Corporation, division: Division, city: CityName): void {
   if (corp.funds < corpConstants.warehouseInitialCost) return;
   if (division.warehouses[city]) return;
-  corp.loseFunds(corpConstants.warehouseInitialCost, "warehouse");
+  corp.loseFunds(corpConstants.warehouseInitialCost, "division");
   division.warehouses[city] = new Warehouse({
     division: division,
     loc: city,

--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -5,7 +5,6 @@ import { CorporationState } from "./CorporationState";
 import { CorpUnlocks } from "./data/CorporationUnlocks";
 import { CorpUpgrades } from "./data/CorporationUpgrades";
 import * as corpConstants from "./data/Constants";
-import { IndustriesData } from "./data/IndustryData";
 import { FundsSource, LongTermFundsSources } from "./data/FundsSource";
 import { Division } from "./Division";
 import { calculateUpgradeCost } from "./helpers";
@@ -229,7 +228,7 @@ export class Corporation {
   updateTotalAssets(): void {
     let assets = this.funds;
     this.divisions.forEach((ind) => {
-      assets += IndustriesData[ind.type].startingCost;
+      assets += ind.calculateRecoupableValue();
       for (const warehouse of getRecordValues(ind.warehouses)) {
         for (const mat of getRecordValues(warehouse.materials)) {
           assets += mat.stored * mat.averagePrice;

--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -84,7 +84,11 @@ export class Corporation {
       return;
     }
     if (LongTermFundsSources.has(source)) {
-      this.totalAssets += amt;
+      // This cycle's assets include the purchase price of a capital expenditure.
+      // (It will likely depreciate in the following cycle.)
+      // Or the value of some non-accounted item (equity, hashes) that was sold for a capital gain.
+      // (It will remain as funds, with no effect on assetDelta.)
+      this.totalAssets += Math.abs(amt);
     }
     this.funds += amt;
   }

--- a/src/Corporation/data/FundsSource.ts
+++ b/src/Corporation/data/FundsSource.ts
@@ -2,7 +2,6 @@
 // This includes capital expenditures (which may be recoupable), time-limited actions, and transfers to/from other game mechanics.
 const FundsSourceLongTerm = [
   "product development",
-  "division",
   "office",
   "warehouse",
   "upgrades",
@@ -16,6 +15,7 @@ const FundsSourceLongTerm = [
 // Funds transactions which should be included in earnings projections for valuation.
 // This includes all automatic or indefinetly-repeatable income and operating expenses.
 type FundsSourceShortTerm =
+  | "division"
   | "operating expenses"
   | "operating revenue"
   | "dividends"


### PR DESCRIPTION
This PR handles some edge cases in #949 reported by jeek

- Count capital expenditures as positive assets during the cycle they are purchased.  
(In the next cycle they will depreciate to their recoupable value.)
- Count capital gains as virtual positive assets during the cycle they are realized.  
(In the next cycle they will remain as cash and not effect projected earnings.)

This fixes an exploit where some capital expenditures were counted as capital gains instead, resulting in absurd valuations.