### PR TITLE
BUGFIX: Fix wrong corruptable text when switching between different companies

### DIFF
--- a/src/ui/React/CorruptableText.tsx
+++ b/src/ui/React/CorruptableText.tsx
@@ -34,6 +34,8 @@ export function CorruptableText(props: CorruptableTextProps): JSX.Element {
       return;
     }
 
+    setContent(props.content);
+
     let counter = 5;
     const timers: number[] = [];
     const intervalId = setInterval(() => {


### PR DESCRIPTION
This PR fixes #998.

Before:

https://github.com/bitburner-official/bitburner-src/assets/152669316/392870bd-132c-4b40-8d0f-da75a65192a1

After:

https://github.com/bitburner-official/bitburner-src/assets/152669316/9a6c320d-e450-4b47-b6dd-73fbeb2b4fed

There are comments about the wrong job requirement. It's caused by a different bug. I'll fix it in another PR.
