### PR TITLE
BUGFIX: fix current HP from being NaN when a stat is infinite

### DIFF
--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -180,7 +180,7 @@ export function updateSkillLevels(this: Person): void {
     Math.floor(this.calculateSkill(this.exp.charisma, this.mults.charisma * currentNodeMults.CharismaLevelMultiplier)),
   );
 
-  const ratio: number = Math.min(this.hp.current / this.hp.max, 1);
+  const ratio: number = Math.min(this.hp.current / this.hp.max, 1) || 1;
   this.hp.max = Math.floor(10 + this.skills.defense / 10);
   this.hp.current = Math.round(this.hp.max * ratio);
 }

--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -181,7 +181,7 @@ export function updateSkillLevels(this: Person): void {
     Math.floor(this.calculateSkill(this.exp.charisma, this.mults.charisma * currentNodeMults.CharismaLevelMultiplier)),
   );
   //In case MaxHP is Infinite, setting ratio to 1
-  const ratio = Number.isFinite(this.hp.current) ? this.hp.current / this.hp.max : 1;
+  const ratio = Math.min(Number.isFinite(this.hp.current) ? this.hp.current / this.hp.max : 1);
   this.hp.max = Math.floor(10 + this.skills.defense / 10);
   this.hp.current = Math.round(this.hp.max * ratio);
 }

--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -44,7 +44,8 @@ export function gainDefenseExp(this: Person, exp: number): void {
   }
 
   this.skills.defense = calculateSkill(this.exp.defense, this.mults.defense * currentNodeMults.DefenseLevelMultiplier);
-  const ratio = this.hp.current / this.hp.max;
+  //In case MaxHP is Infinite, setting ratio to 1
+  const ratio = this.hp.current / this.hp.max || 1;
   this.hp.max = Math.floor(10 + this.skills.defense / 10);
   this.hp.current = Math.round(this.hp.max * ratio);
 }
@@ -179,7 +180,7 @@ export function updateSkillLevels(this: Person): void {
     1,
     Math.floor(this.calculateSkill(this.exp.charisma, this.mults.charisma * currentNodeMults.CharismaLevelMultiplier)),
   );
-
+  //In case MaxHP is Infinite, setting ratio to 1
   const ratio: number = Math.min(this.hp.current / this.hp.max, 1) || 1;
   this.hp.max = Math.floor(10 + this.skills.defense / 10);
   this.hp.current = Math.round(this.hp.max * ratio);

--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -45,7 +45,7 @@ export function gainDefenseExp(this: Person, exp: number): void {
 
   this.skills.defense = calculateSkill(this.exp.defense, this.mults.defense * currentNodeMults.DefenseLevelMultiplier);
   //In case MaxHP is Infinite, setting ratio to 1
-  const ratio = this.hp.current / this.hp.max || 1;
+  const ratio = Number.isFinite(this.hp.current) ? this.hp.current / this.hp.max : 1;
   this.hp.max = Math.floor(10 + this.skills.defense / 10);
   this.hp.current = Math.round(this.hp.max * ratio);
 }
@@ -181,7 +181,7 @@ export function updateSkillLevels(this: Person): void {
     Math.floor(this.calculateSkill(this.exp.charisma, this.mults.charisma * currentNodeMults.CharismaLevelMultiplier)),
   );
   //In case MaxHP is Infinite, setting ratio to 1
-  const ratio: number = Math.min(this.hp.current / this.hp.max, 1) || 1;
+  const ratio = Number.isFinite(this.hp.current) ? this.hp.current / this.hp.max : 1;
   this.hp.max = Math.floor(10 + this.skills.defense / 10);
   this.hp.current = Math.round(this.hp.max * ratio);
 }


### PR DESCRIPTION
Current HP is a ratio of Current/Max.  If Max is infinite that ratio is invalid so current becomes NaN

![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/54859304-b891-47c4-86ff-20b8e21131f8)

Changing the ratio to return 1 if NaN allows for the calculation to succeed

![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/0c2b8165-4637-426d-a73d-e9b39948755f)
