### PR TITLE
UI: Wrap long text in Active Scripts UI

### DIFF
--- a/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
+++ b/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
@@ -68,7 +68,7 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
       <ListItemButton onClick={() => setOpen((old) => !old)} component={Paper}>
         <ListItemText
           primary={
-            <Typography>
+            <Typography style={{ wordWrap: "break-word" }}>
               └ {props.workerScript.name} {JSON.stringify(props.workerScript.args)}
             </Typography>
           }


### PR DESCRIPTION
The problem with pagination elements in #22 is not relevant in our current UI, but the long argument list still "overflows". This PR fixes that.

Before:
![before](https://github.com/bitburner-official/bitburner-src/assets/152669316/8abfc53c-3bb5-4389-930a-01afb5ab21c0)

After:
![after](https://github.com/bitburner-official/bitburner-src/assets/152669316/173ff1a2-3def-4a9b-a941-62421a4a6ff3)

Closes #22.