### PR TITLE
BUGFIX: Fixed bug that returned Infinity cost for most skills

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -2299,14 +2299,13 @@ export class Bladeburner {
     }
 
     const skill = Skills[skillName];
-    const currentLevel = this.skills[skillName];
-    if (currentLevel == null) {
-      return skill.calculateCost(0, count);
-    } else if (currentLevel + count > skill.maxLvl) {
+    const currentLevel = this.skills[skillName] ?? 0;
+
+    if (skill.maxLvl !== 0 && currentLevel + count > skill.maxLvl) {
       return Infinity;
-    } else {
-      return skill.calculateCost(currentLevel, count);
     }
+
+    return skill.calculateCost(currentLevel, count);
   }
 
   upgradeSkillNetscriptFn(skillName: string, count: number, workerScript: WorkerScript): boolean {


### PR DESCRIPTION
In [my last PR](https://github.com/bitburner-official/bitburner-src/pull/1060), I didn't notice skills with no maximum were 0, I assumed it was Infinity. Yes, I know, my bad, I'm really sorry...
This introduced a bug, in which whenever your skill level were above 1 in any skill without maximum level, the cost would always return Infinity.
![imagem](https://github.com/bitburner-official/bitburner-src/assets/99666293/d33d5b60-5e79-4d24-bac1-e210286afa2d)
This PR fixes this bug, keeping the last PR's intended functionality.
```js
/** @param {NS} ns */
export async function main(ns) {
  console.log(ns.bladeburner.getSkillUpgradeCost("Cloak")); // With level 1+, this was Infinity
  console.log(ns.bladeburner.getSkillUpgradeCost("Cloak", 90)); // With level 1+, this was Infinity
  console.log(ns.bladeburner.getSkillUpgradeCost("Overclock")); // Overclock is the only one that was working properly at any level
  console.log(ns.bladeburner.getSkillUpgradeCost("Overclock", 100));
}
```
/\ Testing code here.