### PR TITLE
MISC: Handle error when getting save data

### DIFF
--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -12,6 +12,7 @@ import { CONSTANTS } from "./Constants";
 import { hash } from "./hash/hash";
 import { resolveFilePath } from "./Paths/FilePath";
 import { hasScriptExtension } from "./Paths/ScriptFilePath";
+import { handleGetSaveDataError } from "./Netscript/ErrorMessages";
 
 interface IReturnWebStatus extends IReturnStatus {
   data?: Record<string, unknown>;
@@ -159,7 +160,13 @@ function initElectronBridge(): void {
   if (!bridge) return;
 
   bridge.receive("get-save-data-request", async () => {
-    const saveData = await window.appSaveFns.getSaveData();
+    let saveData;
+    try {
+      saveData = await window.appSaveFns.getSaveData();
+    } catch (error) {
+      handleGetSaveDataError(error);
+      return;
+    }
     bridge.send("get-save-data-response", saveData);
   });
   bridge.receive("get-save-info-request", async (saveData: unknown) => {

--- a/src/Netscript/ErrorMessages.ts
+++ b/src/Netscript/ErrorMessages.ts
@@ -105,3 +105,14 @@ export function handleUnknownError(e: unknown, ws: WorkerScript | ScriptDeath | 
   }
   dialogBoxCreate(initialText + e);
 }
+
+/** Use this handler to handle the error when we call getSaveData function */
+export function handleGetSaveDataError(error: unknown) {
+  console.error(error);
+  const baseErrorMessage = "Cannot get save data";
+  if (error instanceof RangeError) {
+    dialogBoxCreate(`${baseErrorMessage}. Error: ${error}. This may be because the save data is too large.`);
+  } else {
+    dialogBoxCreate(`${baseErrorMessage}. Error: ${error}.`);
+  }
+}

--- a/src/Netscript/ErrorMessages.ts
+++ b/src/Netscript/ErrorMessages.ts
@@ -109,10 +109,12 @@ export function handleUnknownError(e: unknown, ws: WorkerScript | ScriptDeath | 
 /** Use this handler to handle the error when we call getSaveData function */
 export function handleGetSaveDataError(error: unknown) {
   console.error(error);
-  const baseErrorMessage = "Cannot get save data";
+  let errorMessage = `Cannot get save data. Error: ${error}.`;
   if (error instanceof RangeError) {
-    dialogBoxCreate(`${baseErrorMessage}. Error: ${error}. This may be because the save data is too large.`);
-  } else {
-    dialogBoxCreate(`${baseErrorMessage}. Error: ${error}.`);
+    errorMessage += " This may be because the save data is too large.";
   }
+  if (error instanceof Error && error.stack) {
+    errorMessage += `\nStack:\n${error.stack}`;
+  }
+  dialogBoxCreate(errorMessage);
 }

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -42,6 +42,7 @@ import { SaveData } from "./types";
 import { SaveDataError, canUseBinaryFormat, decodeSaveData, encodeJsonSaveString } from "./utils/SaveDataUtils";
 import { isBinaryFormat } from "../electron/saveDataBinaryFormat";
 import { downloadContentAsFile } from "./utils/FileUtils";
+import { handleGetSaveDataError } from "./Netscript/ErrorMessages";
 
 /* SaveObject.js
  *  Defines the object used to save/load games
@@ -123,7 +124,13 @@ class BitburnerSaveObject {
   async saveGame(emitToastEvent = true): Promise<void> {
     const savedOn = new Date().getTime();
     Player.lastSave = savedOn;
-    const saveData = await this.getSaveData();
+    let saveData;
+    try {
+      saveData = await this.getSaveData();
+    } catch (error) {
+      handleGetSaveDataError(error);
+      return;
+    }
     try {
       await save(saveData);
     } catch (error) {
@@ -157,7 +164,13 @@ class BitburnerSaveObject {
   }
 
   async exportGame(): Promise<void> {
-    const saveData = await this.getSaveData();
+    let saveData;
+    try {
+      saveData = await this.getSaveData();
+    } catch (error) {
+      handleGetSaveDataError(error);
+      return;
+    }
     const filename = this.getSaveFileName();
     downloadContentAsFile(saveData, filename);
   }

--- a/src/ui/React/ImportSave/ImportSave.tsx
+++ b/src/ui/React/ImportSave/ImportSave.tsx
@@ -125,13 +125,7 @@ export const ImportSave = (props: { saveData: SaveData; automatic: boolean }): J
   useEffect(() => {
     async function fetchData(): Promise<void> {
       const dataBeingImported = await saveObject.getImportDataFromSaveData(props.saveData);
-      let saveData;
-      try {
-        saveData = await saveObject.getSaveData(true);
-      } catch (error) {
-        return Promise.reject(error);
-      }
-      const dataCurrentlyInGame = await saveObject.getImportDataFromSaveData(saveData);
+      const dataCurrentlyInGame = await saveObject.getImportDataFromSaveData(await saveObject.getSaveData(true));
 
       setImportData(dataBeingImported);
       setCurrentData(dataCurrentlyInGame);

--- a/src/ui/React/ImportSave/ImportSave.tsx
+++ b/src/ui/React/ImportSave/ImportSave.tsx
@@ -39,6 +39,7 @@ import { useBoolean } from "../hooks";
 
 import { ComparisonIcon } from "./ComparisonIcon";
 import { SaveData } from "../../../types";
+import { handleGetSaveDataError } from "../../../Netscript/ErrorMessages";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -124,14 +125,29 @@ export const ImportSave = (props: { saveData: SaveData; automatic: boolean }): J
   useEffect(() => {
     async function fetchData(): Promise<void> {
       const dataBeingImported = await saveObject.getImportDataFromSaveData(props.saveData);
-      const dataCurrentlyInGame = await saveObject.getImportDataFromSaveData(await saveObject.getSaveData(true));
+      let saveData;
+      try {
+        saveData = await saveObject.getSaveData(true);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+      const dataCurrentlyInGame = await saveObject.getImportDataFromSaveData(saveData);
 
       setImportData(dataBeingImported);
       setCurrentData(dataCurrentlyInGame);
 
       return Promise.resolve();
     }
-    if (props.saveData) fetchData();
+    if (props.saveData) {
+      fetchData().catch((error) => {
+        handleGoBack();
+        // We cannot show dialog box in this screen (due to "withPopups = false"), so we will try showing it with a
+        // delay. 1 second is usually enough to go back to other normal screens that allow showing popups.
+        setTimeout(() => {
+          handleGetSaveDataError(error);
+        }, 1000);
+      });
+    }
   }, [props.saveData]);
 
   if (!importData || !currentData) return <></>;


### PR DESCRIPTION
In #799, we discussed situations in which the game engine crashes when it cannot save the game data. When the save data is too large, `JSON.stringify` throws a `RangeError`. Before #1162, `getSaveData` (`src\SaveObject.ts`) is a sync method, so if it throws an exception, the game engine will crash (due to the autosave code when `Engine.updateGame` runs). After #1162, `getSaveData` is an async method, so the exception will be caught by code in `setupUncaughtPromiseHandler`. This mitigates the problem, but it's not ideal:
- The default error message is confusing.
- When players try to import another save file, the "Compare Save" UI is a black screen, because `fetchData` (`src\ui\React\ImportSave\ImportSave.tsx`) does not handle the exception.

This PR changes these things:
- Behave consistently when an exception is thrown in `getSaveData`.
- Show a dialog box with a proper error message.
- Prevent the black screen of "Compare Save" UI.

How to generate save data that throws a `RangeError` when calling `getSaveData`:
Run this code:
```js
export async function main(ns) {
  for (let i = 0; i < 10; ++i) {
    ns.write(`test${i}.txt`, "0".repeat(10e7));
  }
}
```

Test cases:
- "Save game" button.
- "Export Game" button.
- Autosave.
- Import Game -> Compare Save.

Closes #799.