### PR TITLE
INFILTRATION: Fix a crash when rendering InfiltrationRoot with an invalid location

### DIFF
--- a/src/Infiltration/ui/InfiltrationRoot.tsx
+++ b/src/Infiltration/ui/InfiltrationRoot.tsx
@@ -5,6 +5,8 @@ import { Page } from "../../ui/Router";
 import { calculateDifficulty, calculateReward } from "../formulas/game";
 import { Game } from "./Game";
 import { Intro } from "./Intro";
+import { dialogBoxCreate } from "../../ui/React/DialogBox";
+
 interface IProps {
   location: Location;
 }
@@ -12,7 +14,20 @@ interface IProps {
 export function InfiltrationRoot(props: IProps): React.ReactElement {
   const [start, setStart] = useState(false);
 
-  if (props.location.infiltrationData === undefined) throw new Error("Trying to do infiltration on invalid location.");
+  if (!props.location.infiltrationData) {
+    /**
+     * Using setTimeout is unnecessary, because we can just call cancel() and dialogBoxCreate(). However, without
+     * setTimeout, we will go to City page (in "cancel" function) and update GameRoot while still rendering
+     * InfiltrationRoot. React will complain: "Warning: Cannot update a component (`GameRoot`) while rendering a
+     * different component (`InfiltrationRoot`)".
+     */
+    setTimeout(() => {
+      cancel();
+      dialogBoxCreate(`You tried to infiltrate an invalid location: ${props.location.name}`);
+    }, 100);
+    return <></>;
+  }
+
   const startingSecurityLevel = props.location.infiltrationData.startingSecurityLevel;
   const difficulty = calculateDifficulty(startingSecurityLevel);
   const reward = calculateReward(startingSecurityLevel);


### PR DESCRIPTION
In #84, a player reported a crash in `InfiltrationRoot` when being rendered with an invalid location. This bug is invalid in our current version, but I still provide a "fix" in this PR.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  await ns.sleep(5000);
  ns.singularity.travelToCity("Aevum");
  ns.singularity.goToLocation("Iker Molina Casino");
}
```

How to reproduce it in the old version (00adc2ffa230652ad23421dd26b5ade248623f09):
- Run test code.
- Open Infiltration UI.
- Wait until singularity code runs.

How to force this bug to happen in our current version:
- In `src\NetscriptFunctions\Singularity.ts`, `goToLocation` function: replace `Router.toPage(Page.Location, { location });` with `Router.toPage(Page.Infiltration, { location });`.
- Rebuild.
- Use the same steps as in the old version.

I tested both "proposed issue cases" in current version. This bug is invalid now.

Fixes #84.