### PR TITLE
DOCUMENTATION: Fix wrong identification of inline mathematical expressions

### DIFF
--- a/src/Documentation/doc/advanced/faction_list.md
+++ b/src/Documentation/doc/advanced/faction_list.md
@@ -5,14 +5,14 @@
 | Faction Name       | Requirements                                                                                                            |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | CyberSec           | \* Install a backdoor on the `CSEC` server                                                                              |
-| Tian Di Hui        | \* \$1m<br />\* Hacking Level 50<br />\* Be in Chongqing, New Tokyo, or Ishima                                           |
+| Tian Di Hui        | \* \$1m<br />\* Hacking Level 50<br />\* Be in Chongqing, New Tokyo, or Ishima                                          |
 | Netburners         | \* Hacking Level 80<br />\* Total Hacknet Levels of 100<br />\* Total Hacknet RAM of 8<br />\* Total Hacknet Cores of 4 |
 | Shadows of Anarchy | \* Successfully infiltrate a company                                                                                    |
 
 ### City Factions
 
-| Faction Name | Requirements                    | Cannot join if you are working for:                                           |
-| ------------ | ------------------------------- | ----------------------------------------------------------------------------- |
+| Faction Name | Requirements                     | Cannot join if you are working for:                                           |
+| ------------ | -------------------------------- | ----------------------------------------------------------------------------- |
 | Sector-12    | \* Be in Sector-12<br />\* \$15m | \* Chongqing<br />\* New Tokyo<br />\* Ishima<br />\* Volhaven                |
 | Chongqing    | \* Be in Chongqing<br />\* \$20m | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
 | New Tokyo    | \* Be in New Tokyo<br />\* \$20m | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
@@ -48,17 +48,17 @@
 
 | Faction Name          | Requirements                                                                                                           | Cannot join if you are working for: |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| Slum Snakes           | \* All Combat Stats of 30<br />\* \$1m<br />\* -9 Karma                                                                 |                                     |
+| Slum Snakes           | \* All Combat Stats of 30<br />\* \$1m<br />\* -9 Karma                                                                |                                     |
 | Tetrads               | \* Be in Chongqing, New Tokyo, or Ishima<br />\* All Combat Stats of 75<br />\* -18 Karma                              |                                     |
-| Silhouette            | \* CTO, CFO, or CEO of a company<br />\* \$15m<br />\* -22 Karma                                                        |                                     |
+| Silhouette            | \* CTO, CFO, or CEO of a company<br />\* \$15m<br />\* -22 Karma                                                       |                                     |
 | Speakers for the Dead | \* Hacking Level 100<br />\* All Combat Stats of 300<br />\* 30 People Killed<br />\* -45 Karma                        | \* CIA<br />\* NSA                  |
 | The Dark Army         | \* Hacking Level 300<br />\* All Combat Stats of 300<br />\* Be in Chongqing<br />\* 5 People Killed<br />\* -45 Karma | \* CIA<br />\* NSA                  |
-| The Syndicate         | \* Hacking Level 200<br />\* All Combat Stats of 200<br />\* Be in Aevum or Sector-12<br />\* \$10m<br />\* -90 Karma   | \* CIA<br />\* NSA                  |
+| The Syndicate         | \* Hacking Level 200<br />\* All Combat Stats of 200<br />\* Be in Aevum or Sector-12<br />\* \$10m<br />\* -90 Karma  | \* CIA<br />\* NSA                  |
 
 ### Lategame Factions
 
-| Faction Name | Requirements                                                                                     |
-| ------------ | ------------------------------------------------------------------------------------------------ |
+| Faction Name | Requirements                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------- |
 | The Covenant | \* 20 Augmentations<br />\* \$75b<br />\* Hacking Level of 850<br />\* All Combat Stats of 850    |
 | Illuminati   | \* 30 Augmentations<br />\* \$150b<br />\* Hacking Level of 1500<br />\* All Combat Stats of 1200 |
 | Daedalus     | \* 30+ Augmentations<br />\* \$100b<br />\* Hacking Level of 2500 OR All Combat Stats of 1500     |

--- a/src/Documentation/doc/advanced/faction_list.md
+++ b/src/Documentation/doc/advanced/faction_list.md
@@ -5,7 +5,7 @@
 | Faction Name       | Requirements                                                                                                            |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | CyberSec           | \* Install a backdoor on the `CSEC` server                                                                              |
-| Tian Di Hui        | \* $1m<br />\* Hacking Level 50<br />\* Be in Chongqing, New Tokyo, or Ishima                                           |
+| Tian Di Hui        | \* \$1m<br />\* Hacking Level 50<br />\* Be in Chongqing, New Tokyo, or Ishima                                           |
 | Netburners         | \* Hacking Level 80<br />\* Total Hacknet Levels of 100<br />\* Total Hacknet RAM of 8<br />\* Total Hacknet Cores of 4 |
 | Shadows of Anarchy | \* Successfully infiltrate a company                                                                                    |
 
@@ -13,12 +13,12 @@
 
 | Faction Name | Requirements                    | Cannot join if you are working for:                                           |
 | ------------ | ------------------------------- | ----------------------------------------------------------------------------- |
-| Sector-12    | \* Be in Sector-12<br />\* $15m | \* Chongqing<br />\* New Tokyo<br />\* Ishima<br />\* Volhaven                |
-| Chongqing    | \* Be in Chongqing<br />\* $20m | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
-| New Tokyo    | \* Be in New Tokyo<br />\* $20m | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
-| Ishima       | \* Be in Ishima<br />\* $30m    | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
-| Aevum        | \* Be in Aevum<br />\* $40m     | \* Chongqing<br />\* New Tokyo<br />\* Ishima<br />\* Volhaven                |
-| Volhaven     | \* Be in Volhaven<br />\* $50m  | \* Sector-12<br />\* Aevum<br />\* Chongqing<br />\* New Tokyo<br />\* Ishima |
+| Sector-12    | \* Be in Sector-12<br />\* \$15m | \* Chongqing<br />\* New Tokyo<br />\* Ishima<br />\* Volhaven                |
+| Chongqing    | \* Be in Chongqing<br />\* \$20m | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
+| New Tokyo    | \* Be in New Tokyo<br />\* \$20m | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
+| Ishima       | \* Be in Ishima<br />\* \$30m    | \* Sector-12<br />\* Aevum<br />\* Volhaven                                   |
+| Aevum        | \* Be in Aevum<br />\* \$40m     | \* Chongqing<br />\* New Tokyo<br />\* Ishima<br />\* Volhaven                |
+| Volhaven     | \* Be in Volhaven<br />\* \$50m  | \* Sector-12<br />\* Aevum<br />\* Chongqing<br />\* New Tokyo<br />\* Ishima |
 
 ### Hacking Groups
 
@@ -48,20 +48,20 @@
 
 | Faction Name          | Requirements                                                                                                           | Cannot join if you are working for: |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| Slum Snakes           | \* All Combat Stats of 30<br />\* $1m<br />\* -9 Karma                                                                 |                                     |
+| Slum Snakes           | \* All Combat Stats of 30<br />\* \$1m<br />\* -9 Karma                                                                 |                                     |
 | Tetrads               | \* Be in Chongqing, New Tokyo, or Ishima<br />\* All Combat Stats of 75<br />\* -18 Karma                              |                                     |
-| Silhouette            | \* CTO, CFO, or CEO of a company<br />\* $15m<br />\* -22 Karma                                                        |                                     |
+| Silhouette            | \* CTO, CFO, or CEO of a company<br />\* \$15m<br />\* -22 Karma                                                        |                                     |
 | Speakers for the Dead | \* Hacking Level 100<br />\* All Combat Stats of 300<br />\* 30 People Killed<br />\* -45 Karma                        | \* CIA<br />\* NSA                  |
 | The Dark Army         | \* Hacking Level 300<br />\* All Combat Stats of 300<br />\* Be in Chongqing<br />\* 5 People Killed<br />\* -45 Karma | \* CIA<br />\* NSA                  |
-| The Syndicate         | \* Hacking Level 200<br />\* All Combat Stats of 200<br />\* Be in Aevum or Sector-12<br />\* $10m<br />\* -90 Karma   | \* CIA<br />\* NSA                  |
+| The Syndicate         | \* Hacking Level 200<br />\* All Combat Stats of 200<br />\* Be in Aevum or Sector-12<br />\* \$10m<br />\* -90 Karma   | \* CIA<br />\* NSA                  |
 
 ### Lategame Factions
 
 | Faction Name | Requirements                                                                                     |
 | ------------ | ------------------------------------------------------------------------------------------------ |
-| The Covenant | \* 20 Augmentations<br />\* $75b<br />\* Hacking Level of 850<br />\* All Combat Stats of 850    |
-| Illuminati   | \* 30 Augmentations<br />\* $150b<br />\* Hacking Level of 1500<br />\* All Combat Stats of 1200 |
-| Daedalus     | \* 30+ Augmentations<br />\* $100b<br />\* Hacking Level of 2500 OR All Combat Stats of 1500     |
+| The Covenant | \* 20 Augmentations<br />\* \$75b<br />\* Hacking Level of 850<br />\* All Combat Stats of 850    |
+| Illuminati   | \* 30 Augmentations<br />\* \$150b<br />\* Hacking Level of 1500<br />\* All Combat Stats of 1200 |
+| Daedalus     | \* 30+ Augmentations<br />\* \$100b<br />\* Hacking Level of 2500 OR All Combat Stats of 1500     |
 
 ### Endgame Factions
 

--- a/src/Documentation/doc/basic/scripts.md
+++ b/src/Documentation/doc/basic/scripts.md
@@ -56,7 +56,7 @@ When running a script, you can use [flags](https://github.com/bitburner-official
 
 A script can be run with multiple threads, which we call "multithreading."
 Multithreading affects every call to the `ns.hack()`, `ns.grow()`, and `ns.weaken()` methods, multiplying their effects by the number of threads used.
-For example, if a script run with 1 thread is able to hack $10,000, then running the same script with 5 threads would hack $50,000.
+For example, if a script run with 1 thread is able to hack \$10,000, then running the same script with 5 threads would hack $50,000.
 
 [Note -- Scripts will not actually become multithreaded in the real-world sense - Javascript is a "single-threaded" coding language.]
 

--- a/src/Documentation/doc/basic/scripts.md
+++ b/src/Documentation/doc/basic/scripts.md
@@ -56,7 +56,7 @@ When running a script, you can use [flags](https://github.com/bitburner-official
 
 A script can be run with multiple threads, which we call "multithreading."
 Multithreading affects every call to the `ns.hack()`, `ns.grow()`, and `ns.weaken()` methods, multiplying their effects by the number of threads used.
-For example, if a script run with 1 thread is able to hack \$10,000, then running the same script with 5 threads would hack $50,000.
+For example, if a script run with 1 thread is able to hack \$10,000, then running the same script with 5 threads would hack \$50,000.
 
 [Note -- Scripts will not actually become multithreaded in the real-world sense - Javascript is a "single-threaded" coding language.]
 

--- a/src/Documentation/doc/basic/stockmarket.md
+++ b/src/Documentation/doc/basic/stockmarket.md
@@ -77,15 +77,15 @@ For example if you choose to short a stock with 5000 shares using a Market Order
 
 A Limit Order is an order that only executes under certain conditions.
 A Limit Order is used to buy or sell a stock at a specified price or better.
-For example, lets say you purchased a Long position of 100 shares of some stock at a price of $10 per share.
-You can place a Limit Order to sell those 100 shares at $50 or better.
-The Limit Order will execute when the price of the stock reaches a value of $50 or higher.
+For example, lets say you purchased a Long position of 100 shares of some stock at a price of \$10 per share.
+You can place a Limit Order to sell those 100 shares at \$50 or better.
+The Limit Order will execute when the price of the stock reaches a value of \$50 or higher.
 
 A Stop Order is the opposite of a Limit Order.
 It is used to buy or sell a stock at a specified price (before the price gets 'worse').
-For example, lets say you purchased a Short position of 100 shares of some stock at a price of $100 per share.
-The current price of the stock is $80 (a profit of $20 per share).
-You can place a Stop Order to sell the Short position if the stock's price reaches $90 or higher.
+For example, lets say you purchased a Short position of 100 shares of some stock at a price of \$100 per share.
+The current price of the stock is \$80 (a profit of \$20 per share).
+You can place a Stop Order to sell the Short position if the stock's price reaches \$90 or higher.
 This can be used to lock in your profits and limit any losses.
 
 Here is a summary of how each order works and when they execute:

--- a/src/Documentation/doc/changelog.md
+++ b/src/Documentation/doc/changelog.md
@@ -113,7 +113,7 @@
 - Added basic protection for certain global values that could cause a recovery screen if reassigned (@Snarling)
 - Fixed conditions for an easter egg message (@cigarmemr)
 - (Bitverse) Changed listed difficulty for BN3 to "hard"
-- (CodingContract) Reduce incidence of $0 coding contract rewards in circumstances where the reward would be $0 (@trambelus)
+- (CodingContract) Reduce incidence of \$0 coding contract rewards in circumstances where the reward would be $0 (@trambelus)
 - (Corporation) Added better accounting of funds transactions (@jjclark1982)
 - (Corporation) Remove cooldown on starting over corporation, but maintain remaining cooldown for selling shares (@jjclark1982)
 - (Corporation) Removed some legacy code that was not doing anything (@catloversg)
@@ -3128,7 +3128,7 @@ Stanek Gift
 
   - Each stock now has a maximum number of shares you can purchase (both Long and Short positions combined)
   - Added getStockMaxShares() Netscript function to the TIX API
-  - The cost of 4S Market Data TIX API Access increased from $20b to $25b
+  - The cost of 4S Market Data TIX API Access increased from \$20b to $25b
 
 - Job Changes:
 
@@ -3157,7 +3157,7 @@ Stanek Gift
   - The sale price of materials can no longer be marked-up as high
   - Added a Research Tree mechanic. Spend Scientific Research on permanent upgrades for each industry
   - You can now redistribute earnings to shareholders (including yourself) as dividends
-  - Cost of "Smart Supply" upgraded reduced from $50b to $25b
+  - Cost of "Smart Supply" upgraded reduced from \$50b to $25b
   - Now has offline progress, which works similarly to the Gang/Bladeburner mechanics
   - Slightly reduced the amount of money offered to you by investment firms
   - Employee salaries now slowly increase over time
@@ -3168,7 +3168,7 @@ Stanek Gift
   - Buying back shares must now be done at a premium
   - Selling shares can now only be done once per hour
   - Selling large amounts of shares now immediately impacts stock price (during the transaction)
-  - Reduced the initial cost of the DreamSense upgrade from $8b to $4b, but increased its price multiplier
+  - Reduced the initial cost of the DreamSense upgrade from \$8b to $4b, but increased its price multiplier
   - Reduced the price multiplier for ABC SalesBots upgrade
 
 - Added getOrders() Netscript function to the TIX API
@@ -3456,7 +3456,7 @@ Stanek Gift
 
 - After joining the Bladeburners division, there is now a button to go to the Bladeburner content
   in the 'City' page
-- You now start with $250m in BitNode-8 (increased from $100m)
+- You now start with \$250m in BitNode-8 (increased from $100m)
 - Bug Fix: You can now no longer directly edit Hacknet Node values through NetscriptJS (hopefully)
 - Bug Fix: Bladeburners is no longer accessible in BN-8
 - Bug Fix: getBitNodeMultipliers() Netscript function now returns a copy rather than the original object
@@ -4123,7 +4123,7 @@ Similar concepts apply for Terminal Commands such as tail, and Netscript command
 - Cancelling a full time job early now only results in halved gains for reputation. Exp and money earnings are gained in full
 - Added exec() Netscript command, used to run scripts on other servers.
 - NEW HACKING MECHANICS: Whenever a server is hacked, its 'security level' is increased by a very small amount. The security level is denoted by a number between 1-100. A higher security level makes it harder to hack a server and also decreases the amount of money you steal from it. Two Netscript functions, weaken() and getServerSecurityLevel() level, were added. The weaken(server) function lowers a server's security level. See the Netscript documentation for more details
-- When donating to factions, the base rate is now $1,000,000 for 1 reputation point. Before, it was $1,000 for 1 reputation point.
+- When donating to factions, the base rate is now \$1,000,000 for 1 reputation point. Before, it was $1,000 for 1 reputation point.
 - Monetary costs for all Augmentations increased. They are now about ~3.3 - 3.75 times more expensive than before
 
 ## v0.17.1
@@ -4141,7 +4141,7 @@ Similar concepts apply for Terminal Commands such as tail, and Netscript command
 - Added getHostname() command in Netscript that returns the hostname of the server a script is running on
 - jQuery preventDefault() called when pressing ctrl+b in script editor
 - The Neuroflux Governor augmentation (the one that can be repeatedly leveled up) now increases ALL multipliers by 1%. To balance it out, it's price multiplier when it levels up was increased
-- Hacknet Node base production decreased from $1.75/s to $1.65/s
+- Hacknet Node base production decreased from \$1.75/s to $1.65/s
 - Fixed issue with nested for loops in Netscript (stupid Javascript references)
 - Added 'scp' command to Terminal and Netscript
 - Slightly nerfed Hacknet Node Kernel DNI and Hacknet Node Core DNI Augmentations

--- a/src/Documentation/doc/changelog.md
+++ b/src/Documentation/doc/changelog.md
@@ -113,7 +113,7 @@
 - Added basic protection for certain global values that could cause a recovery screen if reassigned (@Snarling)
 - Fixed conditions for an easter egg message (@cigarmemr)
 - (Bitverse) Changed listed difficulty for BN3 to "hard"
-- (CodingContract) Reduce incidence of \$0 coding contract rewards in circumstances where the reward would be $0 (@trambelus)
+- (CodingContract) Reduce incidence of \$0 coding contract rewards in circumstances where the reward would be \$0 (@trambelus)
 - (Corporation) Added better accounting of funds transactions (@jjclark1982)
 - (Corporation) Remove cooldown on starting over corporation, but maintain remaining cooldown for selling shares (@jjclark1982)
 - (Corporation) Removed some legacy code that was not doing anything (@catloversg)
@@ -172,7 +172,7 @@ For the Steam version, any special options you have enabled in the File menu may
 - Fix an error that would occur in some cases when using gymGains or universityGains (@cigarmemr)
 - Fix tab autocompletion when running a sceript without the run command (@mytskine)
 - Fix a bug that could cause the wrong coding contract to be deleted when using rm (@TheAimMan)
-- Scripts no longer show $0 for offline money income (@alutman)
+- Scripts no longer show \$0 for offline money income (@alutman)
 - Faction invitations are now cleared properly when performing a reset (@alutman)
 - API functions that work on a hostname no longer work on servers that have not been added to the network. (@TheAimMan)
 - Fix an issue where the "True Recursion" achievement could be granted incorrectly (@jjclark1982)
@@ -423,7 +423,7 @@ PERFORMANCE:
 NETSCRIPT GENERAL:
 
 - Remove requirement for script args to be unique. This was also related to performance improvements. (@d0sboots)
-- ns.hackAnalyzeThreads no longer indicates infinity any time a single thread would hack less than $1 (@Snarling)
+- ns.hackAnalyzeThreads no longer indicates infinity any time a single thread would hack less than \$1 (@Snarling)
 - ns.renamePurchasedServer no longer crashes if player is connected to the server being renamed (@Snarling)
 - ns.hackAnalyzeThreads now return -1 (instead of 0) if no money can be hacked from the targeted server. (@d0sboots)
 - Fix a possible infinite atExit loop if a script killed itself. (@Snarling)
@@ -1351,7 +1351,7 @@ Stanek Gift
 - Include map bundles in electron for easier debugging (@MartinFournier)
 - Fix importing very large files (@MartinFournier)
 - Cache program blob, reducing ram usage of the game (@theit8514)
-- Dev menu can set server to $0 (@mikomyazaki)
+- Dev menu can set server to \$0 (@mikomyazaki)
 - 'backdoor' allows direct connect (@mikomyazaki)
 - Github workflow work (@MartinFournier)
 - workForFaction / workForCompany have a new parameter (@theit8514)
@@ -2297,7 +2297,7 @@ Stanek Gift
 
 **Misc.**
 
-- Very large number will no longer appear as "$NaNt"
+- Very large number will no longer appear as "\$NaNt"
 - Hash capacity now displays in the "big number" format.
 - nerf noodle bar
 
@@ -2986,7 +2986,7 @@ Stanek Gift
 - 'Generate Coding Contract' hash upgrade is now more expensive
 - 'Generate Coding Contract' hash upgrade now generates the contract randomly on the server, rather than on home computer
 - The cost of selling hashes for money no longer increases each time
-- Selling hashes for money now costs 4 hashes (in exchange for $1m)
+- Selling hashes for money now costs 4 hashes (in exchange for \$1m)
 - Bug Fix: Hacknet Node earnings should work properly when game is inactive/offline
 - Bug Fix: Duplicate Sleeve augmentations are now properly reset when switching to a new BitNode
 
@@ -3128,7 +3128,7 @@ Stanek Gift
 
   - Each stock now has a maximum number of shares you can purchase (both Long and Short positions combined)
   - Added getStockMaxShares() Netscript function to the TIX API
-  - The cost of 4S Market Data TIX API Access increased from \$20b to $25b
+  - The cost of 4S Market Data TIX API Access increased from \$20b to \$25b
 
 - Job Changes:
 
@@ -3150,14 +3150,14 @@ Stanek Gift
 
 - Corporation Changes:
 
-  - Corporation can now be self-funded with $150b or using seed money in exchange for 500m newly-issued shares
-  - In BitNode-3, you no longer start with $150b
+  - Corporation can now be self-funded with \$150b or using seed money in exchange for 500m newly-issued shares
+  - In BitNode-3, you no longer start with \$150b
   - Changed initial market prices for many materials
   - Changed the way a material's demand, competition, and market price change over time
   - The sale price of materials can no longer be marked-up as high
   - Added a Research Tree mechanic. Spend Scientific Research on permanent upgrades for each industry
   - You can now redistribute earnings to shareholders (including yourself) as dividends
-  - Cost of "Smart Supply" upgraded reduced from \$50b to $25b
+  - Cost of "Smart Supply" upgraded reduced from \$50b to \$25b
   - Now has offline progress, which works similarly to the Gang/Bladeburner mechanics
   - Slightly reduced the amount of money offered to you by investment firms
   - Employee salaries now slowly increase over time
@@ -3168,7 +3168,7 @@ Stanek Gift
   - Buying back shares must now be done at a premium
   - Selling shares can now only be done once per hour
   - Selling large amounts of shares now immediately impacts stock price (during the transaction)
-  - Reduced the initial cost of the DreamSense upgrade from \$8b to $4b, but increased its price multiplier
+  - Reduced the initial cost of the DreamSense upgrade from \$8b to \$4b, but increased its price multiplier
   - Reduced the price multiplier for ABC SalesBots upgrade
 
 - Added getOrders() Netscript function to the TIX API
@@ -3456,7 +3456,7 @@ Stanek Gift
 
 - After joining the Bladeburners division, there is now a button to go to the Bladeburner content
   in the 'City' page
-- You now start with \$250m in BitNode-8 (increased from $100m)
+- You now start with \$250m in BitNode-8 (increased from \$100m)
 - Bug Fix: You can now no longer directly edit Hacknet Node values through NetscriptJS (hopefully)
 - Bug Fix: Bladeburners is no longer accessible in BN-8
 - Bug Fix: getBitNodeMultipliers() Netscript function now returns a copy rather than the original object
@@ -3644,7 +3644,7 @@ Stanek Gift
   - purchaseServer(): increased by 0.25GB
 - Note: You may need to re-save all of your scripts in order to re-calculate their RAM usages. Otherwise, it should automatically be re-calculated when you reset/prestige
 - The cost to upgrade your home computer's RAM has been increased (both the base cost and the exponential upgrade multiplier)
-- The cost of purchasing a server was increased by 10% (it is now $55k per RAM)
+- The cost of purchasing a server was increased by 10% (it is now \$55k per RAM)
 - Bug fix: (Hopefully) removed an exploit where you could avoid RAM usage for Netscript function calls by assigning functions to a variable (foo = hack(); foo('helios');)
 - Bug fix: (Hopefully) removed an exploit where you could run arbitrary Javascript code using the constructor() method
 - Thanks to Github user mateon1 and Reddit users havoc_mayhem and spaceglace for notifying me of the above exploits
@@ -3710,7 +3710,7 @@ Stanek Gift
 
 - Game now saves to IndexedDb (if your browser supports it). This means you should no longer have trouble saving the game when your save file gets too big (from running too many scripts). The game will still be saved to localStorage as well
 - New file type: text files (.txt). You can read or write to text files using the read()/write() Netscript commands. You can view text files in Terminal using 'cat'. Eventually I will make it so you can edit them in the editor but that's not available yet. You can also download files to your real computer using the 'download' Terminal command
-- Added a new Crime: Bond Forgery. This crime takes 5 minutes to attempt and gives $4,500,000 if successful. It is meant for mid game.
+- Added a new Crime: Bond Forgery. This crime takes 5 minutes to attempt and gives \$4,500,000 if successful. It is meant for mid game.
 - Added commitCrime(), getCrimeChance(), isBusy(), and getStats() Singularity Functions.
 - Removed getIntelligence() Netscript function
 - Added sprintf and vsprintf to Netscript. See [https://github.com/alexei/sprintf.js this Github page for details]
@@ -4082,7 +4082,7 @@ Similar concepts apply for Terminal Commands such as tail, and Netscript command
 - Added killall Terminal command. Kills all running scripts on the current machine
 - Added kill() and killall() Netscript commands. Used to kill scripts on specified machines. See Netscript documentation
 - Re-designed 'Active Scripts' tab
-- Hacknet Node base production rate lowered from 1.6 to 1.55 ($/second)
+- Hacknet Node base production rate lowered from 1.6 to 1.55 (\$/second)
 - Increased monetary cost of RAM (Upgrading home computer and purchasing servers will now be more expensive)
 - NEW GROWTH MECHANICS - The rate of growth on a server now depends on a server's security level. A higher security level will result in lower growth on a server when using the grow() command. Furthermore, calling grow() on a server raises that server's security level by 0.004. For reference, if a server has a security level of 10 it will have approximately the same growth rate as before.
 - Server growth no longer happens naturally
@@ -4123,7 +4123,7 @@ Similar concepts apply for Terminal Commands such as tail, and Netscript command
 - Cancelling a full time job early now only results in halved gains for reputation. Exp and money earnings are gained in full
 - Added exec() Netscript command, used to run scripts on other servers.
 - NEW HACKING MECHANICS: Whenever a server is hacked, its 'security level' is increased by a very small amount. The security level is denoted by a number between 1-100. A higher security level makes it harder to hack a server and also decreases the amount of money you steal from it. Two Netscript functions, weaken() and getServerSecurityLevel() level, were added. The weaken(server) function lowers a server's security level. See the Netscript documentation for more details
-- When donating to factions, the base rate is now \$1,000,000 for 1 reputation point. Before, it was $1,000 for 1 reputation point.
+- When donating to factions, the base rate is now \$1,000,000 for 1 reputation point. Before, it was \$1,000 for 1 reputation point.
 - Monetary costs for all Augmentations increased. They are now about ~3.3 - 3.75 times more expensive than before
 
 ## v0.17.1
@@ -4141,11 +4141,11 @@ Similar concepts apply for Terminal Commands such as tail, and Netscript command
 - Added getHostname() command in Netscript that returns the hostname of the server a script is running on
 - jQuery preventDefault() called when pressing ctrl+b in script editor
 - The Neuroflux Governor augmentation (the one that can be repeatedly leveled up) now increases ALL multipliers by 1%. To balance it out, it's price multiplier when it levels up was increased
-- Hacknet Node base production decreased from \$1.75/s to $1.65/s
+- Hacknet Node base production decreased from \$1.75/s to \$1.65/s
 - Fixed issue with nested for loops in Netscript (stupid Javascript references)
 - Added 'scp' command to Terminal and Netscript
 - Slightly nerfed Hacknet Node Kernel DNI and Hacknet Node Core DNI Augmentations
-- Increased TOR Router cost to $200k
+- Increased TOR Router cost to \$200k
 
 ## v0.16.0
 

--- a/src/Documentation/doc/help/getting_started.md
+++ b/src/Documentation/doc/help/getting_started.md
@@ -631,10 +631,10 @@ Remember that most of your [Scripts](../basic/scripts.md) are targeting `joesgun
 It will take a bit for them to `grow()` and `weaken()` the [Server](../basic/servers.md) to the appropriate values before they start [hacking](../basic/hacking.md) it.
 Once they do, however, the [Scripts](../basic/scripts.md) will be very profitable.
 
-For reference, in about two hours after starting my first [Script](../basic/scripts.md), my [Scripts](../basic/scripts.md) had a production rate of $20k per second and had earned a total of $70 million.
+For reference, in about two hours after starting my first [Script](../basic/scripts.md), my [Scripts](../basic/scripts.md) had a production rate of \$20k per second and had earned a total of $70 million.
 (You can see these stats on the `Active Scripts` tab).
 
-After another 15 minutes, the production rate had increased to $25k per second and the [Scripts](../basic/scripts.md) had made an additional $55 million.
+After another 15 minutes, the production rate had increased to \$25k per second and the [Scripts](../basic/scripts.md) had made an additional $55 million.
 
 Your results will vary based on how fast you earned money from [crime](../basic/crimes.md)/[working](../basic/companies.md)/[hacknet nodes](../basic/hacknet_nodes.md), but this will hopefully give you a good indication of how much the [Scripts](../basic/scripts.md) can earn.
 

--- a/src/Documentation/doc/help/getting_started.md
+++ b/src/Documentation/doc/help/getting_started.md
@@ -405,7 +405,7 @@ This early in the game, we don't have enough [RAM](../basic/ram.md) to efficient
 You should definitely do this later on, though!
 
 Note that purchasing a [Server](../basic/servers.md) is fairly expensive, and purchasing the maximum amount of [Servers](../basic/servers.md) even more so.
-At the time of writing this guide, the [Script](../basic/scripts.md) above requires $11 million in order to finish purchasing all of the 8GB [Servers](../basic/servers.md).
+At the time of writing this guide, the [Script](../basic/scripts.md) above requires \$11 million in order to finish purchasing all of the 8GB [Servers](../basic/servers.md).
 Therefore, we need to find additional ways to make money to speed up the process!
 These are covered in the next section.
 
@@ -439,10 +439,10 @@ Nothing bad happens if you fail a [crime](../basic/crimes.md), but you won't ear
 Raising your stats improves your chance of successfully committing a [crime](../basic/crimes.md).
 
 Right now, the best option is the `Rob Store` [crime](../basic/crimes.md).
-This takes 60 seconds to attempt, gives $400k if successful, and gives hacking experience (which is very important right now).
+This takes 60 seconds to attempt, gives \$400k if successful, and gives hacking experience (which is very important right now).
 
 Alternatively, you can also use the `Shoplift` [crime](../basic/crimes.md).
-This takes 2 seconds to attempt and gives $15k if successful.
+This takes 2 seconds to attempt and gives \$15k if successful.
 This [crime](../basic/crimes.md) is slightly easier and more profitable than `Rob Store`, but doesn't give hacking experience.
 
 ## Work for a Company
@@ -455,7 +455,7 @@ At `Joe's Guns`, there will be an option that says `Apply to be an Employee`.
 Click this to get the job.
 Then, a new option will appear that simply says `Work`.
 Click this to start working.
-Working at `Joe's Guns` earns $110 per second and also grants some experience for every stat except hacking.
+Working at `Joe's Guns` earns \$110 per second and also grants some experience for every stat except hacking.
 
 Working for a [company](../basic/companies.md), like [crime](../basic/crimes.md), is completely passive.
 You can choose to focus on your work, do something else simultaneously, or switch between those two.
@@ -471,7 +471,7 @@ Feel free to explore!
 
 ## After you Purchase your New Servers
 
-After you've made a total of $11 million, your automatic [Server](../basic/servers.md)-purchasing [Script](../basic/scripts.md) should finish running.
+After you've made a total of \$11 million, your automatic [Server](../basic/servers.md)-purchasing [Script](../basic/scripts.md) should finish running.
 This will free up some [RAM](../basic/ram.md) on your home computer.
 We don't want this [RAM](../basic/ram.md) to go to waste, so we'll make use of it.
 Go to `Terminal` and enter the following commands:
@@ -631,10 +631,10 @@ Remember that most of your [Scripts](../basic/scripts.md) are targeting `joesgun
 It will take a bit for them to `grow()` and `weaken()` the [Server](../basic/servers.md) to the appropriate values before they start [hacking](../basic/hacking.md) it.
 Once they do, however, the [Scripts](../basic/scripts.md) will be very profitable.
 
-For reference, in about two hours after starting my first [Script](../basic/scripts.md), my [Scripts](../basic/scripts.md) had a production rate of \$20k per second and had earned a total of $70 million.
+For reference, in about two hours after starting my first [Script](../basic/scripts.md), my [Scripts](../basic/scripts.md) had a production rate of \$20k per second and had earned a total of \$70 million.
 (You can see these stats on the `Active Scripts` tab).
 
-After another 15 minutes, the production rate had increased to \$25k per second and the [Scripts](../basic/scripts.md) had made an additional $55 million.
+After another 15 minutes, the production rate had increased to \$25k per second and the [Scripts](../basic/scripts.md) had made an additional \$55 million.
 
 Your results will vary based on how fast you earned money from [crime](../basic/crimes.md)/[working](../basic/companies.md)/[hacknet nodes](../basic/hacknet_nodes.md), but this will hopefully give you a good indication of how much the [Scripts](../basic/scripts.md) can earn.
 
@@ -649,7 +649,7 @@ You can cancel your [faction](../basic/factions.md) work at any time with no pen
 
 ## Purchasing Upgrades and Augmentations
 
-As I mentioned before, within 1-2 hours I had earned over $200 million.
+As I mentioned before, within 1-2 hours I had earned over \$200 million.
 Now, it's time to spend all of this money on some persistent upgrades to help progress!
 
 ## Upgrading RAM on Home computer

--- a/src/Documentation/doc/programming/hackingalgorithms.md
+++ b/src/Documentation/doc/programming/hackingalgorithms.md
@@ -40,7 +40,7 @@ This algorithm is perfectly capable of paving the way through the majority of th
 
 - It tends to make all your scripts on every server do the same thing.
   (e.g. If the target is 0.01 security above the minimum, all scripts will decide to weaken, when only a handful of threads should be devoted to the task)
-- At higher thread counts, these scripts have the potential to hack the server to $0, or maximum security, requiring a long setup time while the scripts return the server to the best stats.
+- At higher thread counts, these scripts have the potential to hack the server to \$0, or maximum security, requiring a long setup time while the scripts return the server to the best stats.
 - Requires function calls such as `getServerSecurityLevel` and `getServerMoneyAvailable`, as well as calling all three hacking functions, increasing RAM cost which is multiplied by the number of allocated threads
 
 ## Loop algorithms


### PR DESCRIPTION
Our in-game markdown viewer renders incorrectly in some cases when it encounters "potential" inline mathematical expressions (`$something$`):

Error:
![error](https://github.com/bitburner-official/bitburner-src/assets/152669316/31e973cd-6127-47d5-b850-0c926f3727bf)

Fixed:
![fixed](https://github.com/bitburner-official/bitburner-src/assets/152669316/2d5cdb67-3d68-4991-8c83-c43d554c3762)
