### PR TITLE
PORTS: Support all serializable data.

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1328,12 +1328,6 @@ export const ns: InternalAPI<NSFull> = {
   },
   writePort: (ctx) => (_portNumber, data) => {
     const portNumber = helpers.portNumber(ctx, _portNumber);
-    if (typeof data !== "string" && typeof data !== "number") {
-      throw helpers.makeRuntimeErrorMsg(
-        ctx,
-        `Trying to write invalid data to a port: only strings and numbers are valid.`,
-      );
-    }
     return writePort(portNumber, data);
   },
   write: (ctx) => (_filename, _data, _mode) => {
@@ -1366,12 +1360,6 @@ export const ns: InternalAPI<NSFull> = {
   },
   tryWritePort: (ctx) => (_portNumber, data) => {
     const portNumber = helpers.portNumber(ctx, _portNumber);
-    if (typeof data !== "string" && typeof data !== "number") {
-      throw helpers.makeRuntimeErrorMsg(
-        ctx,
-        `Trying to write invalid data to a port: only strings and numbers are valid.`,
-      );
-    }
     return tryWritePort(portNumber, data);
   },
   nextPortWrite: (ctx) => (_portNumber) => {

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -8,7 +8,7 @@ const emptyPortData = "NULL PORT DATA";
 /** The object property is for typechecking and is not present at runtime */
 export type PortNumber = PositiveInteger & { __PortNumber: true };
 
-function isObject(value: unknown): value is Object {
+function isObject(value: unknown): value is object {
   return (typeof value === "object" && value !== null) || typeof value === "function";
 }
 
@@ -26,7 +26,7 @@ export class Port {
   data: any[] = [];
   resolver: Resolver | null = null;
   promise: Promise<void> | null = null;
-  add(data: any): any {
+  add(data: any) {
     this.data.push(data);
     if (!this.resolver) return;
     this.resolver();

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -8,7 +8,7 @@ const emptyPortData = "NULL PORT DATA";
 /** The object property is for typechecking and is not present at runtime */
 export type PortNumber = PositiveInteger & { __PortNumber: true };
 
-function isObject(value: unknown): value is object {
+function isObjectLike(value: unknown): value is object {
   return (typeof value === "object" && value !== null) || typeof value === "function";
 }
 
@@ -50,7 +50,7 @@ export function portHandle(n: PortNumber): NetscriptPort {
 export function writePort(n: PortNumber, value: unknown): any {
   const port = getPort(n);
   // Primitives don't need to be cloned.
-  port.add(isObject(value) ? structuredClone(value) : value);
+  port.add(isObjectLike(value) ? structuredClone(value) : value);
   if (port.data.length > Settings.MaxPortCapacity) return port.data.shift();
   return null;
 }
@@ -59,7 +59,7 @@ export function tryWritePort(n: PortNumber, value: unknown): boolean {
   const port = getPort(n);
   if (port.data.length >= Settings.MaxPortCapacity) return false;
   // Primitives don't need to be cloned.
-  port.add(isObject(value) ? structuredClone(value) : value);
+  port.add(isObjectLike(value) ? structuredClone(value) : value);
   return true;
 }
 
@@ -75,7 +75,7 @@ export function peekPort(n: PortNumber): any {
   const port = NetscriptPorts.get(n);
   if (!port || !port.data.length) return emptyPortData;
   // Needed to avoid exposing internal objects.
-  return isObject(port.data[0]) ? structuredClone(port.data[0]) : port.data[0];
+  return isObjectLike(port.data[0]) ? structuredClone(port.data[0]) : port.data[0];
 }
 
 export function nextPortWrite(n: PortNumber) {

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -79,11 +79,12 @@ export function readPort(n: PortNumber): any {
 export function peekPort(n: PortNumber): any {
   const port = NetscriptPorts.get(n);
   if (!port || !port.data.length) return emptyPortData;
+  const value = port.data[0];
   // Needed to avoid exposing internal objects.
   if ((typeof value === "object" || typeof value === "function") && value !== null) {
-    return structuredClone(port.data[0]);
+    return structuredClone(value);
   }
-  return port.data[0];
+  return value;
 }
 
 export function nextPortWrite(n: PortNumber) {

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -63,7 +63,7 @@ export function tryWritePort(n: PortNumber, value: unknown): boolean {
   }
   const port = getPort(n);
   if (port.data.length >= Settings.MaxPortCapacity) return false;
-  port.data.push(value);
+  port.data.push(data);
   port.resolve();
   return true;
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1051,7 +1051,7 @@ export interface NetscriptPort {
    * @remarks
    * RAM cost: 0 GB
    *
-   * @param value Data to write, it's cloned with structuredClone().
+   * @param value - Data to write, it's cloned with structuredClone().
    * @returns The data popped off the queue if it was full.
    */
   write(value: any): any;
@@ -1061,7 +1061,7 @@ export interface NetscriptPort {
    * @remarks
    * RAM cost: 0 GB
    *
-   * @param value Data to write, it's cloned with structuredClone().
+   * @param value - Data to write, it's cloned with structuredClone().
    * @returns True if the data was added to the port, false if the port was full
    */
   tryWrite(value: any): boolean;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1051,7 +1051,9 @@ export interface NetscriptPort {
    * @remarks
    * RAM cost: 0 GB
    *
-   * @returns The data popped off the queue if it was full. */
+   * @param value Data to write, it's cloned with structuredClone().
+   * @returns The data popped off the queue if it was full.
+   */
   write(value: any): any;
 
   /**
@@ -1059,12 +1061,13 @@ export interface NetscriptPort {
    * @remarks
    * RAM cost: 0 GB
    *
+   * @param value Data to write, it's cloned with structuredClone().
    * @returns True if the data was added to the port, false if the port was full
    */
   tryWrite(value: any): boolean;
 
   /**
-   * Sleeps until the port is written to.
+   * Waits until the port is written to.
    * @remarks
    * RAM cost: 0 GB
    */
@@ -6639,7 +6642,7 @@ export interface NS {
    * Otherwise, the data will be written normally.
    *
    * @param portNumber - Port to attempt to write to. Must be a positive integer.
-   * @param data - Data to write.
+   * @param data - Data to write, it's cloned with structuredClone().
    * @returns True if the data is successfully written to the port, and false otherwise.
    */
   tryWritePort(portNumber: number, data: any): boolean;
@@ -6713,7 +6716,7 @@ export interface NS {
    *
    * Write data to the given Netscript port.
    * @param portNumber - Port to write to. Must be a positive integer.
-   * @param data - Data to write.
+   * @param data - Data to write, it's cloned with structuredClone().
    * @returns The data popped off the queue if it was full, or null if it was not full.
    */
   writePort(portNumber: number, data: any): any;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -25,9 +25,6 @@ interface Skills {
 type CodingContractData = any;
 
 /** @public */
-type PortData = string | number;
-
-/** @public */
 type ScriptArg = string | number | boolean;
 
 /** @public */
@@ -1055,7 +1052,7 @@ export interface NetscriptPort {
    * RAM cost: 0 GB
    *
    * @returns The data popped off the queue if it was full. */
-  write(value: string | number): PortData | null;
+  write(value: any): any;
 
   /**
    * Attempt to write data to the port.
@@ -1064,7 +1061,7 @@ export interface NetscriptPort {
    *
    * @returns True if the data was added to the port, false if the port was full
    */
-  tryWrite(value: string | number): boolean;
+  tryWrite(value: any): boolean;
 
   /**
    * Sleeps until the port is written to.
@@ -1082,7 +1079,7 @@ export interface NetscriptPort {
    * If the port is empty, then the string “NULL PORT DATA” will be returned.
    * @returns the data read.
    */
-  read(): PortData;
+  read(): any;
 
   /**
    * Retrieve the first element from the port without removing it.
@@ -1094,7 +1091,7 @@ export interface NetscriptPort {
    * the port is empty, the string “NULL PORT DATA” will be returned.
    * @returns the data read
    */
-  peek(): PortData;
+  peek(): any;
 
   /**
    * Check if the port is full.
@@ -6645,7 +6642,7 @@ export interface NS {
    * @param data - Data to write.
    * @returns True if the data is successfully written to the port, and false otherwise.
    */
-  tryWritePort(portNumber: number, data: string | number): boolean;
+  tryWritePort(portNumber: number, data: any): boolean;
 
   /**
    * Listen for a port write.
@@ -6685,7 +6682,7 @@ export interface NS {
    * @param portNumber - Port to peek. Must be a positive integer.
    * @returns Data in the specified port.
    */
-  peek(portNumber: number): PortData;
+  peek(portNumber: number): any;
 
   /**
    * Clear data from a file.
@@ -6719,7 +6716,7 @@ export interface NS {
    * @param data - Data to write.
    * @returns The data popped off the queue if it was full, or null if it was not full.
    */
-  writePort(portNumber: number, data: string | number): PortData | null;
+  writePort(portNumber: number, data: any): any;
   /**
    * Read data from a port.
    * @remarks
@@ -6731,7 +6728,7 @@ export interface NS {
    * @param portNumber - Port to read from. Must be a positive integer.
    * @returns The data read.
    */
-  readPort(portNumber: number): PortData;
+  readPort(portNumber: number): any;
 
   /**
    * Get all data on a port.


### PR DESCRIPTION
A significant portion of players who use ports are passing objects through them. Currently they are required to handle that themselves via JSON serialization. This PR adds better support for passing objects; which is more convenient, extensive, and optimized (probably, more on this one later).

This adds zero overhead to existing (or when passing any primitive types) port usage, and also isn't a breaking change. The questions to debate here are:
1. Should objects be supported in the first place?
2. If so, how exactly do we want to serialize objects?

Based on an extensive discussion in Discord, the overwhelming majority answered "yes" to question one. As for question two, that has been much more hotly contested. There were three main ideas:
1. Just use `structuredClone()`, it's not slow enough to actually matter. (@d0sboots is looking into that)
2. Use JSON serialization with a custom `replacer` and `reviver` to add better error handling and support a few popular types such as `Map`s and `Set`s.
3. Use a simplified deep cloning method, it'll only support basic objects and arrays that contain primitive values. (maybe only one dimensional?)

Since the first idea has been the most popular so far, I opened the PR with it. I can switch to a different serialization option if desired after testing and feedback.