### PR TITLE
DOCS: Fixed a typo in tutorial

### DIFF
--- a/src/Documentation/doc/help/getting_started.md
+++ b/src/Documentation/doc/help/getting_started.md
@@ -69,7 +69,7 @@ Enter the following code in the [Script](../basic/scripts.md) editor:
         // In this case, it is set to the maximum amount of money.
         const moneyThresh = ns.getServerMaxMoney(target);
 
-        // Defines the maximum security level the target server can
+        // Defines the minimum security level the target server can
         // have. If the target's security level is higher than this,
         // we'll weaken it before doing anything else
         const securityThresh = ns.getServerMinSecurityLevel(target);


### PR DESCRIPTION
Minor documentation change. "Maximum" changed to "Minimum" in the tutorial script, as it is now otherwise incorrect after the "+ 5" was removed from that script.