### PR TITLE
PORTS: Add ns.nextPortWrite() as a safer option

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -544,6 +544,7 @@ export const RamCosts: RamCostTree<NSFull> = {
   peek: 0,
   clear: 0,
   writePort: 0,
+  nextPortWrite: 0,
   readPort: 0,
   getPortHandle: 0,
   rm: RamCostConstants.ReadWrite,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -97,7 +97,15 @@ import { getBitNodeMultipliers } from "./BitNode/BitNode";
 import { assert, arrayAssert, stringAssert, objectAssert } from "./utils/helpers/typeAssertion";
 import { cloneDeep, escapeRegExp } from "lodash";
 import numeral from "numeral";
-import { clearPort, peekPort, portHandle, readPort, tryWritePort, writePort } from "./NetscriptPort";
+import {
+  clearPort,
+  peekPort,
+  portHandle,
+  readPort,
+  tryWritePort,
+  writePort,
+  nextPortWrite,
+} from "./NetscriptPort";
 import { FilePath, resolveFilePath } from "./Paths/FilePath";
 import { hasScriptExtension } from "./Paths/ScriptFilePath";
 import { hasTextExtension } from "./Paths/TextFilePath";
@@ -1372,6 +1380,10 @@ export const ns: InternalAPI<NSFull> = {
       );
     }
     return tryWritePort(portNumber, data);
+  },
+  nextPortWrite: (ctx) => (_portNumber) => {
+    const portNumber = helpers.portNumber(ctx, _portNumber);
+    return nextPortWrite(portNumber);
   },
   readPort: (ctx) => (_portNumber) => {
     const portNumber = helpers.portNumber(ctx, _portNumber);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -97,15 +97,7 @@ import { getBitNodeMultipliers } from "./BitNode/BitNode";
 import { assert, arrayAssert, stringAssert, objectAssert } from "./utils/helpers/typeAssertion";
 import { cloneDeep, escapeRegExp } from "lodash";
 import numeral from "numeral";
-import {
-  clearPort,
-  peekPort,
-  portHandle,
-  readPort,
-  tryWritePort,
-  writePort,
-  nextPortWrite,
-} from "./NetscriptPort";
+import { clearPort, peekPort, portHandle, readPort, tryWritePort, writePort, nextPortWrite } from "./NetscriptPort";
 import { FilePath, resolveFilePath } from "./Paths/FilePath";
 import { hasScriptExtension } from "./Paths/ScriptFilePath";
 import { hasTextExtension } from "./Paths/TextFilePath";

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -36,7 +36,7 @@ export function portHandle(n: PortNumber): NetscriptPort {
     tryWrite: (value: unknown) => tryWritePort(n, value),
     read: () => readPort(n),
     peek: () => peekPort(n),
-    nextWrite: () => nextWritePort(n),
+    nextWrite: () => nextPortWrite(n),
     full: () => isFullPort(n),
     empty: () => isEmptyPort(n),
     clear: () => clearPort(n),
@@ -83,10 +83,9 @@ export function peekPort(n: PortNumber): PortData {
   return port.data[0];
 }
 
-function nextWritePort(n: PortNumber) {
+export function nextPortWrite(n: PortNumber) {
   const port = getPort(n);
-  if (port.promise) return port.promise;
-  port.promise = new Promise<void>((res) => (port.resolver = res));
+  if (!port.promise) port.promise = new Promise<void>((res) => (port.resolver = res));
   return port.promise;
 }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6645,6 +6645,17 @@ export interface NS {
   tryWritePort(portNumber: number, data: string | number): boolean;
 
   /**
+   * Listen for a port write.
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * Sleeps until the port is written to.
+   *
+   * @param port - Port to listen for a write on. Must be a positive integer.
+   */
+  nextPortWrite(port: number): Promise<void>;
+
+  /**
    * Read content of a file.
    * @remarks
    * RAM cost: 0 GB


### PR DESCRIPTION
As discussed on discord, this fills a hole in the API and also provides a safer to use option that checks for concurrent function calls and script death.

This needs to be tested by someone but that should be very easy to do.