### PR TITLE
SINGULARITY: Fix API documentation

### DIFF
--- a/markdown/bitburner.singularity.createprogram.md
+++ b/markdown/bitburner.singularity.createprogram.md
@@ -33,7 +33,7 @@ This function will automatically set you to start working on creating the specif
 
 This function returns true if you successfully start working on the specified program, and false otherwise.
 
-Note that creating a program using this function has the same hacking level requirements as it normally would. These level requirements are: \* BruteSSH.exe: 50 \* FTPCrack.exe: 100 \* relaySMTP.exe: 250 \* HTTPWorm.exe: 500 \* SQLInject.exe: 750 \* DeepscanV1.exe: 75 \* DeepscanV2.exe: 400 \* ServerProfiler.exe: 75 \* AutoLink.exe: 25
+Note that creating a program using this function has the same hacking level requirements as it normally would. These level requirements are:<br/> - BruteSSH.exe: 50<br/> - FTPCrack.exe: 100<br/> - relaySMTP.exe: 250<br/> - HTTPWorm.exe: 500<br/> - SQLInject.exe: 750<br/> - DeepscanV1.exe: 75<br/> - DeepscanV2.exe: 400<br/> - ServerProfiler.exe: 75<br/> - AutoLink.exe: 25
 
 ## Example
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2201,16 +2201,16 @@ export interface Singularity {
    * This function returns true if you successfully start working on the specified program, and false otherwise.
    *
    * Note that creating a program using this function has the same hacking level requirements as it normally would.
-   * These level requirements are:
-   * * BruteSSH.exe: 50
-   * * FTPCrack.exe: 100
-   * * relaySMTP.exe: 250
-   * * HTTPWorm.exe: 500
-   * * SQLInject.exe: 750
-   * * DeepscanV1.exe: 75
-   * * DeepscanV2.exe: 400
-   * * ServerProfiler.exe: 75
-   * * AutoLink.exe: 25
+   * These level requirements are:<br/>
+   * - BruteSSH.exe: 50<br/>
+   * - FTPCrack.exe: 100<br/>
+   * - relaySMTP.exe: 250<br/>
+   * - HTTPWorm.exe: 500<br/>
+   * - SQLInject.exe: 750<br/>
+   * - DeepscanV1.exe: 75<br/>
+   * - DeepscanV2.exe: 400<br/>
+   * - ServerProfiler.exe: 75<br/>
+   * - AutoLink.exe: 25
    *
    * @example
    * ```js


### PR DESCRIPTION
This PR fixes the documentation of `Singularity.createProgram`. It uses the `<br/>` trick in #1171.