### PR TITLE
IPVGO: Bugfix Ensure full name of method is recorded in possibleLogs

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1789,10 +1789,10 @@ function getFunctionNames(obj: object, prefix: string): string[] {
   for (const [key, value] of Object.entries(obj)) {
     if (key === "args") {
       continue;
-    } else if (typeof value == "function") {
+    } else if (typeof value === "function") {
       functionNames.push(prefix + key);
-    } else if (typeof value == "object") {
-      functionNames.push(...getFunctionNames(value, key + "."));
+    } else if (typeof value === "object") {
+      functionNames.push(...getFunctionNames(value, `${prefix}${key}.`));
     }
   }
   return functionNames;


### PR DESCRIPTION
Previously the `getFunctionNames()` method in NetscriptFunctions.ts would drop the given prefix if it handled recursive object calls. This would cause certain methods to be listed as e.g. `cheat.destroyNode` instead of `go.cheat.destroyNode`. 

Because of this difference, ns.disableLog() did not work for these functions, and they would log anyway.

This PR fixes the issue to correctly capture the full nested name of functions. (This only affects go.cheat.XX and go.analysis.XX currently)