### PR TITLE
MISC: Rework reputation bonus after installing a backdoor

### DIFF
--- a/src/Company/utils.ts
+++ b/src/Company/utils.ts
@@ -1,4 +1,6 @@
 import type { CompanyName, LocationName } from "@enums";
+import { CONSTANTS } from "../Constants";
+import { isBackdoorInstalledInCompanyServer } from "../Server/ServerHelpers";
 
 type LocationNameString = `${LocationName}`;
 type CompanyNameString = `${CompanyName}`;
@@ -8,4 +10,10 @@ const __companyNameCheck: CompanyNamesAreAllLocationNames = true;
 export function companyNameAsLocationName(companyName: CompanyName): LocationName {
   // Due to the check above, we know that all company names are valid location names.
   return companyName as unknown as LocationName;
+}
+
+export function calculateEffectiveRequiredReputation(companyName: CompanyName, reputation: number): number {
+  return (
+    reputation * (isBackdoorInstalledInCompanyServer(companyName) ? CONSTANTS.CompanyRequiredReputationMultiplier : 1)
+  );
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -53,6 +53,7 @@ export const CONSTANTS: {
   SoARepMult: number;
   EntropyEffect: number;
   Donations: number; // number of blood/plasma/palette donation the dev have verified., boosts NFG
+  CompanyRequiredReputationMultiplier: number; // Only use this if a backdoor is installed in the company's server
   LatestUpdate: string;
 } = {
   VersionString: "2.6.1dev",
@@ -152,6 +153,8 @@ export const CONSTANTS: {
   EntropyEffect: 0.98,
 
   Donations: 151,
+
+  CompanyRequiredReputationMultiplier: 0.75,
 
   // Also update doc/source/changelog.rst
   LatestUpdate: `

--- a/src/Documentation/doc/advanced/faction_list.md
+++ b/src/Documentation/doc/advanced/faction_list.md
@@ -31,6 +31,8 @@
 
 ### Megacorporations
 
+If you install a backdoor on a company's server, the required reputation of that company faction is reduced by 25%.
+
 | Faction Name                | Requirements                                                                                          |
 | --------------------------- | ----------------------------------------------------------------------------------------------------- |
 | ECorp                       | \* Have 400k reputation with the Corporation                                                          |

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -57,6 +57,7 @@ import { getRecordEntries } from "../Types/Record";
 import { JobTracks } from "../Company/data/JobTracks";
 import { ServerConstants } from "../Server/data/Constants";
 import { blackOpsArray } from "../Bladeburner/data/BlackOperations";
+import { calculateEffectiveRequiredReputation } from "../Company/utils";
 
 export function NetscriptSingularity(): InternalAPI<ISingularity> {
   const runAfterReset = function (cbScript: ScriptFilePath) {
@@ -691,7 +692,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         field: job.field,
         nextPosition: job.nextPosition,
         salary: job.baseSalary * company.salaryMultiplier,
-        requiredReputation: job.requiredReputation,
+        requiredReputation: calculateEffectiveRequiredReputation(companyName, job.requiredReputation),
         requiredSkills: job.requiredSkills(company.jobStatReqOffset),
       };
       return res;

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -10,6 +10,7 @@ import { Person as IPerson } from "@nsdefs";
 import { Server as IServer } from "@nsdefs";
 import { workerScripts } from "../Netscript/WorkerScripts";
 import { killWorkerScriptByPid } from "../Netscript/killWorkerScript";
+import { serverMetadata } from "./data/servers";
 
 /**
  * Constructs a new server, while also ensuring that the new server
@@ -234,6 +235,15 @@ export function isBackdoorInstalled(server: BaseServer): boolean {
     return server.backdoorInstalled;
   }
   return false;
+}
+
+export function isBackdoorInstalledInCompanyServer(companyName: string): boolean {
+  const serverMeta = serverMetadata.find((s) => s.specialName === companyName);
+  const server = GetServer(serverMeta ? serverMeta.hostname : "");
+  if (!server) {
+    return false;
+  }
+  return isBackdoorInstalled(server);
 }
 
 export function getCoreBonus(cores = 1): number {


### PR DESCRIPTION
If players install a backdoor on a company's server, they always have a reputation bonus (100k) when we check the required reputation for joining that company's faction or applying for that company's jobs. There are at least 3 problems:
- Players can apply for a job that has a required reputation of less than 100k when they have 0 reputation.
- The UI of the Job tab does not take account of this reputation bonus.
- `ns.singularity.getFactionInviteRequirements` and `ns.singularity.getCompanyPositionInfo` do not take account of this reputation bonus.

Snarling suggests that we can change this flat reduction to a percentage.

This PR fixes those problems.

Fixes #1067.