### PR TITLE
IPVGO: Bugfix: Require special opponent to be on the fixed size board

### DIFF
--- a/src/Go/boardState/boardState.ts
+++ b/src/Go/boardState/boardState.ts
@@ -23,6 +23,7 @@ export function getNewBoardState(
 ): BoardState {
   if (ai === GoOpponent.w0r1d_d43m0n) {
     boardToCopy = resetCoordinates(rotate90Degrees(boardFromSimpleBoard(bitverseBoardShape)));
+    boardSize = 19;
   }
 
   const newBoardState: BoardState = {
@@ -166,12 +167,12 @@ export function updateChains(board: Board, resetChains = true): void {
  * Modifies the board in place.
  */
 export function updateCaptures(board: Board, playerWhoMoved: GoColor, resetChains = true): void {
-  const boardState = updateChains(board, resetChains);
+  updateChains(board, resetChains);
   const chains = getAllChains(board);
 
   const chainsToCapture = findAllCapturedChains(chains, playerWhoMoved);
   if (!chainsToCapture?.length) {
-    return boardState;
+    return;
   }
 
   chainsToCapture?.forEach((chain) => captureChain(chain));

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -259,7 +259,7 @@ export async function determineCheatSuccess(
  * Cheating success rate scales with player's crime success rate, and decreases with prior cheat attempts.
  */
 export function cheatSuccessChance(cheatCount: number) {
-  return Math.min(0.6 * 0.8 ** cheatCount * Player.mults.crime_success, 1);
+  return Math.min(0.6 * 0.65 ** cheatCount * Player.mults.crime_success, 1);
 }
 
 /**

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -259,7 +259,7 @@ export async function determineCheatSuccess(
  * Cheating success rate scales with player's crime success rate, and decreases with prior cheat attempts.
  */
 export function cheatSuccessChance(cheatCount: number) {
-  return Math.min(0.6 * (0.8 ^ cheatCount) * Player.mults.crime_success, 1);
+  return Math.min(0.6 * (0.8 ** cheatCount) * Player.mults.crime_success, 1);
 }
 
 /**

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -259,7 +259,7 @@ export async function determineCheatSuccess(
  * Cheating success rate scales with player's crime success rate, and decreases with prior cheat attempts.
  */
 export function cheatSuccessChance(cheatCount: number) {
-  return Math.min(0.6 * (0.8 ** cheatCount) * Player.mults.crime_success, 1);
+  return Math.min(0.6 * 0.8 ** cheatCount * Player.mults.crime_success, 1);
 }
 
 /**

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -176,7 +176,7 @@ function logEndGame(logger: (s: string) => void) {
  * Clears the board, resets winstreak if applicable
  */
 export function resetBoardState(error: (s: string) => void, opponent: GoOpponent, boardSize: number) {
-  if (![5, 7, 9, 13].includes(boardSize)) {
+  if (![5, 7, 9, 13].includes(boardSize) && opponent !== GoOpponent.w0r1d_d43m0n) {
     error(`Invalid subnet size requested (${boardSize}), size must be 5, 7, 9, or 13`);
     return;
   }

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -3,14 +3,14 @@ import type { BoardState } from "../Types";
 import React, { useEffect, useState } from "react";
 import { Box, Button, Typography } from "@mui/material";
 
-import { GoOpponent, GoColor, GoPlayType, GoValidity, ToastVariant } from "@enums";
+import { GoColor, GoOpponent, GoPlayType, GoValidity, ToastVariant } from "@enums";
 import { Go, GoEvents } from "../Go";
 import { SnackbarEvents } from "../../ui/React/Snackbar";
 import { getNewBoardState, getStateCopy, makeMove, passTurn, updateCaptures } from "../boardState/boardState";
 import { getMove } from "../boardAnalysis/goAI";
 import { bitverseArt, weiArt } from "../boardState/asciiArt";
 import { getScore, resetWinstreak } from "../boardAnalysis/scoring";
-import { evaluateIfMoveIsValid, getAllValidMoves, boardFromSimpleBoard } from "../boardAnalysis/boardAnalysis";
+import { boardFromSimpleBoard, evaluateIfMoveIsValid, getAllValidMoves } from "../boardAnalysis/boardAnalysis";
 import { useRerender } from "../../ui/React/hooks";
 import { OptionSwitch } from "../../ui/React/OptionSwitch";
 import { boardStyles } from "../boardState/goStyles";
@@ -36,8 +36,7 @@ interface GoGameboardWrapperProps {
 export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps): React.ReactElement {
   const rerender = useRerender();
   useEffect(() => {
-    const unsubscribe = GoEvents.subscribe(rerender);
-    return unsubscribe;
+    return GoEvents.subscribe(rerender);
   }, [rerender]);
 
   const boardState = Go.currentGame;
@@ -56,7 +55,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   // Only run this once on first component mount, to handle scenarios where the game was saved or closed while waiting on the AI to make a move
   useEffect(() => {
-    if (boardState.previousPlayer === GoColor.black && !waitingOnAI) {
+    if (boardState.previousPlayer === GoColor.black && !waitingOnAI && boardState.ai !== GoOpponent.none) {
       takeAiTurn(Go.currentGame);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -102,6 +101,10 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
   function passPlayerTurn() {
     if (boardState.previousPlayer === GoColor.white) {
       passTurn(boardState, GoColor.black);
+      rerender();
+    }
+    if (boardState.previousPlayer === GoColor.black && boardState.ai === GoOpponent.none) {
+      passTurn(boardState, GoColor.white);
       rerender();
     }
     if (boardState.previousPlayer === null) {
@@ -150,7 +153,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
       resetWinstreak(boardState.ai, false);
     }
 
-    Go.currentGame = getNewBoardState(newBoardSize, newOpponent, false);
+    Go.currentGame = getNewBoardState(newBoardSize, newOpponent, true);
     rerender();
   }
 


### PR DESCRIPTION
Previously, the API allowed for the user to specify small boards for the secret opponent, but it would do strange things once the special boardshape was applied. This ensures it is correctly on a 19x19 board, as intended

Also, fix calculation for cheat success chance to get harder with each cheat, as intended