### PR TITLE
BUGFIX: Make hacknet node a bit bigger and change unit to em

### DIFF
--- a/src/Hacknet/ui/HacknetRoot.tsx
+++ b/src/Hacknet/ui/HacknetRoot.tsx
@@ -117,7 +117,7 @@ export function HacknetRoot(): React.ReactElement {
 
       {hasHacknetServers() && <Button onClick={() => setOpen(true)}>Spend Hashes on Upgrades</Button>}
 
-      <Box sx={{ display: "grid", width: "100%", gridTemplateColumns: "repeat(auto-fit, 380px)" }}>{nodes}</Box>
+      <Box sx={{ display: "grid", width: "100%", gridTemplateColumns: "repeat(auto-fit, 30em)" }}>{nodes}</Box>
       <HashUpgradeModal open={open} onClose={() => setOpen(false)} />
     </>
   );


### PR DESCRIPTION
PR #1070 caused some overflow when having hacknet servers.

pic from @Semanual 
![grafik](https://github.com/bitburner-official/bitburner-src/assets/48560522/03bec6d6-c955-4119-84df-c8aa3ee00ce9)

I made the nodes a little bigger and also changed the unit from px to em.