### PR TITLE
MISC: Fix an easter egg of BN-12 to display message under certain condition

### DIFF
--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -267,8 +267,8 @@ export function prestigeSourceFile(isFlume: boolean): void {
     );
   }
 
-  // BitNode 12: Digital Carbon
-  if (Player.bitNodeN === 12 && Player.sourceFileLvl(10) > 100) {
+  // BitNode 12: The Recursion
+  if (Player.bitNodeN === 12 && Player.sourceFileLvl(12) > 100) {
     delayedDialog("Saynt_Garmo is watching you");
   }
 


### PR DESCRIPTION
The code seems to be intended to show a special message when BN-12 is entered with level of SF-12 owned being above 100, as a message to surprise the player "Hey buddy you've recurred too many times, some evil being is watching you".
The original line requires >100 level of SF-10, which is unobtainable through normal game play. Fix the BN number to `12` should allow the message to display correctly.