### PR TITLE
API: Fix for stanek.acceptGift not working

### DIFF
--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -110,11 +110,14 @@ export function NetscriptStanek(): InternalAPI<IStanek> {
     acceptGift: (ctx) => () => {
       const cotmgFaction = Factions[FactionName.ChurchOfTheMachineGod];
       // Check if the player is eligible to join the church
-      if (cotmgFaction.getInfo().inviteReqs.isSatisfied(Player)) {
-        // Attempt to join CotMG
-        joinFaction(cotmgFaction);
-        // Attempt to install the first Stanek aug (unless it is already queued)
-        if (!Player.hasAugmentation(AugmentationName.StaneksGift1, false)) {
+      if (Player.canAccessCotMG()) {
+        const augs = [...Player.augmentations, ...Player.queuedAugmentations].filter(
+          (a) => a.name !== AugmentationName.NeuroFluxGovernor,
+        );
+        if (augs.length == 0) {
+          // Join the CotMG factionn
+          joinFaction(cotmgFaction);
+          // Install the first Stanek aug
           applyAugmentation({ name: AugmentationName.StaneksGift1, level: 1 });
           helpers.log(
             ctx,


### PR DESCRIPTION
PR #953 made it impossible to satisfy the conditions for `ns.stanek.acceptGift()`.

This PR makes the API function use the same augmentation-counting logic as the manual process, but does not include other faction join conditions which were not meant to be satisfiable as this faction does not issue normal invites.

Fixes #1000