### PR TITLE
MISC: Log invalid file request in Electron app

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -206,7 +206,7 @@ app.on("ready", async () => {
     if ((method === "GET" && relativePath.startsWith("dist")) || relativePath.match(/^[a-zA-Z-_]*\.html/)) {
       return callback(filePath);
     }
-    log.error("Tried to access a page outside sandbox.");
+    log.error(`Tried to access a page outside the sandbox. Url: ${url}. Method: ${method}.`);
     callback(path.join(__dirname, "fileError.txt"));
   });
 


### PR DESCRIPTION
A player reports a problem with loading our Steam app. One of their screenshots shows the error of accessing files outside the sandbox. It's hard to troubleshoot the problem without more information/logs.
This PR logs the invalid url when there is an invalid file request.