### PR TITLE
BUGFIX: Fix #997

### DIFF
--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -144,6 +144,7 @@ export class PlayerObject extends Person implements IPlayer {
         window.innerHeight +
         getRandomInt(100, 999),
     );
+    this.lastAugReset = this.lastNodeReset = Date.now();
   }
 
   whoAmI(): string {

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -432,7 +432,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
     "jobs": {},
     "karma": 0,
     "lastAugReset": 1687611703623,
-    "lastNodeReset": -1,
+    "lastNodeReset": 1687611703623,
     "lastSave": 0,
     "lastUpdate": 1687611703623,
     "location": "Travel Agency",


### PR DESCRIPTION
This PR sets `lastAugReset` and `lastNodeReset` to the current timestamp in the constructor of `PlayerObject`.

Fixes #997.