### PR TITLE
MISC: Fix bugs in useRerender hook and ns.moveTail

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -58,6 +58,7 @@ export class LogBoxProperties {
     this.x = x;
     this.y = y;
     this.updateDOM();
+    this.rerender();
   }
 
   setSize(width: number, height: number): void {

--- a/src/ui/React/hooks.ts
+++ b/src/ui/React/hooks.ts
@@ -4,9 +4,9 @@ import { useCallback, useEffect, useState } from "react";
  * @param autoRerenderTime: Optional. If provided and nonzero, used as the ms interval to automatically call the rerender function.
  */
 export function useRerender(autoRerenderTime?: number) {
-  const [__, setRerender] = useState(false);
+  const [__, setRerender] = useState(0);
 
-  const rerender = useCallback(() => setRerender((old) => !old), []);
+  const rerender = useCallback(() => setRerender((currentValue) => currentValue + 1), []);
 
   useEffect(() => {
     if (!autoRerenderTime) return;


### PR DESCRIPTION
This PR fixes 2 bugs:
- Calling `rerender` an even number of times will make the boolean state come back to the old value, so React won't rerender.
- `setPosition` of `LogBoxProperties` does not call `this.rerender();`.

How to test:
- Use the reproducible code in #656.
- Test these cases:
  - Only call `resizeTail`.
  - Only call `moveTail`.
  - Call `resizeTail` + `moveTail`.
  - Call `resizeTail` twice.
  - Call `moveTail` twice.

Fixes #656.