### PR TITLE
NETSCRIPT: A minorly breaking change around script launch, and refactoring.

### DIFF
--- a/markdown/bitburner.goopponent.md
+++ b/markdown/bitburner.goopponent.md
@@ -8,5 +8,12 @@
 **Signature:**
 
 ```typescript
-type GoOpponent = "Netburners" | "Slum Snakes" | "The Black Hand" | "Tetrads" | "Daedalus" | "Illuminati" | "????????????";
+type GoOpponent =
+  | "Netburners"
+  | "Slum Snakes"
+  | "The Black Hand"
+  | "Tetrads"
+  | "Daedalus"
+  | "Illuminati"
+  | "????????????";
 ```

--- a/markdown/bitburner.ns.args.md
+++ b/markdown/bitburner.ns.args.md
@@ -9,7 +9,7 @@ Arguments passed into the script.
 **Signature:**
 
 ```typescript
-readonly args: (string | number | boolean)[];
+readonly args: ScriptArg[];
 ```
 
 ## Remarks
@@ -17,6 +17,8 @@ readonly args: (string | number | boolean)[];
 RAM cost: 0 GB
 
 Arguments passed into a script can be accessed as a normal array by using the `[]` operator (`args[0]`<!-- -->, `args[1]`<!-- -->, etc...). Arguments can be string, number, or boolean. Use `args.length` to get the number of arguments that were passed into a script.
+
+Arguments can also be accessed as additional arguments to `main`<!-- -->.
 
 ## Example
 
@@ -30,6 +32,13 @@ export async function main(ns) {
   ns.tprint(ns.args[1]); // "text" (string)
   ns.tprint(ns.args[2]); // true (boolean)
   ns.tprint(ns.args[3]); // undefined, because only 3 arguments were provided
+}
+```
+
+```js
+// example2.js
+export async function main(ns, ...args) {
+  // The array "args" will contain the same values as ns.args.
 }
 ```
 

--- a/markdown/bitburner.ns.args.md
+++ b/markdown/bitburner.ns.args.md
@@ -18,8 +18,6 @@ RAM cost: 0 GB
 
 Arguments passed into a script can be accessed as a normal array by using the `[]` operator (`args[0]`<!-- -->, `args[1]`<!-- -->, etc...). Arguments can be string, number, or boolean. Use `args.length` to get the number of arguments that were passed into a script.
 
-Arguments can also be accessed as additional arguments to `main`<!-- -->.
-
 ## Example
 
 `run example.js 7 text true`
@@ -32,13 +30,6 @@ export async function main(ns) {
   ns.tprint(ns.args[1]); // "text" (string)
   ns.tprint(ns.args[2]); // true (boolean)
   ns.tprint(ns.args[3]); // undefined, because only 3 arguments were provided
-}
-```
-
-```js
-// example2.js
-export async function main(ns, ...args) {
-  // The array "args" will contain the same values as ns.args.
 }
 ```
 

--- a/markdown/bitburner.ns.exec.md
+++ b/markdown/bitburner.ns.exec.md
@@ -9,12 +9,7 @@ Start another script on any server.
 **Signature:**
 
 ```typescript
-exec(
-    script: string,
-    hostname: string,
-    threadOrOptions?: number | RunOptions,
-    ...args: (string | number | boolean)[]
-  ): number;
+exec(script: string, hostname: string, threadOrOptions?: number | RunOptions, ...args: ScriptArg[]): number;
 ```
 
 ## Parameters
@@ -24,7 +19,7 @@ exec(
 |  script | string | Filename of script to execute. This file must already exist on the target server. |
 |  hostname | string | Hostname of the <code>target server</code> on which to execute the script. |
 |  threadOrOptions | number \| [RunOptions](./bitburner.runoptions.md) | _(Optional)_ Either an integer number of threads for new script, or a [RunOptions](./bitburner.runoptions.md) object. Threads defaults to 1. |
-|  args | (string \| number \| boolean)\[\] | Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the third argument threadOrOptions must be filled in with a value. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the third argument threadOrOptions must be filled in with a value. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.getrunningscript.md
+++ b/markdown/bitburner.ns.getrunningscript.md
@@ -9,11 +9,7 @@ Get general info about a running script.
 **Signature:**
 
 ```typescript
-getRunningScript(
-    filename?: FilenameOrPID,
-    hostname?: string,
-    ...args: (string | number | boolean)[]
-  ): RunningScript | null;
+getRunningScript(filename?: FilenameOrPID, hostname?: string, ...args: ScriptArg[]): RunningScript | null;
 ```
 
 ## Parameters
@@ -22,7 +18,7 @@ getRunningScript(
 |  --- | --- | --- |
 |  filename | [FilenameOrPID](./bitburner.filenameorpid.md) | _(Optional)_ Optional. Filename or PID of the script. |
 |  hostname | string | _(Optional)_ Hostname of target server. Optional, defaults to the server the calling script is running on. |
-|  args | (string \| number \| boolean)\[\] | Arguments to specify/identify the script. Optional, when looking for scripts run without arguments. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments to specify/identify the script. Optional, when looking for scripts run without arguments. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.getscriptexpgain.md
+++ b/markdown/bitburner.ns.getscriptexpgain.md
@@ -9,7 +9,7 @@ Get the exp gain of a script.
 **Signature:**
 
 ```typescript
-getScriptExpGain(script: string, host: string, ...args: (string | number | boolean)[]): number;
+getScriptExpGain(script: string, host: string, ...args: ScriptArg[]): number;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ getScriptExpGain(script: string, host: string, ...args: (string | number | boole
 |  --- | --- | --- |
 |  script | string | Filename of script. |
 |  host | string | Server on which script is running. |
-|  args | (string \| number \| boolean)\[\] | Arguments that the script is running with. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments that the script is running with. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.getscriptincome.md
+++ b/markdown/bitburner.ns.getscriptincome.md
@@ -9,7 +9,7 @@ Get the income of a script.
 **Signature:**
 
 ```typescript
-getScriptIncome(script: string, host: string, ...args: (string | number | boolean)[]): number;
+getScriptIncome(script: string, host: string, ...args: ScriptArg[]): number;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ getScriptIncome(script: string, host: string, ...args: (string | number | boolea
 |  --- | --- | --- |
 |  script | string | Filename of script. |
 |  host | string | Server on which script is running. |
-|  args | (string \| number \| boolean)\[\] | Arguments that the script is running with. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments that the script is running with. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.getscriptlogs.md
+++ b/markdown/bitburner.ns.getscriptlogs.md
@@ -9,7 +9,7 @@ Get all the logs of a script.
 **Signature:**
 
 ```typescript
-getScriptLogs(fn?: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): string[];
+getScriptLogs(fn?: FilenameOrPID, host?: string, ...args: ScriptArg[]): string[];
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ getScriptLogs(fn?: FilenameOrPID, host?: string, ...args: (string | number | boo
 |  --- | --- | --- |
 |  fn | [FilenameOrPID](./bitburner.filenameorpid.md) | _(Optional)_ Optional. Filename or PID of script to get logs from. |
 |  host | string | _(Optional)_ Optional. Hostname of the server that the script is on. |
-|  args | (string \| number \| boolean)\[\] | Arguments to identify which scripts to get logs for. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments to identify which scripts to get logs for. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.isrunning.md
+++ b/markdown/bitburner.ns.isrunning.md
@@ -9,7 +9,7 @@ Check if a script is running.
 **Signature:**
 
 ```typescript
-isRunning(script: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): boolean;
+isRunning(script: FilenameOrPID, host?: string, ...args: ScriptArg[]): boolean;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ isRunning(script: FilenameOrPID, host?: string, ...args: (string | number | bool
 |  --- | --- | --- |
 |  script | [FilenameOrPID](./bitburner.filenameorpid.md) | Filename or PID of script to check. This is case-sensitive. |
 |  host | string | _(Optional)_ Hostname of target server. Optional, defaults to the server the calling script is running on. |
-|  args | (string \| number \| boolean)\[\] | Arguments to specify/identify the script. Optional, when looking for scripts run without arguments. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments to specify/identify the script. Optional, when looking for scripts run without arguments. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -31,7 +31,7 @@ export async function main(ns) {
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [args](./bitburner.ns.args.md) | <code>readonly</code> | (string \| number \| boolean)\[\] | Arguments passed into the script. |
+|  [args](./bitburner.ns.args.md) | <code>readonly</code> | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments passed into the script. |
 |  [bladeburner](./bitburner.ns.bladeburner.md) | <code>readonly</code> | [Bladeburner](./bitburner.bladeburner.md) | Namespace for bladeburner functions. Contains spoilers. |
 |  [codingcontract](./bitburner.ns.codingcontract.md) | <code>readonly</code> | [CodingContract](./bitburner.codingcontract.md) | Namespace for codingcontract functions. |
 |  [corporation](./bitburner.ns.corporation.md) | <code>readonly</code> | [Corporation](./bitburner.corporation.md) | Namespace for corporation functions. Contains spoilers. |

--- a/markdown/bitburner.ns.run.md
+++ b/markdown/bitburner.ns.run.md
@@ -9,7 +9,7 @@ Start another script on the current server.
 **Signature:**
 
 ```typescript
-run(script: string, threadOrOptions?: number | RunOptions, ...args: (string | number | boolean)[]): number;
+run(script: string, threadOrOptions?: number | RunOptions, ...args: ScriptArg[]): number;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ run(script: string, threadOrOptions?: number | RunOptions, ...args: (string | nu
 |  --- | --- | --- |
 |  script | string | Filename of script to run. |
 |  threadOrOptions | number \| [RunOptions](./bitburner.runoptions.md) | _(Optional)_ Either an integer number of threads for new script, or a [RunOptions](./bitburner.runoptions.md) object. Threads defaults to 1. |
-|  args | (string \| number \| boolean)\[\] | Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the second argument threadOrOptions must be filled in with a value. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the second argument threadOrOptions must be filled in with a value. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.spawn.md
+++ b/markdown/bitburner.ns.spawn.md
@@ -9,7 +9,7 @@ Terminate current script and start another in a defined number of milliseconds.
 **Signature:**
 
 ```typescript
-spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: (string | number | boolean)[]): void;
+spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: ScriptArg[]): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: (string 
 |  --- | --- | --- |
 |  script | string | Filename of script to execute. |
 |  threadOrOptions | number \| [SpawnOptions](./bitburner.spawnoptions.md) | _(Optional)_ Either an integer number of threads for new script, or a [SpawnOptions](./bitburner.spawnoptions.md) object. Threads defaults to 1 and spawnDelay defaults to 10,000 ms. |
-|  args | (string \| number \| boolean)\[\] | Additional arguments to pass into the new script that is being run. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Additional arguments to pass into the new script that is being run. |
 
 **Returns:**
 

--- a/markdown/bitburner.ns.tail.md
+++ b/markdown/bitburner.ns.tail.md
@@ -9,7 +9,7 @@ Open the tail window of a script.
 **Signature:**
 
 ```typescript
-tail(fn?: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): void;
+tail(fn?: FilenameOrPID, host?: string, ...args: ScriptArg[]): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ tail(fn?: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]):
 |  --- | --- | --- |
 |  fn | [FilenameOrPID](./bitburner.filenameorpid.md) | _(Optional)_ Optional. Filename or PID of the script being tailed. If omitted, the current script is tailed. |
 |  host | string | _(Optional)_ Optional. Hostname of the script being tailed. Defaults to the server this script is running on. If args are specified, this is not optional. |
-|  args | (string \| number \| boolean)\[\] | Arguments for the script being tailed. |
+|  args | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments for the script being tailed. |
 
 **Returns:**
 

--- a/markdown/bitburner.processinfo.args.md
+++ b/markdown/bitburner.processinfo.args.md
@@ -9,5 +9,5 @@ Script's arguments
 **Signature:**
 
 ```typescript
-args: (string | number | boolean)[];
+args: ScriptArg[];
 ```

--- a/markdown/bitburner.processinfo.md
+++ b/markdown/bitburner.processinfo.md
@@ -16,7 +16,7 @@ interface ProcessInfo
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [args](./bitburner.processinfo.args.md) |  | (string \| number \| boolean)\[\] | Script's arguments |
+|  [args](./bitburner.processinfo.args.md) |  | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Script's arguments |
 |  [filename](./bitburner.processinfo.filename.md) |  | string | Script name. |
 |  [pid](./bitburner.processinfo.pid.md) |  | number | Process ID |
 |  [temporary](./bitburner.processinfo.temporary.md) |  | boolean | Whether this process is excluded from saves |

--- a/markdown/bitburner.runningscript.args.md
+++ b/markdown/bitburner.runningscript.args.md
@@ -9,5 +9,5 @@ Arguments the script was called with
 **Signature:**
 
 ```typescript
-args: (string | number | boolean)[];
+args: ScriptArg[];
 ```

--- a/markdown/bitburner.runningscript.md
+++ b/markdown/bitburner.runningscript.md
@@ -15,7 +15,7 @@ interface RunningScript
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [args](./bitburner.runningscript.args.md) |  | (string \| number \| boolean)\[\] | Arguments the script was called with |
+|  [args](./bitburner.runningscript.args.md) |  | [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\] | Arguments the script was called with |
 |  [filename](./bitburner.runningscript.filename.md) |  | string | Filename of the script |
 |  [logs](./bitburner.runningscript.logs.md) |  | string\[\] | Script logs as an array. The newest log entries are at the bottom. Timestamps, if enabled, are placed inside <code>[brackets]</code> at the start of each line. |
 |  [offlineExpGained](./bitburner.runningscript.offlineexpgained.md) |  | number | Total amount of hacking experience earned from this script when offline |

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -1,4 +1,5 @@
 import type { NetscriptContext } from "./APIWrapper";
+import type { RunningScript as IRunningScript, Person as IPerson, Server as IServer, ScriptArg } from "@nsdefs";
 
 import React from "react";
 import { killWorkerScript } from "./killWorkerScript";
@@ -6,8 +7,6 @@ import { GetAllServers, GetServer } from "../Server/AllServers";
 import { Player } from "@player";
 import { ScriptDeath } from "./ScriptDeath";
 import { formatExp, formatMoney, formatRam, formatThreads } from "../ui/formatNumber";
-import { ScriptArg } from "./ScriptArg";
-import { RunningScript as IRunningScript, Person as IPerson, Server as IServer } from "@nsdefs";
 import { Server } from "../Server/Server";
 import {
   calculateHackingChance,

--- a/src/Netscript/ScriptArg.ts
+++ b/src/Netscript/ScriptArg.ts
@@ -1,1 +1,0 @@
-export type ScriptArg = string | number | boolean;

--- a/src/Netscript/ScriptIdentifier.ts
+++ b/src/Netscript/ScriptIdentifier.ts
@@ -1,4 +1,4 @@
-import { ScriptArg } from "./ScriptArg";
+import type { ScriptArg } from "@nsdefs";
 
 //This was previously in INetscriptHelper.ts, may move to its own file or a generic types file.
 export type ScriptIdentifier =

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -12,7 +12,7 @@ import type { NSFull } from "../NetscriptFunctions";
 import type { ScriptFilePath } from "../Paths/ScriptFilePath";
 import type { RunningScript } from "../Script/RunningScript";
 import type { Script } from "../Script/Script";
-import type { ScriptArg } from "./ScriptArg";
+import type { ScriptArg } from "@nsdefs";
 import type { ScriptDeath } from "./ScriptDeath";
 
 import { Environment } from "./Environment";

--- a/src/NetscriptFunctions/Flags.ts
+++ b/src/NetscriptFunctions/Flags.ts
@@ -1,6 +1,6 @@
+import type { ScriptArg } from "@nsdefs";
 import { toNative } from "./toNative";
 import libarg from "arg";
-import { ScriptArg } from "../Netscript/ScriptArg";
 import { NetscriptContext } from "../Netscript/APIWrapper";
 
 type FlagType = StringConstructor | NumberConstructor | BooleanConstructor | StringConstructor[];

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -57,10 +57,12 @@ async function startNetscript2Script(workerScript: WorkerScript): Promise<void> 
   const loadedModule = await compile(script, scripts);
 
   if (!loadedModule) throw `${script.filename} cannot be run because the script module won't load`;
+  const mainFunc = loadedModule.main;
   // TODO unplanned: Better error for "unexpected reserved word" when using await in non-async function?
-  if (typeof loadedModule.main !== "function")
+  if (typeof mainFunc !== "function")
     throw `${script.filename} cannot be run because it does not have a main function.`;
-  await loadedModule.main(ns);
+  // Explicitly called from a variable so that we don't bind "this".
+  await mainFunc(ns, ...workerScript.args);
 }
 
 async function startNetscript1Script(workerScript: WorkerScript): Promise<void> {

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -62,7 +62,7 @@ async function startNetscript2Script(workerScript: WorkerScript): Promise<void> 
   if (typeof mainFunc !== "function")
     throw `${script.filename} cannot be run because it does not have a main function.`;
   // Explicitly called from a variable so that we don't bind "this".
-  await mainFunc(ns, ...workerScript.args);
+  await mainFunc(ns);
 }
 
 async function startNetscript1Script(workerScript: WorkerScript): Promise<void> {

--- a/src/Script/LoadedModule.ts
+++ b/src/Script/LoadedModule.ts
@@ -1,12 +1,12 @@
-import { NSFull } from "../NetscriptFunctions";
-import { AutocompleteData } from "@nsdefs";
+import type { NSFull } from "../NetscriptFunctions";
+import type { AutocompleteData, ScriptArg } from "@nsdefs";
 
 // The object portion of this type is not runtime information, it's only to ensure type validation
 // And make it harder to overwrite a url with a random non-url string.
 export type ScriptURL = string & { __type: "ScriptURL" };
 
 export interface ScriptModule {
-  main?: (ns: NSFull) => unknown;
+  main?: (ns: NSFull, ...args: ScriptArg[]) => unknown;
   autocomplete?: (data: AutocompleteData, flags: string[]) => unknown;
 }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -211,7 +211,7 @@ interface ReactElement {
 /** @public */
 interface RunningScript {
   /** Arguments the script was called with */
-  args: (string | number | boolean)[];
+  args: ScriptArg[];
   /** Filename of the script */
   filename: string;
   /**
@@ -435,7 +435,7 @@ interface ProcessInfo {
   /** Number of threads script is running with */
   threads: number;
   /** Script's arguments */
-  args: (string | number | boolean)[];
+  args: ScriptArg[];
   /** Process ID */
   pid: number;
   /** Whether this process is excluded from saves */
@@ -5351,6 +5351,8 @@ export interface NS {
    * Arguments can be string, number, or boolean.
    * Use `args.length` to get the number of arguments that were passed into a script.
    *
+   * Arguments can also be accessed as additional arguments to `main`.
+   *
    * @example
    * `run example.js 7 text true`
    *
@@ -5364,8 +5366,15 @@ export interface NS {
    *   ns.tprint(ns.args[3]); // undefined, because only 3 arguments were provided
    * }
    * ```
+   *
+   * ```js
+   * // example2.js
+   * export async function main(ns, ...args) {
+   *   // The array "args" will contain the same values as ns.args.
+   * }
+   * ```
    */
-  readonly args: (string | number | boolean)[];
+  readonly args: ScriptArg[];
 
   /** The current script's PID */
   readonly pid: number;
@@ -5834,7 +5843,7 @@ export interface NS {
    * @param args - Arguments to identify which scripts to get logs for.
    * @returns Returns a string array, where each line is an element in the array. The most recently logged line is at the end of the array.
    */
-  getScriptLogs(fn?: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): string[];
+  getScriptLogs(fn?: FilenameOrPID, host?: string, ...args: ScriptArg[]): string[];
 
   /**
    * Get an array of recently killed scripts across all servers.
@@ -5884,7 +5893,7 @@ export interface NS {
    * @param host - Optional. Hostname of the script being tailed. Defaults to the server this script is running on. If args are specified, this is not optional.
    * @param args - Arguments for the script being tailed.
    */
-  tail(fn?: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): void;
+  tail(fn?: FilenameOrPID, host?: string, ...args: ScriptArg[]): void;
 
   /**
    * Move a tail window.
@@ -6119,7 +6128,7 @@ export interface NS {
    * @param args - Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the second argument threadOrOptions must be filled in with a value.
    * @returns Returns the PID of a successfully started script, and 0 otherwise.
    */
-  run(script: string, threadOrOptions?: number | RunOptions, ...args: (string | number | boolean)[]): number;
+  run(script: string, threadOrOptions?: number | RunOptions, ...args: ScriptArg[]): number;
 
   /**
    * Start another script on any server.
@@ -6159,12 +6168,7 @@ export interface NS {
    * @param args - Additional arguments to pass into the new script that is being run. Note that if any arguments are being passed into the new script, then the third argument threadOrOptions must be filled in with a value.
    * @returns Returns the PID of a successfully started script, and 0 otherwise.
    */
-  exec(
-    script: string,
-    hostname: string,
-    threadOrOptions?: number | RunOptions,
-    ...args: (string | number | boolean)[]
-  ): number;
+  exec(script: string, hostname: string, threadOrOptions?: number | RunOptions, ...args: ScriptArg[]): number;
 
   /**
    * Terminate current script and start another in a defined number of milliseconds.
@@ -6189,7 +6193,7 @@ export interface NS {
    * @param threadOrOptions - Either an integer number of threads for new script, or a {@link SpawnOptions} object. Threads defaults to 1 and spawnDelay defaults to 10,000 ms.
    * @param args - Additional arguments to pass into the new script that is being run.
    */
-  spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: (string | number | boolean)[]): void;
+  spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: ScriptArg[]): void;
   /**
    * Terminate the script with the provided PID.
    * @remarks
@@ -6586,7 +6590,7 @@ export interface NS {
    * @param args - Arguments to specify/identify the script. Optional, when looking for scripts run without arguments.
    * @returns True if the specified script is running on the target server, and false otherwise.
    */
-  isRunning(script: FilenameOrPID, host?: string, ...args: (string | number | boolean)[]): boolean;
+  isRunning(script: FilenameOrPID, host?: string, ...args: ScriptArg[]): boolean;
 
   /**
    * Get general info about a running script.
@@ -6605,11 +6609,7 @@ export interface NS {
    * @param args  - Arguments to specify/identify the script. Optional, when looking for scripts run without arguments.
    * @returns The info about the running script if found, and null otherwise.
    */
-  getRunningScript(
-    filename?: FilenameOrPID,
-    hostname?: string,
-    ...args: (string | number | boolean)[]
-  ): RunningScript | null;
+  getRunningScript(filename?: FilenameOrPID, hostname?: string, ...args: ScriptArg[]): RunningScript | null;
 
   /**
    * Get cost of purchasing a server.
@@ -7020,7 +7020,7 @@ export interface NS {
    * @param args - Arguments that the script is running with.
    * @returns Amount of income the specified script generates while online.
    */
-  getScriptIncome(script: string, host: string, ...args: (string | number | boolean)[]): number;
+  getScriptIncome(script: string, host: string, ...args: ScriptArg[]): number;
 
   /**
    * Get the exp gain of all scripts.
@@ -7048,7 +7048,7 @@ export interface NS {
    * @param args - Arguments that the script is running with.
    * @returns Amount of hacking experience the specified script generates while online.
    */
-  getScriptExpGain(script: string, host: string, ...args: (string | number | boolean)[]): number;
+  getScriptExpGain(script: string, host: string, ...args: ScriptArg[]): number;
 
   /**
    * Returns the amount of time in milliseconds that have passed since you last installed Augmentations.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5351,8 +5351,6 @@ export interface NS {
    * Arguments can be string, number, or boolean.
    * Use `args.length` to get the number of arguments that were passed into a script.
    *
-   * Arguments can also be accessed as additional arguments to `main`.
-   *
    * @example
    * `run example.js 7 text true`
    *
@@ -5364,13 +5362,6 @@ export interface NS {
    *   ns.tprint(ns.args[1]); // "text" (string)
    *   ns.tprint(ns.args[2]); // true (boolean)
    *   ns.tprint(ns.args[3]); // undefined, because only 3 arguments were provided
-   * }
-   * ```
-   *
-   * ```js
-   * // example2.js
-   * export async function main(ns, ...args) {
-   *   // The array "args" will contain the same values as ns.args.
    * }
    * ```
    */

--- a/src/utils/helpers/scriptKey.ts
+++ b/src/utils/helpers/scriptKey.ts
@@ -1,4 +1,4 @@
-import type { ScriptArg } from "../../Netscript/ScriptArg";
+import type { ScriptArg } from "@nsdefs";
 import type { ScriptFilePath } from "../../Paths/ScriptFilePath";
 
 // This needs to be high in the dependency graph, with few/no dependencies of


### PR DESCRIPTION
This changes it so that "this" will be unbound when `main()` is called, ~~and also passes `ns.args` as additional arguments to the `main` function.~~

Both of these are technically breaking changes, but in very minor ways: Someone could be calling exported functions/variables with `this.func()`, but given the simpler `func()` is available and works universally for exported *and* unexported functions, it seems unlikely that anyone would do this. It's also a very easy fix.

~~Similarly, adding new parameters to `main()` could break someone if they were calling `main()` recursively and depending on them to be empty, as they are now. Note that they will *still* be empty if the program is called with no arguments, so this is also a tough needle to hit, in exchange for better usability.~~ Adding new parameters to `main()` was reverted.

There is also some refactoring, to use `ScriptArg` consistently everywhere.

I checked that scripts still launch correctly, and args can now be accessed from the extra args. Also, `this` is now `undefined`.