### PR TITLE
MISC: Several typo fix in corporation modals

### DIFF
--- a/src/Corporation/ui/modals/PurchaseMaterialModal.tsx
+++ b/src/Corporation/ui/modals/PurchaseMaterialModal.tsx
@@ -144,7 +144,7 @@ export function PurchaseMaterialModal(props: IProps): React.ReactElement {
       <Typography>
         Enter the amount of {props.mat.name} you would like to purchase per second. This material's cost changes
         constantly.
-        {props.disablePurchaseLimit ? "Note: Purchase amount is disabled as smart supply is enabled" : ""}
+        {props.disablePurchaseLimit ? " Note: Purchase amount is disabled as smart supply is enabled" : ""}
       </Typography>
       <TextField
         value={buyAmt}

--- a/src/Corporation/ui/modals/SellDivisionModal.tsx
+++ b/src/Corporation/ui/modals/SellDivisionModal.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 
 import { Modal } from "../../../ui/React/Modal";
 import { Money } from "../../../ui/React/Money";
+import { MoneyRate } from "../../../ui/React/MoneyRate";
+import { StatsTable } from "../../../ui/React/StatsTable";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import MenuItem from "@mui/material/MenuItem";
@@ -34,7 +36,8 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
     props.onClose();
     dialogBoxCreate(
       <Typography>
-        Sold <b>{divisionToSell.name}</b> for <Money money={soldPrice} />, you now have space for {corp.maxDivisions - corp.divisions.size} more divisions.
+        Sold <b>{divisionToSell.name}</b> for <Money money={soldPrice} />, you now have space for
+        {" "}{corp.maxDivisions - corp.divisions.size} more divisions.
       </Typography>,
     );
   }
@@ -55,12 +58,14 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
           ))}
         </Select>
         <Typography>Division {divisionToSell.name} has:</Typography>
-        <Typography>
-          Profit: <Money money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10} /> / sec{" "}
-        </Typography>
-        <Typography>Cities: {getRecordKeys(divisionToSell.offices).length}</Typography>
-        <Typography>Warehouses: {getRecordKeys(divisionToSell.warehouses).length}</Typography>
-        {divisionToSell.makesProducts ?? <Typography>Products: {divisionToSell.products.size}</Typography>}
+        <StatsTable
+          rows={[
+            ["Profit:", <MoneyRate money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10} />],
+            ["Cities:", getRecordKeys(divisionToSell.offices).length],
+            ["Warehouses:", getRecordKeys(divisionToSell.warehouses).length],
+            divisionToSell.makesProducts ? ["Products:", divisionToSell.products.size] : [],
+          ]}
+        />
         <br />
         <Typography>
           Sell price: <Money money={price} />

--- a/src/Corporation/ui/modals/SellDivisionModal.tsx
+++ b/src/Corporation/ui/modals/SellDivisionModal.tsx
@@ -60,7 +60,7 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
         <Typography>Division {divisionToSell.name} has:</Typography>
         <StatsTable
           rows={[
-            ["Profit:", <MoneyRate money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10} />],
+            ["Profit:", <MoneyRate key="profit" money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10} />],
             ["Cities:", getRecordKeys(divisionToSell.offices).length],
             ["Warehouses:", getRecordKeys(divisionToSell.warehouses).length],
             divisionToSell.makesProducts ? ["Products:", divisionToSell.products.size] : [],

--- a/src/Corporation/ui/modals/SellDivisionModal.tsx
+++ b/src/Corporation/ui/modals/SellDivisionModal.tsx
@@ -34,8 +34,7 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
     props.onClose();
     dialogBoxCreate(
       <Typography>
-        Sold <b>{divisionToSell.name}</b> for <Money money={soldPrice} />, you now have space for
-        {corp.maxDivisions - corp.divisions.size} more divisions.
+        Sold <b>{divisionToSell.name}</b> for <Money money={soldPrice} />, you now have space for {corp.maxDivisions - corp.divisions.size} more divisions.
       </Typography>,
     );
   }
@@ -59,8 +58,8 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
         <Typography>
           Profit: <Money money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10} /> / sec{" "}
         </Typography>
-        <Typography>Cities:{getRecordKeys(divisionToSell.offices).length}</Typography>
-        <Typography>Warehouses:{getRecordKeys(divisionToSell.warehouses).length}</Typography>
+        <Typography>Cities: {getRecordKeys(divisionToSell.offices).length}</Typography>
+        <Typography>Warehouses: {getRecordKeys(divisionToSell.warehouses).length}</Typography>
         {divisionToSell.makesProducts ?? <Typography>Products: {divisionToSell.products.size}</Typography>}
         <br />
         <Typography>

--- a/src/Corporation/ui/modals/SellDivisionModal.tsx
+++ b/src/Corporation/ui/modals/SellDivisionModal.tsx
@@ -36,8 +36,8 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
     props.onClose();
     dialogBoxCreate(
       <Typography>
-        Sold <b>{divisionToSell.name}</b> for <Money money={soldPrice} />, you now have space for
-        {" "}{corp.maxDivisions - corp.divisions.size} more divisions.
+        Sold <b>{divisionToSell.name}</b> for <Money money={soldPrice} />, you now have space for{" "}
+        {corp.maxDivisions - corp.divisions.size} more divisions.
       </Typography>,
     );
   }
@@ -60,7 +60,13 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
         <Typography>Division {divisionToSell.name} has:</Typography>
         <StatsTable
           rows={[
-            ["Profit:", <MoneyRate key="profit" money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10} />],
+            [
+              "Profit:",
+              <MoneyRate
+                key="profit"
+                money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10}
+              />,
+            ],
             ["Cities:", getRecordKeys(divisionToSell.offices).length],
             ["Warehouses:", getRecordKeys(divisionToSell.warehouses).length],
             divisionToSell.makesProducts ? ["Products:", divisionToSell.products.size] : [],


### PR DESCRIPTION
Missing space between sentences in PurchaseMaterialModal when Smart Supply is enabled:
![image](https://github.com/bitburner-official/bitburner-src/assets/26317456/31553ef1-f855-44b6-b066-fa05e91c60ab)

Tested locally:
![image](https://github.com/bitburner-official/bitburner-src/assets/26317456/03d7921f-409a-4aef-b803-b96d926344c6)

Missing space between colon and number in SellDivisionModal:
![image](https://github.com/bitburner-official/bitburner-src/assets/26317456/955e0efe-442f-4490-ab8b-5bd6151dfd96)

Tested locally:
![image](https://github.com/bitburner-official/bitburner-src/assets/26317456/55c6de68-6d93-4817-a6f8-b6b618aeb209)

Missing space between "for" and number:
![image](https://github.com/bitburner-official/bitburner-src/assets/26317456/b6e47235-8641-4041-ab38-cfbfc3fa2210)

Tested locally:
![image](https://github.com/bitburner-official/bitburner-src/assets/26317456/e64d2763-010e-4d32-a70d-48b7f7427438)


