### PR TITLE
BLADEBURNER: Different solution for Enter key support in team member modal

### DIFF
--- a/src/Bladeburner/ui/TeamSizeModal.tsx
+++ b/src/Bladeburner/ui/TeamSizeModal.tsx
@@ -8,7 +8,6 @@ import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import { KEY } from "../../utils/helpers/keyCodes";
 
-
 interface IProps {
   bladeburner: Bladeburner;
   action: Action;
@@ -46,7 +45,14 @@ export function TeamSizeModal(props: IProps): React.ReactElement {
         Enter the amount of team members you would like to take on this Op. If you do not have the specified number of
         team members, then as many as possible will be used. Note that team members may be lost during operations.
       </Typography>
-      <TextField autoFocus type="number" placeholder="Team size" value={teamSize} onChange={onTeamSize} onKeyDown={onKeyDown} />
+      <TextField
+        autoFocus
+        type="number"
+        placeholder="Team size"
+        value={teamSize}
+        onChange={onTeamSize}
+        onKeyDown={onKeyDown}
+      />
       <Button sx={{ mx: 2 }} onClick={confirmTeamSize}>
         Confirm
       </Button>

--- a/src/Bladeburner/ui/TeamSizeModal.tsx
+++ b/src/Bladeburner/ui/TeamSizeModal.tsx
@@ -1,61 +1,51 @@
+import type { Action } from "../Action";
+import type { Bladeburner } from "../Bladeburner";
+
 import React, { useState } from "react";
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import { Modal } from "../../ui/React/Modal";
-import { Action } from "../Action";
-import { Bladeburner } from "../Bladeburner";
-import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
-import TextField from "@mui/material/TextField";
-import { KEY } from "../../utils/helpers/keyCodes";
+import { Button, TextField, Typography } from "@mui/material";
 
-interface IProps {
+interface TeamSizeModalProps {
   bladeburner: Bladeburner;
   action: Action;
   open: boolean;
   onClose: () => void;
 }
 
-export function TeamSizeModal(props: IProps): React.ReactElement {
+export function TeamSizeModal({ bladeburner, action, open, onClose }: TeamSizeModalProps): React.ReactElement {
   const [teamSize, setTeamSize] = useState<number | undefined>();
 
-  function confirmTeamSize(): void {
+  function confirmTeamSize(event: React.FormEvent): void {
+    event.preventDefault();
     if (teamSize === undefined) return;
     const num = Math.round(teamSize);
     if (isNaN(num) || num < 0) {
-      dialogBoxCreate("Invalid value entered for number of Team Members (must be numeric, positive)");
+      dialogBoxCreate("Invalid value entered for number of Team Members (must be numeric and non-negative)");
     } else {
-      props.action.teamCount = num;
+      action.teamCount = num;
     }
-    props.onClose();
+    onClose();
   }
 
   function onTeamSize(event: React.ChangeEvent<HTMLInputElement>): void {
     const x = parseFloat(event.target.value);
-    if (x > props.bladeburner.teamSize) setTeamSize(props.bladeburner.teamSize);
+    if (x > bladeburner.teamSize) setTeamSize(bladeburner.teamSize);
     else setTeamSize(x);
   }
 
-  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
-    if (event.key === KEY.ENTER) confirmTeamSize();
-  }
-
   return (
-    <Modal open={props.open} onClose={props.onClose}>
-      <Typography>
-        Enter the amount of team members you would like to take on this Op. If you do not have the specified number of
-        team members, then as many as possible will be used. Note that team members may be lost during operations.
-      </Typography>
-      <TextField
-        autoFocus
-        type="number"
-        placeholder="Team size"
-        value={teamSize}
-        onChange={onTeamSize}
-        onKeyDown={onKeyDown}
-      />
-      <Button sx={{ mx: 2 }} onClick={confirmTeamSize}>
-        Confirm
-      </Button>
+    <Modal open={open} onClose={onClose}>
+      <form onSubmit={confirmTeamSize}>
+        <Typography>
+          Enter the amount of team members you would like to take on this Op. If you do not have the specified number of
+          team members, then as many as possible will be used. Note that team members may be lost during operations.
+        </Typography>
+        <TextField autoFocus type="number" placeholder="Team size" value={teamSize} onChange={onTeamSize} />
+        <Button sx={{ mx: 2 }} type={"submit"}>
+          Confirm
+        </Button>
+      </form>
     </Modal>
   );
 }

--- a/src/Bladeburner/ui/TeamSizeModal.tsx
+++ b/src/Bladeburner/ui/TeamSizeModal.tsx
@@ -6,6 +6,8 @@ import { Bladeburner } from "../Bladeburner";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import { KEY } from "../../utils/helpers/keyCodes";
+
 
 interface IProps {
   bladeburner: Bladeburner;
@@ -34,13 +36,17 @@ export function TeamSizeModal(props: IProps): React.ReactElement {
     else setTeamSize(x);
   }
 
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === KEY.ENTER) confirmTeamSize();
+  }
+
   return (
     <Modal open={props.open} onClose={props.onClose}>
       <Typography>
         Enter the amount of team members you would like to take on this Op. If you do not have the specified number of
         team members, then as many as possible will be used. Note that team members may be lost during operations.
       </Typography>
-      <TextField autoFocus type="number" placeholder="Team size" value={teamSize} onChange={onTeamSize} />
+      <TextField autoFocus type="number" placeholder="Team size" value={teamSize} onChange={onTeamSize} onKeyDown={onKeyDown} />
       <Button sx={{ mx: 2 }} onClick={confirmTeamSize}>
         Confirm
       </Button>

--- a/src/Bladeburner/ui/TeamSizeModal.tsx
+++ b/src/Bladeburner/ui/TeamSizeModal.tsx
@@ -17,6 +17,7 @@ export function TeamSizeModal({ bladeburner, action, open, onClose }: TeamSizeMo
   const [teamSize, setTeamSize] = useState<number | undefined>();
 
   function confirmTeamSize(event: React.FormEvent): void {
+    // Prevent reloading page when submitting form
     event.preventDefault();
     if (teamSize === undefined) return;
     const num = Math.round(teamSize);


### PR DESCRIPTION
Alternative to #975 , Using a form to add keyboard support for submitting a modal that is essentially a form (instead of sending custom onKeyDown handler on the text field that manually checks for the enter key).

@jjclark1982 Any concerns with using this approach instead?