### PR TITLE
API: Add donationForRep() to Formulas

### DIFF
--- a/src/Faction/formulas/donation.ts
+++ b/src/Faction/formulas/donation.ts
@@ -9,6 +9,10 @@ export function repFromDonation(amt: number, person: IPerson): number {
   return (amt / CONSTANTS.DonateMoneyToRepDivisor) * person.mults.faction_rep * currentNodeMults.FactionWorkRepGain;
 }
 
+export function donationForRep(rep: number, person: IPerson): number {
+  return (rep * CONSTANTS.DonateMoneyToRepDivisor) / person.mults.faction_rep / currentNodeMults.FactionWorkRepGain;
+}
+
 export function repNeededToDonate(): number {
   return Math.floor(CONSTANTS.BaseFavorToDonate * currentNodeMults.RepToDonateToFaction);
 }

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -632,6 +632,7 @@ export const RamCosts: RamCostTree<NSFull> = {
       calculateFavorToRep: 0,
       calculateRepToFavor: 0,
       repFromDonation: 0,
+      donationForRep: 0,
     },
     skills: {
       calculateSkill: 0,

--- a/src/NetscriptFunctions/Formulas.ts
+++ b/src/NetscriptFunctions/Formulas.ts
@@ -37,7 +37,7 @@ import {
   calculateAscensionPointsGain,
 } from "../Gang/formulas/formulas";
 import { favorToRep as calculateFavorToRep, repToFavor as calculateRepToFavor } from "../Faction/formulas/favor";
-import { repFromDonation } from "../Faction/formulas/donation";
+import { repFromDonation, donationForRep } from "../Faction/formulas/donation";
 import { InternalAPI, NetscriptContext, setRemovedFunctions } from "../Netscript/APIWrapper";
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { calculateCrimeWorkStats } from "../Work/Formulas";
@@ -127,6 +127,12 @@ export function NetscriptFormulas(): InternalAPI<IFormulas> {
         const person = helpers.person(ctx, _player);
         checkFormulasAccess(ctx);
         return repFromDonation(amount, person);
+      },
+      donationForRep: (ctx) => (_reputation, _player) => {
+        const reputation = helpers.number(ctx, "reputation", _reputation);
+        const person = helpers.person(ctx, _player);
+        checkFormulasAccess(ctx);
+        return donationForRep(reputation, person);
       },
     },
     skills: {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5209,6 +5209,13 @@ interface ReputationFormulas {
    * @param player - Player info, typically from {@link NS.getPlayer | getPlayer}
    */
   repFromDonation(amount: number, player: Person): number;
+
+  /**
+   * Calculate the donation amount needed to gain a specific amount of reputation.
+   * @param reputation - Amount of reputation
+   * @param player - Player info, typically from {@link NS.getPlayer | getPlayer}
+   */
+  donationForRep(reputation: number, player: Person): number;
 }
 
 /**

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5211,7 +5211,7 @@ interface ReputationFormulas {
   repFromDonation(amount: number, player: Person): number;
 
   /**
-   * Calculate the donation amount needed to gain a specific amount of reputation.
+   * Calculate the donation needed to gain an amount of reputation.
    * @param reputation - Amount of reputation
    * @param player - Player info, typically from {@link NS.getPlayer | getPlayer}
    */


### PR DESCRIPTION
This was motivated by [a player asking](https://discord.com/channels/415207508303544321/415247422638522395/1215024497661321338) if there was a formulas method to calculate the donation needed to gain an amount of reputation, noting that one existed to calculate the reputation gained from a donation.

With that in mind, these methods simply implement the formulas shown in the faction UI:
```js
ns.formulas.reputation.calculateRepToFavor();
ns.formulas.reputation.repFromDonation();
```
And there's already an inverse method for the first one:
```js
ns.formulas.reputation.calculateFavorToRep();
```
But there was no inverse method for the second one, which is why this PR is adding this:
```js
ns.formulas.reputation.donationForRep();
```