### PR TITLE
API: Changing return value of ns.bladeburner.getSkillUpgradeCost to return Infinity when the skill's level overshoot the maximum level

### DIFF
--- a/markdown/bitburner.bladeburner.getskillupgradecost.md
+++ b/markdown/bitburner.bladeburner.getskillupgradecost.md
@@ -31,5 +31,5 @@ RAM cost: 4 GB
 
 This function returns the number of skill points needed to upgrade the specified skill the specified number of times.
 
-The function returns -1 if an invalid skill name is passed in.
+The function returns -1 if an invalid skill name is passed in, and Infinity if the count overflows the maximum level.
 

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -2299,7 +2299,7 @@ export class Bladeburner {
     }
 
     const skill = Skills[skillName];
-    const currentLevel = this.skills[skillName]
+    const currentLevel = this.skills[skillName];
     if (currentLevel == null) {
       return skill.calculateCost(0, count);
     } else if (currentLevel + count > skill.maxLvl) {

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -2299,10 +2299,13 @@ export class Bladeburner {
     }
 
     const skill = Skills[skillName];
-    if (this.skills[skillName] == null) {
+    const currentLevel = this.skills[skillName]
+    if (currentLevel == null) {
       return skill.calculateCost(0, count);
+    } else if (currentLevel + count > skill.maxLvl) {
+      return Infinity;
     } else {
-      return skill.calculateCost(this.skills[skillName], count);
+      return skill.calculateCost(currentLevel, count);
     }
   }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3257,7 +3257,7 @@ export interface Bladeburner {
    *
    * This function returns the number of skill points needed to upgrade the specified skill the specified number of times.
    *
-   * The function returns -1 if an invalid skill name is passed in.
+   * The function returns -1 if an invalid skill name is passed in, and Infinity if the count overflows the maximum level.
    *
    * @param skillName - Name of skill. Case-sensitive and must be an exact match.
    * @param count - Number of times to upgrade the skill. Defaults to 1 if not specified.


### PR DESCRIPTION
We have no way to know whether a skill overshooted or not the maximum skill level other than hardcoding that Overclock is at most 90. Following `getPurchasedServerCost`'s logic, I made it return Infinity when it does.

Testing code, with overclock at level 70:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.print(ns.bladeburner.getSkillUpgradeCost("Overclock"))
  ns.print(ns.bladeburner.getSkillUpgradeCost("Overclock", 10))
  ns.print(ns.bladeburner.getSkillUpgradeCost("Overclock", 20))
  ns.print(ns.bladeburner.getSkillUpgradeCost("Overclock", 21))
  ns.print(ns.bladeburner.getSkillUpgradeCost("Overclock", 90))
}
```
![imagem](https://github.com/bitburner-official/bitburner-src/assets/99666293/0e0c94eb-994a-4e81-83f3-d524ad35cfa3)