### PR TITLE
MISC: Don't include temporary scripts into Recently Killed

### DIFF
--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -68,7 +68,6 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
  *                                  its index in the global workerScripts array
  */
 function removeWorkerScript(workerScript: WorkerScript): void {
-	debugger
   const ip = workerScript.hostname;
 
   // Get the server on which the script runs
@@ -94,6 +93,7 @@ function removeWorkerScript(workerScript: WorkerScript): void {
   server.updateRamUsed(roundToTwo(server.ramUsed - rs.ramUsage * rs.threads));
 
   workerScripts.delete(workerScript.pid);
-  if (rs.temporary===false)
-  {AddRecentScript(workerScript);}
+  if (rs.temporary === false) {
+    AddRecentScript(workerScript);
+  }
 }

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -68,6 +68,7 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
  *                                  its index in the global workerScripts array
  */
 function removeWorkerScript(workerScript: WorkerScript): void {
+	debugger
   const ip = workerScript.hostname;
 
   // Get the server on which the script runs
@@ -93,5 +94,6 @@ function removeWorkerScript(workerScript: WorkerScript): void {
   server.updateRamUsed(roundToTwo(server.ramUsed - rs.ramUsage * rs.threads));
 
   workerScripts.delete(workerScript.pid);
-  AddRecentScript(workerScript);
+  if (rs.temporary===false)
+  {AddRecentScript(workerScript);}
 }


### PR DESCRIPTION
Stopped temporary scripts from being added to the recently killed list.  Most players would apply this flag to batching scripts, or scripts that they run very very often.  Having them added to the recently killed removes it usability as a script that launches 1000x a minute isn't one a player wants to look back on.  Not to mention these scripts flood the list making the scripts they may want to see get removed quickly.