### PR TITLE
INFILTRATION: Different visual rework for CheatCodeGame

### DIFF
--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -1781,7 +1781,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       repCost: 1e4,
       moneyCost: 1e6,
       info: "Penta-dynamo-neurovascular-valve inserted in the carpal ligament, enhances dexterity.",
-      stats: "This augmentation makes the Cheat Code minigame easier by allowing the opposite character.",
+      stats: "This augmentation makes the Cheat Code minigame easier by showing what character will come next.",
       isSpecial: true,
       factions: [FactionName.ShadowsOfAnarchy],
     },

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -1,16 +1,9 @@
 import { Paper, Typography } from "@mui/material";
 import React, { useState } from "react";
 import { AugmentationName } from "@enums";
+import { Settings } from "../../Settings/Settings";
 import { Player } from "@player";
-import {
-  downArrowSymbol,
-  getArrow,
-  getInverseArrow,
-  leftArrowSymbol,
-  random,
-  rightArrowSymbol,
-  upArrowSymbol,
-} from "../utils";
+import { downArrowSymbol, getArrow, leftArrowSymbol, random, rightArrowSymbol, upArrowSymbol } from "../utils";
 import { interpolate } from "./Difficulty";
 import { GameTimer } from "./GameTimer";
 import { IMinigameProps } from "./IMinigameProps";
@@ -43,9 +36,12 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
   const [index, setIndex] = useState(0);
   const hasAugment = Player.hasAugmentation(AugmentationName.TrickeryOfHermes, true);
 
+  const focusColor = Settings.theme.primary;
+  const hintColor = Settings.theme.disabled;
+
   function press(this: Document, event: KeyboardEvent): void {
     event.preventDefault();
-    if (code[index] !== getArrow(event) && (!hasAugment || code[index] !== getInverseArrow(event))) {
+    if (code[index] !== getArrow(event)) {
       props.onFailure();
       return;
     }
@@ -58,7 +54,18 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
       <GameTimer millis={timer} onExpire={props.onFailure} />
       <Paper sx={{ display: "grid", justifyItems: "center" }}>
         <Typography variant="h4">Enter the Code!</Typography>
-        <Typography variant="h4">{code[index]}</Typography>
+        <Typography variant="h4">
+          {hasAugment && (
+            <>
+              <span style={{ color: hintColor }}>{index > 1 ? code[index - 2] : "\u00a0"}&nbsp;</span>
+              <span style={{ color: hintColor }}>{index > 0 ? code[index - 1] : "\u00a0"}&nbsp;</span>
+              <span style={{ color: focusColor }}>{code[index]}</span>
+              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 1 ? code[index + 1] : "\u00a0"}</span>
+              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 2 ? code[index + 2] : "\u00a0"}</span>
+            </>
+          )}
+          {!hasAugment && <span style={{ color: focusColor }}>{code[index]}</span>}
+        </Typography>
         <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
       </Paper>
     </>

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -1,19 +1,8 @@
 import { Paper, Typography } from "@mui/material";
 import React, { useState } from "react";
 import { AugmentationName } from "@enums";
-import { Settings } from "../../Settings/Settings";
 import { Player } from "@player";
-import {
-  downArrowSymbol,
-  getArrow,
-  leftArrowSymbol,
-  random,
-  rightArrowSymbol,
-  upArrowSymbol,
-  leftDashedArrowSymbol,
-  rightDashedArrowSymbol,
-  toDashedArrow,
-} from "../utils";
+import { Arrow, downArrowSymbol, getArrow, leftArrowSymbol, random, rightArrowSymbol, upArrowSymbol } from "../utils";
 import { interpolate } from "./Difficulty";
 import { GameTimer } from "./GameTimer";
 import { IMinigameProps } from "./IMinigameProps";
@@ -46,9 +35,6 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
   const [index, setIndex] = useState(0);
   const hasAugment = Player.hasAugmentation(AugmentationName.TrickeryOfHermes, true);
 
-  const focusColor = Settings.theme.primary;
-  const hintColor = Settings.theme.disabled;
-
   function press(this: Document, event: KeyboardEvent): void {
     event.preventDefault();
     if (code[index] !== getArrow(event)) {
@@ -59,26 +45,28 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
     if (index + 1 >= code.length) props.onSuccess();
   }
 
-  // Hidden arrows are to force a consistent column width for the grid layout,
-  // based on the widest character (left and right dashed arrows)
   return (
     <>
       <GameTimer millis={timer} onExpire={props.onFailure} />
       <Paper sx={{ display: "grid", justifyItems: "center" }}>
         <Typography variant="h4">Enter the Code!</Typography>
         <Typography variant="h4">
-          {hasAugment && (
-            <div style={{ display: "grid", gap: "2rem", gridTemplateColumns: "repeat(7, 1fr)", textAlign: "center" }}>
-              <span style={{ visibility: "hidden" }}>{leftDashedArrowSymbol}</span>
-              <span style={{ color: hintColor }}>{index > 1 && toDashedArrow(code[index - 2])}</span>
-              <span style={{ color: hintColor }}>{index > 0 && toDashedArrow(code[index - 1])}</span>
-              <span style={{ color: focusColor }}>{code[index]}</span>
-              <span style={{ color: hintColor }}>{index < code.length - 1 && toDashedArrow(code[index + 1])}</span>
-              <span style={{ color: hintColor }}>{index < code.length - 2 && toDashedArrow(code[index + 2])}</span>
-              <span style={{ visibility: "hidden" }}>{rightDashedArrowSymbol}</span>
-            </div>
-          )}
-          {!hasAugment && <span style={{ color: focusColor }}>{code[index]}</span>}
+          <div
+            style={{
+              display: "grid",
+              gap: "2rem",
+              gridTemplateColumns: `repeat(${code.length}, 1fr)`,
+              textAlign: "center",
+            }}
+          >
+            {code.map((arrow, i) => {
+              return (
+                <span key={i} style={i !== index ? { opacity: 0.4 } : {}}>
+                  {i > index && !hasAugment ? "?" : arrow}
+                </span>
+              );
+            })}
+          </div>
         </Typography>
         <KeyHandler onKeyDown={press} onFailure={props.onFailure} />
       </Paper>
@@ -86,14 +74,13 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
   );
 }
 
-function generateCode(difficulty: Difficulty): string {
-  const arrows = [leftArrowSymbol, rightArrowSymbol, upArrowSymbol, downArrowSymbol];
-  let code = "";
+function generateCode(difficulty: Difficulty): Arrow[] {
+  const arrows: Arrow[] = [leftArrowSymbol, rightArrowSymbol, upArrowSymbol, downArrowSymbol];
+  const code: Arrow[] = [];
   for (let i = 0; i < random(difficulty.min, difficulty.max); i++) {
     let arrow = arrows[Math.floor(4 * Math.random())];
     while (arrow === code[code.length - 1]) arrow = arrows[Math.floor(4 * Math.random())];
-    code += arrow;
+    code.push(arrow);
   }
-
   return code;
 }

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -3,7 +3,17 @@ import React, { useState } from "react";
 import { AugmentationName } from "@enums";
 import { Settings } from "../../Settings/Settings";
 import { Player } from "@player";
-import { downArrowSymbol, getArrow, leftArrowSymbol, random, rightArrowSymbol, upArrowSymbol } from "../utils";
+import {
+  downArrowSymbol,
+  getArrow,
+  leftArrowSymbol,
+  random,
+  rightArrowSymbol,
+  upArrowSymbol,
+  leftDashedArrowSymbol,
+  rightDashedArrowSymbol,
+  toDashedArrow,
+} from "../utils";
 import { interpolate } from "./Difficulty";
 import { GameTimer } from "./GameTimer";
 import { IMinigameProps } from "./IMinigameProps";
@@ -49,6 +59,8 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
     if (index + 1 >= code.length) props.onSuccess();
   }
 
+  // Hidden arrows are to force a consistent column width for the grid layout,
+  // based on the widest character (left and right dashed arrows)
   return (
     <>
       <GameTimer millis={timer} onExpire={props.onFailure} />
@@ -56,13 +68,15 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
         <Typography variant="h4">Enter the Code!</Typography>
         <Typography variant="h4">
           {hasAugment && (
-            <>
-              <span style={{ color: hintColor }}>{index > 1 ? code[index - 2] : "\u00a0"}&nbsp;</span>
-              <span style={{ color: hintColor }}>{index > 0 ? code[index - 1] : "\u00a0"}&nbsp;</span>
+            <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(7, 1fr)", textAlign: "center" }}>
+              <span style={{ visibility: "hidden" }}>{leftDashedArrowSymbol}</span>
+              <span style={{ color: hintColor }}>{index > 1 && toDashedArrow(code[index - 2])}</span>
+              <span style={{ color: hintColor }}>{index > 0 && toDashedArrow(code[index - 1])}</span>
               <span style={{ color: focusColor }}>{code[index]}</span>
-              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 1 ? code[index + 1] : "\u00a0"}</span>
-              <span style={{ color: hintColor }}>&nbsp;{index < code.length - 2 ? code[index + 2] : "\u00a0"}</span>
-            </>
+              <span style={{ color: hintColor }}>{index < code.length - 1 && toDashedArrow(code[index + 1])}</span>
+              <span style={{ color: hintColor }}>{index < code.length - 2 && toDashedArrow(code[index + 2])}</span>
+              <span style={{ visibility: "hidden" }}>{rightDashedArrowSymbol}</span>
+            </div>
           )}
           {!hasAugment && <span style={{ color: focusColor }}>{code[index]}</span>}
         </Typography>

--- a/src/Infiltration/ui/CheatCodeGame.tsx
+++ b/src/Infiltration/ui/CheatCodeGame.tsx
@@ -68,7 +68,7 @@ export function CheatCodeGame(props: IMinigameProps): React.ReactElement {
         <Typography variant="h4">Enter the Code!</Typography>
         <Typography variant="h4">
           {hasAugment && (
-            <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(7, 1fr)", textAlign: "center" }}>
+            <div style={{ display: "grid", gap: "2rem", gridTemplateColumns: "repeat(7, 1fr)", textAlign: "center" }}>
               <span style={{ visibility: "hidden" }}>{leftDashedArrowSymbol}</span>
               <span style={{ color: hintColor }}>{index > 1 && toDashedArrow(code[index - 2])}</span>
               <span style={{ color: hintColor }}>{index > 0 && toDashedArrow(code[index - 1])}</span>

--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -46,11 +46,12 @@ export function Game(props: GameProps): React.ReactElement {
   const [results, setResults] = useState("");
   const [gameIds, setGameIds] = useState({
     lastGames: [-1, -1],
-    id: Math.floor(Math.random() * minigames.length),
+    id: 4, //Math.floor(Math.random() * minigames.length),
   });
 
   const setupNextGame = useCallback(() => {
     const nextGameId = () => {
+      return 4;
       let id = gameIds.lastGames[0];
       const ids = [gameIds.lastGames[0], gameIds.lastGames[1], gameIds.id];
       while (ids.includes(id)) {

--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -46,12 +46,11 @@ export function Game(props: GameProps): React.ReactElement {
   const [results, setResults] = useState("");
   const [gameIds, setGameIds] = useState({
     lastGames: [-1, -1],
-    id: 4, //Math.floor(Math.random() * minigames.length),
+    id: Math.floor(Math.random() * minigames.length),
   });
 
   const setupNextGame = useCallback(() => {
     const nextGameId = () => {
-      return 4;
       let id = gameIds.lastGames[0];
       const ids = [gameIds.lastGames[0], gameIds.lastGames[1], gameIds.id];
       while (ids.includes(id)) {

--- a/src/Infiltration/utils.ts
+++ b/src/Infiltration/utils.ts
@@ -9,12 +9,9 @@ export const downArrowSymbol = "↓";
 export const leftArrowSymbol = "←";
 export const rightArrowSymbol = "→";
 
-export const leftDashedArrowSymbol = "\u21e0";
-export const upDashedArrowSymbol = "\u21e1";
-export const rightDashedArrowSymbol = "\u21e2";
-export const downDashedArrowSymbol = "\u21e3";
+export type Arrow = typeof leftArrowSymbol | typeof rightArrowSymbol | typeof upArrowSymbol | typeof downArrowSymbol;
 
-export function getArrow(event: KeyboardEvent): string {
+export function getArrow(event: KeyboardEvent): Arrow | undefined {
   switch (event.key) {
     case KEY.UP_ARROW:
     case KEY.W:
@@ -29,37 +26,4 @@ export function getArrow(event: KeyboardEvent): string {
     case KEY.D:
       return rightArrowSymbol;
   }
-  return "";
-}
-
-export function getInverseArrow(event: KeyboardEvent): string {
-  switch (event.key) {
-    case KEY.DOWN_ARROW:
-    case KEY.S:
-      return upArrowSymbol;
-    case KEY.RIGHT_ARROW:
-    case KEY.D:
-      return leftArrowSymbol;
-    case KEY.UP_ARROW:
-    case KEY.W:
-      return downArrowSymbol;
-    case KEY.LEFT_ARROW:
-    case KEY.A:
-      return rightArrowSymbol;
-  }
-  return "";
-}
-
-export function toDashedArrow(arrow: string): string {
-  switch (arrow) {
-    case downArrowSymbol:
-      return downDashedArrowSymbol;
-    case rightArrowSymbol:
-      return rightDashedArrowSymbol;
-    case upArrowSymbol:
-      return upDashedArrowSymbol;
-    case leftArrowSymbol:
-      return leftDashedArrowSymbol;
-  }
-  return "";
 }

--- a/src/Infiltration/utils.ts
+++ b/src/Infiltration/utils.ts
@@ -9,6 +9,11 @@ export const downArrowSymbol = "↓";
 export const leftArrowSymbol = "←";
 export const rightArrowSymbol = "→";
 
+export const leftDashedArrowSymbol = "\u21e0";
+export const upDashedArrowSymbol = "\u21e1";
+export const rightDashedArrowSymbol = "\u21e2";
+export const downDashedArrowSymbol = "\u21e3";
+
 export function getArrow(event: KeyboardEvent): string {
   switch (event.key) {
     case KEY.UP_ARROW:
@@ -41,6 +46,20 @@ export function getInverseArrow(event: KeyboardEvent): string {
     case KEY.LEFT_ARROW:
     case KEY.A:
       return rightArrowSymbol;
+  }
+  return "";
+}
+
+export function toDashedArrow(arrow: string): string {
+  switch (arrow) {
+    case downArrowSymbol:
+      return downDashedArrowSymbol;
+    case rightArrowSymbol:
+      return rightDashedArrowSymbol;
+    case upArrowSymbol:
+      return upDashedArrowSymbol;
+    case leftArrowSymbol:
+      return leftDashedArrowSymbol;
   }
   return "";
 }


### PR DESCRIPTION
This is based on #874 but reworks the display in a different direction.

In 874, the current arrow was always at the center of the screen, so if a player is looking ahead at the next part of the code, the code segments would shift on the page after every entry.

In this version, the entire code is displayed at a static location on the page, which allows the player to fully control their own scanning ahead of the code. This matches some other examples of code entry minigames in other games, like Auron's overdrive minigame in Final Fantasy X.

Here is what this version of the game looks like with and without the augmentation, with short and long code sequences (high stats at Joes Guns vs low stats at Megacorp):

Short / No aug:

https://github.com/bitburner-official/bitburner-src/assets/84951833/9d4fa657-7853-4717-b140-a9f9864acbee

Long / No aug:

https://github.com/bitburner-official/bitburner-src/assets/84951833/fc764985-7e41-4c27-b8f1-e50663facd6c

Short / Aug:

https://github.com/bitburner-official/bitburner-src/assets/84951833/cf13ea23-4c3b-4992-ad49-59dd0d0e1f23

Long / Aug (fails on the 5th game due to an incorrect key entry):

https://github.com/bitburner-official/bitburner-src/assets/84951833/8a4d3e52-e307-48f1-bf37-b746c78515de