### PR TITLE
PORTS: added rejection to nextWrite

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1403,7 +1403,7 @@ export const ns: InternalAPI<NSFull> = {
   },
   getPortHandle: (ctx) => (_portNumber) => {
     const portNumber = helpers.portNumber(ctx, _portNumber);
-    return portHandle(portNumber);
+    return portHandle(portNumber, ctx);
   },
   rm: (ctx) => (_fn, _hostname) => {
     const filepath = helpers.filePath(ctx, "fn", _fn);

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -4,6 +4,7 @@ import { NetscriptPorts } from "./NetscriptWorker";
 import { PositiveInteger } from "./types";
 import { NetscriptContext } from "./Netscript/APIWrapper";
 import { helpers } from "./Netscript/NetscriptHelpers";
+import { ScriptDeath } from "./Netscript/ScriptDeath";
 
 type PortData = string | number;
 type Resolver = () => void;
@@ -81,7 +82,10 @@ export function peekPort(n: PortNumber): PortData {
 function nextWritePort(n: PortNumber, ctx: NetscriptContext) {
   const { resolvers } = getPort(n);
   return new Promise<void>((res, rej) => resolvers.push(() => (ctx.workerScript.env.stopFlag ? rej() : res()))).catch(
-    () => helpers.log(ctx, () => `nextWrite was rejected on port ${n}`),
+    () => {
+      helpers.log(ctx, () => `nextWrite was rejected on port ${n}`);
+      throw new ScriptDeath(ctx.workerScript);
+    },
   );
 }
 


### PR DESCRIPTION
one common problem with nextWrite are the lingering resolvers on the port when the script is already dead

we would now push a closure instead of just the resolvers
containing a reference to the ctx and based on the env.stopFlag reject or resolve the promise

a rejection is catched with a small error message in the tail
![image](https://github.com/bitburner-official/bitburner-src/assets/115591472/12725728-c563-4f5b-9ffc-7b06aa722506)
