### PR TITLE
IPVGO: Bugfix: ensure the 'No AI' white player can still pass, and fix missing dead nodes

### DIFF
--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -3,14 +3,14 @@ import type { BoardState } from "../Types";
 import React, { useEffect, useState } from "react";
 import { Box, Button, Typography } from "@mui/material";
 
-import { GoOpponent, GoColor, GoPlayType, GoValidity, ToastVariant } from "@enums";
+import { GoColor, GoOpponent, GoPlayType, GoValidity, ToastVariant } from "@enums";
 import { Go, GoEvents } from "../Go";
 import { SnackbarEvents } from "../../ui/React/Snackbar";
 import { getNewBoardState, getStateCopy, makeMove, passTurn, updateCaptures } from "../boardState/boardState";
 import { getMove } from "../boardAnalysis/goAI";
 import { bitverseArt, weiArt } from "../boardState/asciiArt";
 import { getScore, resetWinstreak } from "../boardAnalysis/scoring";
-import { evaluateIfMoveIsValid, getAllValidMoves, boardFromSimpleBoard } from "../boardAnalysis/boardAnalysis";
+import { boardFromSimpleBoard, evaluateIfMoveIsValid, getAllValidMoves } from "../boardAnalysis/boardAnalysis";
 import { useRerender } from "../../ui/React/hooks";
 import { OptionSwitch } from "../../ui/React/OptionSwitch";
 import { boardStyles } from "../boardState/goStyles";
@@ -36,8 +36,7 @@ interface GoGameboardWrapperProps {
 export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps): React.ReactElement {
   const rerender = useRerender();
   useEffect(() => {
-    const unsubscribe = GoEvents.subscribe(rerender);
-    return unsubscribe;
+    return GoEvents.subscribe(rerender);
   }, [rerender]);
 
   const boardState = Go.currentGame;
@@ -56,7 +55,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   // Only run this once on first component mount, to handle scenarios where the game was saved or closed while waiting on the AI to make a move
   useEffect(() => {
-    if (boardState.previousPlayer === GoColor.black && !waitingOnAI) {
+    if (boardState.previousPlayer === GoColor.black && !waitingOnAI && boardState.ai !== GoOpponent.none) {
       takeAiTurn(Go.currentGame);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -102,6 +101,10 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
   function passPlayerTurn() {
     if (boardState.previousPlayer === GoColor.white) {
       passTurn(boardState, GoColor.black);
+      rerender();
+    }
+    if (boardState.previousPlayer === GoColor.black && boardState.ai === GoOpponent.none) {
+      passTurn(boardState, GoColor.white);
       rerender();
     }
     if (boardState.previousPlayer === null) {
@@ -150,7 +153,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
       resetWinstreak(boardState.ai, false);
     }
 
-    Go.currentGame = getNewBoardState(newBoardSize, newOpponent, false);
+    Go.currentGame = getNewBoardState(newBoardSize, newOpponent, true);
     rerender();
   }
 


### PR DESCRIPTION
* Ensure offline nodes are applied when manually resetting the board via UI
* Ensure that the auto-start AI does not trigger with "No AI" as the opponent
* Fix passing as white with "No AI" as the opponent