### PR TITLE
UI: show sleeves int stat if appropriate

### DIFF
--- a/src/PersonObjects/Sleeve/ui/MoreStatsModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/MoreStatsModal.tsx
@@ -1,4 +1,5 @@
 import { Sleeve } from "../Sleeve";
+import { Player } from "@player";
 import { formatExp, formatPercent } from "../../../ui/formatNumber";
 import { convertTimeMsToTimeElapsedString } from "../../../utils/StringHelperFunctions";
 import { CONSTANTS } from "../../../Constants";
@@ -28,6 +29,16 @@ export function MoreStatsModal(props: IProps): React.ReactElement {
           ],
           [<>Agility:&nbsp;</>, props.sleeve.skills.agility, <>&nbsp;({formatExp(props.sleeve.exp.agility)} exp)</>],
           [<>Charisma:&nbsp;</>, props.sleeve.skills.charisma, <>&nbsp;({formatExp(props.sleeve.exp.charisma)} exp)</>],
+          [
+            ...(Player.sourceFileLvl(5) > 0 || Player.bitNodeN === 5
+              ? [
+                  <>Intelligence:&nbsp;</>,
+                  props.sleeve.skills.intelligence,
+                  <>&nbsp;({formatExp(props.sleeve.exp.intelligence)} exp)</>,
+                ]
+              : [<></>]),
+          ],
+          [<></>],
         ]}
         title="Stats:"
       />

--- a/src/PersonObjects/Sleeve/ui/StatsElement.tsx
+++ b/src/PersonObjects/Sleeve/ui/StatsElement.tsx
@@ -76,6 +76,13 @@ export function StatsElement(props: IProps): React.ReactElement {
           color={Settings.theme.cha}
           data={{ level: props.sleeve.skills.charisma, exp: props.sleeve.exp.charisma }}
         />
+        {(Player.sourceFileLvl(5) > 0 || Player.bitNodeN === 5) && (
+          <StatsRow
+            name="Intelligence"
+            color={Settings.theme.int}
+            data={{ level: props.sleeve.skills.intelligence, exp: props.sleeve.exp.intelligence }}
+          />
+        )}
         <TableRow>
           <TableCell classes={{ root: classes.cellNone }}>
             <br />


### PR DESCRIPTION
currently the sleeve int stat is only available on the Sleeve object from the getSleeve function
this change adds it to the sleeve overview and the more stats overview when in bn5 or if SF5 Level >0
![grafik](https://github.com/bitburner-official/bitburner-src/assets/115591472/11a2815b-b3af-487a-b007-c3417479e2a3)
![grafik](https://github.com/bitburner-official/bitburner-src/assets/115591472/debb0085-b0d7-4db6-a687-d4bf5d362210)

there are probably cleaner solutions if so let me know!