### PR TITLE
API: Move heart.break out of Extra.ts

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1763,6 +1763,7 @@ export const ns: InternalAPI<NSFull> = {
     ctx.workerScript.print(wrapUserNode(value));
   },
   flags: Flags,
+  heart: { break: () => () => Player.karma },
   ...NetscriptExtra(),
 };
 

--- a/src/NetscriptFunctions/Extra.ts
+++ b/src/NetscriptFunctions/Extra.ts
@@ -7,9 +7,6 @@ import { helpers } from "../Netscript/NetscriptHelpers";
 import { RamCostConstants } from "../Netscript/RamCostGenerator";
 
 export interface INetscriptExtra {
-  heart: {
-    break(): number;
-  };
   openDevMenu(): void;
   exploit(): void;
   bypass(doc: Document): void;
@@ -19,9 +16,6 @@ export interface INetscriptExtra {
 
 export function NetscriptExtra(): InternalAPI<INetscriptExtra> {
   return {
-    heart: {
-      break: () => () => Player.karma,
-    },
     openDevMenu: () => () => devMenu.emit(),
     exploit: () => () => Player.giveExploit(Exploit.UndocumentedFunctionCall),
     bypass: (ctx) => (doc) => {


### PR DESCRIPTION
Documentation for heart.break was added in #1131, so this no longer needs to be in NetscriptExtra