### PR TITLE
TYPOFIX: Fix "Booster Fragments" typo in tutorial text of stanek's gift

### DIFF
--- a/src/CotMG/ui/StaneksGiftRoot.tsx
+++ b/src/CotMG/ui/StaneksGiftRoot.tsx
@@ -62,7 +62,7 @@ export function StaneksGiftRoot({ staneksGift }: IProps): React.ReactElement {
                   for the fragment to gain stat boosts, it must be charged. The other kind of fragments are known as
                   Booster Fragments, which take up 5 tiles of the grid. There is no shortage of Booster Fragments, and
                   it is virtually impossible to run out of them. While not providing any direct stat increases to their
-                  user, Stat Fragments increase the efficacy of adjacent Stat Fragments by 10%, and do not need to be
+                  user, Booster Fragments increase the efficacy of adjacent Stat Fragments by 10%, and do not need to be
                   charged.
                 </Typography>
                 <br />


### PR DESCRIPTION
This line misleads the player as it is talking about Stat Fragments, which should be Booster Fragments:
![image](https://github.com/bitburner-official/bitburner-src/assets/26317456/9a4753ab-839c-45ed-9a4c-07a46b2e24e7)

Change it to "Booster Fragments" should fix the problem.