### PR TITLE
DEVMENU: Fix bug in Time skip menu

### DIFF
--- a/src/DevMenu/ui/TimeSkip.tsx
+++ b/src/DevMenu/ui/TimeSkip.tsx
@@ -18,6 +18,9 @@ export function TimeSkip(): React.ReactElement {
     return () => {
       Player.lastUpdate -= time;
       Engine._lastUpdate -= time;
+      // (time / CONSTANTS.MilliPerCycle) is enough to counter the decrement of Engine.Counters.autoSaveCounter, but we
+      // use (time) to ensure that autosave does not happen in the delay time (1 second) before we reload.
+      Engine.Counters.autoSaveCounter += time;
       saveObject.saveGame();
       setTimeout(() => location.reload(), 1000);
     };


### PR DESCRIPTION
This PR fixes a bug in the Time skip menu. The root cause is the autosave feature. The flow:
- `Player.lastUpdate` and `Engine._lastUpdate` are decreased in `TimeSkip.tsx`. [Step 1]
- Engine loop in `Engine.start` runs. It calculates `diff`, **set `Engine._lastUpdate` and `Engine._lastUpdate` to current time** (minus a small offset), then call `Engine.updateGame(diff)`. [Step 2]
- `Engine.updateGame` calls `Engine.decrementAllCounters`.
- `Engine.decrementAllCounters` decreases `Engine.Counters.autoSaveCounter`.
- `Engine.updateGame` calls `Engine.checkCounters`.
- `Engine.checkCounters` checks `Engine.Counters.autoSaveCounter`. `Engine.Counters.autoSaveCounter` is very likely negative at this point, especially if we skip 1 hour/day. Autosave happens, and it saves `Player.lastUpdate` of step 2 (current time), not step 1.

The fix is simple. We only need to counter the decrement of `Engine.Counters.autoSaveCounter`.

Fixes #795.