### PR TITLE
AUGMENTATIONS: Add missing descriptions

### DIFF
--- a/src/Augmentation/Augmentation.ts
+++ b/src/Augmentation/Augmentation.ts
@@ -144,8 +144,15 @@ function generateStatsDescription(mults: Multipliers, programs?: string[], start
     desc += `\n-${f(-(mults.hacknet_node_purchase_cost - 1))} hacknet nodes cost`;
   }
   if (mults.hacknet_node_level_cost !== 1) {
-    desc += `\n-${f(-(mults.hacknet_node_level_cost - 1))} hacknet nodes upgrade cost`;
+    desc += `\n-${f(-(mults.hacknet_node_level_cost - 1))} hacknet level upgrade cost`;
   }
+  if (mults.hacknet_node_ram_cost !== 1) {
+    desc += `\n-${f(-(mults.hacknet_node_ram_cost - 1))} hacknet RAM cost`;
+  }
+  if (mults.hacknet_node_core_cost !== 1) {
+    desc += `\n-${f(-(mults.hacknet_node_core_cost - 1))} hacknet core cost`;
+  }
+
   // Bladeburner
   if (mults.bladeburner_max_stamina !== 1) desc += `\n+${f(mults.bladeburner_max_stamina - 1)} Bladeburner Max Stamina`;
   if (mults.bladeburner_stamina_gain !== 1) {


### PR DESCRIPTION
This PR adds descriptions for `hacknet_node_ram_cost` and `hacknet_node_core_cost` that were not being displayed in the UI.