### PR TITLE
CORPORATION: more granular office size upgrades

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -22,6 +22,7 @@ import {
   buybackSharesFailureReason,
   issueNewSharesFailureReason,
 } from "./helpers";
+import { PositiveInteger } from "../types";
 
 export function NewDivision(corporation: Corporation, industry: IndustryType, name: string): void {
   if (corporation.divisions.size >= corporation.maxDivisions)
@@ -361,7 +362,7 @@ export function BuyBackShares(corporation: Corporation, numShares: number): bool
   return true;
 }
 
-export function UpgradeOfficeSize(corp: Corporation, office: OfficeSpace, increase: number): void {
+export function UpgradeOfficeSize(corp: Corporation, office: OfficeSpace, increase: PositiveInteger): void {
   const cost = calculateOfficeSizeUpgradeCost(office.size, increase);
   if (corp.funds < cost) return;
   office.size += increase;

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -16,7 +16,12 @@ import { isRelevantMaterial } from "./ui/Helpers";
 import { CityName } from "@enums";
 import { getRandomInt } from "../utils/helpers/getRandomInt";
 import { getRecordValues } from "../Types/Record";
-import { sellSharesFailureReason, buybackSharesFailureReason, issueNewSharesFailureReason } from "./helpers";
+import {
+  calculateOfficeSizeUpgradeCost,
+  sellSharesFailureReason,
+  buybackSharesFailureReason,
+  issueNewSharesFailureReason,
+} from "./helpers";
 
 export function NewDivision(corporation: Corporation, industry: IndustryType, name: string): void {
   if (corporation.divisions.size >= corporation.maxDivisions)
@@ -356,17 +361,10 @@ export function BuyBackShares(corporation: Corporation, numShares: number): bool
   return true;
 }
 
-export function UpgradeOfficeSize(corp: Corporation, office: OfficeSpace, size: number): void {
-  const initialPriceMult = Math.round(office.size / corpConstants.officeInitialSize);
-  const costMultiplier = 1.09;
-  // Calculate cost to upgrade size by 15 employees
-  let mult = 0;
-  for (let i = 0; i < size / corpConstants.officeInitialSize; ++i) {
-    mult += Math.pow(costMultiplier, initialPriceMult + i);
-  }
-  const cost = corpConstants.officeInitialCost * mult;
+export function UpgradeOfficeSize(corp: Corporation, office: OfficeSpace, increase: number): void {
+  const cost = calculateOfficeSizeUpgradeCost(office.size, increase);
   if (corp.funds < cost) return;
-  office.size += size;
+  office.size += increase;
   corp.loseFunds(cost, "office");
 }
 

--- a/src/Corporation/helpers.ts
+++ b/src/Corporation/helpers.ts
@@ -13,13 +13,13 @@ export function calculateUpgradeCost(corporation: Corporation, upgrade: CorpUpgr
   return cost;
 }
 
-export function calculateOfficeSizeUpgradeCost(currentSize: number, sizeIncrease: number): number {
-  if (sizeIncrease < 0) throw new Error("Invalid value for sizeIncrease argument! Must be at least 0!");
-  if (sizeIncrease == 0) return 0;
-  const baseCostMultiplier = 1.09;
+export function calculateOfficeSizeUpgradeCost(currentSize: number, sizeIncrease: PositiveInteger): number {
+  if (sizeIncrease <= 0) throw new Error("Invalid value for sizeIncrease argument! Must be at least 0!");
+  const baseCostDivisor = 0.09;
+  const baseCostMultiplier = 1 + baseCostDivisor;
   const currentSizeFactor = baseCostMultiplier ** (currentSize / 3);
   const sizeIncreaseFactor = baseCostMultiplier ** (sizeIncrease / 3) - 1;
-  return (corpConstants.officeInitialCost / (baseCostMultiplier - 1)) * currentSizeFactor * sizeIncreaseFactor;
+  return (corpConstants.officeInitialCost / baseCostDivisor) * currentSizeFactor * sizeIncreaseFactor;
 }
 
 export function calculateMaxAffordableUpgrade(corp: Corporation, upgrade: CorpUpgrade): 0 | PositiveInteger {

--- a/src/Corporation/helpers.ts
+++ b/src/Corporation/helpers.ts
@@ -16,14 +16,10 @@ export function calculateUpgradeCost(corporation: Corporation, upgrade: CorpUpgr
 export function calculateOfficeSizeUpgradeCost(currentSize: number, sizeIncrease: number): number {
   if (sizeIncrease < 0) throw new Error("Invalid value for sizeIncrease argument! Must be at least 0!");
   if (sizeIncrease == 0) return 0;
-  const baseSize = corpConstants.officeInitialSize;
-  const initialPriceMult = Math.round(currentSize / baseSize);
-  const costMultiplier = 1.09;
-  let mult = 0;
-  for (let i = 0; i < sizeIncrease / baseSize; ++i) {
-    mult += Math.pow(costMultiplier, initialPriceMult + i);
-  }
-  return corpConstants.officeInitialCost * mult;
+  const baseCostMultiplier = 1.09;
+  const currentSizeFactor = baseCostMultiplier ** (currentSize / 3);
+  const sizeIncreaseFactor = baseCostMultiplier ** (sizeIncrease / 3) - 1;
+  return (corpConstants.officeInitialCost / (baseCostMultiplier - 1)) * currentSizeFactor * sizeIncreaseFactor;
 }
 
 export function calculateMaxAffordableUpgrade(corp: Corporation, upgrade: CorpUpgrade): 0 | PositiveInteger {

--- a/src/Corporation/helpers.ts
+++ b/src/Corporation/helpers.ts
@@ -3,6 +3,7 @@ import { PositiveInteger, isPositiveInteger } from "../types";
 import { formatShares } from "../ui/formatNumber";
 import { Corporation } from "./Corporation";
 import { CorpUpgrade } from "./data/CorporationUpgrades";
+import * as corpConstants from "./data/Constants";
 
 export function calculateUpgradeCost(corporation: Corporation, upgrade: CorpUpgrade, amount: PositiveInteger): number {
   const priceMult = upgrade.priceMult;
@@ -10,6 +11,19 @@ export function calculateUpgradeCost(corporation: Corporation, upgrade: CorpUpgr
   const baseCost = upgrade.basePrice * Math.pow(priceMult, level);
   const cost = (baseCost * (1 - Math.pow(priceMult, amount))) / (1 - priceMult);
   return cost;
+}
+
+export function calculateOfficeSizeUpgradeCost(currentSize: number, sizeIncrease: number): number {
+  if (sizeIncrease < 0) throw new Error("Invalid value for sizeIncrease argument! Must be at least 0!");
+  if (sizeIncrease == 0) return 0;
+  const baseSize = corpConstants.officeInitialSize;
+  const initialPriceMult = Math.round(currentSize / baseSize);
+  const costMultiplier = 1.09;
+  let mult = 0;
+  for (let i = 0; i < sizeIncrease / baseSize; ++i) {
+    mult += Math.pow(costMultiplier, initialPriceMult + i);
+  }
+  return corpConstants.officeInitialCost * mult;
 }
 
 export function calculateMaxAffordableUpgrade(corp: Corporation, upgrade: CorpUpgrade): 0 | PositiveInteger {

--- a/src/Corporation/ui/modals/UpgradeOfficeSizeModal.tsx
+++ b/src/Corporation/ui/modals/UpgradeOfficeSizeModal.tsx
@@ -11,6 +11,7 @@ import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
 import Box from "@mui/material/Box";
 import { calculateOfficeSizeUpgradeCost } from "../../helpers";
+import { PositiveInteger } from "../../../types";
 
 interface IUpgradeButton {
   cost: number;
@@ -23,7 +24,7 @@ interface IUpgradeButton {
 
 function UpgradeSizeButton(props: IUpgradeButton): React.ReactElement {
   const corp = useCorporation();
-  function upgradeSize(cost: number, size: number): void {
+  function upgradeSize(cost: number, size: PositiveInteger): void {
     if (corp.funds < cost) {
       return;
     }
@@ -35,7 +36,10 @@ function UpgradeSizeButton(props: IUpgradeButton): React.ReactElement {
   return (
     <Tooltip title={formatMoney(props.cost)}>
       <span>
-        <Button disabled={corp.funds < props.cost} onClick={() => upgradeSize(props.cost, props.size)}>
+        <Button
+          disabled={corp.funds < props.cost}
+          onClick={() => upgradeSize(props.cost, props.size as PositiveInteger)}
+        >
           +{props.size}
         </Button>
       </span>
@@ -54,18 +58,18 @@ export function UpgradeOfficeSizeModal(props: IProps): React.ReactElement {
   const corp = useCorporation();
 
   // appears as +3 office size upgrade
-  const upgradeSizeBase = corpConstants.officeInitialSize;
+  const upgradeSizeBase = corpConstants.officeInitialSize as PositiveInteger;
   const upgradeCostBase = calculateOfficeSizeUpgradeCost(props.office.size, upgradeSizeBase);
 
   // appears as +15 office size upgrade
-  const upgradeSize5x = 5 * corpConstants.officeInitialSize;
-  const upgradeCost5x = calculateOfficeSizeUpgradeCost(props.office.size, 5 * corpConstants.officeInitialSize);
+  const upgradeSize5x = (5 * corpConstants.officeInitialSize) as PositiveInteger;
+  const upgradeCost5x = calculateOfficeSizeUpgradeCost(props.office.size, upgradeSize5x);
 
   // optionally appears as largest affordable office size upgrade (up to +150)
   let upgradeSizeMax = 150;
   let upgradeCostMax = Infinity;
   while (upgradeSizeMax > props.office.size) {
-    upgradeCostMax = calculateOfficeSizeUpgradeCost(props.office.size, upgradeSizeMax - props.office.size);
+    upgradeCostMax = calculateOfficeSizeUpgradeCost(props.office.size, upgradeSizeMax as PositiveInteger);
     if (corp.funds > upgradeCostMax) break;
     upgradeSizeMax -= corpConstants.officeInitialSize;
   }

--- a/src/Corporation/ui/modals/UpgradeOfficeSizeModal.tsx
+++ b/src/Corporation/ui/modals/UpgradeOfficeSizeModal.tsx
@@ -24,12 +24,12 @@ interface IUpgradeButton {
 
 function UpgradeSizeButton(props: IUpgradeButton): React.ReactElement {
   const corp = useCorporation();
-  function upgradeSize(cost: number, size: PositiveInteger): void {
+  function upgradeSize(cost: number, increase: PositiveInteger): void {
     if (corp.funds < cost) {
       return;
     }
 
-    UpgradeOfficeSize(corp, props.office, size);
+    UpgradeOfficeSize(corp, props.office, increase);
     props.rerender();
     props.onClose();
   }

--- a/src/Documentation/doc/advanced/corporation/office.md
+++ b/src/Documentation/doc/advanced/corporation/office.md
@@ -55,8 +55,6 @@ Maximum size with a given `MaxCost`:
 
 $$MaxUpgradeLevel = 3\ast\log_{1.09}\left( MaxCost\ast\frac{0.09}{BasePrice} + {1.09}^{\frac{CurrentSize}{3}} \right)$$
 
-When we divide office's size by 3, we need to use `Math.ceil()` to round up the value. This means upgrading from size 3 to size 4 costs the same as upgrading from size 3 to size 6. The most cost-effective size is always a multiple of 3.
-
 ## Energy and morale
 
 They are calculated in START state.

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -63,7 +63,7 @@ import { InternalAPI, NetscriptContext, setRemovedFunctions } from "../Netscript
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { getEnumHelper } from "../utils/EnumHelper";
 import { MaterialInfo } from "../Corporation/MaterialInfo";
-import { calculateUpgradeCost } from "../Corporation/helpers";
+import { calculateOfficeSizeUpgradeCost, calculateUpgradeCost } from "../Corporation/helpers";
 import { PositiveInteger } from "../types";
 import { getRecordKeys } from "../Types/Record";
 
@@ -511,13 +511,15 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const size = helpers.number(ctx, "size", _size);
       if (size < 0) throw new Error("Invalid value for size field! Must be numeric and greater than 0");
       const office = getOffice(divisionName, cityName);
-      const initialPriceMult = Math.round(office.size / corpConstants.officeInitialSize);
-      const costMultiplier = 1.09;
-      let mult = 0;
-      for (let i = 0; i < size / corpConstants.officeInitialSize; ++i) {
-        mult += Math.pow(costMultiplier, initialPriceMult + i);
-      }
-      return corpConstants.officeInitialCost * mult;
+      return calculateOfficeSizeUpgradeCost(office.size, size);
+      // const initialPriceMult = Math.round(office.size / corpConstants.officeInitialSize);
+      // const costMultiplier = 1.09;
+      // let mult = 0;
+      // //
+      // for (let i = 0; i < size / corpConstants.officeInitialSize; ++i) {
+      //   mult += Math.pow(costMultiplier, initialPriceMult + i);
+      // }
+      // return corpConstants.officeInitialCost * mult;
     },
     setAutoJobAssignment: (ctx) => (_divisionName, _cityName, _job, _amount) => {
       checkAccess(ctx, CorpUnlockName.OfficeAPI);
@@ -559,7 +561,8 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const divisionName = helpers.string(ctx, "divisionName", _divisionName);
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
       const size = helpers.number(ctx, "size", _size);
-      if (size < 0) throw new Error("Invalid value for size field! Must be numeric and greater than 0");
+      //
+      if (size < 0) throw new Error("Invalid value for size field! Can't decrease office size.");
       const office = getOffice(divisionName, cityName);
       const corporation = getCorporation();
       UpgradeOfficeSize(corporation, office, size);

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -512,14 +512,6 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       if (size < 0) throw new Error("Invalid value for size field! Must be numeric and greater than 0");
       const office = getOffice(divisionName, cityName);
       return calculateOfficeSizeUpgradeCost(office.size, size);
-      // const initialPriceMult = Math.round(office.size / corpConstants.officeInitialSize);
-      // const costMultiplier = 1.09;
-      // let mult = 0;
-      // //
-      // for (let i = 0; i < size / corpConstants.officeInitialSize; ++i) {
-      //   mult += Math.pow(costMultiplier, initialPriceMult + i);
-      // }
-      // return corpConstants.officeInitialCost * mult;
     },
     setAutoJobAssignment: (ctx) => (_divisionName, _cityName, _job, _amount) => {
       checkAccess(ctx, CorpUnlockName.OfficeAPI);
@@ -561,8 +553,9 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const divisionName = helpers.string(ctx, "divisionName", _divisionName);
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
       const size = helpers.number(ctx, "size", _size);
-      //
+
       if (size < 0) throw new Error("Invalid value for size field! Can't decrease office size.");
+
       const office = getOffice(divisionName, cityName);
       const corporation = getCorporation();
       UpgradeOfficeSize(corporation, office, size);

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -504,13 +504,13 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const researchName = getEnumHelper("CorpResearchName").nsGetMember(ctx, _researchName, "researchName");
       return hasResearched(getDivision(divisionName), researchName);
     },
-    getOfficeSizeUpgradeCost: (ctx) => (_divisionName, _cityName, _size) => {
+    getOfficeSizeUpgradeCost: (ctx) => (_divisionName, _cityName, _increase) => {
       checkAccess(ctx, CorpUnlockName.OfficeAPI);
       const divisionName = helpers.string(ctx, "divisionName", _divisionName);
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
-      const size = helpers.positiveInteger(ctx, "size", _size);
+      const increase = helpers.positiveInteger(ctx, "increase", _increase);
       const office = getOffice(divisionName, cityName);
-      return calculateOfficeSizeUpgradeCost(office.size, size);
+      return calculateOfficeSizeUpgradeCost(office.size, increase);
     },
     setAutoJobAssignment: (ctx) => (_divisionName, _cityName, _job, _amount) => {
       checkAccess(ctx, CorpUnlockName.OfficeAPI);

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -508,8 +508,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       checkAccess(ctx, CorpUnlockName.OfficeAPI);
       const divisionName = helpers.string(ctx, "divisionName", _divisionName);
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
-      const size = helpers.number(ctx, "size", _size);
-      if (size < 0) throw new Error("Invalid value for size field! Must be numeric and greater than 0");
+      const size = helpers.positiveInteger(ctx, "size", _size);
       const office = getOffice(divisionName, cityName);
       return calculateOfficeSizeUpgradeCost(office.size, size);
     },
@@ -552,9 +551,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       checkAccess(ctx, CorpUnlockName.OfficeAPI);
       const divisionName = helpers.string(ctx, "divisionName", _divisionName);
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
-      const size = helpers.number(ctx, "size", _size);
-
-      if (size < 0) throw new Error("Invalid value for size field! Can't decrease office size.");
+      const size = helpers.positiveInteger(ctx, "size", _size);
 
       const office = getOffice(divisionName, cityName);
       const corporation = getCorporation();

--- a/test/jest/Corporation.test.ts
+++ b/test/jest/Corporation.test.ts
@@ -138,35 +138,35 @@ describe("Corporation", () => {
     };
 
     describe("upgrade office size from size 3", () => {
-      it("should be correct when upgrading from 3->6", () => {
+      it("should match game v2.6.0 when upgrading from 3->6", () => {
         expect(calculateOfficeSizeUpgradeCost(3, 3)).toBeCloseTo(refCosts.from3[3], 1);
       });
-      it("should be correct when upgrading from 3->18", () => {
+      it("should match game v2.6.0 when upgrading from 3->18", () => {
         expect(calculateOfficeSizeUpgradeCost(3, 15)).toBeCloseTo(refCosts.from3[15], 1);
       });
-      it("should be correct when upgrading from 3->153", () => {
+      it("should match game v2.6.0 when upgrading from 3->153", () => {
         expect(calculateOfficeSizeUpgradeCost(3, 150)).toBeCloseTo(refCosts.from3[150], 1);
       });
     });
     describe("upgrade office size from size 6", () => {
-      it("should be correct when upgrading from 6->9", () => {
+      it("should match game v2.6.0 when upgrading from 6->9", () => {
         expect(calculateOfficeSizeUpgradeCost(6, 3)).toBeCloseTo(refCosts.from6[3], 1);
       });
-      it("should be correct when upgrading from 6->21", () => {
+      it("should match game v2.6.0 when upgrading from 6->21", () => {
         expect(calculateOfficeSizeUpgradeCost(6, 15)).toBeCloseTo(refCosts.from6[15], 1);
       });
-      it("should be correct when upgrading from 6->156", () => {
+      it("should match game v2.6.0 when upgrading from 6->156", () => {
         expect(calculateOfficeSizeUpgradeCost(6, 150)).toBeCloseTo(refCosts.from6[150], 1);
       });
     });
     describe("upgrade office size from size 9", () => {
-      it("should be correct when upgrading from 9->12", () => {
+      it("should match game v2.6.0 when upgrading from 9->12", () => {
         expect(calculateOfficeSizeUpgradeCost(9, 3)).toBeCloseTo(refCosts.from9[3], 1);
       });
-      it("should be correct when upgrading from 9->24", () => {
+      it("should match game v2.6.0 when upgrading from 9->24", () => {
         expect(calculateOfficeSizeUpgradeCost(9, 15)).toBeCloseTo(refCosts.from9[15], 1);
       });
-      it("should be correct when upgrading from 9->159", () => {
+      it("should match game v2.6.0 when upgrading from 9->159", () => {
         expect(calculateOfficeSizeUpgradeCost(9, 150)).toBeCloseTo(refCosts.from9[150], 1);
       });
     });

--- a/test/jest/Corporation.test.ts
+++ b/test/jest/Corporation.test.ts
@@ -1,7 +1,11 @@
 import { PositiveInteger } from "../../src/types";
 import { Corporation } from "../../src/Corporation/Corporation";
 import { CorpUpgrades } from "../../src/Corporation/data/CorporationUpgrades";
-import { calculateMaxAffordableUpgrade, calculateUpgradeCost } from "../../src/Corporation/helpers";
+import {
+  calculateMaxAffordableUpgrade,
+  calculateUpgradeCost,
+  calculateOfficeSizeUpgradeCost,
+} from "../../src/Corporation/helpers";
 import { Player, setPlayer } from "../../src/Player";
 import { PlayerObject } from "../../src/PersonObjects/Player/PlayerObject";
 import {
@@ -110,6 +114,107 @@ describe("Corporation", () => {
       corporation.shareSaleCooldown = 0;
       SellShares(corporation, numShares);
       expectSharesToAddUp(corporation);
+    });
+  });
+});
+
+describe("Corporation simple formulas", () => {
+  describe("helpers.calculateOfficeSizeUpgradeCost", () => {
+    // These values were pulled from v2.6.0 as reference test values
+    const refCosts = {
+      from3: {
+        3: 4360000000,
+        15: 26093338259.60001,
+        150: 3553764305895.2593,
+      },
+      from6: {
+        3: 4752400000.000001,
+        15: 28441738702.964012,
+        150: 3873603093425.833,
+      },
+      from9: {
+        3: 5180116000.000002,
+        15: 31001495186.230778,
+        150: 4222227371834.1587,
+      },
+    };
+
+    describe("close to exact", () => {
+      describe("upgrade office size from size 3", () => {
+        it("should be correct when upgrading from 3->6", () => {
+          expect(calculateOfficeSizeUpgradeCost(3, 3)).toBeCloseTo(refCosts.from3[3]);
+        });
+        it("should be correct when upgrading from 3->18", () => {
+          expect(calculateOfficeSizeUpgradeCost(3, 15)).toBeCloseTo(refCosts.from3[15]);
+        });
+        it("should be correct when upgrading from 3->153", () => {
+          expect(calculateOfficeSizeUpgradeCost(3, 150)).toBeCloseTo(refCosts.from3[150]);
+        });
+      });
+      describe("upgrade office size from size 6", () => {
+        it("should be correct when upgrading from 6->9", () => {
+          expect(calculateOfficeSizeUpgradeCost(6, 3)).toBeCloseTo(refCosts.from6[3]);
+        });
+        it("should be correct when upgrading from 6->21", () => {
+          expect(calculateOfficeSizeUpgradeCost(6, 15)).toBeCloseTo(refCosts.from6[15]);
+        });
+        it("should be correct when upgrading from 6->156", () => {
+          expect(calculateOfficeSizeUpgradeCost(6, 150)).toBeCloseTo(refCosts.from6[150]);
+        });
+      });
+      describe("upgrade office size from size 9", () => {
+        it("should be correct when upgrading from 9->12", () => {
+          expect(calculateOfficeSizeUpgradeCost(9, 3)).toBeCloseTo(refCosts.from9[3]);
+        });
+        it("should be correct when upgrading from 9->24", () => {
+          expect(calculateOfficeSizeUpgradeCost(9, 15)).toBeCloseTo(refCosts.from9[15]);
+        });
+        it("should be correct when upgrading from 9->159", () => {
+          expect(calculateOfficeSizeUpgradeCost(9, 150)).toBeCloseTo(refCosts.from9[150]);
+        });
+      });
+    });
+
+    const tolerances = {
+      3: 1e6,
+      15: 1e7,
+      150: 1e9,
+    };
+
+    describe("within tolerance", () => {
+      describe("upgrade office size from size 3", () => {
+        it("should be within tolerance when upgrading from 3->6", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(3, 3) - refCosts.from3[3])).toBeLessThan(tolerances[3]);
+        });
+        it("should be within tolerance when upgrading from 3->18", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(3, 15) - refCosts.from3[15])).toBeLessThan(tolerances[15]);
+        });
+        it("should be within tolerance when upgrading from 3->153", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(3, 150) - refCosts.from3[150])).toBeLessThan(tolerances[150]);
+        });
+      });
+      describe("upgrade office size from size 6", () => {
+        it("should be within tolerance when upgrading from 6->9", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(6, 3) - refCosts.from6[3])).toBeLessThan(tolerances[3]);
+        });
+        it("should be within tolerance when upgrading from 6->21", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(6, 15) - refCosts.from6[15])).toBeLessThan(tolerances[15]);
+        });
+        it("should be within tolerance when upgrading from 6->156", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(6, 150) - refCosts.from6[150])).toBeLessThan(tolerances[150]);
+        });
+      });
+      describe("upgrade office size from size 9", () => {
+        it("should be within tolerance when upgrading from 9->12", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(9, 3) - refCosts.from9[3])).toBeLessThan(tolerances[3]);
+        });
+        it("should be within tolerance when upgrading from 9->24", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(9, 15) - refCosts.from9[15])).toBeLessThan(tolerances[15]);
+        });
+        it("should be within tolerance when upgrading from 9->159", () => {
+          expect(Math.abs(calculateOfficeSizeUpgradeCost(9, 150) - refCosts.from9[150])).toBeLessThan(tolerances[150]);
+        });
+      });
     });
   });
 });

--- a/test/jest/Corporation.test.ts
+++ b/test/jest/Corporation.test.ts
@@ -117,58 +117,24 @@ describe("Corporation", () => {
     });
   });
 
-  describe("helpers.calculateOfficeSizeUpgradeCost", () => {
-    // These values were pulled from v2.6.0 as reference test values
-    const refCosts = {
-      from3: {
-        3: 4360000000,
-        15: 26093338259.60001,
-        150: 3553764305895.2593,
+  describe("helpers.calculateOfficeSizeUpgradeCost matches documented formula", () => {
+    // for discussion and computation of these test values, see:
+    // https://github.com/bitburner-official/bitburner-src/pull/1179#discussion_r1534948725
+    it.each([
+      { fromSize: 3, increaseBy: 3, expectedCost: 4360000000.0 },
+      { fromSize: 3, increaseBy: 15, expectedCost: 26093338259.6 },
+      { fromSize: 3, increaseBy: 150, expectedCost: 3553764305895.24902 },
+      { fromSize: 6, increaseBy: 3, expectedCost: 4752400000.0 },
+      { fromSize: 6, increaseBy: 15, expectedCost: 28441738702.964 },
+      { fromSize: 6, increaseBy: 150, expectedCost: 3873603093425.821 },
+      { fromSize: 9, increaseBy: 3, expectedCost: 5180116000.0 },
+      { fromSize: 9, increaseBy: 15, expectedCost: 31001495186.23076 },
+      { fromSize: 9, increaseBy: 150, expectedCost: 4222227371834.145 },
+    ])(
+      "should cost $expectedCost to upgrade office by $increase from size $fromSize",
+      ({ fromSize, increaseBy, expectedCost }) => {
+        expect(calculateOfficeSizeUpgradeCost(fromSize, increaseBy as PositiveInteger)).toBeCloseTo(expectedCost, 1);
       },
-      from6: {
-        3: 4752400000.000001,
-        15: 28441738702.964012,
-        150: 3873603093425.833,
-      },
-      from9: {
-        3: 5180116000.000002,
-        15: 31001495186.230778,
-        150: 4222227371834.1587,
-      },
-    };
-
-    describe("upgrade office size from size 3", () => {
-      it("should match game v2.6.0 when upgrading from 3->6", () => {
-        expect(calculateOfficeSizeUpgradeCost(3, 3 as PositiveInteger)).toBeCloseTo(refCosts.from3[3], 1);
-      });
-      it("should match game v2.6.0 when upgrading from 3->18", () => {
-        expect(calculateOfficeSizeUpgradeCost(3, 15 as PositiveInteger)).toBeCloseTo(refCosts.from3[15], 1);
-      });
-      it("should match game v2.6.0 when upgrading from 3->153", () => {
-        expect(calculateOfficeSizeUpgradeCost(3, 150 as PositiveInteger)).toBeCloseTo(refCosts.from3[150], 1);
-      });
-    });
-    describe("upgrade office size from size 6", () => {
-      it("should match game v2.6.0 when upgrading from 6->9", () => {
-        expect(calculateOfficeSizeUpgradeCost(6, 3 as PositiveInteger)).toBeCloseTo(refCosts.from6[3], 1);
-      });
-      it("should match game v2.6.0 when upgrading from 6->21", () => {
-        expect(calculateOfficeSizeUpgradeCost(6, 15 as PositiveInteger)).toBeCloseTo(refCosts.from6[15], 1);
-      });
-      it("should match game v2.6.0 when upgrading from 6->156", () => {
-        expect(calculateOfficeSizeUpgradeCost(6, 150 as PositiveInteger)).toBeCloseTo(refCosts.from6[150], 1);
-      });
-    });
-    describe("upgrade office size from size 9", () => {
-      it("should match game v2.6.0 when upgrading from 9->12", () => {
-        expect(calculateOfficeSizeUpgradeCost(9, 3 as PositiveInteger)).toBeCloseTo(refCosts.from9[3], 1);
-      });
-      it("should match game v2.6.0 when upgrading from 9->24", () => {
-        expect(calculateOfficeSizeUpgradeCost(9, 15 as PositiveInteger)).toBeCloseTo(refCosts.from9[15], 1);
-      });
-      it("should match game v2.6.0 when upgrading from 9->159", () => {
-        expect(calculateOfficeSizeUpgradeCost(9, 150 as PositiveInteger)).toBeCloseTo(refCosts.from9[150], 1);
-      });
-    });
+    );
   });
 });

--- a/test/jest/Corporation.test.ts
+++ b/test/jest/Corporation.test.ts
@@ -131,7 +131,7 @@ describe("Corporation", () => {
       { fromSize: 9, increaseBy: 15, expectedCost: 31001495186.23076 },
       { fromSize: 9, increaseBy: 150, expectedCost: 4222227371834.145 },
     ])(
-      "should cost $expectedCost to upgrade office by $increase from size $fromSize",
+      "should cost $expectedCost to upgrade office by $increaseBy from size $fromSize",
       ({ fromSize, increaseBy, expectedCost }) => {
         expect(calculateOfficeSizeUpgradeCost(fromSize, increaseBy as PositiveInteger)).toBeCloseTo(expectedCost, 1);
       },

--- a/test/jest/Corporation.test.ts
+++ b/test/jest/Corporation.test.ts
@@ -139,35 +139,35 @@ describe("Corporation", () => {
 
     describe("upgrade office size from size 3", () => {
       it("should match game v2.6.0 when upgrading from 3->6", () => {
-        expect(calculateOfficeSizeUpgradeCost(3, 3)).toBeCloseTo(refCosts.from3[3], 1);
+        expect(calculateOfficeSizeUpgradeCost(3, 3 as PositiveInteger)).toBeCloseTo(refCosts.from3[3], 1);
       });
       it("should match game v2.6.0 when upgrading from 3->18", () => {
-        expect(calculateOfficeSizeUpgradeCost(3, 15)).toBeCloseTo(refCosts.from3[15], 1);
+        expect(calculateOfficeSizeUpgradeCost(3, 15 as PositiveInteger)).toBeCloseTo(refCosts.from3[15], 1);
       });
       it("should match game v2.6.0 when upgrading from 3->153", () => {
-        expect(calculateOfficeSizeUpgradeCost(3, 150)).toBeCloseTo(refCosts.from3[150], 1);
+        expect(calculateOfficeSizeUpgradeCost(3, 150 as PositiveInteger)).toBeCloseTo(refCosts.from3[150], 1);
       });
     });
     describe("upgrade office size from size 6", () => {
       it("should match game v2.6.0 when upgrading from 6->9", () => {
-        expect(calculateOfficeSizeUpgradeCost(6, 3)).toBeCloseTo(refCosts.from6[3], 1);
+        expect(calculateOfficeSizeUpgradeCost(6, 3 as PositiveInteger)).toBeCloseTo(refCosts.from6[3], 1);
       });
       it("should match game v2.6.0 when upgrading from 6->21", () => {
-        expect(calculateOfficeSizeUpgradeCost(6, 15)).toBeCloseTo(refCosts.from6[15], 1);
+        expect(calculateOfficeSizeUpgradeCost(6, 15 as PositiveInteger)).toBeCloseTo(refCosts.from6[15], 1);
       });
       it("should match game v2.6.0 when upgrading from 6->156", () => {
-        expect(calculateOfficeSizeUpgradeCost(6, 150)).toBeCloseTo(refCosts.from6[150], 1);
+        expect(calculateOfficeSizeUpgradeCost(6, 150 as PositiveInteger)).toBeCloseTo(refCosts.from6[150], 1);
       });
     });
     describe("upgrade office size from size 9", () => {
       it("should match game v2.6.0 when upgrading from 9->12", () => {
-        expect(calculateOfficeSizeUpgradeCost(9, 3)).toBeCloseTo(refCosts.from9[3], 1);
+        expect(calculateOfficeSizeUpgradeCost(9, 3 as PositiveInteger)).toBeCloseTo(refCosts.from9[3], 1);
       });
       it("should match game v2.6.0 when upgrading from 9->24", () => {
-        expect(calculateOfficeSizeUpgradeCost(9, 15)).toBeCloseTo(refCosts.from9[15], 1);
+        expect(calculateOfficeSizeUpgradeCost(9, 15 as PositiveInteger)).toBeCloseTo(refCosts.from9[15], 1);
       });
       it("should match game v2.6.0 when upgrading from 9->159", () => {
-        expect(calculateOfficeSizeUpgradeCost(9, 150)).toBeCloseTo(refCosts.from9[150], 1);
+        expect(calculateOfficeSizeUpgradeCost(9, 150 as PositiveInteger)).toBeCloseTo(refCosts.from9[150], 1);
       });
     });
   });

--- a/test/jest/Corporation.test.ts
+++ b/test/jest/Corporation.test.ts
@@ -116,9 +116,7 @@ describe("Corporation", () => {
       expectSharesToAddUp(corporation);
     });
   });
-});
 
-describe("Corporation simple formulas", () => {
   describe("helpers.calculateOfficeSizeUpgradeCost", () => {
     // These values were pulled from v2.6.0 as reference test values
     const refCosts = {
@@ -139,81 +137,37 @@ describe("Corporation simple formulas", () => {
       },
     };
 
-    describe("close to exact", () => {
-      describe("upgrade office size from size 3", () => {
-        it("should be correct when upgrading from 3->6", () => {
-          expect(calculateOfficeSizeUpgradeCost(3, 3)).toBeCloseTo(refCosts.from3[3]);
-        });
-        it("should be correct when upgrading from 3->18", () => {
-          expect(calculateOfficeSizeUpgradeCost(3, 15)).toBeCloseTo(refCosts.from3[15]);
-        });
-        it("should be correct when upgrading from 3->153", () => {
-          expect(calculateOfficeSizeUpgradeCost(3, 150)).toBeCloseTo(refCosts.from3[150]);
-        });
+    describe("upgrade office size from size 3", () => {
+      it("should be correct when upgrading from 3->6", () => {
+        expect(calculateOfficeSizeUpgradeCost(3, 3)).toBeCloseTo(refCosts.from3[3], 1);
       });
-      describe("upgrade office size from size 6", () => {
-        it("should be correct when upgrading from 6->9", () => {
-          expect(calculateOfficeSizeUpgradeCost(6, 3)).toBeCloseTo(refCosts.from6[3]);
-        });
-        it("should be correct when upgrading from 6->21", () => {
-          expect(calculateOfficeSizeUpgradeCost(6, 15)).toBeCloseTo(refCosts.from6[15]);
-        });
-        it("should be correct when upgrading from 6->156", () => {
-          expect(calculateOfficeSizeUpgradeCost(6, 150)).toBeCloseTo(refCosts.from6[150]);
-        });
+      it("should be correct when upgrading from 3->18", () => {
+        expect(calculateOfficeSizeUpgradeCost(3, 15)).toBeCloseTo(refCosts.from3[15], 1);
       });
-      describe("upgrade office size from size 9", () => {
-        it("should be correct when upgrading from 9->12", () => {
-          expect(calculateOfficeSizeUpgradeCost(9, 3)).toBeCloseTo(refCosts.from9[3]);
-        });
-        it("should be correct when upgrading from 9->24", () => {
-          expect(calculateOfficeSizeUpgradeCost(9, 15)).toBeCloseTo(refCosts.from9[15]);
-        });
-        it("should be correct when upgrading from 9->159", () => {
-          expect(calculateOfficeSizeUpgradeCost(9, 150)).toBeCloseTo(refCosts.from9[150]);
-        });
+      it("should be correct when upgrading from 3->153", () => {
+        expect(calculateOfficeSizeUpgradeCost(3, 150)).toBeCloseTo(refCosts.from3[150], 1);
       });
     });
-
-    const tolerances = {
-      3: 1e6,
-      15: 1e7,
-      150: 1e9,
-    };
-
-    describe("within tolerance", () => {
-      describe("upgrade office size from size 3", () => {
-        it("should be within tolerance when upgrading from 3->6", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(3, 3) - refCosts.from3[3])).toBeLessThan(tolerances[3]);
-        });
-        it("should be within tolerance when upgrading from 3->18", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(3, 15) - refCosts.from3[15])).toBeLessThan(tolerances[15]);
-        });
-        it("should be within tolerance when upgrading from 3->153", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(3, 150) - refCosts.from3[150])).toBeLessThan(tolerances[150]);
-        });
+    describe("upgrade office size from size 6", () => {
+      it("should be correct when upgrading from 6->9", () => {
+        expect(calculateOfficeSizeUpgradeCost(6, 3)).toBeCloseTo(refCosts.from6[3], 1);
       });
-      describe("upgrade office size from size 6", () => {
-        it("should be within tolerance when upgrading from 6->9", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(6, 3) - refCosts.from6[3])).toBeLessThan(tolerances[3]);
-        });
-        it("should be within tolerance when upgrading from 6->21", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(6, 15) - refCosts.from6[15])).toBeLessThan(tolerances[15]);
-        });
-        it("should be within tolerance when upgrading from 6->156", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(6, 150) - refCosts.from6[150])).toBeLessThan(tolerances[150]);
-        });
+      it("should be correct when upgrading from 6->21", () => {
+        expect(calculateOfficeSizeUpgradeCost(6, 15)).toBeCloseTo(refCosts.from6[15], 1);
       });
-      describe("upgrade office size from size 9", () => {
-        it("should be within tolerance when upgrading from 9->12", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(9, 3) - refCosts.from9[3])).toBeLessThan(tolerances[3]);
-        });
-        it("should be within tolerance when upgrading from 9->24", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(9, 15) - refCosts.from9[15])).toBeLessThan(tolerances[15]);
-        });
-        it("should be within tolerance when upgrading from 9->159", () => {
-          expect(Math.abs(calculateOfficeSizeUpgradeCost(9, 150) - refCosts.from9[150])).toBeLessThan(tolerances[150]);
-        });
+      it("should be correct when upgrading from 6->156", () => {
+        expect(calculateOfficeSizeUpgradeCost(6, 150)).toBeCloseTo(refCosts.from6[150], 1);
+      });
+    });
+    describe("upgrade office size from size 9", () => {
+      it("should be correct when upgrading from 9->12", () => {
+        expect(calculateOfficeSizeUpgradeCost(9, 3)).toBeCloseTo(refCosts.from9[3], 1);
+      });
+      it("should be correct when upgrading from 9->24", () => {
+        expect(calculateOfficeSizeUpgradeCost(9, 15)).toBeCloseTo(refCosts.from9[15], 1);
+      });
+      it("should be correct when upgrading from 9->159", () => {
+        expect(calculateOfficeSizeUpgradeCost(9, 150)).toBeCloseTo(refCosts.from9[150], 1);
       });
     });
   });


### PR DESCRIPTION
# CORPORATION: more granular office size upgrades

Allows `corporation.upgradeOfficeSize` to increase the size of a Corporation office by a non-multiple of 3 and also be charged a corresponding amount of corporate funds.  See #1166 for details of current behavior.

## Effect of change

### Before

```
[home /]> run test.js
Running script with 1 thread(s), pid 1 and args: [].
test.js: Expanded AgriTest office size in Sector-12 from 3 to 4 at a total cost of: -4.360e9
test.js: Expanded AgriTest office size in Aevum from 3 to 5 at a total cost of: -4.360e9
test.js: Expanded AgriTest office size in Ishima from 3 to 6 at a total cost of: -4.360e9
```

### After

```
[home /]> run test.js 
Running script with 1 thread(s), pid 2 and args: [].
test.js: Expanded AgriTest office size in Sector-12 from 3 to 4 at a total cost of: -1.412e9
test.js: Expanded AgriTest office size in Aevum from 3 to 5 at a total cost of: -2.865e9
test.js: Expanded AgriTest office size in Ishima from 3 to 6 at a total cost of: -4.360e9
```

## Plan [DONE]

1. **[DONE]** Factor out the corporate office size upgrade cost computation into a helper function.
2. **[DONE]** Add tests to make sure the values closely match those in v2.6.0 of the game.
31415926. **[DONE]** Replace computation with one that will allow upgrade cost to change with each employee slot added instead of only in multiples of 3. (Thanks for the actual formula used, @d0sboots!)
5. **[DONE]** Update documentation as required. (Deferring additional documentation changes to @catloversg in #1191.)
9. **[DONE]** Profit!!!!1! (this is, after all, about Corporate stuff)

## Linked issues

closes #1166

# Testing

- Some unit tests have been added for the actual computation.
- UX changes were tested manually to make sure UX behavior had not changed.