### PR TITLE
DOC: Fix outdated example for ns.spawn()

### DIFF
--- a/markdown/bitburner.ns.spawn.md
+++ b/markdown/bitburner.ns.spawn.md
@@ -17,7 +17,7 @@ spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: (string 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  script | string | Filename of script to execute. |
-|  threadOrOptions | number \| [SpawnOptions](./bitburner.spawnoptions.md) | _(Optional)_ Either an integer number of threads for new script, or a [SpawnOptions](./bitburner.spawnoptions.md) object. Threads defaults to 1. |
+|  threadOrOptions | number \| [SpawnOptions](./bitburner.spawnoptions.md) | _(Optional)_ Either an integer number of threads for new script, or a [SpawnOptions](./bitburner.spawnoptions.md) object. Threads defaults to 1 and spawnDelay defaults to 10,000 ms. |
 |  args | (string \| number \| boolean)\[\] | Additional arguments to pass into the new script that is being run. |
 
 **Returns:**
@@ -39,6 +39,6 @@ Running this function with 0 or fewer threads will cause a runtime error.
 
 ```js
 //The following example will execute the script ‘foo.js’ with 10 threads, in 500 milliseconds and the arguments ‘foodnstuff’ and 90:
-ns.spawn('foo.js', 10, 500, 'foodnstuff', 90);
+ns.spawn('foo.js', {threads: 10, spawnDelay: 500}, 'foodnstuff', 90);
 ```
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6054,10 +6054,10 @@ export interface NS {
    * @example
    * ```js
    * //The following example will execute the script ‘foo.js’ with 10 threads, in 500 milliseconds and the arguments ‘foodnstuff’ and 90:
-   * ns.spawn('foo.js', 10, 500, 'foodnstuff', 90);
+   * ns.spawn('foo.js', {threads: 10, spawnDelay: 500}, 'foodnstuff', 90);
    * ```
    * @param script - Filename of script to execute.
-   * @param threadOrOptions - Either an integer number of threads for new script, or a {@link SpawnOptions} object. Threads defaults to 1.
+   * @param threadOrOptions - Either an integer number of threads for new script, or a {@link SpawnOptions} object. Threads defaults to 1 and spawnDelay defaults to 10,000 ms.
    * @param args - Additional arguments to pass into the new script that is being run.
    */
   spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: (string | number | boolean)[]): void;


### PR DESCRIPTION
# DOC: Fix outdated example for ns.spawn()

The existing example for `ns.spawn()` is outdated and this PR updates it.  Also mentions the 10s default `spawnDelay` which is not otherwise in the description of `spawn` anymore.

### Background

During the course of #807 which made `spawn`'s now default 10s delay configurable (thanks!), the example was added and was accurate at that time.  Later in the PR, the call signature of `spawn()` changed, but the example was apparently overlooked for update.  This brings the example in line with the current implementation of `spawn`.