### PR TITLE
MISC: Fix ghost processes when Electron code crashes too early

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2,19 +2,15 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { app, dialog, BrowserWindow, ipcMain, protocol } = require("electron");
 
+const log = require("electron-log");
+log.catchErrors();
+
 // This handler must be set ASAP to prevent ghost processes.
 process.on("uncaughtException", function () {
   // The exception will be logged by electron-log.
   app.quit();
   process.exit(1);
 });
-
-const log = require("electron-log");
-log.catchErrors();
-const Store = require("electron-store");
-const store = new Store();
-log.transports.file.level = store.get("file-log-level", "info");
-log.transports.console.level = store.get("console-log-level", "debug");
 
 // This handler must be set ASAP to prevent ghost processes.
 app.on("window-all-closed", () => {
@@ -30,8 +26,13 @@ const achievements = require("./achievements");
 const utils = require("./utils");
 const storage = require("./storage");
 const debounce = require("lodash/debounce");
+const Store = require("electron-store");
+const store = new Store();
 const path = require("path");
 const { fileURLToPath } = require("url");
+
+log.transports.file.level = store.get("file-log-level", "info");
+log.transports.console.level = store.get("console-log-level", "debug");
 
 log.info(`Started app: ${JSON.stringify(process.argv)}`);
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,7 +1,28 @@
 /* eslint-disable no-process-exit */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { app, dialog, BrowserWindow, ipcMain, protocol } = require("electron");
+
+// This handler must be set ASAP to prevent ghost processes.
+process.on("uncaughtException", function () {
+  // The exception will be logged by electron-log.
+  app.quit();
+  process.exit(1);
+});
+
 const log = require("electron-log");
+log.catchErrors();
+const Store = require("electron-store");
+const store = new Store();
+log.transports.file.level = store.get("file-log-level", "info");
+log.transports.console.level = store.get("console-log-level", "debug");
+
+// This handler must be set ASAP to prevent ghost processes.
+app.on("window-all-closed", () => {
+  log.info("Quitting the app...");
+  app.quit();
+  process.exit(0);
+});
+
 const greenworks = require("./greenworks");
 const api = require("./api-server");
 const gameWindow = require("./gameWindow");
@@ -9,22 +30,10 @@ const achievements = require("./achievements");
 const utils = require("./utils");
 const storage = require("./storage");
 const debounce = require("lodash/debounce");
-const Store = require("electron-store");
-const store = new Store();
 const path = require("path");
 const { fileURLToPath } = require("url");
 
-log.transports.file.level = store.get("file-log-level", "info");
-log.transports.console.level = store.get("console-log-level", "debug");
-
-log.catchErrors();
 log.info(`Started app: ${JSON.stringify(process.argv)}`);
-
-process.on("uncaughtException", function () {
-  // The exception will already have been logged by electron-log
-  app.quit();
-  process.exit(1);
-});
 
 // We want to fail gracefully if we cannot connect to Steam
 try {
@@ -41,13 +50,6 @@ try {
 }
 
 let isRestoreDisabled = false;
-
-// This was moved so that startup errors do not lead to ghost processes
-app.on("window-all-closed", () => {
-  log.info("Quitting the app...");
-  app.quit();
-  process.exit(0);
-});
 
 function setStopProcessHandler(app, window) {
   const closingWindowHandler = async (e) => {


### PR DESCRIPTION
Current error handlers are placed after all required modules, so if there is any uncaught exception in those modules, we cannot prevent the ghost processes. This PR moves those error handlers to the top.

Tested on Windows.

How to test:
- Update `electron` package without updating greenworks binaries to force a crash while loading greenworks module.
- Build and run the Electron app.
- Use Task Manager (Windows) or `top` (Linux, MacOS) to check if there is any ghost process.