### PR TITLE
GRAFTING: Add Check for Grafting

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -380,6 +380,7 @@ const grafting = {
   getAugmentationGraftTime: 3.75,
   getGraftableAugmentations: 5,
   graftAugmentation: 7.5,
+  isGrafting: 3.75,
 } as const;
 
 const corporation = {

--- a/src/NetscriptFunctions/Grafting.ts
+++ b/src/NetscriptFunctions/Grafting.ts
@@ -52,6 +52,18 @@ export function NetscriptGrafting(): InternalAPI<IGrafting> {
       return graftableAugs;
     },
 
+    isGrafting: (ctx) => () => {
+      checkGraftingAPIAccess(ctx);
+      let grafting = false;
+      const work = Player.currentWork;
+      if (work) {
+        if (work.type == "GRAFTING") {
+          grafting = true;
+        }
+      }
+      return grafting;
+    },
+
     graftAugmentation:
       (ctx) =>
       (_augName, _focus = true) => {

--- a/src/NetscriptFunctions/Grafting.ts
+++ b/src/NetscriptFunctions/Grafting.ts
@@ -54,14 +54,8 @@ export function NetscriptGrafting(): InternalAPI<IGrafting> {
 
     isGrafting: (ctx) => () => {
       checkGraftingAPIAccess(ctx);
-      let grafting = false;
-      const work = Player.currentWork;
-      if (work) {
-        if (work.type == "GRAFTING") {
-          grafting = true;
-        }
-      }
-      return grafting;
+      const work = Player.currentWork ?? false;
+      return work && work.type === "GRAFTING";
     },
 
     graftAugmentation:

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4497,6 +4497,15 @@ export interface Grafting {
    * @throws Will error if called while you are not in New Tokyo.
    */
   graftAugmentation(augName: string, focus?: boolean): boolean;
+
+  /**
+   * Checks to see if the player is currently grafting
+   * @remarks
+   * RAM cost: 3.75 GB
+   *
+   * @returns True if player is currently Grafting, false otherwise.
+   */
+  isGrafting(): boolean;
 }
 
 /**


### PR DESCRIPTION
Potential fix for https://github.com/bitburner-official/bitburner-src/issues/1012

Current commands for grafting only return how long it will take to graft with perfect focus.  Any deviation from that will cause the sleep to fire off too soon.  If the player does not have access to SF4 they can not tell if they're still grafting or not.

Figured an easy solution would just be to add a command to let the player know if they are grafting or not.  Then they can wait until that condition is false and act on that information, instead of attempting to sleep for a very specific amount of time.

*NOTE: I ran 'npm run doc' and GitHub doesn't show that I can commit anything new :(.  I seem to always fail at this part of the PR.