### PR TITLE
API: Fix `serverExists()` return true for not revealed servers

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1116,7 +1116,8 @@ export const ns: InternalAPI<NSFull> = {
   },
   serverExists: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
-    return GetServer(hostname) !== null;
+    const server = GetServer(hostname);
+    return server !== null && server.serversOnNetwork.length > 0 || server.hostname === "home";
   },
   fileExists: (ctx) => (_filename, _hostname) => {
     const filename = helpers.string(ctx, "filename", _filename);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1117,7 +1117,7 @@ export const ns: InternalAPI<NSFull> = {
   serverExists: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
     const server = GetServer(hostname);
-    return server !== null && server.serversOnNetwork.length > 0 || server.hostname === "home";
+    return server !== null && (server.serversOnNetwork.length > 0 || server.hostname === "home");
   },
   fileExists: (ctx) => (_filename, _hostname) => {
     const filename = helpers.string(ctx, "filename", _filename);


### PR DESCRIPTION
closes #980

copied condition from [here](https://github.com/bitburner-official/bitburner-src/blob/dev/src/Netscript/NetscriptHelpers.tsx#L456)