### PR TITLE
CORPORATION: Fix wrong average price of material

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -358,7 +358,8 @@ export function BulkPurchase(
   const cost = amt * material.marketPrice;
   if (corp.funds >= cost) {
     corp.loseFunds(cost, "materials");
-    material.stored += amt;
+    material.averagePrice = (material.averagePrice * material.stored + material.marketPrice * amt) / (material.stored + amt);
+    material.stored += amt;    
     warehouse.sizeUsed = warehouse.sizeUsed + amt * matSize;
   } else {
     throw new Error(`You cannot afford this purchase.`);

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -358,8 +358,9 @@ export function BulkPurchase(
   const cost = amt * material.marketPrice;
   if (corp.funds >= cost) {
     corp.loseFunds(cost, "materials");
-    material.averagePrice = (material.averagePrice * material.stored + material.marketPrice * amt) / (material.stored + amt);
-    material.stored += amt;    
+    material.averagePrice =
+      (material.averagePrice * material.stored + material.marketPrice * amt) / (material.stored + amt);
+    material.stored += amt;
     warehouse.sizeUsed = warehouse.sizeUsed + amt * matSize;
   } else {
     throw new Error(`You cannot afford this purchase.`);

--- a/src/Corporation/Material.ts
+++ b/src/Corporation/Material.ts
@@ -77,6 +77,7 @@ export class Material {
     this.competition = MaterialInfo[this.name].competitionBase;
     this.competitionRange = MaterialInfo[this.name].competitionRange;
     this.marketPrice = MaterialInfo[this.name].baseCost;
+    this.averagePrice = this.marketPrice;
     this.maxVolatility = MaterialInfo[this.name].maxVolatility;
     this.markup = MaterialInfo[this.name].baseMarkup;
   }
@@ -135,7 +136,13 @@ export class Material {
   // Initializes a Material object from a JSON save state.
   static fromJSON(value: IReviverValue): Material {
     const material = Generic_fromJSON(Material, value.data);
-    if (isNaN(material.quality)) material.quality = 1;
+    if (isNaN(material.quality)) {
+      material.quality = 1;
+    }
+    // averagePrice has not been initialized properly, so if it is 0 (wrong initial value), we set it to marketPrice.
+    if (material.averagePrice === 0) {
+      material.averagePrice = material.marketPrice;
+    }
     return material;
   }
 }


### PR DESCRIPTION
This PR fixes an exploit in Corporation. Minimal reproducible example:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  const cities = ["Sector-12", "Aevum", "Chongqing", "New Tokyo", "Ishima", "Volhaven"];
  const divisionName = "Restaurant";
  const materialName = "Real Estate";
  ns.corporation.createCorporation("Corp", false);
  ns.corporation.expandIndustry(divisionName, divisionName);
  const division = ns.corporation.getDivision(divisionName);
  for (const city of cities) {
    if (!division.cities.includes(city)) {
      ns.corporation.expandCity(divisionName, city);
    }
    while (ns.corporation.hireEmployee(divisionName, city, "Business")) {
    }
    if (!ns.corporation.hasWarehouse(divisionName, city)) {
      ns.corporation.purchaseWarehouse(divisionName, city);
    }
    ns.corporation.upgradeWarehouse(divisionName, city, 1);
  }
  for (let i = 0; i < 8; i++) {
    ns.corporation.hireAdVert(divisionName);
  }  
  const maxSize = ns.corporation.getWarehouse(divisionName, "Sector-12").size;
  for (const city of cities) {
    ns.corporation.bulkPurchase(
      divisionName,
      city,
      materialName,
      maxSize / ns.corporation.getMaterialData(materialName).size
    );
    ns.corporation.sellMaterial(divisionName, city, materialName, "MAX", "MP");
  }
  while (true) {
    if (ns.corporation.getCorporation().prevState === "START") {
      ns.print("Offer:", ns.formatNumber(ns.corporation.getInvestmentOffer().funds));
    }
    await ns.corporation.nextUpdate();
  }
}
```
This exploit only works with "bulk purchase", not "buy per second". The root cause:
- In `updateTotalAssets` of `Corporation.ts`, we use `averagePrice` (`assets += mat.stored * mat.averagePrice`) to calculate the total asset.
- `averagePrice` is initialize with 0. It's only updated when the material is purchased(per second)/produced/imported, so if we use "bulk purchase" to buy it, `averagePrice` is still 0 when it's used for the calculation in `updateTotalAssets`.

This PR fixes it by:
- Initializing `averagePrice` with `marketPrice`.
- Setting `averagePrice` to `marketPrice` if there is a wrong initial value in the JSON save data.
- Updating `averagePrice` when players use the "bulk purchase" feature.