### PR TITLE
GO: hide buttons until discovered

### DIFF
--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -35,6 +35,7 @@ import { HacknetServer } from "../../Hacknet/HacknetServer";
 import { GetServer } from "../../Server/AllServers";
 import { ArcadeRoot } from "../../Arcade/ui/ArcadeRoot";
 import { currentNodeMults } from "../../BitNode/BitNodeMultipliers";
+import { playerHasDiscoveredGo } from "../../Go/effects/effect";
 
 interface SpecialLocationProps {
   loc: Location;
@@ -333,13 +334,15 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
     }
     case LocationName.Sector12CIA:
     case LocationName.NewTokyoDefComm: {
-      return (
+      return playerHasDiscoveredGo() ? (
         <>
           <br />
           <br />
           <br />
           <Button onClick={() => Router.toPage(Page.Go)}>IPvGO Subnet Takeover</Button>
         </>
+      ) : (
+        <></>
       );
     }
     default:


### PR DESCRIPTION
iam not sure if GO is supposed to be visible before entering BN14 or having SF14 
but currently the button is shown in the Locations

this adds a small check if it should be shown or not

might want to change the playerHasDiscoveredGo function aswell force check BN14 || SF14 
ill do that if it should be hidden if not then ill just close this