### PR TITLE
BUGFIX: few bandaids for Bladeburner

### DIFF
--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -111,10 +111,8 @@ export class Bladeburner {
   }
   /*
     just a quick fix for the broken implementation
-    the BlackOperations are only initialized on game load with a count of 1
-    and not reset on BitNode change or dev menu reset
-    this disables the start button for manual play
-    if the game wasnt reloaded since last completion of the Blop
+    BlackOperations are only initialized on game load with a count of 1
+    and are not reset on BitNode change or dev menu reset of bladeburner
   */
   resetBlackOps(): void {
     for (const [blackopName, blackop] of Object.entries(BlackOperations)) {
@@ -127,6 +125,7 @@ export class Bladeburner {
   }
 
   calculateStaminaPenalty(): number {
+    if (this.stamina === this.maxStamina) return 1;
     return Math.min(1, this.stamina / (0.5 * this.maxStamina));
   }
 

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -2180,6 +2180,7 @@ export class Bladeburner {
 
     try {
       this.startAction(actionId);
+      if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true)) Player.finishWork(true);
       workerScript.log(
         "bladeburner.startAction",
         () => `Starting bladeburner action with type '${type}' and name '${name}'`,

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -2166,6 +2166,7 @@ export class Bladeburner {
 
     try {
       this.startAction(actionId);
+      if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true)) Player.finishWork(true);
       workerScript.log(
         "bladeburner.startAction",
         () => `Starting bladeburner action with type '${type}' and name '${name}'`,

--- a/src/Bladeburner/Bladeburner.tsx
+++ b/src/Bladeburner/Bladeburner.tsx
@@ -109,6 +109,18 @@ export class Bladeburner {
     this.stamina = this.maxStamina;
     this.create();
   }
+  /*
+    just a quick fix for the broken implementation
+    the BlackOperations are only initialized on game load with a count of 1
+    and not reset on BitNode change or dev menu reset
+    this disables the start button for manual play
+    if the game wasnt reloaded since last completion of the Blop
+  */
+  resetBlackOps(): void {
+    for (const [blackopName, blackop] of Object.entries(BlackOperations)) {
+      blackop.count = Number(!this.blackops[blackopName]);
+    }
+  }
 
   getCurrentCity(): City {
     return this.cities[this.city];
@@ -1998,6 +2010,8 @@ export class Bladeburner {
   process(): void {
     // Edge race condition when the engine checks the processing counters and attempts to route before the router is initialized.
     if (!Router.isInitialized) return;
+    //safety measure this needs to be removed in a bigger refactor
+    this.resetBlackOps();
 
     // If the Player starts doing some other actions, set action to idle and alert
     if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true) && Player.currentWork) {
@@ -2166,7 +2180,6 @@ export class Bladeburner {
 
     try {
       this.startAction(actionId);
-      if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true)) Player.finishWork(true);
       workerScript.log(
         "bladeburner.startAction",
         () => `Starting bladeburner action with type '${type}' and name '${name}'`,

--- a/src/Bladeburner/ui/StartButton.tsx
+++ b/src/Bladeburner/ui/StartButton.tsx
@@ -31,10 +31,11 @@ export function StartButton(props: IProps): React.ReactElement {
   }
   function onStart(): void {
     if (disabled) return;
-    props.bladeburner.action.type = props.type;
-    props.bladeburner.action.name = props.name;
+    const action = new ActionIdentifier();
+    action.type = props.type;
+    action.name = props.name;
     if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true)) Player.finishWork(true);
-    props.bladeburner.startAction(props.bladeburner.action);
+    props.bladeburner.startAction(action);
     props.rerender();
   }
 


### PR DESCRIPTION
bandaids for 3 bugs in bladeburner
this really needs proper fixes and a alot of refactoring!

1.
the manual action start didnt start tasks the right way, modifying an existing action object instead of creating a new one
therefore the current action wasnt shown on the stats overview

2.
the api start action didnt check for the BladesSimulacrum Aug and didnt stop current Player tasks 
so the next time Bladeburner proccessed it stopped the bladeburner tasks again 
when the player was doing something else like crimes

3.
sometimes blops had an action.count of 0 even when they wherent done in that bladeburner instance yet

this happends because the BlackOps class instances are only initialized on game load 
and then later on BlackOps completion manipulated
this change doesnt reset on a bitnode change or when bladeburner is deleted through the dev Menu
as a quick fix i added a new resetBlackOps function that always runs when Bladeburner processes
this isnt the best solution but any proper fix i came up with requires a refactor that i couldnt do at this moment

credits to @TheAimMan for finding the clue that the count is the problem not the rank!


edit,;
added a 4th bandaid to avoid NaN Stamina Penalty when stamina is infinite


