### PR TITLE
MISC: Add a credits page to documentation

### DIFF
--- a/src/Documentation/doc/credits.md
+++ b/src/Documentation/doc/credits.md
@@ -1,0 +1,19 @@
+## Maintainers
+
+[BigD/danielyxie](https://github.com/danielyxie): Creator of the original game and BN 1 to 11, maintainer until v0.47.2 (2019-07-15).
+
+[hydroflame](https://github.com/hydroflame): BN 12 and 13, maintainer from v0.48.0 (2021-03-07) until 2.1.0 (2022-09-23).
+
+[Snarling](https://github.com/Snarling): current maintainer from 2.2.0 (2023-01-03).
+
+## Contributors
+
+[ficocelliguy](https://github.com/ficocelliguy): BN 14.
+
+Everyone else who contributed to the github repository.
+
+## Links
+
+Original repository: https://github.com/danielyxie/bitburner
+
+Current repository: https://github.com/bitburner-official/bitburner-src

--- a/src/Documentation/doc/index.md
+++ b/src/Documentation/doc/index.md
@@ -48,6 +48,7 @@
 - [Game Frozen or Stuck?](programming/game_frozen.md)
 - [Tools & Resources](help/tools_and_resources.md)
 - [Changelog](changelog.md)
+- [Credits and history](credits.md)
 
 ## Migration
 


### PR DESCRIPTION
> It's so easy for history and credit to get wiped away. [...] There are thousands of people whose good work on games will never be properly credited, who we might have already forgotten about. Gaming is still a young medium but already the sands of our history are spilling through our Monster Energy-sodden fingers. Entire games are at risk of being forgotten, never mind the human beings who created them. [...] The thing about history is, it happens and then it's gone. If we don't work to preserve it, eventually it becomes impossible. To quote a famous Nintendo quit screen, "Everything not saved will be lost." And just as a kicker how hard it is to remember things accurately, the popularized version of the quote is wrong. It's actually, "Anything not saved." [...] Gaming is just old enough that we're losing that first generation. [...] What history will look like 20, 30, 100 years in the future is being decided now.

- hbomberguy, [ROBLOX_OOF.mp3](https://www.youtube.com/watch?v=0twDETh6QaI).

It's not quite as dramatic in our case (the video was more focused on people stealing credit from other people), but I do feel that properly crediting people who worked on the game in the past is pretty important, even if our project is relatively small. This information is pretty easy to retrieve right now, but the more time passes, the more it's at risk of disappearing. Sure, we have the github commit history, but let's be real, nobody's going to dig through that looking for the original creator of a tiny indie game.

So, I though it'd be a good idea to make a small document documenting Bitburner's creation history and dug through the commits, changelog, and discord messages to compile it into this small page. Currently it lists maintainers and people who created BNs, which is 4 people in total. It still feels kind of empty, but I couldn't think of anything else to add - I welcome suggestions. I would also encourage people who made significant contributions to be added or add themselves to the list - I'm no Bitburner history expert and went with a simple criteria for inclusion, which I don't claim to be absolute.

An interesting tidbit that digging through the changelog has uncovered is that Bitnodes weren't created in order from 1 to 11. Do you think that's worth noting?