### PR TITLE
FOLLOWUP: Streamlining for #1056

### DIFF
--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -199,11 +199,14 @@ export class Corporation {
       assetDelta = (this.totalAssets - this.previousTotalAssets) / corpConstants.secondsPerMarketCycle;
     // Handle pre-totalAssets saves
     assetDelta ??= this.revenue - this.expenses;
-    const numberOfOfficesAndWarehouses = [...this.divisions.values()]
-      .map(
-        (division: Division) => getRecordValues(division.offices).length + getRecordValues(division.warehouses).length,
-      )
-      .reduce((sum: number, currentValue: number) => sum + currentValue, 0);
+
+    // Todo: consider tracking this statically on the corp itself (calculate at load time), instead of calculated every cycle
+    let numberOfOfficesAndWarehouses = 0;
+    for (const division of this.divisions.values()) {
+      numberOfOfficesAndWarehouses += getRecordValues(division.offices).length;
+      numberOfOfficesAndWarehouses += getRecordValues(division.warehouses).length;
+    }
+
     if (this.public) {
       // Account for dividends
       if (this.dividendRate > 0) {
@@ -211,14 +214,14 @@ export class Corporation {
       }
 
       val = this.funds + assetDelta * 85e3;
-      val *= Math.pow(Math.pow(1.1, 1 / 12), numberOfOfficesAndWarehouses);
+      val *= Math.pow(1.008, numberOfOfficesAndWarehouses);
       val = Math.max(val, 0);
     } else {
       val = 10e9 + this.funds / 3;
       if (assetDelta > 0) {
         val += assetDelta * 315e3;
       }
-      val *= Math.pow(Math.pow(1.1, 1 / 12), numberOfOfficesAndWarehouses);
+      val *= Math.pow(1.008, numberOfOfficesAndWarehouses);
       val -= val % 1e6; //Round down to nearest million
     }
     if (val < 10e9) val = 10e9; // Base valuation


### PR DESCRIPTION
I couldn't push to #1056 so I'm just making a followup PR.

* Removed some extra iteration steps
* Hardcoded 1.008 as the base instead of calculating 1.1^(1/12) every time it was needed. 1.008 is very slightly rounding up (results in 5.08 instead of 5.05 mult at max corp loadout)