### PR TITLE
DOC: Add namespaced example to disableLog doc.

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5689,6 +5689,8 @@ export interface NS {
    *
    * Logging can be disabled for all functions by passing `ALL` as the argument.
    *
+   * For specific interfaces, use the form "namespace.functionName". (e.g. "ui.setTheme")
+   *
    * @param fn - Name of function for which to disable logging.
    */
   disableLog(fn: string): void;


### PR DESCRIPTION
# DOC: Add namespaced example to disableLog doc.

A minor addition to the `disableLog` docs.

Embarrassingly, I didn't realize how to disable logging for namespaced functions until I saw:
https://github.com/danielyxie/bitburner/issues/1800

Including this in the docs would make this discoverable in-game instead of in the old repository's issue tracker.

It probably won't be used that often itself, but `ui.setTheme` seemed the least spoilery function name to use as an example.