### PR TITLE
GO: Alternate fix for race conditions

### DIFF
--- a/src/Go/Go.ts
+++ b/src/Go/Go.ts
@@ -1,6 +1,6 @@
-import type { GoOpponent } from "@enums";
 import type { BoardState, OpponentStats, Play } from "./Types";
 
+import { GoPlayType, type GoOpponent } from "@enums";
 import { getRecordValues, PartialRecord } from "../Types/Record";
 import { getNewBoardState } from "./boardState/boardState";
 import { EventEmitter } from "../utils/EventEmitter";
@@ -10,7 +10,7 @@ export class GoObject {
   previousGame: BoardState | null = null;
   currentGame: BoardState = getNewBoardState(7);
   stats: PartialRecord<GoOpponent, OpponentStats> = {};
-  nextTurn: Promise<Play> | null = null;
+  nextTurn: Promise<Play> = Promise.resolve({ type: GoPlayType.gameOver, x: null, y: null });
 
   prestigeAugmentation() {
     for (const stats of getRecordValues(this.stats)) {

--- a/src/Go/SaveLoad.ts
+++ b/src/Go/SaveLoad.ts
@@ -9,6 +9,7 @@ import { assertLoadingType } from "../utils/TypeAssertion";
 import { getEnumHelper } from "../utils/EnumHelper";
 import { boardSizes } from "./Constants";
 import { isInteger, isNumber } from "../types";
+import { makeAIMove } from "./boardAnalysis/goAI";
 
 type PreviousGameSaveData = { ai: GoOpponent; board: SimpleBoard; previousPlayer: GoColor | null } | null;
 type CurrentGameSaveData = PreviousGameSaveData & {
@@ -77,6 +78,10 @@ export function loadGo(data: unknown): boolean {
   Go.currentGame = currentGame;
   Go.previousGame = previousGame;
   Go.stats = stats;
+
+  // If it's the AI's turn, initiate their turn
+  if (currentGame.previousPlayer === GoColor.black && currentGame.ai !== GoOpponent.none) makeAIMove(currentGame);
+
   return true;
 }
 

--- a/src/Go/SaveLoad.ts
+++ b/src/Go/SaveLoad.ts
@@ -2,9 +2,9 @@ import type { BoardState, OpponentStats, SimpleBoard } from "./Types";
 import type { PartialRecord } from "../Types/Record";
 
 import { Truthy } from "lodash";
-import { GoColor, GoOpponent } from "@enums";
+import { GoColor, GoOpponent, GoPlayType } from "@enums";
 import { Go } from "./Go";
-import { boardStateFromSimpleBoard, simpleBoardFromBoard } from "./boardAnalysis/boardAnalysis";
+import { boardStateFromSimpleBoard, getPreviousMove, simpleBoardFromBoard } from "./boardAnalysis/boardAnalysis";
 import { assertLoadingType } from "../utils/TypeAssertion";
 import { getEnumHelper } from "../utils/EnumHelper";
 import { boardSizes } from "./Constants";
@@ -79,9 +79,17 @@ export function loadGo(data: unknown): boolean {
   Go.previousGame = previousGame;
   Go.stats = stats;
 
-  // If it's the AI's turn, initiate their turn
+  // If it's the AI's turn, initiate their turn, which will populate nextTurn
   if (currentGame.previousPlayer === GoColor.black && currentGame.ai !== GoOpponent.none) makeAIMove(currentGame);
-
+  // If it's not the AI's turn and we're not in gameover status, initialize nextTurn promise based on the previous move/pass
+  else if (currentGame.previousPlayer) {
+    const previousMove = getPreviousMove();
+    Go.nextTurn = Promise.resolve(
+      previousMove
+        ? { type: GoPlayType.move, x: previousMove[0], y: previousMove[1] }
+        : { type: GoPlayType.pass, x: null, y: null },
+    );
+  }
   return true;
 }
 

--- a/src/Go/Types.ts
+++ b/src/Go/Types.ts
@@ -51,11 +51,17 @@ export type PointState = {
   y: number;
 };
 
-export type Play = {
-  type: GoPlayType;
-  x: number | null;
-  y: number | null;
-};
+export type Play =
+  | {
+      type: GoPlayType.move;
+      x: number;
+      y: number;
+    }
+  | {
+      type: GoPlayType.gameOver | GoPlayType.pass;
+      x: null;
+      y: null;
+    };
 
 export type Neighbor = {
   north: PointState | null;

--- a/src/Go/boardAnalysis/boardAnalysis.ts
+++ b/src/Go/boardAnalysis/boardAnalysis.ts
@@ -1,6 +1,7 @@
 import type { Board, BoardState, Neighbor, PointState, SimpleBoard } from "../Types";
 
 import { GoValidity, GoOpponent, GoColor } from "@enums";
+import { Go } from "../Go";
 import {
   findAdjacentPointsInChain,
   findNeighbors,
@@ -636,5 +637,29 @@ export function getColorOnSimpleBoard(simpleBoard: SimpleBoard, x: number, y: nu
   if (char === "X") return GoColor.black;
   if (char === "O") return GoColor.white;
   if (char === ".") return GoColor.empty;
+  return null;
+}
+
+/** Find a move made by the previous player, if present. */
+export function getPreviousMove(): [number, number] | null {
+  const priorBoard = Go.currentGame?.previousBoards[0];
+  if (Go.currentGame.passCount || !priorBoard) {
+    return null;
+  }
+
+  for (const rowIndexString in Go.currentGame.board) {
+    const row = Go.currentGame.board[+rowIndexString] ?? [];
+    for (const pointIndexString in row) {
+      const point = row[+pointIndexString];
+      const priorColor = point && priorBoard && getColorOnSimpleBoard(priorBoard, point.x, point.y);
+      const currentColor = point?.color;
+      const isPreviousPlayer = currentColor === Go.currentGame.previousPlayer;
+      const isChanged = priorColor !== currentColor;
+      if (priorColor && currentColor && isPreviousPlayer && isChanged) {
+        return [+rowIndexString, +pointIndexString];
+      }
+    }
+  }
+
   return null;
 }

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -21,17 +21,15 @@ import { findAnyMatchedPatterns } from "./patternMatching";
 import { WHRNG } from "../../Casino/RNG";
 import { Go, GoEvents } from "../Go";
 
-let isAIBusy = false;
+let currentAITurn: Promise<Play> | null = null;
 
 /**
  * Retrieves a move from the current faction in response to the player's move
  */
 export function makeAIMove(boardState: BoardState): Promise<Play> {
-  // If an AI move is already in progress, return the already in progress move
-  if (isAIBusy && Go.nextTurn) return Go.nextTurn;
-  // Disallow new AI moves to be triggered during this one
-  isAIBusy = true;
-  Go.nextTurn = getMove(boardState, GoColor.white, Go.currentGame.ai)
+  // If AI is already taking their turn, return the existing turn.
+  if (currentAITurn) return currentAITurn;
+  currentAITurn = Go.nextTurn = getMove(boardState, GoColor.white, Go.currentGame.ai)
     .then(async (play) => {
       if (boardState !== Go.currentGame) return play; //Stale game
       if (play.type === GoPlayType.pass) passTurn(boardState, GoColor.white);
@@ -50,7 +48,7 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
       return play;
     })
     .finally(() => {
-      isAIBusy = false;
+      currentAITurn = null;
       GoEvents.emit();
     });
 

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -1,9 +1,9 @@
-import type { Board, BoardState, EyeMove, Move, MoveOptions, PointState } from "../Types";
+import type { Board, BoardState, EyeMove, Move, MoveOptions, Play, PointState } from "../Types";
 
 import { Player } from "@player";
 import { AugmentationName, GoOpponent, GoColor, GoPlayType } from "@enums";
 import { opponentDetails } from "../Constants";
-import { findNeighbors, floor, isDefined, isNotNull, passTurn } from "../boardState/boardState";
+import { findNeighbors, floor, isDefined, isNotNull, makeMove, passTurn } from "../boardState/boardState";
 import {
   evaluateIfMoveIsValid,
   evaluateMoveResult,
@@ -19,6 +19,44 @@ import {
 import { findDisputedTerritory } from "./controlledTerritory";
 import { findAnyMatchedPatterns } from "./patternMatching";
 import { WHRNG } from "../../Casino/RNG";
+import { Go, GoEvents } from "../Go";
+
+/**
+ * Retrieves a move from the current faction in response to the player's move
+ */
+export async function getAIMove(boardState: BoardState): Promise<Play> {
+  let resolve: (value: Play) => void;
+  Go.nextTurn = new Promise<Play>((res) => {
+    resolve = res;
+  });
+
+  getMove(boardState, GoColor.white, Go.currentGame.ai).then(async (result) => {
+    if (result.type === GoPlayType.pass) {
+      passTurn(Go.currentGame, GoColor.white);
+    }
+
+    // If there is no move to apply, simply return the result
+    if (boardState !== Go.currentGame || result.type !== GoPlayType.move || result.x === null || result.y === null) {
+      return resolve(result);
+    }
+
+    await sleep(400);
+    const aiUpdatedBoard = makeMove(boardState, result.x, result.y, GoColor.white);
+
+    // Handle the AI breaking. This shouldn't ever happen.
+    if (!aiUpdatedBoard) {
+      boardState.previousPlayer = GoColor.white;
+      console.error(`Invalid AI move attempted: ${result.x}, ${result.y}. This should not happen.`);
+      GoEvents.emit();
+      return resolve(result);
+    }
+
+    await sleep(300);
+    GoEvents.emit();
+    resolve(result);
+  });
+  return Go.nextTurn;
+}
 
 /*
   Basic GO AIs, each with some personality and weaknesses

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -30,11 +30,20 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
   // If AI is already taking their turn, return the existing turn.
   if (currentAITurn) return currentAITurn;
   currentAITurn = Go.nextTurn = getMove(boardState, GoColor.white, Go.currentGame.ai)
-    .then(async (play) => {
+    .then(async (play): Promise<Play> => {
       if (boardState !== Go.currentGame) return play; //Stale game
-      if (play.type === GoPlayType.pass) passTurn(boardState, GoColor.white);
-      if (play.type !== GoPlayType.move) return play;
 
+      // Handle AI passing
+      if (play.type === GoPlayType.pass) {
+        passTurn(boardState, GoColor.white);
+        // if passTurn called endGoGame, or the player has no valid moves left, the move should be shown as a game over
+        if (boardState.previousPlayer === null || !getAllValidMoves(boardState, GoColor.black).length) {
+          return { type: GoPlayType.gameOver, x: null, y: null };
+        }
+        return play;
+      }
+
+      // Handle AI making a move
       await sleep(500);
       const aiUpdatedBoard = makeMove(boardState, play.x, play.y, GoColor.white);
 
@@ -77,7 +86,7 @@ export async function getMove(
   player: GoColor,
   opponent: GoOpponent,
   rngOverride?: number,
-): Promise<Play> {
+): Promise<Play & { type: GoPlayType.move | GoPlayType.pass }> {
   await sleep(300);
   const rng = new WHRNG(rngOverride || Player.totalPlaytime);
   const smart = isSmart(opponent, rng.random());
@@ -111,40 +120,10 @@ export async function getMove(
   if (chosenMove) {
     await sleep(200);
     //console.debug(`Non-priority move chosen: ${chosenMove.x} ${chosenMove.y}`);
-    return {
-      type: GoPlayType.move,
-      x: chosenMove.x,
-      y: chosenMove.y,
-    };
-  } else {
-    //console.debug("No valid moves found");
-    return handleNoMoveFound(boardState, player);
+    return { type: GoPlayType.move, x: chosenMove.x, y: chosenMove.y };
   }
-}
-
-/**
- * Detects if the AI is merely passing their turn, or if the game should end.
- *
- * Ends the game if the player passed on the previous turn before the AI passes,
- *   or if the player will be forced to pass their next turn after the AI passes.
- */
-function handleNoMoveFound(boardState: BoardState, player: GoColor): Play {
-  passTurn(boardState, player);
-  const opposingPlayer = player === GoColor.white ? GoColor.black : GoColor.white;
-  const remainingTerritory = getAllValidMoves(boardState, opposingPlayer).length;
-  if (remainingTerritory > 0 && boardState.passCount < 2) {
-    return {
-      type: GoPlayType.pass,
-      x: null,
-      y: null,
-    };
-  } else {
-    return {
-      type: GoPlayType.gameOver,
-      x: null,
-      y: null,
-    };
-  }
+  // Pass if no valid moves were found
+  return { type: GoPlayType.pass, x: null, y: null };
 }
 
 /**

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -51,10 +51,12 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
         console.error(`Invalid AI move attempted: ${play.x}, ${play.y}. This should not happen.`);
       }
 
-      GoEvents.emit();
       return play;
     })
-    .finally(() => (isAIBusy = false));
+    .finally(() => {
+      isAIBusy = false;
+      GoEvents.emit();
+    });
 
   return Go.nextTurn;
 }

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -33,14 +33,10 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
   isAIBusy = true;
   Go.nextTurn = getMove(boardState, GoColor.white, Go.currentGame.ai)
     .then(async (play) => {
-      if (play.type === GoPlayType.pass) {
-        passTurn(Go.currentGame, GoColor.white);
-      }
-
-      // If there is no move to apply, simply return the result
-      if (boardState !== Go.currentGame || play.type !== GoPlayType.move || play.x === null || play.y === null) {
-        return play;
-      }
+      if (boardState !== Go.currentGame) return play; //Stale game
+      if (play.type === GoPlayType.pass) passTurn(boardState, GoColor.white);
+      // The null checking shouldn't be needed below but fixing this requires some types reworking and might be a pain
+      if (play.type !== GoPlayType.move || play.x === null || play.y === null) return play;
 
       await sleep(500);
       const aiUpdatedBoard = makeMove(boardState, play.x, play.y, GoColor.white);

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -33,8 +33,7 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
     .then(async (play) => {
       if (boardState !== Go.currentGame) return play; //Stale game
       if (play.type === GoPlayType.pass) passTurn(boardState, GoColor.white);
-      // The null checking shouldn't be needed below but fixing this requires some types reworking and might be a pain
-      if (play.type !== GoPlayType.move || play.x === null || play.y === null) return play;
+      if (play.type !== GoPlayType.move) return play;
 
       await sleep(500);
       const aiUpdatedBoard = makeMove(boardState, play.x, play.y, GoColor.white);
@@ -73,7 +72,12 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
  *
  * @returns a promise that will resolve with a move (or pass) from the designated AI opponent.
  */
-export async function getMove(boardState: BoardState, player: GoColor, opponent: GoOpponent, rngOverride?: number) {
+export async function getMove(
+  boardState: BoardState,
+  player: GoColor,
+  opponent: GoOpponent,
+  rngOverride?: number,
+): Promise<Play> {
   await sleep(300);
   const rng = new WHRNG(rngOverride || Player.totalPlaytime);
   const smart = isSmart(opponent, rng.random());
@@ -124,7 +128,7 @@ export async function getMove(boardState: BoardState, player: GoColor, opponent:
  * Ends the game if the player passed on the previous turn before the AI passes,
  *   or if the player will be forced to pass their next turn after the AI passes.
  */
-function handleNoMoveFound(boardState: BoardState, player: GoColor) {
+function handleNoMoveFound(boardState: BoardState, player: GoColor): Play {
   passTurn(boardState, player);
   const opposingPlayer = player === GoColor.white ? GoColor.black : GoColor.white;
   const remainingTerritory = getAllValidMoves(boardState, opposingPlayer).length;

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -40,18 +40,15 @@ export async function getAIMove(boardState: BoardState): Promise<Play> {
       return resolve(result);
     }
 
-    await sleep(400);
+    await sleep(500);
     const aiUpdatedBoard = makeMove(boardState, result.x, result.y, GoColor.white);
 
     // Handle the AI breaking. This shouldn't ever happen.
     if (!aiUpdatedBoard) {
       boardState.previousPlayer = GoColor.white;
       console.error(`Invalid AI move attempted: ${result.x}, ${result.y}. This should not happen.`);
-      GoEvents.emit();
-      return resolve(result);
     }
 
-    await sleep(300);
     GoEvents.emit();
     resolve(result);
   });

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -31,31 +31,31 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
   if (isAIBusy && Go.nextTurn) return Go.nextTurn;
   // Disallow new AI moves to be triggered during this one
   isAIBusy = true;
-  let resolve: (play: Play) => void;
-  Go.nextTurn = new Promise<Play>((res) => (resolve = res)).finally(() => (isAIBusy = false));
+  Go.nextTurn = getMove(boardState, GoColor.white, Go.currentGame.ai)
+    .then(async (play) => {
+      if (play.type === GoPlayType.pass) {
+        passTurn(Go.currentGame, GoColor.white);
+      }
 
-  getMove(boardState, GoColor.white, Go.currentGame.ai).then(async (play) => {
-    if (play.type === GoPlayType.pass) {
-      passTurn(Go.currentGame, GoColor.white);
-    }
+      // If there is no move to apply, simply return the result
+      if (boardState !== Go.currentGame || play.type !== GoPlayType.move || play.x === null || play.y === null) {
+        return play;
+      }
 
-    // If there is no move to apply, simply return the result
-    if (boardState !== Go.currentGame || play.type !== GoPlayType.move || play.x === null || play.y === null) {
-      return resolve(play);
-    }
+      await sleep(500);
+      const aiUpdatedBoard = makeMove(boardState, play.x, play.y, GoColor.white);
 
-    await sleep(500);
-    const aiUpdatedBoard = makeMove(boardState, play.x, play.y, GoColor.white);
+      // Handle the AI breaking. This shouldn't ever happen.
+      if (!aiUpdatedBoard) {
+        boardState.previousPlayer = GoColor.white;
+        console.error(`Invalid AI move attempted: ${play.x}, ${play.y}. This should not happen.`);
+      }
 
-    // Handle the AI breaking. This shouldn't ever happen.
-    if (!aiUpdatedBoard) {
-      boardState.previousPlayer = GoColor.white;
-      console.error(`Invalid AI move attempted: ${play.x}, ${play.y}. This should not happen.`);
-    }
+      GoEvents.emit();
+      return play;
+    })
+    .finally(() => (isAIBusy = false));
 
-    GoEvents.emit();
-    resolve(play);
-  });
   return Go.nextTurn;
 }
 

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -26,7 +26,7 @@ let isAIBusy = false;
 /**
  * Retrieves a move from the current faction in response to the player's move
  */
-export async function getAIMove(boardState: BoardState): Promise<Play> {
+export async function makeAIMove(boardState: BoardState): Promise<Play> {
   // If an AI move is already in progress, return the already in progress move
   if (isAIBusy && Go.nextTurn) return Go.nextTurn;
   // Disallow new AI moves to be triggered during this one

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -40,27 +40,27 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
     };
   });
 
-  getMove(boardState, GoColor.white, Go.currentGame.ai).then(async (result) => {
-    if (result.type === GoPlayType.pass) {
+  getMove(boardState, GoColor.white, Go.currentGame.ai).then(async (play) => {
+    if (play.type === GoPlayType.pass) {
       passTurn(Go.currentGame, GoColor.white);
     }
 
     // If there is no move to apply, simply return the result
-    if (boardState !== Go.currentGame || result.type !== GoPlayType.move || result.x === null || result.y === null) {
-      return resolve(result);
+    if (boardState !== Go.currentGame || play.type !== GoPlayType.move || play.x === null || play.y === null) {
+      return resolve(play);
     }
 
     await sleep(500);
-    const aiUpdatedBoard = makeMove(boardState, result.x, result.y, GoColor.white);
+    const aiUpdatedBoard = makeMove(boardState, play.x, play.y, GoColor.white);
 
     // Handle the AI breaking. This shouldn't ever happen.
     if (!aiUpdatedBoard) {
       boardState.previousPlayer = GoColor.white;
-      console.error(`Invalid AI move attempted: ${result.x}, ${result.y}. This should not happen.`);
+      console.error(`Invalid AI move attempted: ${play.x}, ${play.y}. This should not happen.`);
     }
 
     GoEvents.emit();
-    resolve(result);
+    resolve(play);
   });
   return Go.nextTurn;
 }

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -32,13 +32,7 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
   // Disallow new AI moves to be triggered during this one
   isAIBusy = true;
   let resolve: (play: Play) => void;
-  Go.nextTurn = new Promise<Play>((res) => {
-    resolve = (play) => {
-      // Once the promise resolves, stop blocking new AI moves
-      isAIBusy = false;
-      res(play);
-    };
-  });
+  Go.nextTurn = new Promise<Play>((res) => (resolve = res)).finally(() => (isAIBusy = false));
 
   getMove(boardState, GoColor.white, Go.currentGame.ai).then(async (play) => {
     if (play.type === GoPlayType.pass) {

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -21,13 +21,23 @@ import { findAnyMatchedPatterns } from "./patternMatching";
 import { WHRNG } from "../../Casino/RNG";
 import { Go, GoEvents } from "../Go";
 
+let isAIBusy = false;
+
 /**
  * Retrieves a move from the current faction in response to the player's move
  */
 export async function getAIMove(boardState: BoardState): Promise<Play> {
-  let resolve: (value: Play) => void;
+  // If an AI move is already in progress, return the already in progress move
+  if (isAIBusy && Go.nextTurn) return Go.nextTurn;
+  // Disallow new AI moves to be triggered during this one
+  isAIBusy = true;
+  let resolve: (play: Play) => void;
   Go.nextTurn = new Promise<Play>((res) => {
-    resolve = res;
+    resolve = (play) => {
+      // Once the promise resolves, stop blocking new AI moves
+      isAIBusy = false;
+      res(play);
+    };
   });
 
   getMove(boardState, GoColor.white, Go.currentGame.ai).then(async (result) => {

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -26,7 +26,7 @@ let isAIBusy = false;
 /**
  * Retrieves a move from the current faction in response to the player's move
  */
-export async function makeAIMove(boardState: BoardState): Promise<Play> {
+export function makeAIMove(boardState: BoardState): Promise<Play> {
   // If an AI move is already in progress, return the already in progress move
   if (isAIBusy && Go.nextTurn) return Go.nextTurn;
   // Disallow new AI moves to be triggered during this one

--- a/src/Go/boardAnalysis/scoring.ts
+++ b/src/Go/boardAnalysis/scoring.ts
@@ -50,7 +50,6 @@ export function endGoGame(boardState: BoardState) {
     type: GoPlayType.gameOver,
     x: null,
     y: null,
-    success: true,
   });
 
   boardState.previousPlayer = null;

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -96,7 +96,7 @@ export function validateTurn(error: (s: string) => void, moveString = "") {
 /**
  * Pass player's turn and await the opponent's response (or logs the end of the game if both players pass)
  */
-export async function handlePassTurn(logger: (s: string) => void) {
+export function handlePassTurn(logger: (s: string) => void) {
   passTurn(Go.currentGame, GoColor.black);
   logger("Go turn passed.");
 
@@ -111,7 +111,7 @@ export async function handlePassTurn(logger: (s: string) => void) {
 /**
  * Validates and applies the player's router placement
  */
-export async function makePlayerMove(logger: (s: string) => void, error: (s: string) => void, x: number, y: number) {
+export function makePlayerMove(logger: (s: string) => void, error: (s: string) => void, x: number, y: number) {
   const boardState = Go.currentGame;
   const validity = evaluateIfMoveIsValid(boardState, x, y, GoColor.black);
   const moveWasMade = makeMove(boardState, x, y, GoColor.black);
@@ -128,10 +128,10 @@ export async function makePlayerMove(logger: (s: string) => void, error: (s: str
 /**
   Returns the promise that provides the opponent's move, once it finishes thinking.
  */
-export async function getOpponentNextMove(logOpponentMove = true, logger: (s: string) => void) {
+export function getOpponentNextMove(logOpponentMove = true, logger: (s: string) => void) {
   // Only asynchronously log the opponent move if not disabled by the player
   if (logOpponentMove) {
-    return Go.nextTurn.then((move) => {
+    Go.nextTurn.then((move) => {
       if (move.type === GoPlayType.gameOver) {
         logEndGame(logger);
       } else if (move.type === GoPlayType.pass) {
@@ -139,7 +139,6 @@ export async function getOpponentNextMove(logOpponentMove = true, logger: (s: st
       } else if (move.type === GoPlayType.move) {
         logger(`Opponent played move: ${move.x}, ${move.y}`);
       }
-      return move;
     });
   }
 
@@ -329,7 +328,7 @@ export function checkCheatApiAccess(error: (s: string) => void): void {
  *
  * If it fails, determines if the player's turn is skipped, or if the player is ejected from the subnet.
  */
-export async function determineCheatSuccess(
+export function determineCheatSuccess(
   logger: (s: string) => void,
   callback: () => void,
   successRngOverride?: number,
@@ -348,11 +347,11 @@ export async function determineCheatSuccess(
   else if (state.cheatCount && (ejectRngOverride ?? rng.random()) < 0.1) {
     logger(`Cheat failed! You have been ejected from the subnet.`);
     resetBoardState(logger, logger, state.ai, state.board[0].length);
-    return {
+    return Promise.resolve({
       type: GoPlayType.gameOver,
       x: null,
       y: null,
-    };
+    });
   }
   // If the cheat fails, your turn is skipped
   else {

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -129,19 +129,6 @@ export async function makePlayerMove(logger: (s: string) => void, error: (s: str
   Returns the promise that provides the opponent's move, once it finishes thinking.
  */
 export async function getOpponentNextMove(logOpponentMove = true, logger: (s: string) => void) {
-  // Handle the case where Go.nextTurn isn't populated yet
-  if (!Go.nextTurn) {
-    const previousMove = getPreviousMove();
-    const type =
-      Go.currentGame.previousPlayer === null ? GoPlayType.gameOver : previousMove ? GoPlayType.move : GoPlayType.pass;
-
-    Go.nextTurn = Promise.resolve({
-      type,
-      x: previousMove?.[0] ?? null,
-      y: previousMove?.[1] ?? null,
-    });
-  }
-
   // Only asynchronously log the opponent move if not disabled by the player
   if (logOpponentMove) {
     return Go.nextTurn.then((move) => {

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -96,7 +96,7 @@ export function validateTurn(error: (s: string) => void, moveString = "") {
 /**
  * Pass player's turn and await the opponent's response (or logs the end of the game if both players pass)
  */
-export function handlePassTurn(logger: (s: string) => void) {
+export async function handlePassTurn(logger: (s: string) => void) {
   passTurn(Go.currentGame, GoColor.black);
   logger("Go turn passed.");
 
@@ -111,7 +111,7 @@ export function handlePassTurn(logger: (s: string) => void) {
 /**
  * Validates and applies the player's router placement
  */
-export function makePlayerMove(logger: (s: string) => void, error: (s: string) => void, x: number, y: number) {
+export async function makePlayerMove(logger: (s: string) => void, error: (s: string) => void, x: number, y: number) {
   const boardState = Go.currentGame;
   const validity = evaluateIfMoveIsValid(boardState, x, y, GoColor.black);
   const moveWasMade = makeMove(boardState, x, y, GoColor.black);
@@ -128,7 +128,7 @@ export function makePlayerMove(logger: (s: string) => void, error: (s: string) =
 /**
   Returns the promise that provides the opponent's move, once it finishes thinking.
  */
-export function getOpponentNextMove(logOpponentMove = true, logger: (s: string) => void) {
+export async function getOpponentNextMove(logOpponentMove = true, logger: (s: string) => void) {
   // Only asynchronously log the opponent move if not disabled by the player
   if (logOpponentMove) {
     Go.nextTurn.then((move) => {
@@ -328,7 +328,7 @@ export function checkCheatApiAccess(error: (s: string) => void): void {
  *
  * If it fails, determines if the player's turn is skipped, or if the player is ejected from the subnet.
  */
-export function determineCheatSuccess(
+export async function determineCheatSuccess(
   logger: (s: string) => void,
   callback: () => void,
   successRngOverride?: number,
@@ -347,11 +347,11 @@ export function determineCheatSuccess(
   else if (state.cheatCount && (ejectRngOverride ?? rng.random()) < 0.1) {
     logger(`Cheat failed! You have been ejected from the subnet.`);
     resetBoardState(logger, logger, state.ai, state.board[0].length);
-    return Promise.resolve({
+    return {
       type: GoPlayType.gameOver,
       x: null,
       y: null,
-    });
+    };
   }
   // If the cheat fails, your turn is skipped
   else {

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -4,7 +4,7 @@ import { Player } from "@player";
 import { AugmentationName, GoColor, GoOpponent, GoPlayType, GoValidity } from "@enums";
 import { Go, GoEvents } from "../Go";
 import { getNewBoardState, makeMove, passTurn, updateCaptures, updateChains } from "../boardState/boardState";
-import { getAIMove } from "../boardAnalysis/goAI";
+import { makeAIMove } from "../boardAnalysis/goAI";
 import {
   evaluateIfMoveIsValid,
   getColorOnSimpleBoard,
@@ -104,7 +104,7 @@ export async function handlePassTurn(logger: (s: string) => void) {
     logEndGame(logger);
     return getOpponentNextMove(false, logger);
   } else {
-    return getAIMove(Go.currentGame);
+    return makeAIMove(Go.currentGame);
   }
 }
 
@@ -122,7 +122,7 @@ export async function makePlayerMove(logger: (s: string) => void, error: (s: str
 
   GoEvents.emit();
   logger(`Go move played: ${x}, ${y}`);
-  return getAIMove(boardState);
+  return makeAIMove(boardState);
 }
 
 /**
@@ -381,7 +381,7 @@ export async function determineCheatSuccess(
     callback();
     state.cheatCount++;
     GoEvents.emit();
-    return getAIMove(state);
+    return makeAIMove(state);
   }
   // If there have been prior cheat attempts, and the cheat fails, there is a 10% chance of instantly losing
   else if (state.cheatCount && (ejectRngOverride ?? rng.random()) < 0.1) {
@@ -398,7 +398,7 @@ export async function determineCheatSuccess(
     logger(`Cheat failed. Your turn has been skipped.`);
     passTurn(state, GoColor.black, false);
     state.cheatCount++;
-    return getAIMove(state);
+    return makeAIMove(state);
   }
 }
 

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -7,8 +7,8 @@ import { getNewBoardState, makeMove, passTurn, updateCaptures, updateChains } fr
 import { makeAIMove } from "../boardAnalysis/goAI";
 import {
   evaluateIfMoveIsValid,
-  getColorOnSimpleBoard,
   getControlledSpace,
+  getPreviousMove,
   simpleBoardFromBoard,
 } from "../boardAnalysis/boardAnalysis";
 import { getOpponentStats, getScore, resetWinstreak } from "../boardAnalysis/scoring";
@@ -258,32 +258,6 @@ export function getCurrentPlayer(): "None" | "White" | "Black" {
     return "None";
   }
   return Go.currentGame.previousPlayer === GoColor.black ? GoColor.white : GoColor.black;
-}
-
-/**
- * Find a move made by the previous player, if present.
- */
-export function getPreviousMove(): [number, number] | null {
-  const priorBoard = Go.currentGame?.previousBoards[0];
-  if (Go.currentGame.passCount || !priorBoard) {
-    return null;
-  }
-
-  for (const rowIndexString in Go.currentGame.board) {
-    const row = Go.currentGame.board[+rowIndexString] ?? [];
-    for (const pointIndexString in row) {
-      const point = row[+pointIndexString];
-      const priorColor = point && priorBoard && getColorOnSimpleBoard(priorBoard, point.x, point.y);
-      const currentColor = point?.color;
-      const isPreviousPlayer = currentColor === Go.currentGame.previousPlayer;
-      const isChanged = priorColor !== currentColor;
-      if (priorColor && currentColor && isPreviousPlayer && isChanged) {
-        return [+rowIndexString, +pointIndexString];
-      }
-    }
-  }
-
-  return null;
 }
 
 /**

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -131,7 +131,7 @@ export async function makePlayerMove(logger: (s: string) => void, error: (s: str
 export async function getOpponentNextMove(logOpponentMove = true, logger: (s: string) => void) {
   // Only asynchronously log the opponent move if not disabled by the player
   if (logOpponentMove) {
-    Go.nextTurn.then((move) => {
+    return Go.nextTurn.then((move) => {
       if (move.type === GoPlayType.gameOver) {
         logEndGame(logger);
       } else if (move.type === GoPlayType.pass) {
@@ -139,6 +139,7 @@ export async function getOpponentNextMove(logOpponentMove = true, logger: (s: st
       } else if (move.type === GoPlayType.move) {
         logger(`Opponent played move: ${move.x}, ${move.y}`);
       }
+      return move;
     });
   }
 

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -1,10 +1,10 @@
-import { BoardState, Play, SimpleOpponentStats } from "../Types";
+import { Play, SimpleOpponentStats } from "../Types";
 
 import { Player } from "@player";
 import { AugmentationName, GoColor, GoOpponent, GoPlayType, GoValidity } from "@enums";
 import { Go, GoEvents } from "../Go";
-import { getMove, sleep } from "../boardAnalysis/goAI";
 import { getNewBoardState, makeMove, passTurn, updateCaptures, updateChains } from "../boardState/boardState";
+import { getAIMove } from "../boardAnalysis/goAI";
 import {
   evaluateIfMoveIsValid,
   getColorOnSimpleBoard,
@@ -156,43 +156,6 @@ export async function getOpponentNextMove(logOpponentMove = true, logger: (s: st
     });
   }
 
-  return Go.nextTurn;
-}
-
-/**
- * Retrieves a move from the current faction in response to the player's move
- */
-export async function getAIMove(boardState: BoardState): Promise<Play> {
-  let resolve: (value: Play) => void;
-  Go.nextTurn = new Promise<Play>((res) => {
-    resolve = res;
-  });
-
-  getMove(boardState, GoColor.white, Go.currentGame.ai).then(async (result) => {
-    if (result.type === GoPlayType.pass) {
-      passTurn(Go.currentGame, GoColor.white);
-    }
-
-    // If there is no move to apply, simply return the result
-    if (boardState !== Go.currentGame || result.type !== GoPlayType.move || result.x === null || result.y === null) {
-      return resolve(result);
-    }
-
-    await sleep(400);
-    const aiUpdatedBoard = makeMove(boardState, result.x, result.y, GoColor.white);
-
-    // Handle the AI breaking. This shouldn't ever happen.
-    if (!aiUpdatedBoard) {
-      boardState.previousPlayer = GoColor.white;
-      console.error(`Invalid AI move attempted: ${result.x}, ${result.y}. This should not happen.`);
-      GoEvents.emit();
-      return resolve(result);
-    }
-
-    await sleep(300);
-    GoEvents.emit();
-    resolve(result);
-  });
   return Go.nextTurn;
 }
 

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -18,7 +18,7 @@ import { GoScoreModal } from "./GoScoreModal";
 import { GoGameboard } from "./GoGameboard";
 import { GoSubnetSearch } from "./GoSubnetSearch";
 import { CorruptableText } from "../../ui/React/CorruptableText";
-import { getAIMove } from "../boardAnalysis/goAI";
+import { makeAIMove } from "../boardAnalysis/goAI";
 
 interface GoGameboardWrapperProps {
   showInstructions: () => void;
@@ -118,7 +118,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
 
   async function takeAiTurn(boardState: BoardState) {
     setWaitingOnAI(true);
-    const move = await getAIMove(boardState);
+    const move = await makeAIMove(boardState);
 
     if (move.type === GoPlayType.pass) {
       SnackbarEvents.emit(`The opponent passes their turn; It is now your turn to move.`, ToastVariant.WARNING, 4000);

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -18,7 +18,7 @@ import { GoScoreModal } from "./GoScoreModal";
 import { GoGameboard } from "./GoGameboard";
 import { GoSubnetSearch } from "./GoSubnetSearch";
 import { CorruptableText } from "../../ui/React/CorruptableText";
-import { getAIMove } from "../effects/netscriptGoImplementation";
+import { getAIMove } from "../boardAnalysis/goAI";
 
 interface GoGameboardWrapperProps {
   showInstructions: () => void;

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -45,20 +45,12 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
   const [showPriorMove, setShowPriorMove] = useState(false);
   const [scoreOpen, setScoreOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
-  const [waitingOnAI, setWaitingOnAI] = useState(false);
 
   const classes = boardStyles();
   const boardSize = boardState.board[0].length;
   const currentPlayer = boardState.previousPlayer === GoColor.white ? GoColor.black : GoColor.white;
+  const waitingOnAI = boardState.previousPlayer === GoColor.black && boardState.ai !== GoOpponent.none;
   const score = getScore(boardState);
-
-  // Only run this once on first component mount, to handle scenarios where the game was saved or closed while waiting on the AI to make a move
-  useEffect(() => {
-    if (boardState.previousPlayer === GoColor.black && !waitingOnAI && boardState.ai !== GoOpponent.none) {
-      takeAiTurn(Go.currentGame);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // Do not implement useCallback for this function without ensuring GoGameboard still rerenders for every move
   // Currently this function changing is what triggers a GoGameboard rerender, which is needed
@@ -117,7 +109,6 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
   }
 
   async function takeAiTurn(boardState: BoardState) {
-    setWaitingOnAI(true);
     const move = await makeAIMove(boardState);
 
     if (move.type === GoPlayType.pass) {
@@ -130,7 +121,6 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
       setScoreOpen(true);
       return;
     }
-    setWaitingOnAI(false);
   }
 
   function newSubnet() {
@@ -172,8 +162,6 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
   const endGameAvailable = boardState.previousPlayer === GoColor.white && boardState.passCount;
   const noLegalMoves =
     boardState.previousPlayer === GoColor.white && !getAllValidMoves(boardState, GoColor.black).length;
-  const disablePassButton =
-    Go.currentGame.ai !== GoOpponent.none && boardState.previousPlayer === GoColor.black && waitingOnAI;
 
   const scoreBoxText = boardState.previousBoards.length
     ? `Score: Black: ${score[GoColor.black].sum} White: ${score[GoColor.white].sum}`
@@ -186,7 +174,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
     if (boardState.previousPlayer === null) {
       return "View Final Score";
     }
-    if (boardState.previousPlayer === GoColor.black && waitingOnAI) {
+    if (waitingOnAI) {
       return "Waiting for opponent";
     }
     const currentPlayer = boardState.previousPlayer === GoColor.black ? GoColor.white : GoColor.black;
@@ -242,7 +230,7 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
           </Button>
           <Typography className={classes.scoreBox}>{scoreBoxText}</Typography>
           <Button
-            disabled={disablePassButton}
+            disabled={waitingOnAI}
             onClick={passPlayerTurn}
             className={endGameAvailable || noLegalMoves ? classes.buttonHighlight : classes.resetBoard}
           >


### PR DESCRIPTION
@d0sboots @ficocelliguy I believe this stops any possibility for there to be multiple AI turns pending at the same time, but let me know what you think and if there's some other potential race condition that doesn't seem to be addressed.

Because this PR includes a location change + function name change + changes to the function, it makes more sense to look at the individual race condition 1 and 2 commits for reviewing those specific things, instead of the overall changes for the PR which are hard to see the changes in.

The move and rename commits had no changes other than location and name of the function.

6d01457: Moved getAIMove to a different location since it's not netscript specific. No substantive changes, just a location change.

48bfb2a: Close a weird 300ms gap where it's actually the player's turn because the AI move was already applied to the board, but the Go.nextTurn promise for the previous AI turn has not yet resolved. There was an extra sleep that was causing this weird mismatched in-between time. I slightly increased one of the existing sleeps to compensate removing the extra sleep.

afeb6e7: More directly deals with the possibility of multiple concurrent AI turns due to being triggered from different sources. Now AI turns are disallowed from being triggered until the previous one has resolved. If multiple are triggered simultaneously then they will both return the same turn, instead of being two separate instance of the AI attempting to take a turn.

708ba27: Renamed getAITMove to makeAIMove since it actually triggers the AI to make the move. No substantive changes, just a name change.

3eb4dc7: Removed the functionality from the UI where loading Go will take the AI's turn if a game was loaded where it was already the AI's turn. Instead this is handled by the game automatically on game load. Also un-stated the waitingOnAI variable on the gameboardwrapper, because it's a variable handled by Go internal game state and not React state.