### PR TITLE
UI: Change buttons in Tutorial

### DIFF
--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -2,10 +2,7 @@ import React, { useEffect } from "react";
 
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
-import IconButton from "@mui/material/IconButton";
 import Button from "@mui/material/Button";
-import ArrowForwardIos from "@mui/icons-material/ArrowForwardIos";
-import ArrowBackIos from "@mui/icons-material/ArrowBackIos";
 import { ITutorialEvents } from "./ITutorialEvents";
 import { CopyableText } from "../React/CopyableText";
 
@@ -558,17 +555,18 @@ export function InteractiveTutorialRoot(): React.ReactElement {
     <>
       <Paper square sx={{ maxWidth: "70vw", p: 2 }}>
         {content.content}
+        <br />
         {step !== iTutorialSteps.DocumentationPageInfo && (
           <>
             {step !== iTutorialSteps.Start && (
-              <IconButton onClick={iTutorialPrevStep} aria-label="previous">
-                <ArrowBackIos />
-              </IconButton>
+              <Button onClick={iTutorialPrevStep} aria-label="previous" style={{ marginRight: "1em" }}>
+                Previous
+              </Button>
             )}
             {(content.canNext || ITutorial.stepIsDone[step]) && (
-              <IconButton onClick={iTutorialNextStep} aria-label="next">
-                <ArrowForwardIos />
-              </IconButton>
+              <Button onClick={iTutorialNextStep} aria-label="next">
+                Next
+              </Button>
             )}
           </>
         )}


### PR DESCRIPTION
Some new players are confused because of icon buttons for "Previous" and "Next". This PR replaces those icon buttons with text buttons.

Before:
![before 1](https://github.com/bitburner-official/bitburner-src/assets/152669316/0acea29f-e7a4-4428-a830-47cb4ad18b6d)
![before 2](https://github.com/bitburner-official/bitburner-src/assets/152669316/88acfc06-9ef9-4d80-99e7-426d2c8cc8ef)

After:
![after 1](https://github.com/bitburner-official/bitburner-src/assets/152669316/68f638d7-d552-46d5-a463-b079128b24ff)
![after 2](https://github.com/bitburner-official/bitburner-src/assets/152669316/891d41dc-26c8-45c6-a009-6ca0eac56920)


Closes #652.
