### PR TITLE
IPVGO: Remove testing flag [Merge once dev cycle is almost complete]

### DIFF
--- a/src/Go/effects/effect.ts
+++ b/src/Go/effects/effect.ts
@@ -107,10 +107,7 @@ export function playerHasDiscoveredGo() {
   const hasRecords = opponentList.find((opponent) => getPlayerStats(opponent).wins + getPlayerStats(opponent).losses);
   const isInBn14 = Player.bitNodeN === 14;
 
-  // TODO: remove this once testing is completed
-  const isInTesting = true;
-
-  return !!(playedGame || hasRecords || isInBn14 || isInTesting);
+  return !!(playedGame || hasRecords || isInBn14);
 }
 
 function getEffectPowerForFaction(opponent: opponents) {


### PR DESCRIPTION
Currently, IPvGO always appears as a shortcut in the left-hand menu (to make it easy to test). This PR makes it only appear if the user is in BN14, or if the user has an active IPvGO subnet ongoing.

(The subnet is accessible via the UI from DefCon in new Tokyo or CIA in Sector-12, or via the API)