### PR TITLE
IPVGO: add previousPlayer as a dependency to useMemo so it correctly updates when the board is updated

### DIFF
--- a/src/Go/ui/GoGameboard.tsx
+++ b/src/Go/ui/GoGameboard.tsx
@@ -22,12 +22,19 @@ export function GoGameboard({ boardState, traditional, clickHandler, hover }: Go
   const currentPlayer =
     boardState.ai !== GoOpponent.none || boardState.previousPlayer === GoColor.white ? GoColor.black : GoColor.white;
 
+  // "boardState.previousPlayer" is added as a useMemo dependency because useMemo only does pointer comparison for
+  // determining when objects change, so a primitive has to be used to correctly update it
   const availablePoints = useMemo(
     () => (hover ? getAllValidMoves(boardState, currentPlayer) : []),
-    [boardState, hover, currentPlayer],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [boardState, hover, currentPlayer, boardState.previousPlayer],
   );
 
-  const ownedEmptyNodes = useMemo(() => getControlledSpace(boardState), [boardState]);
+  const ownedEmptyNodes = useMemo(
+    () => getControlledSpace(boardState),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [boardState, boardState.previousPlayer],
+  );
 
   function pointIsValid(x: number, y: number) {
     return !!availablePoints.find((point) => point.x === x && point.y === y);

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -176,7 +176,8 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
   const endGameAvailable = boardState.previousPlayer === GoColor.white && boardState.passCount;
   const noLegalMoves = useMemo(
     () => boardState.previousPlayer === GoColor.white && !getAllValidMoves(boardState, GoColor.black).length,
-    [boardState],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [boardState, boardState.previousPlayer],
   );
   const disablePassButton = opponent !== GoOpponent.none && boardState.previousPlayer === GoColor.black && waitingOnAI;
 


### PR DESCRIPTION
React `useMemo()` only updates if an object dependency is completely re-assigned, not if it is updated. This can be fixed by passing the primitive `boardState.previousPlayer` as a dependency to useMemo(). ESLint doesn't understand why this is needed, so some disable-next-lines have been added, along with a comment explaining it.