### PR TITLE
MISC: Remove jquery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bitburner",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {
@@ -29,7 +29,6 @@
         "date-fns": "^2.30.0",
         "escodegen": "^2.1.0",
         "file-saver": "^2.0.5",
-        "jquery": "^3.7.1",
         "js-sha256": "^0.9.0",
         "jszip": "^3.10.1",
         "material-ui-color": "^1.2.0",
@@ -12547,11 +12546,6 @@
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "node_modules/js-sha256": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "date-fns": "^2.30.0",
     "escodegen": "^2.1.0",
     "file-saver": "^2.0.5",
-    "jquery": "^3.7.1",
     "js-sha256": "^0.9.0",
     "jszip": "^3.10.1",
     "material-ui-color": "^1.2.0",

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1636,37 +1636,42 @@ export const ns: InternalAPI<NSFull> = {
       });
     });
   },
-  wget: (ctx) => (_url, _target, _hostname) => {
+  wget: (ctx) => async (_url, _target, _hostname) => {
     const url = helpers.string(ctx, "url", _url);
     const target = helpers.filePath(ctx, "target", _target);
     const hostname = _hostname ? helpers.string(ctx, "hostname", _hostname) : ctx.workerScript.hostname;
     const server = helpers.getServer(ctx, hostname);
     if (!target || (!hasTextExtension(target) && !hasScriptExtension(target))) {
       helpers.log(ctx, () => `Invalid target file: '${target}'. Must be a script or text file.`);
-      return Promise.resolve(false);
+      return false;
     }
-    return new Promise(function (resolve) {
-      fetch(url)
-        .then(async (response) => {
-          if (response.status !== 200) {
-            helpers.log(ctx, () => `wget failed. HTTP code: ${response.status}.`);
-            resolve(false);
-            return;
-          }
-          const writeResult = server.writeToContentFile(target, await response.text());
-          if (writeResult.overwritten) {
-            helpers.log(ctx, () => `Successfully retrieved content and overwrote '${target}' on '${hostname}'`);
-            resolve(true);
-          } else {
-            helpers.log(ctx, () => `Successfully retrieved content to new file '${target}' on '${hostname}'`);
-            resolve(true);
-          }
-        })
-        .catch((reason) => {
-          helpers.log(ctx, () => JSON.stringify(reason, Object.getOwnPropertyNames(reason)));
-          resolve(false);
-        });
-    });
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (error) {
+      /**
+       * Properties in error are not enumerable, so JSON.stringify(error) returns "{}". We need to explicitly specify
+       * the properties in the "replacer" parameter of JSON.stringify. We can do it by using Object.getOwnPropertyNames.
+       *
+       * Ref:
+       * - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+       * - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames
+       * - https://stackoverflow.com/q/18391212
+       */
+      helpers.log(ctx, () => JSON.stringify(error, Object.getOwnPropertyNames(error)));
+      return false;
+    }
+    if (response.status !== 200) {
+      helpers.log(ctx, () => `wget failed. HTTP code: ${response.status}.`);
+      return false;
+    }
+    const writeResult = server.writeToContentFile(target, await response.text());
+    if (writeResult.overwritten) {
+      helpers.log(ctx, () => `Successfully retrieved content and overwrote '${target}' on '${hostname}'`);
+    } else {
+      helpers.log(ctx, () => `Successfully retrieved content to new file '${target}' on '${hostname}'`);
+    }
+    return true;
   },
   getFavorToDonate: () => () => {
     return Math.floor(CONSTANTS.BaseFavorToDonate * currentNodeMults.RepToDonateToFaction);

--- a/src/Terminal/commands/wget.ts
+++ b/src/Terminal/commands/wget.ts
@@ -1,37 +1,34 @@
-import $ from "jquery";
-
 import { Terminal } from "../../Terminal";
 import { BaseServer } from "../../Server/BaseServer";
 import { hasScriptExtension } from "../../Paths/ScriptFilePath";
 import { hasTextExtension } from "../../Paths/TextFilePath";
 
 export function wget(args: (string | number | boolean)[], server: BaseServer): void {
-  if (args.length !== 2) {
+  if (args.length !== 2 || typeof args[0] !== "string" || typeof args[1] !== "string") {
     Terminal.error("Incorrect usage of wget command. Usage: wget [url] [target file]");
     return;
   }
 
-  const url = args[0] + "";
-  const target = Terminal.getFilepath(args[1] + "");
+  const target = Terminal.getFilepath(args[1]);
   if (!target || (!hasScriptExtension(target) && !hasTextExtension(target))) {
-    return Terminal.error(`wget failed: Invalid target file. Target file must be script or text file`);
+    Terminal.error(`wget failed: Invalid target file. Target file must be a script file or a text file.`);
+    return;
   }
-  $.get(
-    url,
-    function (data: unknown) {
-      let res;
-      if (hasTextExtension(target)) {
-        res = server.writeToTextFile(target, String(data));
+
+  fetch(args[0])
+    .then(async (response) => {
+      if (response.status !== 200) {
+        Terminal.error(`wget failed. HTTP code: ${response.status}.`);
+        return;
+      }
+      const writeResult = server.writeToContentFile(target, await response.text());
+      if (writeResult.overwritten) {
+        Terminal.print(`wget successfully retrieved content and overwrote ${target}`);
       } else {
-        res = server.writeToScriptFile(target, String(data));
+        Terminal.print(`wget successfully retrieved content to new file ${target}`);
       }
-      if (res.overwritten) {
-        return Terminal.print(`wget successfully retrieved content and overwrote ${target}`);
-      }
-      return Terminal.print(`wget successfully retrieved content to new file ${target}`);
-    },
-    "text",
-  ).fail(function (e) {
-    return Terminal.error("wget failed: " + JSON.stringify(e));
-  });
+    })
+    .catch((reason) => {
+      Terminal.error(`wget failed: ${JSON.stringify(reason, Object.getOwnPropertyNames(reason))}`);
+    });
 }

--- a/src/Terminal/commands/wget.ts
+++ b/src/Terminal/commands/wget.ts
@@ -29,6 +29,7 @@ export function wget(args: (string | number | boolean)[], server: BaseServer): v
       }
     })
     .catch((reason) => {
+      // Check the comment in wget of src\NetscriptFunctions.ts to see why we use Object.getOwnPropertyNames.
       Terminal.error(`wget failed: ${JSON.stringify(reason, Object.getOwnPropertyNames(reason))}`);
     });
 }


### PR DESCRIPTION
This PR replaces the usage of `jquery.get` with `fetch`. After that, we can remove the `jquery` library.

One concern that I notice when making this PR is the duplication of logic between many functions in `NetscriptFunctions.ts` and code in `src\Terminal\commands\*.ts`. It may require a big PR to solve that problem, so I skip it in this PR.
