### PR TITLE
DOCS: fix typo in comment and API doc

### DIFF
--- a/markdown/bitburner.ns.gethackingmultipliers.md
+++ b/markdown/bitburner.ns.gethackingmultipliers.md
@@ -29,6 +29,6 @@ Returns an object containing the Player’s hacking related multipliers. These m
 ```js
 const mults = ns.getHackingMultipliers();
 print(`chance: ${mults.chance}`);
-print(`growthL ${mults.growth}`);
+print(`growth: ${mults.growth}`);
 ```
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6371,7 +6371,7 @@ export interface NS {
    * ```js
    * const mults = ns.getHackingMultipliers();
    * print(`chance: ${mults.chance}`);
-   * print(`growthL ${mults.growth}`);
+   * print(`growth: ${mults.growth}`);
    * ```
    * @returns Object containing the Player’s hacking related multipliers.
    */


### PR DESCRIPTION
fix typo in a comment in a `.d.ts` file and an associated markdown API doc.