### PR TITLE
DOCS: Link to stable instead of dev for player-facing docs

### DIFF
--- a/src/Documentation/doc/advanced/bitnodes.md
+++ b/src/Documentation/doc/advanced/bitnodes.md
@@ -24,7 +24,7 @@ In this BitNode, most forms of income such as working at a [Company](../basic/co
 [Servers](../basic/servers.md) have less money on them and lowered growth rates, but it is easier to lower their security level using the `weaken` function.
 
 Furthermore, some BitNodes introduce new content and mechanics.
-For example, there is one BitNode that grants access to the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md).
+For example, there is one BitNode that grants access to the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.singularity.md).
 There is another BitNode in which you can manage a [Gang](gang.md) to earn money and [Reputation](../basic/reputation.md).
 
 ## How to destroy a BitNode

--- a/src/Documentation/doc/basic/augmentations.md
+++ b/src/Documentation/doc/basic/augmentations.md
@@ -46,7 +46,7 @@ Here is everything you will **KEEP** when you install an Augmentation:
 - Every Augmentation you have previously installed
 - [Scripts](scripts.md) on your home computer
 - [RAM](ram.md) / Core Upgrades on your home computer
-- [World Stock Exchange account](stockmarket.md) and [TIX API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.tix.md) Access
+- [World Stock Exchange account](stockmarket.md) and [TIX API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.tix.md) Access
 
 ## Purchasing Multiple Augmentations
 

--- a/src/Documentation/doc/basic/codingcontracts.md
+++ b/src/Documentation/doc/basic/codingcontracts.md
@@ -3,7 +3,7 @@
 Coding Contracts are a mechanic that lets players earn rewards in exchange for solving programming problems.
 
 Coding Contracts are files with the `.cct` extension.
-They can be accessed through the [Terminal](terminal.md) or through [Scripts](scripts.md) using the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
+They can be accessed through the [Terminal](terminal.md) or through [Scripts](scripts.md) using the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).
 
 Each contract has a limited number of attempts.
 If you provide the wrong answer too many times and exceed the number of attempts, the contract will self destruct (delete itself).
@@ -22,16 +22,16 @@ The popup will display the contract's problem, the number of attempts remaining,
 
 ## Interacting through Scripts
 
-See the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
+See the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).
 Interacting with Coding Contracts via the [Terminal](terminal.md) can be tedious the more contracts you solve.
-Consider using the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) to automate various aspects of your solution.
+Consider using the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) to automate various aspects of your solution.
 For example, some contracts have long solutions while others have even longer solutions.
-You might want to use the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) to automate the process of submitting your solution rather than copy and paste a long solution into an answer box.
+You might want to use the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) to automate the process of submitting your solution rather than copy and paste a long solution into an answer box.
 
-However, using the [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) comes at a cost.
-Like most functions in other APIs, each function in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) has a RAM cost.
-Depending on which function you use, the initial [RAM](ram.md) on your home server might not be enough to allow you to use various [API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md) functions.
-Plan on upgrading the [RAM](ram.md) on your home server if you want to use the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.md).
+However, using the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) comes at a cost.
+Like most functions in other APIs, each function in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) has a RAM cost.
+Depending on which function you use, the initial [RAM](ram.md) on your home server might not be enough to allow you to use various [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) functions.
+Plan on upgrading the [RAM](ram.md) on your home server if you want to use the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).
 
 ## Submitting Solutions
 

--- a/src/Documentation/doc/basic/stockmarket.md
+++ b/src/Documentation/doc/basic/stockmarket.md
@@ -144,7 +144,7 @@ The potency of this effect is based on how effective you are when you work (i.e.
 ## Automating the Stock Market
 
 You can write scripts to perform automatic and algorithmic trading on the Stock Market.
-See [TIX API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.tix.md) for more details.
+See [TIX API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.tix.md) for more details.
 
 ## Under the Hood
 

--- a/src/Documentation/doc/changelog.md
+++ b/src/Documentation/doc/changelog.md
@@ -582,7 +582,7 @@ DOCUMENTATION
 
 - Many documentation updates (@Mughur, @d0sboots, @Snarling, @teauxfu).
 - Official non-markdown docs are at https://github.com/bitburner-official/bitburner-src/tree/dev/src/Documentation/doc
-- Official dev version markdown docs are at https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.ns.md
+- Official dev version markdown docs are at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md
 - Official stable version markdown docs are at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md
 - Dev version documentation is now kept up to date as changes are made. (@Snarling)
 
@@ -607,7 +607,7 @@ Hotfix / bugfix:
 - Fixed an issue with sleeve HP calculation
 - Possible fix for MathJax "Typesetting Failed" errors
 - There was an issue with Corporations decaying their employees to 0 stats, even though the minimum was supposed to be 5. Moved the variable storing the min decay value to corporation constants, and raised it to 10.
-- Regenerated documentation at https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.ns.md due to corporation changes related to min decay stats.
+- Regenerated documentation at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md due to corporation changes related to min decay stats.
 - Faction XP was unintentionally providing 20x the experience gain as it did prior to v2.0. This caused faction work to exceed gym/university as the optimal way to gain experience. Values have been reduced to only about 2x what they were prior to v2.0, and they are no longer better than gym/university.
 - Fixed an issue where the overview skill bars could be displayed inaccurately based on player multipliers.
 
@@ -1553,7 +1553,7 @@ Stanek Gift
 ** Documentation **
 
 - The new documentation for the netscript API is available at
-  https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.ns.md
+  https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md
   This documentation is used in-game to validate the code, in-editor to autocomplete, and
   for users to reference. This is a huge quality of life improvements for me.
 

--- a/src/Documentation/doc/help/bitnode_order.md
+++ b/src/Documentation/doc/help/bitnode_order.md
@@ -31,7 +31,7 @@ These paths do not recommend the absolute fastest path, since speed of progressi
    The [Intelligence](../advanced/intelligence.md) stat it unlocks will gradually build up as you continue to play the game, and will be helpful in the future.
    The [Source-File](../advanced/sourcefiles.md) also provides [hacking](../basic/hacking.md) multipliers, which are strong because [hacking](../basic/hacking.md) is typically one of the best ways of earning money.
 
-5. Do BN-4. Its [Source-File](../advanced/sourcefiles.md) does not directly make you more powerful in any way, but unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md).
+5. Do BN-4. Its [Source-File](../advanced/sourcefiles.md) does not directly make you more powerful in any way, but unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.singularity.md).
    This API allows you to automate significantly more aspects of the game.
    Consider repeating until Level 3, since each level decreases the [RAM](../basic/ram.md) cost of the functions.
 
@@ -56,15 +56,15 @@ The [Sleeves](../advanced/sleeves.md) granted by the [Source-File](../advanced/s
 
 ## For more scripting/hacking
 
-BN-4 unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.singularity.md), which can be used to automate many different aspects of the game, including working for [Factions](../basic/factions.md) / [Companies](../basic/companies.md), purchasing & installing [Augmentations](../basic/augmentations.md), and creating programs
+BN-4 unlocks the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.singularity.md), which can be used to automate many different aspects of the game, including working for [Factions](../basic/factions.md) / [Companies](../basic/companies.md), purchasing & installing [Augmentations](../basic/augmentations.md), and creating programs
 
-BN-6 and BN-7 unlock [Bladeburner](../advanced/bladeburners.md) and its corresponding [Bladeburner API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.bladeburner.md).
+BN-6 and BN-7 unlock [Bladeburner](../advanced/bladeburners.md) and its corresponding [Bladeburner API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.bladeburner.md).
 This allows you to automate an entire new mechanic.
 
 BN-2 also unlocks a new mechanic and API for automating the [Gang](../advanced/gang.md) mechanic.
 However, it is not as interesting as [Bladeburner](../advanced/bladeburners.md)
 
-BN-9 unlocks the [Hacknet Server](../advanced/hacknetservers.md) mechanic and several new functions in the [Hacknet Node API](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.hacknet.md) for using it.
+BN-9 unlocks the [Hacknet Server](../advanced/hacknetservers.md) mechanic and several new functions in the [Hacknet Node API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.hacknet.md) for using it.
 
 ## For new mechanics
 

--- a/src/Documentation/doc/programming/go_algorithms.md
+++ b/src/Documentation/doc/programming/go_algorithms.md
@@ -4,7 +4,7 @@ IPvGO is a strategic territory control minigame accessible from DefComm in New T
 
 For basic instructions, go to DefComm or CIA to access the current subnet, and look through the "How to Play" section. This document is specifically focused on building scripts to automate subnet takeover, which will be more applicable you have played a few subnets.
 
-For a full list of all IpvGO methods and their descriptions and documentation, you can use the game's [API documentation page](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.go.md).
+For a full list of all IpvGO methods and their descriptions and documentation, you can use the game's [API documentation page](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.go.md).
 
 &nbsp;
 


### PR DESCRIPTION
Avoid confusion about features that are not yet released or finalized by ensuring player-facing links go to stable branch instead of dev
