### PR TITLE
IPVGO: Ensure that the player has the prerequisites to face the secret opponent

### DIFF
--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -1,7 +1,7 @@
 import type { BoardState, Play } from "../Types";
 
 import { Player } from "@player";
-import { GoColor, GoPlayType, GoValidity, GoOpponent } from "@enums";
+import { AugmentationName, GoColor, GoOpponent, GoPlayType, GoValidity } from "@enums";
 import { Go, GoEvents } from "../Go";
 import { getMove, sleep } from "../boardAnalysis/goAI";
 import { getNewBoardState, makeMove, passTurn, updateCaptures, updateChains } from "../boardState/boardState";
@@ -177,7 +177,12 @@ function logEndGame(logger: (s: string) => void) {
  */
 export function resetBoardState(error: (s: string) => void, opponent: GoOpponent, boardSize: number) {
   if (![5, 7, 9, 13].includes(boardSize)) {
-    error(`Invalid subnet size requested (${boardSize}, size must be 5, 7, 9, or 13`);
+    error(`Invalid subnet size requested (${boardSize}), size must be 5, 7, 9, or 13`);
+    return;
+  }
+
+  if (opponent === GoOpponent.w0r1d_d43m0n && !Player.hasAugmentation(AugmentationName.TheRedPill, true)) {
+    error(`Invalid opponent requested (${opponent}), this opponent has not yet been discovered`);
     return;
   }
 

--- a/test/jest/Go/NetscriptGo.test.ts
+++ b/test/jest/Go/NetscriptGo.test.ts
@@ -1,7 +1,7 @@
-import { setPlayer } from "@player";
-import { GoOpponent, GoColor, GoPlayType } from "@enums";
-import { Go } from "../../../src/Go/Go";
-import { boardStateFromSimpleBoard, simpleBoardFromBoard } from "../../../src/Go/boardAnalysis/boardAnalysis";
+import {setPlayer} from "@player";
+import {GoColor, GoOpponent, GoPlayType} from "@enums";
+import {Go} from "../../../src/Go/Go";
+import {boardStateFromSimpleBoard, simpleBoardFromBoard} from "../../../src/Go/boardAnalysis/boardAnalysis";
 import {
   cheatPlayTwoMoves,
   cheatRemoveRouter,
@@ -15,9 +15,9 @@ import {
   makePlayerMove,
   resetBoardState,
 } from "../../../src/Go/effects/netscriptGoImplementation";
-import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
+import {PlayerObject} from "../../../src/PersonObjects/Player/PlayerObject";
 import "../../../src/Faction/Factions";
-import { getNewBoardState } from "../../../src/Go/boardState/boardState";
+import {getNewBoardState} from "../../../src/Go/boardState/boardState";
 
 jest.mock("../../../src/Faction/Factions", () => ({
   Factions: {},
@@ -87,19 +87,17 @@ describe("Netscript Go API unit tests", () => {
       expect(Go.currentGame.board.length).toEqual(9);
       expect(Go.currentGame.ai).toEqual(GoOpponent.SlumSnakes);
     });
-    /* This typechecking is now done prior to calling resetBoardState (it's checked in the ns function via getEnumHelper("GoOpponent".nsGetMember()))
     it("should throw an error if an invalid opponent is requested", () => {
       const board = ["OXX..", ".....", ".....", ".....", "..###"];
-      Go.boardState = getBoardFromSimplifiedBoardState(board);
+      Go.currentGame = boardStateFromSimpleBoard(board);
       const mockError = jest.fn();
 
-      resetBoardState(mockError, "fake opponent", 9);
+      resetBoardState(mockError, GoOpponent.w0r1d_d43m0n, 9);
 
       expect(mockError).toHaveBeenCalledWith(
-        "Invalid opponent requested (fake opponent), valid options are Netburners, Slum Snakes, The Black Hand, Tetrads, Daedalus, Illuminati",
+        `Invalid opponent requested (${GoOpponent.w0r1d_d43m0n}), this opponent has not yet been discovered`,
       );
     });
-*/
     it("should throw an error if an invalid size is requested", () => {
       const board = ["OXX..", ".....", ".....", ".....", "..###"];
       Go.currentGame = boardStateFromSimpleBoard(board);
@@ -107,7 +105,7 @@ describe("Netscript Go API unit tests", () => {
 
       resetBoardState(mockError, GoOpponent.TheBlackHand, 31337);
 
-      expect(mockError).toHaveBeenCalledWith("Invalid subnet size requested (31337, size must be 5, 7, 9, or 13");
+      expect(mockError).toHaveBeenCalledWith("Invalid subnet size requested (31337), size must be 5, 7, 9, or 13");
     });
   });
 

--- a/test/jest/Go/NetscriptGo.test.ts
+++ b/test/jest/Go/NetscriptGo.test.ts
@@ -1,7 +1,7 @@
-import {setPlayer} from "@player";
-import {GoColor, GoOpponent, GoPlayType} from "@enums";
-import {Go} from "../../../src/Go/Go";
-import {boardStateFromSimpleBoard, simpleBoardFromBoard} from "../../../src/Go/boardAnalysis/boardAnalysis";
+import { setPlayer } from "@player";
+import { GoColor, GoOpponent, GoPlayType } from "@enums";
+import { Go } from "../../../src/Go/Go";
+import { boardStateFromSimpleBoard, simpleBoardFromBoard } from "../../../src/Go/boardAnalysis/boardAnalysis";
 import {
   cheatPlayTwoMoves,
   cheatRemoveRouter,
@@ -15,9 +15,9 @@ import {
   makePlayerMove,
   resetBoardState,
 } from "../../../src/Go/effects/netscriptGoImplementation";
-import {PlayerObject} from "../../../src/PersonObjects/Player/PlayerObject";
+import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
 import "../../../src/Faction/Factions";
-import {getNewBoardState} from "../../../src/Go/boardState/boardState";
+import { getNewBoardState } from "../../../src/Go/boardState/boardState";
 
 jest.mock("../../../src/Faction/Factions", () => ({
   Factions: {},


### PR DESCRIPTION
Players need to have TRP installed to face the final opponent. This change ensures the requirement is enforced in the netscript API.