### PR TITLE
EDITOR: Add "arguments" to the keyword list

### DIFF
--- a/src/ScriptEditor/ScriptEditor.ts
+++ b/src/ScriptEditor/ScriptEditor.ts
@@ -45,7 +45,7 @@ export class ScriptEditor {
       l.language.tokenizer.root.unshift([new RegExp("\\bns\\b"), { token: "ns" }]);
       for (const symbol of apiKeys)
         l.language.tokenizer.root.unshift([new RegExp(`\\b${symbol}\\b`), { token: "netscriptfunction" }]);
-      const otherKeywords = ["let", "const", "var", "function"];
+      const otherKeywords = ["let", "const", "var", "function", "arguments"];
       const otherKeyvars = ["true", "false", "null", "undefined"];
       otherKeywords.forEach((k) =>
         l.language.tokenizer.root.unshift([new RegExp(`\\b${k}\\b`), { token: "otherkeywords" }]),


### PR DESCRIPTION
This change was suggested by @Caldwell-74 on Discord.
`arguments` is not a keyword in the default javascript support of `monaco-editor` (https://github.com/microsoft/monaco-editor/blob/main/src/basic-languages/javascript/javascript.ts). This PR adds it to our custom keyword list.