### PR TITLE
MISC: Remove isString utility function

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -8,7 +8,6 @@ import { calculateEffectWithFactors } from "../utils/calculateEffectWithFactors"
 import { OfficeSpace } from "./OfficeSpace";
 import { Product } from "./Product";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
-import { isString } from "../utils/helpers/string";
 import { MaterialInfo } from "./MaterialInfo";
 import { Warehouse } from "./Warehouse";
 import { Corporation } from "./Corporation";
@@ -522,7 +521,7 @@ export class Division {
             // The amount gets re-multiplied later, so this is the correct
             // amount to calculate with for "MAX".
             const adjustedQty = mat.stored / (corpConstants.secondsPerMarketCycle * marketCycles);
-            if (isString(mat.desiredSellAmount)) {
+            if (typeof mat.desiredSellAmount === "string") {
               //Dynamically evaluated
               let tmp = mat.desiredSellAmount.replace(/MAX/g, adjustedQty.toString());
               tmp = tmp.replace(/PROD/g, mat.productionAmount.toString());
@@ -575,7 +574,7 @@ export class Division {
             } else if (mat.marketTa1) {
               sCost = mat.marketPrice + markupLimit;
               // check truthyness to avoid unnecessary eval
-            } else if (isString(mat.desiredSellPrice) && mat.desiredSellPrice) {
+            } else if (typeof mat.desiredSellPrice === "string" && mat.desiredSellPrice) {
               sCost = mat.desiredSellPrice.replace(/MP/g, mat.marketPrice.toString());
               sCost = eval(sCost);
             } else {
@@ -853,7 +852,7 @@ export class Division {
           // amount to calculate with for "MAX".
           const adjustedQty = product.cityData[city].stored / (corpConstants.secondsPerMarketCycle * marketCycles);
           const desiredSellAmount = product.cityData[city].desiredSellAmount;
-          if (isString(desiredSellAmount)) {
+          if (typeof desiredSellAmount === "string") {
             //Sell amount is dynamically evaluated
             let tmp: number | string = desiredSellAmount.replace(/MAX/g, adjustedQty.toString());
             tmp = tmp.replace(/PROD/g, product.cityData[city].productionAmount.toString());
@@ -909,7 +908,7 @@ export class Division {
             sCost = optimalPrice;
           } else if (product.marketTa1) {
             sCost = product.cityData[city].productionCost + markupLimit;
-          } else if (isString(sellPrice)) {
+          } else if (typeof sellPrice === "string") {
             let sCostString = sellPrice;
             if (product.markup === 0) {
               console.error(`mku is zero, reverting to 1 to avoid Infinity`);

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -9,7 +9,6 @@ import { ExportModal } from "./modals/ExportModal";
 import { SellMaterialModal } from "./modals/SellMaterialModal";
 import { PurchaseMaterialModal } from "./modals/PurchaseMaterialModal";
 import { formatBigNumber, formatCorpStat, formatQuality } from "../../ui/formatNumber";
-import { isString } from "../../utils/helpers/string";
 import { Money } from "../../ui/React/Money";
 import { useCorporation, useDivision } from "./Context";
 import { LimitMaterialProductionModal } from "./modals/LimitMaterialProductionModal";
@@ -54,7 +53,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
   // Sell material button
   let sellButtonText: JSX.Element;
   if (mat.desiredSellAmount) {
-    if (isString(mat.desiredSellAmount)) {
+    if (typeof mat.desiredSellAmount === "string") {
       sellButtonText = (
         <>
           Sell ({formatBigNumber(mat.actualSellAmount)}/{mat.desiredSellAmount})

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -10,7 +10,6 @@ import { CancelProductModal } from "./modals/CancelProductModal";
 
 import { formatBigNumber, formatPercent } from "../../ui/formatNumber";
 
-import { isString } from "../../utils/helpers/string";
 import { Money } from "../../ui/React/Money";
 import { useCorporation, useDivision } from "./Context";
 import { StatsTable } from "../../ui/React/StatsTable";
@@ -41,7 +40,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
   let sellButtonText: JSX.Element;
   const desiredSellAmount = cityData.desiredSellAmount;
   if (desiredSellAmount !== null) {
-    if (isString(desiredSellAmount)) {
+    if (typeof desiredSellAmount === "string") {
       sellButtonText = (
         <>
           Sell ({formatBigNumber(cityData.actualSellAmount)}/{desiredSellAmount})

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -1,5 +1,4 @@
 import { Settings } from "../Settings/Settings";
-import { isString } from "./helpers/string";
 
 /*
 Converts a date representing time in milliseconds to a string with the format H hours M minutes and S seconds
@@ -75,7 +74,7 @@ function longestCommonStart(strings: string[]): string {
 
 // Returns whether an array contains entirely of string objects
 function containsAllStrings(arr: string[]): boolean {
-  return arr.every(isString);
+  return arr.every((value) => typeof value === "string");
 }
 
 // Generates a random alphanumeric string with N characters

--- a/src/utils/helpers/string.ts
+++ b/src/utils/helpers/string.ts
@@ -1,13 +1,3 @@
-// We can probably get rid of isString in favor of just checking typeof value==="string".
-// We are not and should not ever be using `new String()` for anything. Will remove in 2.3.1
-/**
- * Checks whether the value passed in can be considered a string.
- * @param value The value to check if it is a string.
- */
-export function isString(value: unknown): value is string {
-  return typeof value === "string" || value instanceof String;
-}
-
 /** Removes a single layer of matching single or double quotes, if present. */
 export function trimQuotes(value: string): string {
   if (value.length < 2) return value;


### PR DESCRIPTION
This PR replaces `isString` with `typeof variable === "string"`. Our codebase does not use `new String()`, so there is no problem.