### PR TITLE
COMPANY: Show unqualified direct promotion (followup)

### DIFF
--- a/src/Company/ui/ApplyToJobButton.tsx
+++ b/src/Company/ui/ApplyToJobButton.tsx
@@ -1,29 +1,24 @@
-import * as React from "react";
+import type { CompanyPosition } from "../CompanyPosition";
+import type { Company } from "../Company";
 
-import { Company } from "../Company";
-import { CompanyPosition } from "../CompanyPosition";
+import * as React from "react";
 
 import { Player } from "@player";
 import { Typography } from "@mui/material";
 import { ButtonWithTooltip } from "../../ui/Components/ButtonWithTooltip";
-import { CompanyPositions } from "../CompanyPositions";
 import { JobSummary } from "./JobSummary";
 import { Requirement } from "../../ui/Components/Requirement";
 import { getJobRequirements } from "../GetJobRequirements";
 
-interface IProps {
+interface ApplyToJobProps {
   company: Company;
   position: CompanyPosition;
-  currentPosition: CompanyPosition | null;
+  qualified: boolean;
 }
 
 /** React Component for a button that's used to apply for a job */
-export function ApplyToJobButton(props: IProps): React.ReactElement {
-  const underqualified = !Player.isQualified(props.company, props.position);
-  const nextPos = props.position.nextPosition && CompanyPositions[props.position.nextPosition];
-  const overqualified = nextPos != null && Player.isQualified(props.company, nextPos);
-
-  const reqs = getJobRequirements(props.company, props.position);
+export function ApplyToJobButton({ company, position, qualified }: ApplyToJobProps): React.ReactElement {
+  const reqs = getJobRequirements(company, position);
   const positionRequirements =
     reqs.length == 0 ? (
       <Typography>Accepting all applicants</Typography>
@@ -38,8 +33,8 @@ export function ApplyToJobButton(props: IProps): React.ReactElement {
 
   const positionDetails = (
     <>
-      <JobSummary company={props.company} position={props.position} overqualified={overqualified} />
-      {props.position.isPartTime && (
+      <JobSummary company={company} position={position} />
+      {position.isPartTime && (
         <Typography>
           <br />
           Part-time jobs have no penalty for
@@ -48,27 +43,21 @@ export function ApplyToJobButton(props: IProps): React.ReactElement {
       )}
       <br />
       {positionRequirements}
-      {overqualified && (
-        <Typography>
-          <br />
-          You are overqualified for this position.
-        </Typography>
-      )}
     </>
   );
 
   function applyForJob(): void {
-    Player.applyForJob(props.company, props.position);
+    Player.applyForJob(company, position);
   }
 
   return (
     <ButtonWithTooltip
-      disabledTooltip={underqualified && positionDetails}
+      disabledTooltip={!qualified && positionDetails}
       normalTooltip={positionDetails}
       onClick={applyForJob}
       tooltipProps={{ style: { display: "grid" } }}
     >
-      {props.position.applyText}
+      {position.applyText}
     </ButtonWithTooltip>
   );
 }

--- a/src/Company/ui/JobListings.tsx
+++ b/src/Company/ui/JobListings.tsx
@@ -7,33 +7,32 @@ import { CompanyPositions } from "../CompanyPositions";
 import { ApplyToJobButton } from "./ApplyToJobButton";
 import { Player } from "@player";
 
-interface IJobListingsProps {
+interface JobListingsProps {
   company: Company;
   currentPosition: CompanyPosition | null;
 }
 
-export function JobListings(props: IJobListingsProps): React.ReactElement {
-  const { company, currentPosition } = props;
-
+export function JobListings({ company, currentPosition }: JobListingsProps): React.ReactElement {
+  const jobNames = [...company.companyPositions];
+  const qualifiedJobs = new Set(jobNames.filter((jobName) => Player.isQualified(company, CompanyPositions[jobName])));
   const jobsToShow = [];
-  for (const jobName of company.companyPositions) {
-    const offeredPos = CompanyPositions[jobName];
-    const underqualified = !Player.isQualified(props.company, offeredPos);
-    const isCurrentPosition = jobName == props.currentPosition?.name;
-    const nextPos = offeredPos.nextPosition && CompanyPositions[offeredPos.nextPosition];
-    const overqualified = nextPos != null && Player.isQualified(props.company, nextPos);
-    const shouldShowApplyButton =
-      !isCurrentPosition && !overqualified && (!underqualified || offeredPos.requiredReputation == 0);
-
-    if (shouldShowApplyButton) {
-      jobsToShow.push(offeredPos);
+  for (const jobName of jobNames) {
+    if (jobName === currentPosition?.name) continue;
+    const job = CompanyPositions[jobName];
+    const nextJobName = job.nextPosition;
+    // Don't show a job if we already qualify for a later job
+    if (nextJobName && qualifiedJobs.has(nextJobName)) continue;
+    // Don't show a job if we don't qualify for it, unless it's a starting job or a promotion from current job
+    if (!qualifiedJobs.has(jobName) && job.requiredReputation > 0 && jobName !== currentPosition?.nextPosition) {
+      continue;
     }
+    jobsToShow.push(job);
   }
 
   return (
     <>
-      {jobsToShow.map((position) => (
-        <ApplyToJobButton key={position.name} company={company} position={position} currentPosition={currentPosition} />
+      {jobsToShow.map((job) => (
+        <ApplyToJobButton key={job.name} company={company} position={job} qualified={qualifiedJobs.has(job.name)} />
       ))}
     </>
   );

--- a/src/Company/ui/JobListings.tsx
+++ b/src/Company/ui/JobListings.tsx
@@ -20,7 +20,7 @@ export function JobListings({ company, currentPosition }: JobListingsProps): Rea
     if (jobName === currentPosition?.name) continue;
     const job = CompanyPositions[jobName];
     const nextJobName = job.nextPosition;
-    // Don't show a job if we already qualify for a later job
+    // Don't show a job if we already qualify for a later job offered by this company
     if (nextJobName && qualifiedJobs.has(nextJobName)) continue;
     // Don't show a job if we don't qualify for it, unless it's a starting job or a promotion from current job
     if (!qualifiedJobs.has(jobName) && job.requiredReputation > 0 && jobName !== currentPosition?.nextPosition) {

--- a/src/Company/ui/JobSummary.tsx
+++ b/src/Company/ui/JobSummary.tsx
@@ -1,3 +1,6 @@
+import type { Company } from "../Company";
+import type { CompanyPosition } from "../CompanyPosition";
+
 import { Typography } from "@mui/material";
 import { Player } from "@player";
 import * as React from "react";
@@ -6,22 +9,19 @@ import { calculateCompanyWorkStats } from "../../Work/Formulas";
 import { MoneyRate } from "../../ui/React/MoneyRate";
 import { ReputationRate } from "../../ui/React/ReputationRate";
 import { StatsTable } from "../../ui/React/StatsTable";
-import type { Company } from "../Company";
-import type { CompanyPosition } from "../CompanyPosition";
 
 const CYCLES_PER_SEC = 1000 / CONSTANTS.MilliPerCycle;
-interface IJobSummaryProps {
+interface JobSummaryProps {
   company: Company;
   position: CompanyPosition;
-  overqualified?: boolean;
 }
 
-export function JobSummary(props: IJobSummaryProps): React.ReactElement {
-  const workStats = calculateCompanyWorkStats(Player, props.company, props.position, props.company.favor);
+export function JobSummary({ company, position }: JobSummaryProps): React.ReactElement {
+  const workStats = calculateCompanyWorkStats(Player, company, position, company.favor);
   return (
     <>
       <Typography>
-        <u>{props.position.name}</u>
+        <u>{position.name}</u>
       </Typography>
       <StatsTable
         wide


### PR DESCRIPTION
Just some brief followup on #927 

Now the direct promotion job shows an apply button when the player doesn't qualify for the promotion yet, which should help the player figure out when to check back for a promotion, or what to pursue stat-wise for that promotion. There should be no other functional differences, just some minor streamlining or renaming.

@jjclark1982 Can you look this over?