### PR TITLE
UI: Fix location color on light background.

### DIFF
--- a/src/Locations/ui/City.tsx
+++ b/src/Locations/ui/City.tsx
@@ -29,7 +29,8 @@ interface IProps {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     location: {
-      color: rgbToHsl(hexStringToRgb(Settings.theme.backgroundprimary))[2] < 50 ? theme.colors.white : theme.colors.black,
+      color:
+        rgbToHsl(hexStringToRgb(Settings.theme.backgroundprimary))[2] < 50 ? theme.colors.white : theme.colors.black,
       whiteSpace: "nowrap",
       margin: "0px",
       padding: "0px",

--- a/src/Locations/ui/City.tsx
+++ b/src/Locations/ui/City.tsx
@@ -20,6 +20,7 @@ import Button from "@mui/material/Button";
 import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
+import { hexStringToRgb, rgbToHsl } from "../../utils/helpers/colorTools";
 
 interface IProps {
   city: City;
@@ -28,7 +29,7 @@ interface IProps {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     location: {
-      color: theme.colors.white,
+      color: rgbToHsl(hexStringToRgb(Settings.theme.backgroundprimary))[2] < 50 ? theme.colors.white : theme.colors.black,
       whiteSpace: "nowrap",
       margin: "0px",
       padding: "0px",

--- a/src/ui/React/WorldMap.tsx
+++ b/src/ui/React/WorldMap.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { Settings } from "../../Settings/Settings";
 import { createStyles, makeStyles } from "@mui/styles";
 import { Tooltip, Typography } from "@mui/material";
 import { Theme } from "@mui/material/styles";
+import { hexStringToRgb, rgbToHsl } from "../../utils/helpers/colorTools";
 
 import { CityName } from "@enums";
 
@@ -14,7 +16,8 @@ interface ICityProps {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     travel: {
-      color: theme.colors.white,
+      color:
+        rgbToHsl(hexStringToRgb(Settings.theme.backgroundprimary))[2] < 50 ? theme.colors.white : theme.colors.black,
       lineHeight: "1em",
       whiteSpace: "pre",
       cursor: "pointer",

--- a/src/utils/helpers/colorTools.ts
+++ b/src/utils/helpers/colorTools.ts
@@ -3,69 +3,69 @@ export type HslTuple = [number, number, number];
 
 /**
  * Converts a hex color code into a tuple of numbers.
- * 
+ *
  * @example
  *   hexStringToRgb('#FFFFFF'); // returns [255, 255, 255]
  *   hexStringToRgb('#000000'); // returns [0, 0, 0]
  *   hexStringToRgb('#102030'); // returns [16, 32, 48]
- * 
+ *
  * @param hex - The input hexadecimal color code string.
  * @returns A triplet of decimal numbers in the [0-255] range.
  */
 export function hexStringToRgb(hex: string): RgbTuple {
-    const whole_color = parseInt(hex.replace('#', ''), 16);
-    const red = (whole_color >> 16) & 255;
-    const green = (whole_color >> 8) & 255;
-    const blue = whole_color & 255;
+  const whole_color = parseInt(hex.replace("#", ""), 16);
+  const red = (whole_color >> 16) & 255;
+  const green = (whole_color >> 8) & 255;
+  const blue = whole_color & 255;
 
-    const rgb_tuple: RgbTuple = [red, green, blue];
-    return rgb_tuple;
+  const rgb_tuple: RgbTuple = [red, green, blue];
+  return rgb_tuple;
 }
 
 /**
  * Converts an rgb triplet into an hsl triplet.
- * 
+ *
  * @example
  *   rgbToHsl([255, 255, 255]); // returns [0, 0, 100]
  *   rgbToHsl([0, 0, 0]);       // returns [0, 0, 0]
  *   rgbToHsl([16, 32, 48]);    // returns [210, 50, 13]
- * 
+ *
  * @param rgb - The input color as an rgb tuple.
  * @returns A tuple of decimal numbers in the [0-360],
  *          [0-100], and [0-100] ranges.
  */
 export function rgbToHsl(rgb: RgbTuple) {
-    const red = rgb[0] / 255
-    const green = rgb[1] / 255
-    const blue = rgb[2] / 255
+  const red = rgb[0] / 255;
+  const green = rgb[1] / 255;
+  const blue = rgb[2] / 255;
 
-    const color_max = Math.max(red, green, blue)
-    const color_min = Math.min(red, green, blue)
+  const color_max = Math.max(red, green, blue);
+  const color_min = Math.min(red, green, blue);
 
-    const delta = color_max - color_min
+  const delta = color_max - color_min;
 
-    let hue: number = 0;
-    let saturation: number = 0;
-    const lightness = (color_max + color_min) / 2
-    if (!delta) {
-        hue = 0
-        saturation = 0
-    } else {
-        switch (color_max) {
-            case red:
-                hue = (((green - blue) / delta) % 6) / 6;
-                break;
-            case green:
-                hue = (((blue - red) / delta) + 2) / 6;
-                break;
-            case blue:
-                hue = (((red - green) / delta) + 4) / 6;
-                break;
-        }
-
-        saturation = delta / (1 - Math.abs(2 * lightness - 1));
+  let hue: number = 0;
+  let saturation: number = 0;
+  const lightness = (color_max + color_min) / 2;
+  if (!delta) {
+    hue = 0;
+    saturation = 0;
+  } else {
+    switch (color_max) {
+      case red:
+        hue = (((green - blue) / delta) % 6) / 6;
+        break;
+      case green:
+        hue = ((blue - red) / delta + 2) / 6;
+        break;
+      case blue:
+        hue = ((red - green) / delta + 4) / 6;
+        break;
     }
 
-    const hsl_tuple: HslTuple = [Math.round(hue * 360), Math.round(saturation * 100), Math.round(lightness * 100)];
-    return hsl_tuple;
+    saturation = delta / (1 - Math.abs(2 * lightness - 1));
+  }
+
+  const hsl_tuple: HslTuple = [Math.round(hue * 360), Math.round(saturation * 100), Math.round(lightness * 100)];
+  return hsl_tuple;
 }

--- a/src/utils/helpers/colorTools.ts
+++ b/src/utils/helpers/colorTools.ts
@@ -1,0 +1,71 @@
+export type RgbTuple = [number, number, number];
+export type HslTuple = [number, number, number];
+
+/**
+ * Converts a hex color code into a tuple of numbers.
+ * 
+ * @example
+ *   hexStringToRgb('#FFFFFF'); // returns [255, 255, 255]
+ *   hexStringToRgb('#000000'); // returns [0, 0, 0]
+ *   hexStringToRgb('#102030'); // returns [16, 32, 48]
+ * 
+ * @param hex - The input hexadecimal color code string.
+ * @returns A triplet of decimal numbers in the [0-255] range.
+ */
+export function hexStringToRgb(hex: string): RgbTuple {
+    const whole_color = parseInt(hex.replace('#', ''), 16);
+    const red = (whole_color >> 16) & 255;
+    const green = (whole_color >> 8) & 255;
+    const blue = whole_color & 255;
+
+    const rgb_tuple: RgbTuple = [red, green, blue];
+    return rgb_tuple;
+}
+
+/**
+ * Converts an rgb triplet into an hsl triplet.
+ * 
+ * @example
+ *   rgbToHsl([255, 255, 255]); // returns [0, 0, 100]
+ *   rgbToHsl([0, 0, 0]);       // returns [0, 0, 0]
+ *   rgbToHsl([16, 32, 48]);    // returns [210, 50, 13]
+ * 
+ * @param rgb - The input color as an rgb tuple.
+ * @returns A tuple of decimal numbers in the [0-360],
+ *          [0-100], and [0-100] ranges.
+ */
+export function rgbToHsl(rgb: RgbTuple) {
+    const red = rgb[0] / 255
+    const green = rgb[1] / 255
+    const blue = rgb[2] / 255
+
+    const color_max = Math.max(red, green, blue)
+    const color_min = Math.min(red, green, blue)
+
+    const delta = color_max - color_min
+
+    let hue: number = 0;
+    let saturation: number = 0;
+    const lightness = (color_max + color_min) / 2
+    if (!delta) {
+        hue = 0
+        saturation = 0
+    } else {
+        switch (color_max) {
+            case red:
+                hue = (((green - blue) / delta) % 6) / 6;
+                break;
+            case green:
+                hue = (((blue - red) / delta) + 2) / 6;
+                break;
+            case blue:
+                hue = (((red - green) / delta) + 4) / 6;
+                break;
+        }
+
+        saturation = delta / (1 - Math.abs(2 * lightness - 1));
+    }
+
+    const hsl_tuple: HslTuple = [Math.round(hue * 360), Math.round(saturation * 100), Math.round(lightness * 100)];
+    return hsl_tuple;
+}


### PR DESCRIPTION
# UI: Fix location color on light background.

# NOTE: See PR #1079 for a better solution to issue #1039.

The locations on the city map and the cities on the world map always use the "white" color configured in the theme.  This PR uses the theme-configured "white" color when the theme's background color is dark and the "black" color when the background color is light.

Specifically, it converts the `theme.backgroundprimary` color to HSL and sets the locations to render in `theme.colors.white` when `L<50` and `theme.colors.black` when `L>=50`.

## Before:
### Dark background:
![image](https://github.com/bitburner-official/bitburner-src/assets/56762639/40bbb3f8-c821-42f7-90dc-d771966dfcfd)
### Light background:
![image](https://github.com/bitburner-official/bitburner-src/assets/56762639/ef430103-e0dd-4020-9206-89aba47cec67)

## After:
### Dark background:
![image](https://github.com/bitburner-official/bitburner-src/assets/56762639/04c693b0-4c85-4eff-ac8d-cc5c40005aab)
### Light background:
![image](https://github.com/bitburner-official/bitburner-src/assets/56762639/2a766712-a808-43f0-bcd2-19dfde2d8e9d)

# Linked issues
fixes #1039
see also the followup PR #1041
