### PR TITLE
BUGFIX: Update formatPercent to not use a suffixStart of 0

### DIFF
--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -101,7 +101,7 @@ export function formatPercent(n: number, fractionalDigits = 2, multStart = 1e6) 
   if (nAbs * 100 === Infinity) return n < 0 ? "-∞%" : "∞%";
 
   // Mult form. There are probably some areas in the game this wouldn't make sense, but they hopefully won't ever have huge %.
-  if (nAbs >= multStart) return "x" + formatNumber(n, fractionalDigits, 0);
+  if (nAbs >= multStart) return "x" + formatNumber(n, fractionalDigits);
 
   return getFormatter(fractionalDigits, percentFormats, { style: "percent" }).format(n);
 }


### PR DESCRIPTION
Changes in https://github.com/bitburner-official/bitburner-src/pull/957 have formatNumber throwing an error if suffixStart is less than 1000.  

It appears formatPercent can, in rare cases, call formatNumber and it's setting the suffixStart to 0.  Removed the 0 to conform to the expected input of formatNumber.