### PR TITLE
MISC: Update formatHashes function

### DIFF
--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -148,7 +148,18 @@ export const formatFavor = formatNumberNoSuffix;
 /** Standard noninteger formatting with no options set. Collapses to suffix at 1000 and shows 3 fractional digits. */
 export const formatBigNumber = (n: number) => formatNumber(n);
 export const formatExp = formatBigNumber;
-export const formatHashes = formatBigNumber;
+export const formatHashes = (n: number) => {
+  if (n < 0.00001) {
+    return formatNumber(n, 8);
+  }
+  if (n < 0.001) {
+    return formatNumber(n, 6);
+  }
+  if (n < 0.01) {
+    return formatNumber(n, 4);
+  }
+  return formatNumber(n);
+};
 export const formatReputation = formatBigNumber;
 export const formatPopulation = formatBigNumber;
 export const formatSecurity = formatBigNumber;


### PR DESCRIPTION
When hash/hashRate value is too small, `formatHashes` converts it to the useless string `0.000`. This PR fixes that.

Before:
![before](https://github.com/bitburner-official/bitburner-src/assets/152669316/f715c52f-cb8f-46f5-8fe0-6a94c8249cd9)

After:
![after](https://github.com/bitburner-official/bitburner-src/assets/152669316/937ed2e8-cb37-40cd-ae59-f46718a511f5)

Fixes #315.