### PR TITLE
API: Modify the port opening functions to return a bool instead of throwing an error

### DIFF
--- a/markdown/bitburner.ns.brutessh.md
+++ b/markdown/bitburner.ns.brutessh.md
@@ -9,7 +9,7 @@ Runs BruteSSH.exe on a server.
 **Signature:**
 
 ```typescript
-brutessh(host: string): void;
+brutessh(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ brutessh(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+Returns a boolean based on the success of BruteSSH.exe
 
 ## Remarks
 

--- a/markdown/bitburner.ns.ftpcrack.md
+++ b/markdown/bitburner.ns.ftpcrack.md
@@ -9,7 +9,7 @@ Runs FTPCrack.exe on a server.
 **Signature:**
 
 ```typescript
-ftpcrack(host: string): void;
+ftpcrack(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ ftpcrack(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+Returns a boolean based on the success of FTPCrack.exe
 
 ## Remarks
 

--- a/markdown/bitburner.ns.httpworm.md
+++ b/markdown/bitburner.ns.httpworm.md
@@ -9,7 +9,7 @@ Runs HTTPWorm.exe on a server.
 **Signature:**
 
 ```typescript
-httpworm(host: string): void;
+httpworm(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ httpworm(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+Returns a boolean based on the success of HTTPWorm.exe
 
 ## Remarks
 

--- a/markdown/bitburner.ns.nuke.md
+++ b/markdown/bitburner.ns.nuke.md
@@ -9,7 +9,7 @@ Runs NUKE.exe on a server.
 **Signature:**
 
 ```typescript
-nuke(host: string): void;
+nuke(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ nuke(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+Returns a boolean based on the success of NUKE.exe
 
 ## Remarks
 

--- a/markdown/bitburner.ns.relaysmtp.md
+++ b/markdown/bitburner.ns.relaysmtp.md
@@ -9,7 +9,7 @@ Runs relaySMTP.exe on a server.
 **Signature:**
 
 ```typescript
-relaysmtp(host: string): void;
+relaysmtp(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ relaysmtp(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+Returns a boolean based on the success of relaySMTP.exe
 
 ## Remarks
 

--- a/markdown/bitburner.ns.sqlinject.md
+++ b/markdown/bitburner.ns.sqlinject.md
@@ -9,7 +9,7 @@ Runs SQLInject.exe on a server.
 **Signature:**
 
 ```typescript
-sqlinject(host: string): void;
+sqlinject(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ sqlinject(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+Returns a boolean based on the success of SQLInject.exe
 
 ## Remarks
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -606,10 +606,12 @@ export const ns: InternalAPI<NSFull> = {
       return true;
     }
     if (!Player.hasProgram(CompletedProgramName.nuke)) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "You do not have the NUKE.exe virus!");
+      helpers.log(ctx, () => "You do not have the NUKE.exe virus!");
+      return false;
     }
     if (server.openPortCount < server.numOpenPortsRequired) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "Not enough ports opened to use NUKE.exe virus.");
+      helpers.log(ctx, () => "Not enough ports opened to use NUKE.exe virus.");
+      return false;
     }
     server.hasAdminRights = true;
     helpers.log(ctx, () => `Executed NUKE.exe virus on '${server.hostname}' to gain root access.`);
@@ -623,16 +625,18 @@ export const ns: InternalAPI<NSFull> = {
       return false;
     }
     if (!Player.hasProgram(CompletedProgramName.bruteSsh)) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "You do not have the BruteSSH.exe program!");
+      helpers.log(ctx, () => "You do not have the BruteSSH.exe program!");
+      return false;
     }
     if (!server.sshPortOpen) {
       helpers.log(ctx, () => `Executed BruteSSH.exe on '${server.hostname}' to open SSH port (22).`);
       server.sshPortOpen = true;
       ++server.openPortCount;
+      return true;
     } else {
       helpers.log(ctx, () => `SSH Port (22) already opened on '${server.hostname}'.`);
+      return true;
     }
-    return true;
   },
   ftpcrack: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
@@ -642,16 +646,18 @@ export const ns: InternalAPI<NSFull> = {
       return false;
     }
     if (!Player.hasProgram(CompletedProgramName.ftpCrack)) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "You do not have the FTPCrack.exe program!");
+      helpers.log(ctx, () => "You do not have the FTPCrack.exe program!");
+      return false;
     }
     if (!server.ftpPortOpen) {
       helpers.log(ctx, () => `Executed FTPCrack.exe on '${server.hostname}' to open FTP port (21).`);
       server.ftpPortOpen = true;
       ++server.openPortCount;
+      return true;
     } else {
       helpers.log(ctx, () => `FTP Port (21) already opened on '${server.hostname}'.`);
+      return true;
     }
-    return true;
   },
   relaysmtp: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
@@ -661,16 +667,18 @@ export const ns: InternalAPI<NSFull> = {
       return false;
     }
     if (!Player.hasProgram(CompletedProgramName.relaySmtp)) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "You do not have the relaySMTP.exe program!");
+      helpers.log(ctx, () => "You do not have the relaySMTP.exe program!");
+      return false;
     }
     if (!server.smtpPortOpen) {
       helpers.log(ctx, () => `Executed relaySMTP.exe on '${server.hostname}' to open SMTP port (25).`);
       server.smtpPortOpen = true;
       ++server.openPortCount;
+      return true;
     } else {
       helpers.log(ctx, () => `SMTP Port (25) already opened on '${server.hostname}'.`);
+      return true;
     }
-    return true;
   },
   httpworm: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
@@ -680,16 +688,18 @@ export const ns: InternalAPI<NSFull> = {
       return false;
     }
     if (!Player.hasProgram(CompletedProgramName.httpWorm)) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "You do not have the HTTPWorm.exe program!");
+      helpers.log(ctx, () => "You do not have the HTTPWorm.exe program!");
+      return false;
     }
     if (!server.httpPortOpen) {
       helpers.log(ctx, () => `Executed HTTPWorm.exe on '${server.hostname}' to open HTTP port (80).`);
       server.httpPortOpen = true;
       ++server.openPortCount;
+      return true;
     } else {
       helpers.log(ctx, () => `HTTP Port (80) already opened on '${server.hostname}'.`);
+      return true;
     }
-    return true;
   },
   sqlinject: (ctx) => (_hostname) => {
     const hostname = helpers.string(ctx, "hostname", _hostname);
@@ -699,16 +709,18 @@ export const ns: InternalAPI<NSFull> = {
       return false;
     }
     if (!Player.hasProgram(CompletedProgramName.sqlInject)) {
-      throw helpers.makeRuntimeErrorMsg(ctx, "You do not have the SQLInject.exe program!");
+      helpers.log(ctx, () => "You do not have the SQLInject.exe program!");
+      return false;
     }
     if (!server.sqlPortOpen) {
       helpers.log(ctx, () => `Executed SQLInject.exe on '${server.hostname}' to open SQL port (1433).`);
       server.sqlPortOpen = true;
       ++server.openPortCount;
+      return true;
     } else {
       helpers.log(ctx, () => `SQL Port (1433) already opened on '${server.hostname}'.`);
+      return true;
     }
-    return true;
   },
   run:
     (ctx) =>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5872,8 +5872,9 @@ export interface NS {
    * ns.nuke("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns Returns a boolean based on the success of NUKE.exe
    */
-  nuke(host: string): void;
+  nuke(host: string): boolean;
 
   /**
    * Runs BruteSSH.exe on a server.
@@ -5887,8 +5888,9 @@ export interface NS {
    * ns.brutessh("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns Returns a boolean based on the success of BruteSSH.exe
    */
-  brutessh(host: string): void;
+  brutessh(host: string): boolean;
 
   /**
    * Runs FTPCrack.exe on a server.
@@ -5902,8 +5904,9 @@ export interface NS {
    * ns.ftpcrack("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns Returns a boolean based on the success of FTPCrack.exe
    */
-  ftpcrack(host: string): void;
+  ftpcrack(host: string): boolean;
 
   /**
    * Runs relaySMTP.exe on a server.
@@ -5917,8 +5920,9 @@ export interface NS {
    * ns.relaysmtp("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns Returns a boolean based on the success of relaySMTP.exe
    */
-  relaysmtp(host: string): void;
+  relaysmtp(host: string): boolean;
 
   /**
    * Runs HTTPWorm.exe on a server.
@@ -5932,8 +5936,9 @@ export interface NS {
    * ns.httpworm("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns Returns a boolean based on the success of HTTPWorm.exe
    */
-  httpworm(host: string): void;
+  httpworm(host: string): boolean;
 
   /**
    * Runs SQLInject.exe on a server.
@@ -5948,8 +5953,9 @@ export interface NS {
    * ```
    * @remarks RAM cost: 0.05 GB
    * @param host - Hostname of the target server.
+   * @returns Returns a boolean based on the success of SQLInject.exe
    */
-  sqlinject(host: string): void;
+  sqlinject(host: string): boolean;
 
   /**
    * Start another script on the current server.


### PR DESCRIPTION
Modified the opening functions and nuke function to return booleans based on their success instead of simply throwing an error and crashing the script, should make the whole procress of writing a nuking script simpler.
