### PR TITLE
UI: Correct black color value in light theme.

### DIFF
--- a/src/Themes/data/light/index.ts
+++ b/src/Themes/data/light/index.ts
@@ -29,7 +29,7 @@ export const Theme: IPredefinedTheme = {
     welllight: "#f9f9f9",
     well: "#eaeaea",
     white: "#F7F7F7",
-    black: "#F7F7F7",
+    black: "#000000",
     hp: "#BF5C41",
     money: "#E1B121",
     hack: "#47BC38",


### PR DESCRIPTION
# UI: Correct black color value in light theme.

# Documentation

The color "black" in the light theme is set the same as "white": #F7F7F7.  Instead, black should be: #000000 (or at the very least not == white).  This PR fixes that minor issue.

This is a followup to pull request #1040 and issue #1039 by making the Light theme that is selectable in the Theme browser show cities on the city map.

I poked around a bit and didn't spot any places where the color change made anything look weird or wrong.

I didn't create an Issue on Github for this because it seemed too minor; please let me know if it's preferred to have an Issue for every PR.
