### PR TITLE
UI: Increase margin bottom for BitNode Multipliers in Stats page (BN1)

### DIFF
--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -43,7 +43,7 @@ export const BitNodeMultipliersDisplay = ({ n, level }: IProps): React.ReactElem
   const mults = getBitNodeMultipliers(n, level ?? Math.min(Player.sourceFileLvl(n) + 1, maxSfLevel));
 
   return (
-    <Box sx={{ columnCount: 2, columnGap: 1, mb: (n === 1 ? 0 : -2) }}>
+    <Box sx={{ columnCount: 2, columnGap: 1, mb: n === 1 ? 0 : -2 }}>
       <GeneralMults n={n} mults={mults} />
       <SkillMults n={n} mults={mults} />
       <FactionMults n={n} mults={mults} />

--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -43,7 +43,7 @@ export const BitNodeMultipliersDisplay = ({ n, level }: IProps): React.ReactElem
   const mults = getBitNodeMultipliers(n, level ?? Math.min(Player.sourceFileLvl(n) + 1, maxSfLevel));
 
   return (
-    <Box sx={{ columnCount: 2, columnGap: 1, mb: -2 }}>
+    <Box sx={{ columnCount: 2, columnGap: 1, mb: (n === 1 ? 0 : -2) }}>
       <GeneralMults n={n} mults={mults} />
       <SkillMults n={n} mults={mults} />
       <FactionMults n={n} mults={mults} />


### PR DESCRIPTION
In BN1, BitNode Multipliers's table is empty, so the bottom border is too near the text.

Before:
![before](https://github.com/bitburner-official/bitburner-src/assets/152669316/3093c7c1-8d85-47db-9059-24ee1280af28)

After:
![after](https://github.com/bitburner-official/bitburner-src/assets/152669316/31937d0d-5dc8-4e9e-9d4e-43430695f7ed)
