### PR TITLE
API: make ns.atExit add the callback to an array instead of setting it

### DIFF
--- a/markdown/bitburner.ns.atexit.md
+++ b/markdown/bitburner.ns.atexit.md
@@ -9,7 +9,7 @@ Add callback function when the script dies
 **Signature:**
 
 ```typescript
-atExit(f: () => void): void;
+atExit(f: () => void, id?: string): void;
 ```
 
 ## Parameters
@@ -17,6 +17,7 @@ atExit(f: () => void): void;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  f | () =&gt; void |  |
+|  id | string | _(Optional)_ |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -56,7 +56,7 @@ export async function main(ns) {
 |  --- | --- |
 |  [alert(msg)](./bitburner.ns.alert.md) | Open up a message box. |
 |  [asleep(millis)](./bitburner.ns.asleep.md) | Suspends the script for n milliseconds. Doesn't block with concurrent calls. |
-|  [atExit(f)](./bitburner.ns.atexit.md) | Add callback function when the script dies |
+|  [atExit(f, id)](./bitburner.ns.atexit.md) | Add callback function when the script dies |
 |  [brutessh(host)](./bitburner.ns.brutessh.md) | Runs BruteSSH.exe on a server. |
 |  [clear(handle)](./bitburner.ns.clear.md) | Clear data from a file. |
 |  [clearLog()](./bitburner.ns.clearlog.md) | Clears the script’s logs. |

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -79,7 +79,7 @@ export class WorkerScript {
   hostname: string;
 
   /**Map of functions called when the script ends. */
-  atExit: Map<string, (() => void) | undefined> = new Map();
+  atExit: Map<string, () => void> = new Map();
 
   constructor(runningScriptObj: RunningScript, pid: number, nsFuncsGenerator?: (ws: WorkerScript) => NSFull) {
     this.name = runningScriptObj.filename;

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -79,7 +79,7 @@ export class WorkerScript {
   hostname: string;
 
   /**Map of functions called when the script ends. */
-  atExit: Record<string, () => void> = {};
+  atExit: Map<string, (() => void) | undefined> = new Map();
 
   constructor(runningScriptObj: RunningScript, pid: number, nsFuncsGenerator?: (ws: WorkerScript) => NSFull) {
     this.name = runningScriptObj.filename;

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -78,8 +78,8 @@ export class WorkerScript {
   /** hostname on which this script is running */
   hostname: string;
 
-  /** Function called when the script ends. */
-  atExit: (() => void) | undefined = undefined;
+  /**Array of functions called when the script ends. */
+  atExit: (() => void)[] = [];
 
   constructor(runningScriptObj: RunningScript, pid: number, nsFuncsGenerator?: (ws: WorkerScript) => NSFull) {
     this.name = runningScriptObj.filename;

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -78,8 +78,8 @@ export class WorkerScript {
   /** hostname on which this script is running */
   hostname: string;
 
-  /**Array of functions called when the script ends. */
-  atExit: (() => void)[] = [];
+  /**Map of functions called when the script ends. */
+  atExit: Record<string, () => void> = {};
 
   constructor(runningScriptObj: RunningScript, pid: number, nsFuncsGenerator?: (ws: WorkerScript) => NSFull) {
     this.name = runningScriptObj.filename;

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -43,9 +43,9 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   ws.delayReject?.(new ScriptDeath(ws));
   ws.env.runningFn = "";
 
-  ws.atExit.forEach((atExit) => {
+  for (const key in ws.atExit) {
     try {
-      atExit();
+      ws.atExit[key]();
     } catch (e: unknown) {
       handleUnknownError(e, ws, "Error running atExit function.\n\n");
     }
@@ -53,7 +53,7 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
       // If atExit() kills the script, we'll already be stopped, don't stop again.
       return;
     }
-  });
+  }
 
   //ws.atExit was previously set to undefined after being called
   //so empty to queue to stay consistent

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -43,11 +43,13 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   ws.delayReject?.(new ScriptDeath(ws));
   ws.env.runningFn = "";
 
-  for (const key in ws.atExit) {
+  for (const key of ws.atExit.keys()) {
     try {
-      const atExit = ws.atExit[key];
-      delete ws.atExit[key];
-      atExit();
+      const atExit = ws.atExit.get(key);
+      //Calling ns.exit inside ns.atExit can lead to recursion
+      //so the handler must be removed immediatly
+      ws.atExit.set(key, undefined);
+      if (typeof atExit == "function") atExit();
     } catch (e: unknown) {
       handleUnknownError(e, ws, "Error running atExit function.\n\n");
     }

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -42,23 +42,25 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   if (ws.delay) clearTimeout(ws.delay);
   ws.delayReject?.(new ScriptDeath(ws));
   ws.env.runningFn = "";
+  const atExit = ws.atExit;
+  //Calling ns.exit inside ns.atExit can lead to recursion
+  //so the map must be cleared before looping
+  ws.atExit = new Map();
 
-  for (const key of ws.atExit.keys()) {
+  for (const key of atExit.keys()) {
     try {
-      const atExit = ws.atExit.get(key);
-      //Calling ns.exit inside ns.atExit can lead to recursion
-      //so the handler must be removed immediatly
-      ws.atExit.set(key, undefined);
-      if (typeof atExit == "function") atExit();
+      const callback = atExit.get(key);
+      if (typeof callback == "function") callback();
     } catch (e: unknown) {
       handleUnknownError(e, ws, "Error running atExit function.\n\n");
     }
-    if (ws.env.stopFlag) {
-      // If atExit() kills the script, we'll already be stopped, don't stop again.
-      return;
-    }
   }
-
+  
+  if (ws.env.stopFlag) {
+    // If atExit() kills the script, we'll already be stopped, don't stop again.
+    return;
+  }
+  
   ws.env.stopFlag = true;
   removeWorkerScript(ws);
 }

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -56,8 +56,8 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   }
 
   //ws.atExit was previously set to undefined after being called
-  //so empty to queue to stay consistent
-  ws.atExit = [];
+  //so empty the map to stay consistent
+  ws.atExit = {};
 
   ws.env.stopFlag = true;
   removeWorkerScript(ws);

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -55,12 +55,12 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
       handleUnknownError(e, ws, "Error running atExit function.\n\n");
     }
   }
-  
+
   if (ws.env.stopFlag) {
     // If atExit() kills the script, we'll already be stopped, don't stop again.
     return;
   }
-  
+
   ws.env.stopFlag = true;
   removeWorkerScript(ws);
 }

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -43,10 +43,8 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   ws.delayReject?.(new ScriptDeath(ws));
   ws.env.runningFn = "";
 
-  if (typeof ws.atExit === "function") {
+  ws.atExit.forEach((atExit) => {
     try {
-      const atExit = ws.atExit;
-      ws.atExit = undefined;
       atExit();
     } catch (e: unknown) {
       handleUnknownError(e, ws, "Error running atExit function.\n\n");
@@ -55,7 +53,12 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
       // If atExit() kills the script, we'll already be stopped, don't stop again.
       return;
     }
-  }
+  });
+
+  //ws.atExit was previously set to undefined after being called
+  //so empty to queue to stay consistent
+  ws.atExit = [];
+
   ws.env.stopFlag = true;
   removeWorkerScript(ws);
 }

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -45,7 +45,9 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
 
   for (const key in ws.atExit) {
     try {
-      ws.atExit[key]();
+      const atExit = ws.atExit[key];
+      delete ws.atExit[key];
+      atExit();
     } catch (e: unknown) {
       handleUnknownError(e, ws, "Error running atExit function.\n\n");
     }
@@ -54,10 +56,6 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
       return;
     }
   }
-
-  //ws.atExit was previously set to undefined after being called
-  //so empty the map to stay consistent
-  ws.atExit = {};
 
   ws.env.stopFlag = true;
   removeWorkerScript(ws);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1708,14 +1708,21 @@ export const ns: InternalAPI<NSFull> = {
     sinceInstall: Object.assign({}, Player.moneySourceA),
     sinceStart: Object.assign({}, Player.moneySourceB),
   }),
-  atExit: (ctx) => (f) => {
-    if (typeof f !== "function") {
-      throw helpers.errorMessage(ctx, "argument should be function");
-    }
-    ctx.workerScript.atExit.push(() => {
-      f();
-    }); // Wrap the user function to prevent WorkerScript leaking as 'this'
-  },
+  atExit:
+    (ctx) =>
+    (f, id = "default") => {
+      if (typeof f !== "function") {
+        throw helpers.errorMessage(ctx, "argument should be function");
+      }
+
+      if (typeof id !== "string") {
+        throw helpers.errorMessage(ctx, "id should be a string");
+      }
+
+      ctx.workerScript.atExit[id] = () => {
+        f();
+      }; // Wrap the user function to prevent WorkerScript leaking as 'this'
+    },
   mv: (ctx) => (_host, _source, _destination) => {
     const hostname = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, hostname);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1712,9 +1712,9 @@ export const ns: InternalAPI<NSFull> = {
     if (typeof f !== "function") {
       throw helpers.errorMessage(ctx, "argument should be function");
     }
-    ctx.workerScript.atExit = () => {
+    ctx.workerScript.atExit.push(() => {
       f();
-    }; // Wrap the user function to prevent WorkerScript leaking as 'this'
+    }); // Wrap the user function to prevent WorkerScript leaking as 'this'
   },
   mv: (ctx) => (_host, _source, _destination) => {
     const hostname = helpers.string(ctx, "host", _host);

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1719,9 +1719,9 @@ export const ns: InternalAPI<NSFull> = {
         throw helpers.errorMessage(ctx, "id should be a string");
       }
 
-      ctx.workerScript.atExit[id] = () => {
+      ctx.workerScript.atExit.set(id, () => {
         f();
-      }; // Wrap the user function to prevent WorkerScript leaking as 'this'
+      }); // Wrap the user function to prevent WorkerScript leaking as 'this'
     },
   mv: (ctx) => (_host, _source, _destination) => {
     const hostname = helpers.string(ctx, "host", _host);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7246,7 +7246,7 @@ export interface NS {
    *
    * Add callback to be executed when the script dies.
    */
-  atExit(f: () => void): void;
+  atExit(f: () => void, id?: string): void;
 
   /**
    * Move a file on the target server.

--- a/test/jest/Netscript/RunScript.test.ts
+++ b/test/jest/Netscript/RunScript.test.ts
@@ -105,7 +105,7 @@ test.each([
     // await script death.
     const ws = workerScripts.get(pid);
     expect(ws).toBeDefined();
-    const result = await Promise.race([alerted, new Promise((resolve) => (ws.atExit = resolve))]);
+    const result = await Promise.race([alerted, new Promise<void>((resolve) => (ws!.atExit = [resolve]))]);
     // If an error alert was thrown, we catch it here.
     expect(result).not.toBeDefined();
     expect(runningScript.logs).toEqual(expectedLog);

--- a/test/jest/Netscript/RunScript.test.ts
+++ b/test/jest/Netscript/RunScript.test.ts
@@ -105,7 +105,10 @@ test.each([
     // await script death.
     const ws = workerScripts.get(pid);
     expect(ws).toBeDefined();
-    const result = await Promise.race([alerted, new Promise<void>((resolve) => (ws!.atExit = { default: resolve }))]);
+    const result = await Promise.race([
+      alerted,
+      new Promise<void>((resolve) => (ws!.atExit = new Map([["default", resolve]]))),
+    ]);
     // If an error alert was thrown, we catch it here.
     expect(result).not.toBeDefined();
     expect(runningScript.logs).toEqual(expectedLog);

--- a/test/jest/Netscript/RunScript.test.ts
+++ b/test/jest/Netscript/RunScript.test.ts
@@ -105,7 +105,7 @@ test.each([
     // await script death.
     const ws = workerScripts.get(pid);
     expect(ws).toBeDefined();
-    const result = await Promise.race([alerted, new Promise<void>((resolve) => (ws!.atExit = [resolve]))]);
+    const result = await Promise.race([alerted, new Promise<void>((resolve) => (ws!.atExit = { default: resolve }))]);
     // If an error alert was thrown, we catch it here.
     expect(result).not.toBeDefined();
     expect(runningScript.logs).toEqual(expectedLog);


### PR DESCRIPTION
The documentation for ns.atExit says 'Add callback function when the script dies'. This has lead to confusion and unexpected behaviour for me and others as it was expected to be able to add multiple listeners.
This change adds every callback passed to atExit to an array and calls them each before the script dies to be more in line of how the documentation is worded.