### PR TITLE
EDITOR: fix disposing models

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -42,7 +42,7 @@ export function Editor({ onMount, onChange }: EditorProps) {
     // Unmounting
     return () => {
       subscription.current?.dispose();
-      editorRef.current?.getModel()?.dispose();
+      monaco.editor.getModels().forEach((model) => model.dispose());
       editorRef.current?.dispose();
     };
     // this eslint ignore instruction can potentially cause unobvious bugs

--- a/src/ScriptEditor/ui/OpenScript.ts
+++ b/src/ScriptEditor/ui/OpenScript.ts
@@ -1,5 +1,6 @@
 import type { ContentFilePath } from "../../Paths/ContentFile";
-import monaco, { editor, Position } from "monaco-editor";
+import { editor, Position } from "monaco-editor";
+import { makeModel } from "./utils";
 
 type ITextModel = editor.ITextModel;
 
@@ -24,12 +25,6 @@ export class OpenScript {
   }
 
   regenerateModel(): void {
-    const uri = monaco.Uri.from({
-      scheme: "file",
-      path: `${this.hostname}/${this.path}`,
-    });
-    //regenerate an existing model or create a new one, just a safety check we should have disposed it
-    this.model =
-      monaco.editor.getModel(uri) ?? editor.createModel(this.code, this.isTxt ? "plaintext" : "javascript", uri);
+    this.model = makeModel(this.hostname, this.path, this.code);
   }
 }

--- a/src/ScriptEditor/ui/OpenScript.ts
+++ b/src/ScriptEditor/ui/OpenScript.ts
@@ -24,13 +24,12 @@ export class OpenScript {
   }
 
   regenerateModel(): void {
-    this.model = editor.createModel(
-      this.code,
-      this.isTxt ? "plaintext" : "javascript",
-      monaco.Uri.from({
-        scheme: "file",
-        path: `${this.hostname}/${this.path}`,
-      }),
-    );
+    const uri = monaco.Uri.from({
+      scheme: "file",
+      path: `${this.hostname}/${this.path}`,
+    });
+    //regenerate an existing model or create a new one, just a safety check again we should have disposed it
+    this.model =
+      monaco.editor.getModel(uri) ?? editor.createModel(this.code, this.isTxt ? "plaintext" : "javascript", uri);
   }
 }

--- a/src/ScriptEditor/ui/OpenScript.ts
+++ b/src/ScriptEditor/ui/OpenScript.ts
@@ -28,7 +28,7 @@ export class OpenScript {
       scheme: "file",
       path: `${this.hostname}/${this.path}`,
     });
-    //regenerate an existing model or create a new one, just a safety check again we should have disposed it
+    //regenerate an existing model or create a new one, just a safety check we should have disposed it
     this.model =
       monaco.editor.getModel(uri) ?? editor.createModel(this.code, this.isTxt ? "plaintext" : "javascript", uri);
   }

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -264,7 +264,7 @@ function Root(props: IProps): React.ReactElement {
     const closingScript = openScripts[index];
     const savedScriptCode = closingScript.code;
     const wasCurrentScript = openScripts[index] === currentScript;
-    //closingScript.model.dispose()
+
     if (dirty(openScripts, index)) {
       PromptEvent.emit({
         txt: `Do you want to save changes to ${closingScript.path} on ${closingScript.hostname}?`,
@@ -277,7 +277,8 @@ function Root(props: IProps): React.ReactElement {
         },
       });
     }
-
+    //unmounting the editor will dispose all, doesnt hurt to dipose on close aswell
+    closingScript.model.dispose();
     openScripts.splice(index, 1);
     if (openScripts.length === 0) {
       currentScript = null;

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -22,7 +22,7 @@ import { PromptEvent } from "../../ui/React/PromptManager";
 
 import { useRerender } from "../../ui/React/hooks";
 
-import { dirty, getServerCode } from "./utils";
+import { dirty, getServerCode, makeModel } from "./utils";
 import { OpenScript } from "./OpenScript";
 import { Tabs } from "./Tabs";
 import { Toolbar } from "./Toolbar";
@@ -185,19 +185,13 @@ function Root(props: IProps): React.ReactElement {
         editorRef.current.revealLineInCenter(openScript.lastPosition.lineNumber);
         parseCode(openScript.code);
       } else {
-        const uri = monaco.Uri.from({
-          scheme: "file",
-          path: `${props.hostname}/${filename}`,
-        });
         // Open script
         const newScript = new OpenScript(
           filename,
           code,
           props.hostname,
           new monaco.Position(0, 0),
-          //if we somehow messed up and didnt dispose the model just a safety measure
-          monaco.editor.getModel(uri) ??
-            monaco.editor.createModel(code, filename.endsWith(".txt") ? "plaintext" : "javascript", uri),
+          makeModel(props.hostname, filename, code),
         );
         openScripts.push(newScript);
         currentScript = newScript;
@@ -277,7 +271,7 @@ function Root(props: IProps): React.ReactElement {
         },
       });
     }
-    //unmounting the editor will dispose all, doesnt hurt to dipose on close aswell
+    //unmounting the editor will dispose all, doesnt hurt to dispose on close aswell
     closingScript.model.dispose();
     openScripts.splice(index, 1);
     if (openScripts.length === 0) {

--- a/src/ScriptEditor/ui/utils.ts
+++ b/src/ScriptEditor/ui/utils.ts
@@ -1,5 +1,5 @@
 import { GetServer } from "../../Server/AllServers";
-
+import { editor, Uri } from "monaco-editor";
 import { OpenScript } from "./OpenScript";
 
 function getServerCode(scripts: OpenScript[], index: number): string | null {
@@ -21,5 +21,14 @@ function reorder(list: unknown[], startIndex: number, endIndex: number): void {
   const [removed] = list.splice(startIndex, 1);
   list.splice(endIndex, 0, removed);
 }
+function makeModel(hostname: string, filename: string, code: string) {
+  const uri = Uri.from({
+    scheme: "file",
+    path: `${hostname}/${filename}`,
+  });
+  const language = filename.endsWith(".txt") ? "plaintext" : "javascript";
+  //if somehow a model already exist return it
+  return editor.getModel(uri) ?? editor.createModel(code, language, uri);
+}
 
-export { getServerCode, dirty, reorder };
+export { getServerCode, dirty, reorder, makeModel };


### PR DESCRIPTION
the unmount of the editor didnt dispose the models correctly 
could be that this was already the case before the URI changes and only got visible after

added a few more checks that if a model already exist that its loaded instead of creating a new one

and removed an imho annoying toTerminal call when closing and saving a script
it will still go to the terminal when its the last script that gets closed

the extra dispose and checks might be hard to verify that they work but i disabled the dispose on unmount and tested each of them alone