### PR TITLE
BUGFIX: spawn() log reads "seconds" instead of "milliseconds"

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -745,7 +745,7 @@ export const ns: InternalAPI<NSFull> = {
         return runScriptFromScript("spawn", scriptServer, path, args, ctx.workerScript, runOpts);
       }, runOpts.spawnDelay);
 
-      helpers.log(ctx, () => `Will execute '${path}' in ${runOpts.spawnDelay} seconds`);
+      helpers.log(ctx, () => `Will execute '${path}' in ${runOpts.spawnDelay} milliseconds`);
 
       if (killWorkerScript(ctx.workerScript)) {
         helpers.log(ctx, () => "Exiting...");


### PR DESCRIPTION
Bugfix for ns.spawn() logs

Currently checking the recently killed logs for scripts that were killed by ns.spawn() will list "will execute in X seconds" where X is listed as milliseconds.

So it should say "will execute in X milliseconds"