### PR TITLE
EDITOR: Add file URI's to monaco to improve intellisense

### DIFF
--- a/src/ScriptEditor/ui/OpenScript.ts
+++ b/src/ScriptEditor/ui/OpenScript.ts
@@ -24,6 +24,13 @@ export class OpenScript {
   }
 
   regenerateModel(): void {
-    this.model = editor.createModel(this.code, this.isTxt ? "plaintext" : "javascript");
+    this.model = editor.createModel(
+      this.code,
+      this.isTxt ? "plaintext" : "javascript",
+      monaco.Uri.from({
+        scheme: "file",
+        path: `${this.hostname}/${this.path}`,
+      }),
+    );
   }
 }

--- a/src/ScriptEditor/ui/OpenScript.ts
+++ b/src/ScriptEditor/ui/OpenScript.ts
@@ -1,5 +1,5 @@
 import type { ContentFilePath } from "../../Paths/ContentFile";
-import { editor, Position } from "monaco-editor";
+import monaco, { editor, Position } from "monaco-editor";
 
 type ITextModel = editor.ITextModel;
 

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -191,7 +191,14 @@ function Root(props: IProps): React.ReactElement {
           code,
           props.hostname,
           new monaco.Position(0, 0),
-          monaco.editor.createModel(code, filename.endsWith(".txt") ? "plaintext" : "javascript"),
+          monaco.editor.createModel(
+            code,
+            filename.endsWith(".txt") ? "plaintext" : "javascript",
+            monaco.Uri.from({
+              scheme: "file",
+              path: `${props.hostname}/${filename}`,
+            }),
+          ),
         );
         openScripts.push(newScript);
         currentScript = newScript;


### PR DESCRIPTION
This change adds file URI's to the monaco models, allowing monaco to resolve imports to the corresponding scripts. This means that imports can now be typed with JSDoc and have autocomplete.