### PR TITLE
UI: Changing color of stocks going up to success instead of primary

### DIFF
--- a/src/StockMarket/ui/StockTickerHeaderText.tsx
+++ b/src/StockMarket/ui/StockTickerHeaderText.tsx
@@ -45,11 +45,11 @@ export function StockTickerHeaderText(props: IProps): React.ReactElement {
     // hdrText += ` - ${stock.getAbsoluteForecast()} / ${stock.otlkMagForecast}`;
   }
 
-  let color = "primary";
+  let color = Settings.theme.success;
   if (stock.lastPrice === stock.price) {
-    color = "secondary";
+    color = Settings.theme.secondary;
   } else if (stock.lastPrice > stock.price) {
-    color = "error";
+    color = Settings.theme.error;
   }
 
   return (


### PR DESCRIPTION
The stock market color of the stocks going up was your primary color, instead of success. Even though with the default theme it makes no difference (because primary and success are exactly equal to each other), it leads to some unexpected behaviors like this, when the primary color is changed in the theme editor:
![imagem](https://github.com/bitburner-official/bitburner-src/assets/99666293/c8cfbf8c-9483-4b53-8646-fdbfedb3e58e)

I changed the code so that it uses now the success color. After the change, with primary color set to purple:
![imagem](https://github.com/bitburner-official/bitburner-src/assets/99666293/cec2c527-7a3c-474b-90b6-132ae4fab41c)