### PR TITLE
UI: Hash upgrade descriptions use number formatting options

### DIFF
--- a/src/Hacknet/HashUpgrade.ts
+++ b/src/Hacknet/HashUpgrade.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 /** Object representing an upgrade that can be purchased with hashes */
 export interface HashUpgradeParams {

--- a/src/Hacknet/HashUpgrade.ts
+++ b/src/Hacknet/HashUpgrade.ts
@@ -1,8 +1,10 @@
+import { ReactNode } from "react";
+
 /** Object representing an upgrade that can be purchased with hashes */
-export interface IConstructorParams {
+export interface HashUpgradeParams {
   cost?: number;
   costPerLevel: number;
-  desc: string;
+  desc: ReactNode;
   hasTargetServer?: boolean;
   hasTargetCompany?: boolean;
   name: string;
@@ -26,7 +28,7 @@ export class HashUpgrade {
   costPerLevel = 0;
 
   /** Description of what the upgrade does */
-  desc = "";
+  desc: ReactNode = "";
 
   /**
    * Boolean indicating that this upgrade's effect affects a single server,
@@ -47,7 +49,7 @@ export class HashUpgrade {
   // The meaning varies between different upgrades
   value = 0;
 
-  constructor(p: IConstructorParams) {
+  constructor(p: HashUpgradeParams) {
     if (p.cost != null) {
       this.cost = p.cost;
     }

--- a/src/Hacknet/HashUpgrades.ts
+++ b/src/Hacknet/HashUpgrades.ts
@@ -2,12 +2,12 @@
  * Map of all Hash Upgrades
  * Key = Hash name, Value = HashUpgrade object
  */
-import { HashUpgrade, IConstructorParams } from "./HashUpgrade";
+import { HashUpgrade, HashUpgradeParams } from "./HashUpgrade";
 import { HashUpgradesMetadata } from "./data/HashUpgradesMetadata";
 
 export const HashUpgrades: Record<string, HashUpgrade> = {};
 
-function createHashUpgrade(p: IConstructorParams): void {
+function createHashUpgrade(p: HashUpgradeParams): void {
   HashUpgrades[p.name] = new HashUpgrade(p);
 }
 

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -1,14 +1,18 @@
 // Metadata used to construct all Hash Upgrades
 import React from "react";
-import { IConstructorParams } from "../HashUpgrade";
+import { HashUpgradeParams } from "../HashUpgrade";
 import { formatInt } from "../../ui/formatNumber";
 import { Money } from "../../ui/React/Money";
 
-export const HashUpgradesMetadata: IConstructorParams[] = [
+export const HashUpgradesMetadata: HashUpgradeParams[] = [
   {
     cost: 4,
     costPerLevel: 4,
-    desc: "Sell hashes for $1m",
+    desc: (
+      <>
+        Sell hashes for <Money money={1e6} />
+      </>
+    ),
     name: "Sell for Money",
     effectText: (level: number): JSX.Element | null => (
       <>
@@ -19,7 +23,11 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
   },
   {
     costPerLevel: 100,
-    desc: "Sell hashes for $1b in Corporation funds",
+    desc: (
+      <>
+        Sell hashes for <Money money={1e9} /> in Corporation funds
+      </>
+    ),
     name: "Sell for Corporation Funds",
     effectText: (level: number): JSX.Element | null => (
       <>
@@ -33,18 +41,20 @@ export const HashUpgradesMetadata: IConstructorParams[] = [
     desc:
       "Use hashes to decrease the minimum security of a single server by 2%. " +
       "Note that a server's minimum security cannot go below 1. This effect persists " +
-      "until you install Augmentations (since servers are reset at that time).",
+      "until you install Augmentations (since servers are reset at that time)",
     hasTargetServer: true,
     name: "Reduce Minimum Security",
     value: 0.98,
   },
   {
     costPerLevel: 50,
-    desc:
-      "Use hashes to increase the maximum amount of money on a single server by 2%. " +
-      "Note that a server's maximum money is soft capped above $10t. " +
-      "This effect persists until you install Augmentations (since servers " +
-      "are reset at that time).",
+    desc: (
+      <>
+        Use hashes to increase the maximum amount of money on a single server by 2%. This effect persists until you
+        install Augmentations (since servers are reset at that time). Note that a server's maximum money is soft capped
+        above <Money money={10e12} />
+      </>
+    ),
     hasTargetServer: true,
     name: "Increase Maximum Money",
     value: 1.02,


### PR DESCRIPTION
Fixes #988 

Example with numeric display set to engineering form:

![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/d1f171dd-07e5-4f52-b830-9b3df46e43e6)