### PR TITLE
BUGFIX: Fix wrong zoom factor in Electron app

### DIFF
--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -44,6 +44,9 @@ async function createWindow(killall) {
   window.removeMenu();
   noScripts = killall ? { query: { noScripts: killall } } : {};
   window.loadFile("index.html", noScripts);
+  window.once("ready-to-show", () => {
+    utils.setZoomFactor(window, utils.getZoomFactor());
+  });
   window.show();
   if (debug) window.webContents.openDevTools();
 
@@ -60,7 +63,6 @@ async function createWindow(killall) {
 
   achievements.enableAchievementsInterval(window);
   utils.attachUnresponsiveAppHandler(window);
-  utils.setZoomFactor(window);
 
   try {
     await api.initialize(window);

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -212,7 +212,7 @@ function getMenu(window) {
           click: () => window.loadFile("index.html"),
         },
         {
-          label: "Reload & Kill All Scripts",
+          label: "Reload && Kill All Scripts",
           click: () => utils.reloadAndKill(window, true),
         },
       ],

--- a/electron/utils.js
+++ b/electron/utils.js
@@ -7,8 +7,12 @@ const store = new Store();
 
 function reloadAndKill(window, killScripts) {
   log.info("Reloading & Killing all scripts...");
+  const zoomFactor = getZoomFactor();
   window.webContents.forcefullyCrashRenderer();
   window.loadFile("index.html", killScripts ? { query: { noScripts: true } } : {});
+  window.once("ready-to-show", () => {
+    setZoomFactor(window, zoomFactor);
+  });
 }
 
 function promptForReload(window) {


### PR DESCRIPTION
This PR fixes the wrong zoom factor in the Electron app in some cases.

Tested on Windows.

How to test:
- Open the Electron app.
- Zoom in to max level.
- Use `Reload & Kill All Scripts`. Check the zoom factor. It must be at zoom-in max level.
- Zoom out to max level.
- Exit the Electron app.
- Open the Electron app.
- Check the zoom factor. It must be at zoom-out max level.

Fixes #523.