### PR TITLE
RFA: add purchasedByPlayer to RFA server data

### DIFF
--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -40,7 +40,7 @@ export interface FileServer {
   server: string;
 }
 
-export type RFAServerData = Pick<BaseServer, "hostname" | "hasAdminRights">;
+export type RFAServerData = Pick<BaseServer, "hostname" | "hasAdminRights" | "purchasedByPlayer">;
 
 export function isFileData(p: unknown): p is FileData {
   const pf = p as FileData;

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -113,9 +113,10 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => void | R
   },
 
   getAllServers: function (msg: RFAMessage): RFAMessage {
-    const servers = GetAllServers().map(({ hostname, hasAdminRights }) => ({
+    const servers = GetAllServers().map(({ hostname, hasAdminRights, purchasedByPlayer }) => ({
       hostname,
       hasAdminRights,
+      purchasedByPlayer,
     }));
 
     return new RFAMessage({ result: servers, id: msg.id });


### PR DESCRIPTION
It would be really useful to be able to distuingish between player owned servers and non player owned servers when using the getAllServers method of the RFA.  
This way external tools can more easily offer a way to distribute a set of scripts to all your own servers.