### PR TITLE
BUGFIX: fix double stringify on server array in RFA

### DIFF
--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -1,3 +1,5 @@
+import type { BaseServer } from "src/Server/BaseServer";
+
 export class RFAMessage {
   jsonrpc = "2.0"; // Transmits version of JSON-RPC. Compliance maybe allows some funky interaction with external tools?
   public method?: string; // Is defined when it's a request/notification, otherwise undefined
@@ -15,7 +17,7 @@ export class RFAMessage {
   }
 }
 
-type ResultType = string | number | string[] | FileContent[];
+type ResultType = string | number | string[] | FileContent[] | RFAServerData[];
 type FileMetadata = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {
@@ -37,6 +39,8 @@ export interface FileLocation {
 export interface FileServer {
   server: string;
 }
+
+export type RFAServerData = Pick<BaseServer, "hostname" | "hasAdminRights">;
 
 export function isFileData(p: unknown): p is FileData {
   const pf = p as FileData;

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -113,11 +113,11 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => void | R
   },
 
   getAllServers: function (msg: RFAMessage): RFAMessage {
-    const servers = GetAllServers().map((server) => ({
-      hostname: server.hostname,
-      hasAdminRights: server.hasAdminRights,
+    const servers = GetAllServers().map(({ hostname, hasAdminRights }) => ({
+      hostname,
+      hasAdminRights,
     }));
 
-    return new RFAMessage({ result: JSON.stringify(servers), id: msg.id });
+    return new RFAMessage({ result: servers, id: msg.id });
   },
 };


### PR DESCRIPTION
The server array that the RFA currently sends is stringified twice. I fixed that and also added a proper ResultType for the new data