### PR TITLE
MISC: Revert default HGW threads from 1 to number of script threads

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -296,7 +296,7 @@ export function makeRuntimeErrorMsg(ctx: NetscriptContext, msg: string, type = "
 
 function validateHGWOptions(ctx: NetscriptContext, opts: unknown): CompleteHGWOptions {
   const result: CompleteHGWOptions = {
-    threads: 1 as PositiveInteger,
+    threads: ctx.workerScript.scriptRef.threads as PositiveInteger,
     stock: false,
     additionalMsec: 0,
   };

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -296,7 +296,7 @@ export function makeRuntimeErrorMsg(ctx: NetscriptContext, msg: string, type = "
 
 function validateHGWOptions(ctx: NetscriptContext, opts: unknown): CompleteHGWOptions {
   const result: CompleteHGWOptions = {
-    threads: ctx.workerScript.scriptRef.threads as PositiveInteger,
+    threads: ctx.workerScript.scriptRef.threads,
     stock: false,
     additionalMsec: 0,
   };


### PR DESCRIPTION
A recent update changed the default behavior of hack(), grow(), and weaken() to use one thread instead of the total script threads. This reverts that change.