### PR TITLE
UI: Reimplement #954 (Servers sorted on active scripts page)

### DIFF
--- a/src/Hacknet/HacknetServer.ts
+++ b/src/Hacknet/HacknetServer.ts
@@ -53,6 +53,8 @@ export class HacknetServer extends BaseServer implements IHacknetNode {
   // Flag indicating whether this is a purchased server
   purchasedByPlayer = true;
 
+  isHacknetServer = true;
+
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {
     super(params);
 

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -122,6 +122,7 @@ export abstract class BaseServer implements IServer {
   openPortCount?: number;
   requiredHackingSkill?: number;
   serverGrowth?: number;
+  isHacknetServer?: boolean;
 
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {
     this.ip = params.ip ? params.ip : createRandomIp();
@@ -367,6 +368,6 @@ export abstract class BaseServer implements IServer {
 
   // Customize a prune list for a subclass.
   static getIncludedKeys<T extends BaseServer>(ctor: new () => T): readonly (keyof T)[] {
-    return getKeyList(ctor, { removedKeys: ["runningScriptMap", "savedScripts", "ramUsed"] });
+    return getKeyList(ctor, { removedKeys: ["runningScriptMap", "savedScripts", "ramUsed", "isHacknetServer"] });
   }
 }

--- a/src/ui/ActiveScripts/ServerAccordion.tsx
+++ b/src/ui/ActiveScripts/ServerAccordion.tsx
@@ -1,45 +1,29 @@
-/**
- * React Component for rendering the Accordion element for a single
- * server in the 'Active Scripts' UI page
- */
+import type { WorkerScript } from "../../Netscript/WorkerScript";
+import type { BaseServer } from "../../Server/BaseServer";
+
 import * as React from "react";
 
-import Typography from "@mui/material/Typography";
+import { Box, Collapse, ListItemText, ListItemButton, Paper, Typography } from "@mui/material";
+import { ExpandMore, ExpandLess } from "@mui/icons-material";
 
-import ListItemButton from "@mui/material/ListItemButton";
-import ListItemText from "@mui/material/ListItemText";
-
-import Paper from "@mui/material/Paper";
-import Box from "@mui/material/Box";
-import Collapse from "@mui/material/Collapse";
-import ExpandMore from "@mui/icons-material/ExpandMore";
-import ExpandLess from "@mui/icons-material/ExpandLess";
 import { ServerAccordionContent } from "./ServerAccordionContent";
 
-import { WorkerScript } from "../../Netscript/WorkerScript";
-
 import { createProgressBarText } from "../../utils/helpers/createProgressBarText";
-import { GetServer } from "../../Server/AllServers";
 
 interface ServerAccordionProps {
-  hostname: string;
+  server: BaseServer;
   scripts: WorkerScript[];
 }
 
-export function ServerAccordion({ hostname, scripts }: ServerAccordionProps): React.ReactElement {
+export function ServerAccordion({ server, scripts }: ServerAccordionProps): React.ReactElement {
   const [open, setOpen] = React.useState(false);
-  const server = GetServer(hostname);
-  if (!server) {
-    console.error(`Invalid server ${hostname} while displaying active scripts`);
-    return <></>;
-  }
 
   // Accordion's header text
   // TODO: calculate the longest hostname length rather than hard coding it
   const longestHostnameLength = 18;
-  const paddedName = `${hostname}${" ".repeat(longestHostnameLength)}`.slice(
+  const paddedName = `${server.hostname}${" ".repeat(longestHostnameLength)}`.slice(
     0,
-    Math.max(hostname.length, longestHostnameLength),
+    Math.max(server.hostname.length, longestHostnameLength),
   );
   const barOptions = {
     progress: server.ramUsed / server.maxRam,


### PR DESCRIPTION
The changes made in https://github.com/bitburner-official/bitburner-src/pull/1083 were not compatible with https://github.com/bitburner-official/bitburner-src/pull/954. Making changes based on https://github.com/bitburner-official/bitburner-src/pull/954 was not practical due to the scope of changes so I reimplemented the functionality here.

The sorting method here was written to minimize iteration of the base array, which is why I took a different approach to the comparison logic.

* Added an isHacknetServer optional attribute to BaseServers
* HacknetServer has a truthy value added for the new attribute to make comparisons easier
* ActiveScriptsPage gets the server objects because they are needed for sorting. ActiveScriptsPage new passes the actual server object to the ServerAccordion, instead of just the hostname.
* Changed a temporary data structure from a regular object to a Map, so it can be keyed by actual server objects instead of hostnames.

![image](https://github.com/bitburner-official/bitburner-src/assets/84951833/23e9fe0c-2533-47ad-94b6-0e89883ed5de)

Sorting: `home` is first, then all hacknet servers in numerical order, then all other purchased servers in alpha order, then all other servers unsorted