### PR TITLE
API: Minor followup changes for #1059

### DIFF
--- a/src/Netscript/TypeAssertion.ts
+++ b/src/Netscript/TypeAssertion.ts
@@ -26,3 +26,7 @@ export const debugType = (v: unknown): string => {
 export function assertString(ctx: NetscriptContext, argName: string, v: unknown): asserts v is string {
   if (typeof v !== "string") throw errorMessage(ctx, `${argName} expected to be a string. ${debugType(v)}`, "TYPE");
 }
+
+export function assertFunction(ctx: NetscriptContext, argName: string, v: unknown): asserts v is () => void {
+  if (typeof v !== "function") throw errorMessage(ctx, `${argName} expected to be a function ${debugType(v)}`, "TYPE");
+}

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -47,11 +47,11 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   //so the map must be cleared before looping
   ws.atExit = new Map();
 
-  for (const callback of atExit.values()) {
+  for (const [id, callback] of atExit) {
     try {
       callback();
     } catch (e: unknown) {
-      handleUnknownError(e, ws, `Error running atExit function.\n\n`);
+      handleUnknownError(e, ws, `Error running atExit function with id ${id}.\n\n`);
     }
   }
 

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -47,12 +47,11 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   //so the map must be cleared before looping
   ws.atExit = new Map();
 
-  for (const key of atExit.keys()) {
+  for (const callback of atExit.values()) {
     try {
-      const callback = atExit.get(key);
-      if (typeof callback == "function") callback();
+      callback();
     } catch (e: unknown) {
-      handleUnknownError(e, ws, "Error running atExit function.\n\n");
+      handleUnknownError(e, ws, `Error running atExit function.\n\n`);
     }
   }
 


### PR DESCRIPTION
@shyguy1412 @d0sboots FYI

killWorkerScript:
* Callbacks are already guaranteed to be functions -> removed typecheck
* Loop through map directly instead of looping through keys only and then looking up each callback through the map
* Show id of callback if there is an error while running it

TypeAssertion:
* Added an assertion helper for player-provided functions

NetscriptFunctions:
* Use helper functions for type validation
* Set callback directly instead of wrapping in an anonymous function. No `this` leakage possible with new format.