### PR TITLE
UI: Make Hacknet node grid column count dynamic

### DIFF
--- a/src/Hacknet/ui/HacknetRoot.tsx
+++ b/src/Hacknet/ui/HacknetRoot.tsx
@@ -117,7 +117,7 @@ export function HacknetRoot(): React.ReactElement {
 
       {hasHacknetServers() && <Button onClick={() => setOpen(true)}>Spend Hashes on Upgrades</Button>}
 
-      <Box sx={{ display: "grid", width: "fit-content", gridTemplateColumns: "repeat(3, 1fr)" }}>{nodes}</Box>
+      <Box sx={{ display: "grid", width: "100%", gridTemplateColumns: "repeat(auto-fit, 380px)" }}>{nodes}</Box>
       <HashUpgradeModal open={open} onClose={() => setOpen(false)} />
     </>
   );


### PR DESCRIPTION
Right now the Hacknet node grid is fixed to 3 columns and overflows when the viewport is too small.

https://github.com/bitburner-official/bitburner-src/assets/48560522/540501f6-5457-44fc-8dd5-0b20702ad9b1

I changed this so the column count is dynamic and adjusts to the available space

https://github.com/bitburner-official/bitburner-src/assets/48560522/dead1fb3-496e-4f57-9f42-e0e07b721cfd

