### PR TITLE
BUGFIX: Disallow all whitespace in filenames

### DIFF
--- a/src/Paths/Directory.ts
+++ b/src/Paths/Directory.ts
@@ -24,11 +24,11 @@ export const root = "" as Directory;
  * |: Invalid because it might have a use in the terminal in the future.
  * #: Invalid because it might have a use in the terminal in the future.
  * (quote marks): Invalid to avoid conflict with quote marks used in the terminal.
- * (space): Invalid to avoid confusion with terminal command separator */
-const invalidCharacters = ["/", "*", "?", "[", "]", "!", "\\", "~", "|", "#", '"', "'", " "];
+ * (whitespace): Invalid to avoid confusion with terminal command separator */
+const invalidCharacters = ["/", "*", "?", "[", "]", "!", "\\", "~", "|", "#", '"', "'"];
 
 /** A valid character is any character that is not one of the invalid characters */
-export const oneValidCharacter = `[^${escapeRegExp(invalidCharacters.join(""))}]`;
+export const oneValidCharacter = `[^${escapeRegExp(invalidCharacters.join(""))}\\s]`;
 
 /** Regex string for matching the directory part of a valid filepath */
 export const directoryRegexString = `^(?<directory>(?:${oneValidCharacter}+\\/)*)`;


### PR DESCRIPTION
Currently only the space character " " invalidates a filename, all other whitespace characters are allowed. This PR expands the invalid character list to include all whitespace and corrects all filenames with whitespace in existing saves.

This has been tested by @Fireball5939.