### PR TITLE
BUGFIX: Fix #795

### DIFF
--- a/src/DevMenu/ui/TimeSkip.tsx
+++ b/src/DevMenu/ui/TimeSkip.tsx
@@ -8,8 +8,8 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import { Player } from "@player";
-import { saveObject } from "../../SaveObject";
 import { Engine } from "../../engine";
+import { dialogBoxCreate } from "../../ui/React/DialogBox";
 
 // Update as additional BitNodes get implemented
 
@@ -18,8 +18,7 @@ export function TimeSkip(): React.ReactElement {
     return () => {
       Player.lastUpdate -= time;
       Engine._lastUpdate -= time;
-      saveObject.saveGame();
-      setTimeout(() => location.reload(), 1000);
+      dialogBoxCreate("Time skip effect has been applied");
     };
   }
 


### PR DESCRIPTION
This is the follow-up PR for #1223.
@d0sboots's PR fixes the root cause of #795, but there was a concern about the misleading popup after we reload. "Save+reload" is unnecessary now because the effect will be applied in the next engine loop. This PR replaces the "Save+reload" code with a message dialog.

Fixes #795.