### PR TITLE
IPVGO: Handle the previous AI move even if it was made by a different process

### DIFF
--- a/src/Go/boardState/offlineNodes.ts
+++ b/src/Go/boardState/offlineNodes.ts
@@ -8,7 +8,7 @@ import { floor } from "./boardState";
 type rand = (n1: number, n2: number) => number;
 
 export function addObstacles(boardState: BoardState) {
-  const rng = new WHRNG(Player.totalPlaytime);
+  const rng = new WHRNG(Player.totalPlaytime ?? new Date().getTime());
   const random = (n1: number, n2: number) => n1 + floor((n2 - n1 + 1) * rng.random());
 
   const shouldRemoveCorner = !random(0, 4);

--- a/src/Go/boardState/offlineNodes.ts
+++ b/src/Go/boardState/offlineNodes.ts
@@ -8,7 +8,7 @@ import { floor } from "./boardState";
 type rand = (n1: number, n2: number) => number;
 
 export function addObstacles(boardState: BoardState) {
-  const rng = new WHRNG(Player.totalPlaytime ?? new Date().getTime());
+  const rng = new WHRNG(Player.totalPlaytime);
   const random = (n1: number, n2: number) => n1 + floor((n2 - n1 + 1) * rng.random());
 
   const shouldRemoveCorner = !random(0, 4);

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -179,8 +179,19 @@ export async function getAIMove(boardState: BoardState): Promise<Play> {
     await sleep(400);
     const aiUpdatedBoard = makeMove(boardState, result.x, result.y, GoColor.white);
 
-    // Handle the AI breaking. This shouldn't ever happen.
     if (!aiUpdatedBoard) {
+      // If the previous move was made by the AI, log it, even if it didn't come from this thread.
+      // This can happen if multiple scripts are run, or if the user opens or interacts with the gameboard UI while a script is running
+      const priorMove = getPreviousMove();
+      if (Go.currentGame.previousPlayer === GoColor.white && priorMove) {
+        return resolve({
+          type: GoPlayType.move,
+          x: priorMove[0],
+          y: priorMove[1],
+        });
+      }
+
+      // If the previous move wasn't made by the AI, handle the AI trying an invalid move. This shouldn't ever happen.
       boardState.previousPlayer = GoColor.white;
       console.error(`Invalid AI move attempted: ${result.x}, ${result.y}. This should not happen.`);
       GoEvents.emit();

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -18,7 +18,7 @@ import { GoScoreModal } from "./GoScoreModal";
 import { GoGameboard } from "./GoGameboard";
 import { GoSubnetSearch } from "./GoSubnetSearch";
 import { CorruptableText } from "../../ui/React/CorruptableText";
-import { getAIMove } from "../effects/netscriptGoImplementation";
+import { getAIMove, getPreviousMoveDetails } from "../effects/netscriptGoImplementation";
 
 interface GoGameboardWrapperProps {
   showInstructions: () => void;
@@ -123,7 +123,11 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   async function takeAiTurn(boardState: BoardState) {
     setWaitingOnAI(true);
-    const move = await getAIMove(boardState);
+
+    // Ensure that any player-script-triggered AI moves finish
+    await Go.nextTurn;
+    const move =
+      Go.currentGame.previousPlayer === GoColor.black ? await getAIMove(boardState) : getPreviousMoveDetails();
 
     if (move.type === GoPlayType.pass) {
       SnackbarEvents.emit(`The opponent passes their turn; It is now your turn to move.`, ToastVariant.WARNING, 4000);

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -171,7 +171,6 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   function setTraditional(newValue: boolean) {
     Settings.GoTraditionalStyle = newValue;
-    rerender();
   }
 
   const endGameAvailable = boardState.previousPlayer === GoColor.white && boardState.passCount;

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -54,7 +54,12 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   // Only run this once on first component mount, to handle scenarios where the game was saved or closed while waiting on the AI to make a move
   useEffect(() => {
-    if (boardState.previousPlayer === GoColor.black && !waitingOnAI && boardState.ai !== GoOpponent.none) {
+    if (
+      boardState.previousPlayer === GoColor.black &&
+      !waitingOnAI &&
+      boardState.ai !== GoOpponent.none &&
+      !Go.nextTurn
+    ) {
       takeAiTurn(Go.currentGame);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -166,6 +171,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   function setTraditional(newValue: boolean) {
     Settings.GoTraditionalStyle = newValue;
+    rerender();
   }
 
   const endGameAvailable = boardState.previousPlayer === GoColor.white && boardState.passCount;


### PR DESCRIPTION
In some cases, there can be multiple different processes interacting with the IPvGO gameboard between player script(s) and the subnet UI. In those cases, if there is a failure to apply an AI move to the board, check if the prior move was made by white, and return its details, instead of logging an error