### PR TITLE
DARKWEB: Update DarkWeb.tsx to buy all possible programs using buy -a

### DIFF
--- a/src/DarkWeb/DarkWeb.tsx
+++ b/src/DarkWeb/DarkWeb.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DarkWebItems } from "./DarkWebItems";
-
+import { formatMoney } from "../ui/formatNumber";
 import { Player } from "@player";
 import { Terminal } from "../Terminal";
 import { SpecialServers } from "../Server/data/SpecialServers";
@@ -91,7 +91,7 @@ export function buyAllDarkwebItems(): void {
     if (!Player.hasProgram(item.program)) {
       itemsToBuy.push(item);
       if (item.price > Player.money) {
-        Terminal.error("Not enough money to purchase remaining programs");
+        Terminal.error("Need " + formatMoney(item.price - Player.money) + " more to purchase " + item.program);
         return;
       } else {
         buyDarkwebItem(item.program);

--- a/src/DarkWeb/DarkWeb.tsx
+++ b/src/DarkWeb/DarkWeb.tsx
@@ -4,7 +4,6 @@ import { DarkWebItems } from "./DarkWebItems";
 import { Player } from "@player";
 import { Terminal } from "../Terminal";
 import { SpecialServers } from "../Server/data/SpecialServers";
-import { formatMoney } from "../ui/formatNumber";
 import { Money } from "../ui/React/Money";
 import { DarkWebItem } from "./DarkWebItem";
 import { isCreateProgramWork } from "../Work/CreateProgramWork";
@@ -86,13 +85,17 @@ export function buyDarkwebItem(itemName: string): void {
 
 export function buyAllDarkwebItems(): void {
   const itemsToBuy: DarkWebItem[] = [];
-  let cost = 0;
 
   for (const key of Object.keys(DarkWebItems) as (keyof typeof DarkWebItems)[]) {
     const item = DarkWebItems[key];
     if (!Player.hasProgram(item.program)) {
       itemsToBuy.push(item);
-      cost += item.price;
+      if (item.price > Player.money) {
+        Terminal.error("Not enough money to purchase remaining programs");
+        return;
+      } else {
+        buyDarkwebItem(item.program);
+      }
     }
   }
 
@@ -101,12 +104,8 @@ export function buyAllDarkwebItems(): void {
     return;
   }
 
-  if (cost > Player.money) {
-    Terminal.error("Not enough money to purchase remaining programs, " + formatMoney(cost) + " required");
+  if (itemsToBuy.length > 0) {
+    Terminal.print("All programs have been purchased.");
     return;
-  }
-
-  for (const item of itemsToBuy) {
-    buyDarkwebItem(item.program);
   }
 }


### PR DESCRIPTION
Current implementation of buy -a checks to see if the player can afford every remaining program and then buy all of them.  If they can not, then the function fails.

Changed the command to buy every remaining program in the same order until they can no longer afford them, instead of failing outright.

![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/44387997-c4a7-4718-866e-54e17d6b679c)


closes https://github.com/bitburner-official/bitburner-src/issues/1239



