### PR TITLE
MISC: Fix various typos

### DIFF
--- a/src/Documentation/doc/advanced/gang.md
+++ b/src/Documentation/doc/advanced/gang.md
@@ -2,7 +2,7 @@
 
 In the wake of crisis and war, Gang activity surged. Stronger than ever in a lawless world - Enhanced with fantastic technology, no longer held back by ethics and morals, 'free from the shadows'....
 
-Seen by most of the population as nihilistic, murderous and vile, occassional rumors suggest Gangs sometimes involve themselves with vigilanteism, hacktivism, perhaps even plotting against The Enders, seeking to destroy a world they cannot save.
+Seen by most of the population as nihilistic, murderous and vile, occasional rumors suggest Gangs sometimes involve themselves with vigilantism, hacktivism, perhaps even plotting against The Enders, seeking to destroy a world they cannot save.
 
 ## Starting and Recruiting
 

--- a/src/Documentation/doc/advanced/stanek.md
+++ b/src/Documentation/doc/advanced/stanek.md
@@ -2,7 +2,7 @@
 
 Allison is a bit crazy.
 But her special [Augmentation](../basic/augmentations.md) is very useful despite its ~~bugs~~ features.
-The Gift consists of a grid of squares in which tetris-like pieces called fragments can be placed.
+The Gift consists of a grid of squares in which Tetris-like pieces called fragments can be placed.
 Each fragment boost a different player multiplier.
 However, the fragments are not very powerful by themselves.
 

--- a/src/Documentation/doc/basic/programs.md
+++ b/src/Documentation/doc/basic/programs.md
@@ -2,7 +2,7 @@
 
 In Bitburner "Programs" refer specifically to the list of `.exe` files found in the Programs tab of the side menu.
 
-Unlike `.js` [scripts](scripts.md) you write for yourself with Javascript, Programs are supplied to you by Bitburner and are only "programs" in name; they do not require or allow you to access actual lines of code. Instead once you have a Program you will be able to use it directly as a function in the [Terminal](terminal.md) or scripts.
+Unlike `.js` [scripts](scripts.md) you write for yourself with JavaScript, Programs are supplied to you by Bitburner and are only "programs" in name; they do not require or allow you to access actual lines of code. Instead once you have a Program you will be able to use it directly as a function in the [Terminal](terminal.md) or scripts.
 
     [n00dles /]>  run BruteSSH.exe
     [n00dles /]>  scan-analyze 10

--- a/src/Documentation/doc/basic/reputation.md
+++ b/src/Documentation/doc/basic/reputation.md
@@ -11,4 +11,4 @@ Favor increases the rate at which reputation is gained with that faction.
 With enough favor, donations are unlocked.
 Donations allow you to spend money to acquire reputation directly.
 Without working for the faction.
-This feature is particularily useful when a very large amount of reputation is needed for an augmentation.
+This feature is particularly useful when a very large amount of reputation is needed for an augmentation.

--- a/src/Documentation/doc/basic/stats.md
+++ b/src/Documentation/doc/basic/stats.md
@@ -1,5 +1,5 @@
 Below are some of the stats that will increase with play and reset during augmentation installs as you progress through the game.
-Your stats can be found in the Overview panel, the Stats subpage of the sidemenu, or with API methods like `ns.getPlayer()`.
+Your stats can be found in the Overview panel, the Stats subpage of the side menu, or with API methods like `ns.getPlayer()`.
 
 ## Hack Skill
 

--- a/src/Documentation/doc/basic/terminal.md
+++ b/src/Documentation/doc/basic/terminal.md
@@ -10,7 +10,7 @@ The Terminal contains a very basic filesystem to help you organize files into di
 Note that this is **not** a _true_ filesystem implementation and instead relies almost entirely on string manipulation.
 For this reason, some features found in real-world filesystems do not exist in our Terminal. For example:
 
-- Tab autocompletion does not work with relative paths
+- Tab autocomplete does not work with relative paths
 - **`mv` and `rm` commands only accept full filepaths in their arguments.**
   **They do not act on directories.**
 

--- a/src/Documentation/doc/basic/terminal.md
+++ b/src/Documentation/doc/basic/terminal.md
@@ -10,7 +10,7 @@ The Terminal contains a very basic filesystem to help you organize files into di
 Note that this is **not** a _true_ filesystem implementation and instead relies almost entirely on string manipulation.
 For this reason, some features found in real-world filesystems do not exist in our Terminal. For example:
 
-- Tab autocomplete does not work with relative paths
+- Tab autocompletion does not work with relative paths
 - **`mv` and `rm` commands only accept full filepaths in their arguments.**
   **They do not act on directories.**
 

--- a/src/Documentation/doc/help/getting_started.md
+++ b/src/Documentation/doc/help/getting_started.md
@@ -1,6 +1,6 @@
 # Getting Started Guide for Beginner Programmers
 
-_Note_: The [Scripts](../basic/scripts.md) and strategies in this guide aren't necessarily optimal or comperhensive.
+_Note_: The [Scripts](../basic/scripts.md) and strategies in this guide aren't necessarily optimal or comprehensive.
 This guide is tailored to help those with minimal programming knowledge experience Bitburner during early stages of the game.
 
 If you are confused or overwhelmed by the game, especially the coding and scripting aspects, this guide is perfect for you!
@@ -13,7 +13,7 @@ After reaching certain criteria, you will receive invitations from in-game [Fact
 Joining [Factions](../basic/factions.md) and working for them will unlock various [Augmentations](../basic/augmentations.md),
 which are purchased and "installed," adding a persistent bonus to [stats](../basic/stats.md) and other abilities. Working with Factions and installing Augmentations is a basic step for progressing in Bitburner.
 
-The game has an open, minimalistic storyline that can be played in multiple ways to reach your goals.
+The game has an open, minimalist storyline that can be played in multiple ways to reach your goals.
 Since this guide is written as a basic introduction to Bitburner, it will not expose the entire scope or storyline available.
 
 ## First Steps
@@ -692,7 +692,7 @@ That's the end of the walkthrough portion of this guide!
 You should continue to explore what the game has to offer.
 There's quite a few features that aren't covered or mentioned in this guide, and even more that get unlocked as you continue to play!
 
-Also, check out the api documentation to see what it has to offer.
+Also, check out the API documentation to see what it has to offer.
 Writing [Scripts](../basic/scripts.md) to perform and automate various tasks is where most of the fun in the game comes from (in my opinion)!
 
 The following are a few things you may want to consider doing in the near future.

--- a/src/Documentation/doc/help/getting_started.md
+++ b/src/Documentation/doc/help/getting_started.md
@@ -13,7 +13,7 @@ After reaching certain criteria, you will receive invitations from in-game [Fact
 Joining [Factions](../basic/factions.md) and working for them will unlock various [Augmentations](../basic/augmentations.md),
 which are purchased and "installed," adding a persistent bonus to [stats](../basic/stats.md) and other abilities. Working with Factions and installing Augmentations is a basic step for progressing in Bitburner.
 
-The game has an open, minimalist storyline that can be played in multiple ways to reach your goals.
+The game has an open, minimalistic storyline that can be played in multiple ways to reach your goals.
 Since this guide is written as a basic introduction to Bitburner, it will not expose the entire scope or storyline available.
 
 ## First Steps

--- a/src/Documentation/doc/help/tools_and_resources.md
+++ b/src/Documentation/doc/help/tools_and_resources.md
@@ -14,7 +14,7 @@ This extension includes several features such as:
 
 - Dynamic RAM calculation
 - RAM Usage breakdown
-- Typescript definition files with jsdoc comments
+- Typescript definition files with JSDoc comments
 - Syntax highlighting
 
-You can find more information and download links [on this reddit post](https://www.reddit.com/r/Bitburner/comments/bh48y2/visual_studio_code_ram_calculator_extra/).
+You can find more information and download links [on this Reddit post](https://www.reddit.com/r/Bitburner/comments/bh48y2/visual_studio_code_ram_calculator_extra/).

--- a/src/Documentation/doc/programming/game_frozen.md
+++ b/src/Documentation/doc/programming/game_frozen.md
@@ -49,7 +49,7 @@ If the player does not currently have enough money to purchase a server, the `if
 Since the script doesn't have `sleep()` and value `i` will not change without the `if` being true, this will crash the game.
 Adding a `sleep()` that is always reached would prevent the crash.
 
-## Blackscreen
+## Black screen
 
 If the game window becomes a black screen without the game itself crashing, this is caused by the game running too many concurrent scripts (the game runs on a browser and each tab can only use so much ram until it crashes).
 Depending on which scripts are running and your hardware, this number can vary between 50000 to 100000 instances (in version 2.0.2. In prior versions this number was about 1/5th of that).


### PR DESCRIPTION
Fixes various typos I found throughout the Markdown files.

I ran the new build, but obviously nothing seemed to break by these changes.

I'm not aware of any issues talking about typos.