### PR TITLE
HACKNET: Disallow negative `count` argument for spendHashes

### DIFF
--- a/src/NetscriptFunctions/Hacknet.ts
+++ b/src/NetscriptFunctions/Hacknet.ts
@@ -203,7 +203,7 @@ export function NetscriptHacknet(): InternalAPI<IHacknet> {
         const upgTarget = helpers.string(ctx, "upgTarget", _upgTarget);
         const count = Math.floor(helpers.number(ctx, "count", _count));
         if (!(count >= 0)) {
-          throw helpers.errorMessage(ctx, 'count may not be negative');
+          throw helpers.errorMessage(ctx, "count may not be negative");
         }
         if (!hasHacknetServers()) {
           return false;

--- a/src/NetscriptFunctions/Hacknet.ts
+++ b/src/NetscriptFunctions/Hacknet.ts
@@ -201,7 +201,10 @@ export function NetscriptHacknet(): InternalAPI<IHacknet> {
       (_upgName, _upgTarget = "", _count = 1) => {
         const upgName = helpers.string(ctx, "upgName", _upgName);
         const upgTarget = helpers.string(ctx, "upgTarget", _upgTarget);
-        const count = helpers.number(ctx, "count", _count);
+        const count = Math.floor(helpers.number(ctx, "count", _count));
+        if (!(count > 0)) {
+          throw helpers.errorMessage(ctx, 'count must be positive');
+        }
         if (!hasHacknetServers()) {
           return false;
         }

--- a/src/NetscriptFunctions/Hacknet.ts
+++ b/src/NetscriptFunctions/Hacknet.ts
@@ -201,7 +201,11 @@ export function NetscriptHacknet(): InternalAPI<IHacknet> {
       (_upgName, _upgTarget = "", _count = 1) => {
         const upgName = helpers.string(ctx, "upgName", _upgName);
         const upgTarget = helpers.string(ctx, "upgTarget", _upgTarget);
-        const count = helpers.positiveInteger(ctx, "count", _count);
+        const count = Math.floor(helpers.number(ctx, "count", _count));
+        // TODO (3.0.0): use helpers.positiveInteger
+        if (!(count >= 0)) {
+          throw helpers.errorMessage(ctx, "count may not be negative");
+        }
         if (!hasHacknetServers()) {
           return false;
         }

--- a/src/NetscriptFunctions/Hacknet.ts
+++ b/src/NetscriptFunctions/Hacknet.ts
@@ -201,10 +201,7 @@ export function NetscriptHacknet(): InternalAPI<IHacknet> {
       (_upgName, _upgTarget = "", _count = 1) => {
         const upgName = helpers.string(ctx, "upgName", _upgName);
         const upgTarget = helpers.string(ctx, "upgTarget", _upgTarget);
-        const count = Math.floor(helpers.number(ctx, "count", _count));
-        if (!(count >= 0)) {
-          throw helpers.errorMessage(ctx, "count may not be negative");
-        }
+        const count = helpers.positiveInteger(ctx, "count", _count);
         if (!hasHacknetServers()) {
           return false;
         }

--- a/src/NetscriptFunctions/Hacknet.ts
+++ b/src/NetscriptFunctions/Hacknet.ts
@@ -202,8 +202,8 @@ export function NetscriptHacknet(): InternalAPI<IHacknet> {
         const upgName = helpers.string(ctx, "upgName", _upgName);
         const upgTarget = helpers.string(ctx, "upgTarget", _upgTarget);
         const count = Math.floor(helpers.number(ctx, "count", _count));
-        if (!(count > 0)) {
-          throw helpers.errorMessage(ctx, 'count must be positive');
+        if (!(count >= 0)) {
+          throw helpers.errorMessage(ctx, 'count may not be negative');
         }
         if (!hasHacknetServers()) {
           return false;


### PR DESCRIPTION
Tested manually.

This is a very exploitable bug; consider the following script:

```js
export async function main(ns) {
  for (let i = 0; i < 1000; ++i) {
    ns.hacknet.spendHashes('Increase Maximum Money', 'joesguns', -1);
    ns.hacknet.spendHashes('Increase Maximum Money', 'ecorp', 1);
  }
}
```

This boosts the max money of ecorp for no cost (it doesn't decrease joesguns max money, in fact).