### PR TITLE
CONTRACTS: createDummyContract returns filename

### DIFF
--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -9,7 +9,7 @@ Generate a dummy contract.
 **Signature:**
 
 ```typescript
-createDummyContract(type: string): void;
+createDummyContract(type: string): string;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ createDummyContract(type: string): void;
 
 **Returns:**
 
-void
+string
+
+Filename of the contract.
 
 ## Remarks
 

--- a/src/CodingContractGenerator.ts
+++ b/src/CodingContractGenerator.ts
@@ -47,13 +47,15 @@ export function generateRandomContractOnHome(): void {
   serv.addContract(contract);
 }
 
-export const generateDummyContract = (problemType: string): void => {
+export const generateDummyContract = (problemType: string): string => {
   if (!CodingContractTypes[problemType]) throw new Error(`Invalid problem type: '${problemType}'`);
   const serv = Player.getHomeComputer();
 
   const contractFn = getRandomFilename(serv);
   const contract = new CodingContract(contractFn, problemType, null);
   serv.addContract(contract);
+
+  return contractFn;
 };
 
 interface IGenerateContractParams {

--- a/src/NetscriptFunctions/CodingContract.ts
+++ b/src/NetscriptFunctions/CodingContract.ts
@@ -81,7 +81,7 @@ export function NetscriptCodingContract(): InternalAPI<ICodingContract> {
     },
     createDummyContract: (ctx) => (_type) => {
       const type = helpers.string(ctx, "type", _type);
-      generateDummyContract(type);
+      return generateDummyContract(type);
     },
     getContractTypes: () => () => codingContractTypesMetadata.map((c) => c.name),
   };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3577,8 +3577,9 @@ export interface CodingContract {
    * Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
    *
    * @param type - Type of contract to generate
+   * @returns Filename of the contract.
    */
-  createDummyContract(type: string): void;
+  createDummyContract(type: string): string;
 
   /**
    * List all contract types.


### PR DESCRIPTION
# createDummyContract() method now returns filename…

…of generated dummy contract.

This tiny quality-of-life improvement means you don't have to search for the dummy contract you just created, instead its filename is simply returned by the method used to create it.