### PR TITLE
BUGFIX: Format money requirement in fl1ght.exe

### DIFF
--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -296,9 +296,9 @@ export const Programs: Record<CompletedProgramName, Program> = {
           Terminal.print(`[ ] Augmentations: ${Player.augmentations.length} / ${numAugReq}`);
         }
         if (Player.money > 1e11) {
-          Terminal.print(`[x] Money: ${formatMoney(Player.money)} / $100b`);
+          Terminal.print(`[x] Money: ${formatMoney(Player.money)} / ${formatMoney(1e11)}`);
         } else {
-          Terminal.print(`[ ] Money: ${formatMoney(Player.money)} / $100b`);
+          Terminal.print(`[ ] Money: ${formatMoney(Player.money)} / ${formatMoney(1e11)}`);
         }
         if (Player.skills.hacking >= 2500) {
           Terminal.print(`[x] Hacking skill: ${Player.skills.hacking} / 2500`);

--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -288,7 +288,7 @@ export const Programs: Record<CompletedProgramName, Program> = {
     run: (): void => {
       const numAugReq = currentNodeMults.DaedalusAugsRequirement;
       const fulfilled =
-        Player.augmentations.length >= numAugReq && Player.money > 1e11 && Player.skills.hacking >= 2500;
+        Player.augmentations.length >= numAugReq && Player.money >= 1e11 && Player.skills.hacking >= 2500;
       if (!fulfilled) {
         if (Player.augmentations.length >= numAugReq) {
           Terminal.print(`[x] Augmentations: ${Player.augmentations.length} / ${numAugReq}`);

--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -295,7 +295,7 @@ export const Programs: Record<CompletedProgramName, Program> = {
         } else {
           Terminal.print(`[ ] Augmentations: ${Player.augmentations.length} / ${numAugReq}`);
         }
-        if (Player.money > 1e11) {
+        if (Player.money >= 1e11) {
           Terminal.print(`[x] Money: ${formatMoney(Player.money)} / ${formatMoney(1e11)}`);
         } else {
           Terminal.print(`[ ] Money: ${formatMoney(Player.money)} / ${formatMoney(1e11)}`);


### PR DESCRIPTION
Currently the money requirement in fl1ght.exe is hardcoded to the default format, which can cause confusion (example screenshot of the issue below). This change uses the selected format option for the money requirement instead.
![23-173816_JAilYNlZBB](https://github.com/bitburner-official/bitburner-src/assets/23249107/64402129-1951-4f29-a556-794854029c3b)
