### PR TITLE
MISC: Correct rm command help text

### DIFF
--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -361,7 +361,7 @@ export const HelpTexts: Record<string, string[]> = {
   rm: [
     "Usage: rm [file name]",
     " ",
-    "Removes the specified file from the current server. A file can be a script, a program, or a message file. ",
+    "Removes the specified file from the current server. This command doesn't work for message (.msg) files.",
     " ",
     "WARNING: This is permanent and cannot be undone",
     " ",


### PR DESCRIPTION
The `rm` command can delete all file types except for `.msg`, however the help text incorrectly states that `.msg` files can be deleted and doesn't even mention `.txt` or `.lit` files.