### PR TITLE
UI: Fix clipped numbers when values are too big in Augmentations page

### DIFF
--- a/src/Augmentation/ui/PlayerMultipliers.tsx
+++ b/src/Augmentation/ui/PlayerMultipliers.tsx
@@ -24,10 +24,7 @@ interface IBitNodeModifiedStatsProps {
 }
 
 function customFormatPercent(value: number): string {
-  if (value >= 100) {
-    return formatPercent(value, 2, 100);
-  }
-  return formatPercent(value, 2);
+  return formatPercent(value, 2, 100);
 }
 
 function BitNodeModifiedStats(props: IBitNodeModifiedStatsProps): React.ReactElement {

--- a/src/Augmentation/ui/PlayerMultipliers.tsx
+++ b/src/Augmentation/ui/PlayerMultipliers.tsx
@@ -23,14 +23,22 @@ interface IBitNodeModifiedStatsProps {
   color: string;
 }
 
+function customFormatPercent(value: number): string {
+  if (value >= 100) {
+    return formatPercent(value, 2, 100);
+  }
+  return formatPercent(value, 2);
+}
+
 function BitNodeModifiedStats(props: IBitNodeModifiedStatsProps): React.ReactElement {
   // If player doesn't have SF5 or if the property isn't affected by BitNode mults
   if (props.mult === 1 || Player.sourceFileLvl(5) === 0)
-    return <Typography color={props.color}>{formatPercent(props.base)}</Typography>;
+    return <Typography color={props.color}>{customFormatPercent(props.base)}</Typography>;
 
   return (
     <Typography color={props.color}>
-      <span style={{ opacity: 0.5 }}>{formatPercent(props.base)}</span> {formatPercent(props.base * props.mult)}
+      <span style={{ opacity: 0.5 }}>{customFormatPercent(props.base)}</span>{" "}
+      {customFormatPercent(props.base * props.mult)}
     </Typography>
   );
 }


### PR DESCRIPTION
Before:
![before](https://github.com/bitburner-official/bitburner-src/assets/152669316/3127a4c7-ffec-4763-91fa-f8e6d2430b43)

After:
![after](https://github.com/bitburner-official/bitburner-src/assets/152669316/4baafa72-1374-4660-801e-fc34c904721e)

Fixes #614.