### PR TITLE
UI: Infiltration rewards default to the faction you're currently working for

### DIFF
--- a/src/Infiltration/ui/Victory.tsx
+++ b/src/Infiltration/ui/Victory.tsx
@@ -81,12 +81,10 @@ export function Victory(props: IProps): React.ReactElement {
       <Box sx={{ width: "fit-content" }}>
         <Box sx={{ width: "100%" }}>
           <Select value={factionName} onChange={changeDropdown} sx={{ mr: 1 }}>
-            {defaultFaction === "none" ? (
+            {defaultFaction === "none" && (
               <MenuItem key={"none"} value={"none"}>
                 {"none"}
               </MenuItem>
-            ) : (
-              <></>
             )}
             {Player.factions
               .filter((f) => Factions[f].getInfo().offersWork())

--- a/src/Infiltration/ui/Victory.tsx
+++ b/src/Infiltration/ui/Victory.tsx
@@ -17,6 +17,7 @@ import {
   calculateTradeInformationRepReward,
 } from "../formulas/victory";
 import { getEnumHelper } from "../../utils/EnumHelper";
+import { isFactionWork } from "../../Work/FactionWork";
 
 interface IProps {
   StartingDifficulty: number;
@@ -26,7 +27,8 @@ interface IProps {
 }
 
 export function Victory(props: IProps): React.ReactElement {
-  const [factionName, setFactionName] = useState("none");
+  const defaultFaction = isFactionWork(Player.currentWork) ? Player.currentWork.getFaction() : "none";
+  const [factionName, setFactionName] = useState(defaultFaction);
 
   function quitInfiltration(): void {
     handleInfiltrators();
@@ -79,9 +81,13 @@ export function Victory(props: IProps): React.ReactElement {
       <Box sx={{ width: "fit-content" }}>
         <Box sx={{ width: "100%" }}>
           <Select value={factionName} onChange={changeDropdown} sx={{ mr: 1 }}>
-            <MenuItem key={"none"} value={"none"}>
-              {"none"}
-            </MenuItem>
+            {defaultFaction === "none" ? (
+              <MenuItem key={"none"} value={"none"}>
+                {"none"}
+              </MenuItem>
+            ) : (
+              <></>
+            )}
             {Player.factions
               .filter((f) => Factions[f].getInfo().offersWork())
               .map((f) => (

--- a/src/Infiltration/ui/Victory.tsx
+++ b/src/Infiltration/ui/Victory.tsx
@@ -27,7 +27,7 @@ interface IProps {
 }
 
 export function Victory(props: IProps): React.ReactElement {
-  const defaultFaction = isFactionWork(Player.currentWork) ? Player.currentWork.getFaction() : "none";
+  const defaultFaction = isFactionWork(Player.currentWork) ? Player.currentWork.factionName : "none";
   const [factionName, setFactionName] = useState(defaultFaction);
 
   function quitInfiltration(): void {


### PR DESCRIPTION
As [requested in the suggestions channel](https://discord.com/channels/415207508303544321/415213435974975508/1209338928423768074) on Discord, this changes the default faction in the drop-down on the victory screen to be the faction the player is currently working for when possible.

This change needs to be tested.