### PR TITLE
MISC: Suggest automatic translation systems not translate our game

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="utf-8" />
     <title><%= htmlWebpackPlugin.options.title %></title>
@@ -39,6 +39,6 @@
     </style>
   </head>
   <body>
-    <div id="root" style="display:flex" />
+    <div id="root" style="display:flex"></div>
   </body>
 </html>


### PR DESCRIPTION
Some players report errors that say `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`. We speculate that the root cause is the usage of translation extension, so this PR adds `translate` global attribute that suggests automatic translation systems not translate our game.

Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate

Fixes #527.
Fixes #1108.