### PR TITLE
CORPORATION: Change the calculation of valuation

### DIFF
--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -196,6 +196,11 @@ export class Corporation {
       assetDelta = (this.totalAssets - this.previousTotalAssets) / corpConstants.secondsPerMarketCycle;
     // Handle pre-totalAssets saves
     assetDelta ??= this.revenue - this.expenses;
+    const numberOfOfficesAndWarehouses = [...this.divisions.values()]
+      .map(
+        (division: Division) => getRecordValues(division.offices).length + getRecordValues(division.warehouses).length,
+      )
+      .reduce((sum: number, currentValue: number) => sum + currentValue, 0);
     if (this.public) {
       // Account for dividends
       if (this.dividendRate > 0) {
@@ -203,14 +208,14 @@ export class Corporation {
       }
 
       val = this.funds + assetDelta * 85e3;
-      val *= Math.pow(1.1, this.divisions.size);
+      val *= Math.pow(Math.pow(1.1, 1 / 12), numberOfOfficesAndWarehouses);
       val = Math.max(val, 0);
     } else {
       val = 10e9 + this.funds / 3;
       if (assetDelta > 0) {
         val += assetDelta * 315e3;
       }
-      val *= Math.pow(1.1, this.divisions.size);
+      val *= Math.pow(Math.pow(1.1, 1 / 12), numberOfOfficesAndWarehouses);
       val -= val % 1e6; //Round down to nearest million
     }
     if (val < 10e9) val = 10e9; // Base valuation


### PR DESCRIPTION
This PR implements jeek's suggestion for corporation's valuation.
Currently, the valuation is multiplied by $1.1^{𝑁𝑢𝑚𝑏𝑒𝑟𝑂𝑓𝐷𝑖𝑣𝑖𝑠𝑖𝑜𝑛𝑠}$. This can be exploited by creating "dummy division". Dummy division is the division that is created only to increase the valuation of corporation.
This PR mitigates it by changing the multiplier to $(\sqrt[1/12]{1.1})^{NumberOfOfficesAndWarehouses}$. This means a normal division (6 offices + 6 warehouses) still gives benefit like before, but a bare-bones dummy division (1 office + 1 warehouse) is nearly useless. For example:
- Before:
  - 1 dummy division: $1.1^{1}=1.1$
  - 17 dummy divisions: $1.1^{17}=5.05447028499293771$
- After:
  - 1 dummy division: $(\sqrt[1/12]{1.1})^{2}=1.0160118677733873592715906818875$
  - 17 dummy divisions: $(\sqrt[1/12]{1.1})^{34}=1.3100240678456996266428325254671$