### PR TITLE
BUGFIX: Tail window position does not update when being dragged

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -307,8 +307,15 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
     if (
       e instanceof MouseEvent &&
       (e.clientX < 0 || e.clientY < 0 || e.clientX > innerWidth || e.clientY > innerHeight)
-    )
+    ) {
       return false;
+    }
+    if (rootRef.current) {
+      // We can set x,y directly. Calling setPosition will make unnecessary calls of updateDOM and rerender.
+      const currentState = rootRef.current.state as { x: number; y: number };
+      propsRef.current.x = currentState.x;
+      propsRef.current.y = currentState.y;
+    }
   };
 
   // Max [width, height]


### PR DESCRIPTION
`ns.getRunningScript().tailProperties` returns the position and size of the tail window, but the position is not updated when we drag the tail window. This PR fixes that.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  while (true) {
    ns.print(ns.getRunningScript().tailProperties);
    await ns.sleep(500);
  }
}
```