### PR TITLE
IPVGO: Ensure that IPvGO styling is not broken by unusual themes

### DIFF
--- a/src/Go/boardState/goStyles.ts
+++ b/src/Go/boardState/goStyles.ts
@@ -2,8 +2,10 @@ import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
 
-export const pointStyle = makeStyles((theme: Theme) =>
-  createStyles({
+export const pointStyle = makeStyles((theme: Theme) => {
+  const goWhite = colorIsDark(`${theme.colors.white}`) ? "#C3C3C3" : theme.colors.white;
+  const goBlack = colorIsDark(`${theme.colors.black}`) ? theme.colors.black : "#0A0B0B";
+  return createStyles({
     hover: {},
     valid: {},
     priorPoint: {},
@@ -13,17 +15,17 @@ export const pointStyle = makeStyles((theme: Theme) =>
       width: "100%",
 
       "&$hover$valid:hover $innerPoint": {
-        outlineColor: "#C3C3C3",
+        outlineColor: goWhite,
       },
       "&$hover$priorPoint $innerPoint": {
-        outlineColor: "#C3C3C3",
+        outlineColor: goWhite,
       },
       "&$hover$priorPoint $priorStoneTrad$blackPoint": {
-        outlineColor: "#C3C3C3",
+        outlineColor: goWhite,
         display: "block",
       },
       "&$hover$priorPoint $priorStoneTrad$whitePoint": {
-        outlineColor: "#0A0B0B",
+        outlineColor: goBlack,
         display: "block",
       },
       "&$hover:hover $coordinates": {
@@ -64,13 +66,13 @@ export const pointStyle = makeStyles((theme: Theme) =>
       },
       "& $broken": {
         backgroundImage: "none",
-        backgroundColor: "#0A0B0B",
+        backgroundColor: goBlack,
       },
       "& $tradStone": {
         display: "block",
       },
       "& $liberty": {
-        backgroundColor: "#0A0B0B",
+        backgroundColor: goBlack,
         transition: "none",
         "&:not($northLiberty):not($southLiberty):not($eastLiberty):not($westLiberty)": {
           width: 0,
@@ -142,7 +144,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
         left: "15%",
       },
       "& $blackPoint ~ $coordinates": {
-        color: "#C3C3C3",
+        color: goWhite,
       },
     },
     fiveByFive: {
@@ -237,7 +239,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
         margin: 0,
 
         "&:before": {
-          backgroundColor: "#0A0B0B",
+          backgroundColor: goBlack,
           backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
         },
       },
@@ -280,7 +282,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
       width: "10%",
       height: "10%",
       margin: "45%",
-      backgroundColor: "#C3C3C3",
+      backgroundColor: goWhite,
       position: "relative",
     },
     filledPoint: {
@@ -301,8 +303,8 @@ export const pointStyle = makeStyles((theme: Theme) =>
       width: "70%",
       height: "70%",
       margin: "15%",
-      backgroundColor: "#0A0B0B",
-      outlineColor: "#C3C3C3",
+      backgroundColor: goBlack,
+      outlineColor: goWhite,
     },
     fadeLoopAnimation: {
       animation: `$fadeLoop 800ms ${theme.transitions.easing.easeInOut} infinite alternate`,
@@ -355,7 +357,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
       left: "0",
     },
     coordinates: {
-      color: "#C3C3C3",
+      color: goWhite,
       fontFamily: `"Lucida Console", "Lucida Sans Unicode", "Fira Mono", Consolas, "Courier New", Courier, monospace, "Times New Roman"`,
       fontSize: "calc(min(1.3vw, 12px))",
       display: "none",
@@ -378,8 +380,8 @@ export const pointStyle = makeStyles((theme: Theme) =>
       position: "absolute",
       zIndex: "10",
     },
-  }),
-);
+  });
+});
 
 export const boardStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -527,7 +529,7 @@ export const boardStyles = makeStyles((theme: Theme) =>
     background: {
       position: "absolute",
       opacity: 0.09,
-      color: "#C3C3C3",
+      color: "#FFF",
       fontFamily: "monospace",
       fontSize: "calc(min(.65vh - 2px, 0.65vw - 2px))",
       whiteSpace: "pre",
@@ -583,3 +585,13 @@ export const boardStyles = makeStyles((theme: Theme) =>
     },
   }),
 );
+
+function colorIsDark(color: string): boolean {
+  const hexMatch = color.match(/([\da-f]{2})([\da-f]{2})([\da-f]{2})/i) ?? [];
+  const r = parseInt(hexMatch[1], 16);
+  const g = parseInt(hexMatch[2], 16);
+  const b = parseInt(hexMatch[3], 16);
+
+  // HSP equation from http://alienryderflex.com/hsp.html
+  return Math.sqrt(0.299 * (r * r) + 0.587 * (g * g) + 0.114 * (b * b)) < 127.5;
+}

--- a/src/Go/boardState/goStyles.ts
+++ b/src/Go/boardState/goStyles.ts
@@ -13,17 +13,17 @@ export const pointStyle = makeStyles((theme: Theme) =>
       width: "100%",
 
       "&$hover$valid:hover $innerPoint": {
-        outlineColor: theme.colors.white,
+        outlineColor: "#C3C3C3",
       },
       "&$hover$priorPoint $innerPoint": {
-        outlineColor: theme.colors.white,
+        outlineColor: "#C3C3C3",
       },
       "&$hover$priorPoint $priorStoneTrad$blackPoint": {
-        outlineColor: theme.colors.white,
+        outlineColor: "#C3C3C3",
         display: "block",
       },
       "&$hover$priorPoint $priorStoneTrad$whitePoint": {
-        outlineColor: theme.colors.black,
+        outlineColor: "#0A0B0B",
         display: "block",
       },
       "&$hover:hover $coordinates": {
@@ -34,7 +34,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
       },
     },
     broken: {
-      backgroundImage: `repeating-radial-gradient(circle at 17% 32%, ${theme.colors.white}, black 0.00085px)`,
+      backgroundImage: `repeating-radial-gradient(circle at 17% 32%, #FFF, black 0.00085px)`,
       backgroundPosition: "center",
       animation: `$static 5s linear infinite`,
       opacity: "0",
@@ -64,13 +64,13 @@ export const pointStyle = makeStyles((theme: Theme) =>
       },
       "& $broken": {
         backgroundImage: "none",
-        backgroundColor: theme.colors.black,
+        backgroundColor: "#0A0B0B",
       },
       "& $tradStone": {
         display: "block",
       },
       "& $liberty": {
-        backgroundColor: theme.colors.black,
+        backgroundColor: "#0A0B0B",
         transition: "none",
         "&:not($northLiberty):not($southLiberty):not($eastLiberty):not($westLiberty)": {
           width: 0,
@@ -86,12 +86,12 @@ export const pointStyle = makeStyles((theme: Theme) =>
       "&$nineteenByNineteen": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
         "& $coordinates": {
@@ -101,12 +101,12 @@ export const pointStyle = makeStyles((theme: Theme) =>
       "&$thirteenByThirteen": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
         "& $coordinates": {
@@ -116,24 +116,24 @@ export const pointStyle = makeStyles((theme: Theme) =>
       "&$nineByNine": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
       },
       "&$sevenBySeven": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
       },
@@ -142,23 +142,23 @@ export const pointStyle = makeStyles((theme: Theme) =>
         left: "15%",
       },
       "& $blackPoint ~ $coordinates": {
-        color: theme.colors.white,
+        color: "#C3C3C3",
       },
     },
     fiveByFive: {
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     sevenBySeven: {
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(23px, 3vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(23px, 3vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(25px, 3vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(25px, 3vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     nineByNine: {
@@ -166,10 +166,10 @@ export const pointStyle = makeStyles((theme: Theme) =>
         boxShadow: "0px 0px 30px hsla(0, 100%, 100%, 0.48)",
       },
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     thirteenByThirteen: {
@@ -177,10 +177,10 @@ export const pointStyle = makeStyles((theme: Theme) =>
         boxShadow: "0px 0px 18px hsla(0, 100%, 100%, 0.48)",
       },
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     nineteenByNineteen: {
@@ -188,10 +188,10 @@ export const pointStyle = makeStyles((theme: Theme) =>
         boxShadow: "0px 0px 18px hsla(0, 100%, 100%, 0.48)",
       },
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
 
       "& $innerPoint": {
@@ -237,8 +237,8 @@ export const pointStyle = makeStyles((theme: Theme) =>
         margin: 0,
 
         "&:before": {
-          backgroundColor: theme.colors.black,
-          backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.black} 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+          backgroundColor: "#0A0B0B",
+          backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
         },
       },
       "&$whitePoint": {
@@ -249,7 +249,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
 
         "&:before": {
           backgroundColor: "hsla(0, 0%, 90%, 1)",
-          backgroundImage: `linear-gradient(145deg, transparent, ${theme.colors.white} 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+          backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
         },
       },
       "&$emptyPoint": {
@@ -280,7 +280,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
       width: "10%",
       height: "10%",
       margin: "45%",
-      backgroundColor: theme.colors.white,
+      backgroundColor: "#C3C3C3",
       position: "relative",
     },
     filledPoint: {
@@ -301,8 +301,8 @@ export const pointStyle = makeStyles((theme: Theme) =>
       width: "70%",
       height: "70%",
       margin: "15%",
-      backgroundColor: theme.colors.black,
-      outlineColor: theme.colors.white,
+      backgroundColor: "#0A0B0B",
+      outlineColor: "#C3C3C3",
     },
     fadeLoopAnimation: {
       animation: `$fadeLoop 800ms ${theme.transitions.easing.easeInOut} infinite alternate`,
@@ -355,7 +355,7 @@ export const pointStyle = makeStyles((theme: Theme) =>
       left: "0",
     },
     coordinates: {
-      color: theme.colors.white,
+      color: "#C3C3C3",
       fontFamily: `"Lucida Console", "Lucida Sans Unicode", "Fira Mono", Consolas, "Courier New", Courier, monospace, "Times New Roman"`,
       fontSize: "calc(min(1.3vw, 12px))",
       display: "none",
@@ -527,7 +527,7 @@ export const boardStyles = makeStyles((theme: Theme) =>
     background: {
       position: "absolute",
       opacity: 0.09,
-      color: theme.colors.white,
+      color: "#C3C3C3",
       fontFamily: "monospace",
       fontSize: "calc(min(.65vh - 2px, 0.65vw - 2px))",
       whiteSpace: "pre",

--- a/src/Go/boardState/goStyles.ts
+++ b/src/Go/boardState/goStyles.ts
@@ -36,7 +36,7 @@ export const pointStyle = makeStyles((theme: Theme) => {
       },
     },
     broken: {
-      backgroundImage: `repeating-radial-gradient(circle at 17% 32%, #FFF, black 0.00085px)`,
+      backgroundImage: `repeating-radial-gradient(circle at 17% 32%, ${goWhite}, black 0.00085px)`,
       backgroundPosition: "center",
       animation: `$static 5s linear infinite`,
       opacity: "0",
@@ -88,12 +88,12 @@ export const pointStyle = makeStyles((theme: Theme) => {
       "&$nineteenByNineteen": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(30px, 5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
         "& $coordinates": {
@@ -103,12 +103,12 @@ export const pointStyle = makeStyles((theme: Theme) => {
       "&$thirteenByThirteen": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(40px, 6vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
         "& $coordinates": {
@@ -118,24 +118,24 @@ export const pointStyle = makeStyles((theme: Theme) => {
       "&$nineByNine": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(60px, 7vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
       },
       "&$sevenBySeven": {
         "& $blackPoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
           },
         },
         "& $whitePoint": {
           "&:before": {
-            backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+            backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(80px, 8vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
           },
         },
       },
@@ -149,18 +149,18 @@ export const pointStyle = makeStyles((theme: Theme) => {
     },
     fiveByFive: {
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(35px, 4vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     sevenBySeven: {
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(23px, 3vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(23px, 3vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(25px, 3vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(25px, 3vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     nineByNine: {
@@ -168,10 +168,10 @@ export const pointStyle = makeStyles((theme: Theme) => {
         boxShadow: "0px 0px 30px hsla(0, 100%, 100%, 0.48)",
       },
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(15px, 2vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     thirteenByThirteen: {
@@ -179,10 +179,10 @@ export const pointStyle = makeStyles((theme: Theme) => {
         boxShadow: "0px 0px 18px hsla(0, 100%, 100%, 0.48)",
       },
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
     },
     nineteenByNineteen: {
@@ -190,10 +190,10 @@ export const pointStyle = makeStyles((theme: Theme) => {
         boxShadow: "0px 0px 18px hsla(0, 100%, 100%, 0.48)",
       },
       "& $blackPoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
       },
       "& $whitePoint": {
-        backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+        backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(10px, 1.5vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
       },
 
       "& $innerPoint": {
@@ -240,7 +240,7 @@ export const pointStyle = makeStyles((theme: Theme) => {
 
         "&:before": {
           backgroundColor: goBlack,
-          backgroundImage: `linear-gradient(145deg, transparent, #000 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
+          backgroundImage: `linear-gradient(145deg, transparent, ${goBlack} 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.25) 35%, transparent 36%)`,
         },
       },
       "&$whitePoint": {
@@ -251,7 +251,7 @@ export const pointStyle = makeStyles((theme: Theme) => {
 
         "&:before": {
           backgroundColor: "hsla(0, 0%, 90%, 1)",
-          backgroundImage: `linear-gradient(145deg, transparent, #FFF 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
+          backgroundImage: `linear-gradient(145deg, transparent, ${goWhite} 65%), radial-gradient(calc(min(150px, 11vw)) at 42% 38%, white 0%, white 35%, transparent 36%)`,
         },
       },
       "&$emptyPoint": {
@@ -529,7 +529,7 @@ export const boardStyles = makeStyles((theme: Theme) =>
     background: {
       position: "absolute",
       opacity: 0.09,
-      color: "#FFF",
+      color: "${goWhite}",
       fontFamily: "monospace",
       fontSize: "calc(min(.65vh - 2px, 0.65vw - 2px))",
       whiteSpace: "pre",

--- a/src/Go/boardState/goStyles.ts
+++ b/src/Go/boardState/goStyles.ts
@@ -383,8 +383,10 @@ export const pointStyle = makeStyles((theme: Theme) => {
   });
 });
 
-export const boardStyles = makeStyles((theme: Theme) =>
-  createStyles({
+export const boardStyles = makeStyles((theme: Theme) => {
+  const goWhite = colorIsDark(`${theme.colors.white}`) ? "#C3C3C3" : theme.colors.white;
+  const goBackground = colorIsDark(`${theme.colors.backgroundprimary}`) ? "transparent" : "darkgray";
+  return createStyles({
     tab: {
       paddingTop: 0,
       paddingBottom: 0,
@@ -429,6 +431,7 @@ export const boardStyles = makeStyles((theme: Theme) =>
       width: "100%",
       height: "100%",
       position: "relative",
+      background: goBackground,
     },
     traditional: {
       backgroundColor: "#ca973e",
@@ -529,7 +532,7 @@ export const boardStyles = makeStyles((theme: Theme) =>
     background: {
       position: "absolute",
       opacity: 0.09,
-      color: "${goWhite}",
+      color: goWhite,
       fontFamily: "monospace",
       fontSize: "calc(min(.65vh - 2px, 0.65vw - 2px))",
       whiteSpace: "pre",
@@ -583,14 +586,15 @@ export const boardStyles = makeStyles((theme: Theme) =>
     centeredText: {
       textAlign: "center",
     },
-  }),
-);
+  });
+});
 
 function colorIsDark(color: string): boolean {
-  const hexMatch = color.match(/([\da-f]{2})([\da-f]{2})([\da-f]{2})/i) ?? [];
-  const r = parseInt(hexMatch[1], 16);
-  const g = parseInt(hexMatch[2], 16);
-  const b = parseInt(hexMatch[3], 16);
+  const hexMatch = color.match(/#([\da-f]{2})([\da-f]{2})([\da-f]{2})/i);
+  const shortHexMatch = color.match(/#([\da-f])([\da-f])([\da-f])$/i) ?? [];
+  const r = parseInt(hexMatch?.[1] ?? `${shortHexMatch[1]}0`, 16);
+  const g = parseInt(hexMatch?.[2] ?? `${shortHexMatch[1]}0`, 16);
+  const b = parseInt(hexMatch?.[3] ?? `${shortHexMatch[1]}0`, 16);
 
   // HSP equation from http://alienryderflex.com/hsp.html
   return Math.sqrt(0.299 * (r * r) + 0.587 * (g * g) + 0.114 * (b * b)) < 127.5;

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -171,6 +171,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   function setTraditional(newValue: boolean) {
     Settings.GoTraditionalStyle = newValue;
+    rerender();
   }
 
   const endGameAvailable = boardState.previousPlayer === GoColor.white && boardState.passCount;


### PR DESCRIPTION
* Ensure that there is always a contrast between light pieces and dark pieces (because some themes use the same color for the 'white' and 'black' theme entries) via luminance calculation of hex color
* Use a softer color if there is not contrast, to ensure it isn't too bright for people with eye sensitivity
* Ensure that light themes have a medium-luminance background, so you can see all pieces easily
* Ensure changing to traditional go style re-renders the board