### PR TITLE
UI: Handle br tag in markdown tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bitburner",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {

--- a/src/ui/MD/components.tsx
+++ b/src/ui/MD/components.tsx
@@ -80,10 +80,14 @@ const fixAlign = (align: React.CSSProperties["textAlign"]): TableCellProps["alig
 export const Td = (props: React.PropsWithChildren<TableDataCellProps>): React.ReactElement => {
   const classes = useStyles();
   const align = fixAlign(props.style?.textAlign);
+  const content = props.children?.map((child, i) => {
+    if (child === "<br />") return <br key={i} />;
+    return child;
+  });
   return (
     <TableCell align={align}>
       <Typography align={align} classes={{ root: classes.td }}>
-        {props.children}
+        {content}
       </Typography>
     </TableCell>
   );
@@ -92,6 +96,7 @@ export const Td = (props: React.PropsWithChildren<TableDataCellProps>): React.Re
 export const Th = (props: React.PropsWithChildren<TableHeaderCellProps>): React.ReactElement => {
   const classes = useStyles();
   const align = fixAlign(props.style?.textAlign);
+
   return (
     <TableCell align={align}>
       <Typography align={align} classes={{ root: classes.th }}>


### PR DESCRIPTION
The br markup tag is the only way to display a newline in markdown table cells.

This PR adds some manual handling to render these tags as html instead of rendering them as HTML strings.

Fixes #993 

![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/97aa1d59-6a4f-4399-a7ec-10658b090b74)
