### PR TITLE
BUGFIX: Fix unresolved promise in ns.prompt API

### DIFF
--- a/markdown/bitburner.ns.prompt.md
+++ b/markdown/bitburner.ns.prompt.md
@@ -32,7 +32,9 @@ True if the player clicks “Yes”; false if the player clicks “No”; or the
 
 RAM cost: 0 GB
 
-Prompts the player with a dialog box. Here is an explanation of the various options.
+Prompts the player with a dialog box and returns a promise. If the player cancels this dialog box (press X button or click outside the dialog box), the promise is resolved with a default value (empty string or "false"). If this API is called again while the old dialog box still exists, the old dialog box will be replaced with a new one, and the old promise will be resolved with the default value.
+
+Here is an explanation of the various options.
 
 - `options.type` is not provided to the function. If `options.type` is left out and only a string is passed to the function, then the default behavior is to create a boolean dialog box.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7158,7 +7158,12 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * Prompts the player with a dialog box. Here is an explanation of the various options.
+   * Prompts the player with a dialog box and returns a promise. If the player cancels this dialog box (press X button
+   * or click outside the dialog box), the promise is resolved with a default value (empty string or "false"). If this
+   * API is called again while the old dialog box still exists, the old dialog box will be replaced with a new one, and
+   * the old promise will be resolved with the default value.
+   *
+   * Here is an explanation of the various options.
    *
    * - `options.type` is not provided to the function. If `options.type` is left out and
    *   only a string is passed to the function, then the default behavior is to create a

--- a/src/ui/React/PromptManager.tsx
+++ b/src/ui/React/PromptManager.tsx
@@ -18,19 +18,31 @@ interface Prompt {
 
 export function PromptManager({ hidden }: { hidden: boolean }): React.ReactElement {
   const [prompt, setPrompt] = useState<Prompt | null>(null);
+
+  const resolveCurrentPromptWithDefaultValue = (currentPrompt: Prompt) => {
+    if (["text", "select"].includes(currentPrompt.options?.type ?? "")) {
+      currentPrompt.resolve("");
+    } else {
+      currentPrompt.resolve(false);
+    }
+  };
+
   useEffect(() => {
-    return PromptEvent.subscribe((p: Prompt) => {
-      setPrompt(p);
+    return PromptEvent.subscribe((newPrompt: Prompt) => {
+      setPrompt((currentPrompt) => {
+        if (currentPrompt) {
+          resolveCurrentPromptWithDefaultValue(currentPrompt);
+        }
+        return newPrompt;
+      });
     });
   }, []);
 
   function close(): void {
-    if (prompt === null) return;
-    if (["text", "select"].includes(prompt.options?.type ?? "")) {
-      prompt.resolve("");
-    } else {
-      prompt.resolve(false);
+    if (prompt === null) {
+      return;
     }
+    resolveCurrentPromptWithDefaultValue(prompt);
     setPrompt(null);
   }
 


### PR DESCRIPTION
If players call `ns.prompt` while the old dialog box from another call of `ns.prompt` still exists, the old dialog box will be replaced with a new one, but the old promise will never be resolved. This PR fixes that.

Test code:
`a.js`
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.exec("b.js", "home");
  ns.print(await ns.prompt("1"));
}
```
`b.js`
```js
/** @param {NS} ns */
export async function main(ns) {
  await ns.sleep(1000);
  await ns.prompt("2");
}
```