### PR TITLE
EDITOR: Improved infinite loop checking

### DIFF
--- a/src/Documentation/doc/basic/scripts.md
+++ b/src/Documentation/doc/basic/scripts.md
@@ -62,6 +62,21 @@ For example, if a script run with 1 thread is able to hack $10,000, then running
 
 When "multithreading" a script, the total [RAM](ram.md) cost can be calculated by simply multiplying the [RAM](ram.md) cost of a single instance of your script by the number of threads you will use. [See [`ns.getScriptRam()`](https://github.com/bitburner-official/bitburner-src/blob/bec737a25307be29c7efef147fc31effca65eedc/markdown/bitburner.ns.getscriptram.md) or the `mem` terminal command detailed below]
 
+## Never-ending scripts
+
+Sometimes it might be necessary for a script to never end and keep doing a particular task.
+In that case you would want to write your script in a never-ending loop, like `while (true)`.
+
+However, if you are not careful, this can crash your game.
+If the code inside the loop doesn't `await` for some time, it will never give other scripts and the game itself time to process.
+
+<br />
+
+To help you find this potential bug, any `while (true)` loop without any `await` statement inside it will be marked.
+A red decoration will appear on the left side of the script editor, telling you about the issue.
+
+If you are really sure that this is not an oversight, you can suppress the warning using the comment `// @ignore-infinite` directly above the loop.
+
 ## Working with Scripts in Terminal
 
 Here are some [terminal](terminal.md) commands you will find useful when working with scripts:

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -208,7 +208,7 @@ export function checkInfiniteLoop(code: string): number {
     return -1;
   }
   function nodeHasTrueTest(node: acorn.Node): boolean {
-    return node.type === "Literal" && "raw" in node && node.raw === "true";
+    return node.type === "Literal" && "raw" in node && (node.raw === "true" || node.raw === "1");
   }
 
   function hasAwait(ast: acorn.Node): boolean {

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -231,12 +231,12 @@ export function checkInfiniteLoop(code: string): number[] {
     {},
     {
       WhileStatement: (node: Node, st: unknown, walkDeeper: walk.WalkerCallback<any>) => {
-				const previousLines = code.slice(0, node.start).trimEnd().split("\n");
-				const lineNumber = previousLines.length + 1;
-				if (previousLines[previousLines.length - 1].match(/^\s*\/\/\s*@ignore-infinite/)) {
-					return;
-				}
-				if (nodeHasTrueTest(node.test) && !hasAwait(node)) {
+        const previousLines = code.slice(0, node.start).trimEnd().split("\n");
+        const lineNumber = previousLines.length + 1;
+        if (previousLines[previousLines.length - 1].match(/^\s*\/\/\s*@ignore-infinite/)) {
+          return;
+        }
+        if (nodeHasTrueTest(node.test) && !hasAwait(node)) {
           possibleLines.push(lineNumber);
         } else {
           node.body && walkDeeper(node.body, st);

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -199,13 +199,13 @@ function parseOnlyRamCalculate(otherScripts: Map<ScriptFilePath, Script>, code: 
   return { cost: ram, entries: detailedCosts.filter((e) => e.cost > 0) };
 }
 
-export function checkInfiniteLoop(code: string): number {
+export function checkInfiniteLoop(code: string): number[] {
   let ast: acorn.Node;
   try {
     ast = parse(code, { sourceType: "module", ecmaVersion: "latest" });
   } catch (e) {
     // If code cannot be parsed, do not provide infinite loop detection warning
-    return -1;
+    return [];
   }
   function nodeHasTrueTest(node: acorn.Node): boolean {
     return node.type === "Literal" && "raw" in node && (node.raw === "true" || node.raw === "1");
@@ -225,7 +225,7 @@ export function checkInfiniteLoop(code: string): number {
     return hasAwait;
   }
 
-  let missingAwaitLine = -1;
+  const possibleLines: number[] = [];
   walk.recursive(
     ast,
     {},
@@ -237,7 +237,7 @@ export function checkInfiniteLoop(code: string): number {
 					return;
 				}
 				if (nodeHasTrueTest(node.test) && !hasAwait(node)) {
-          missingAwaitLine = lineNumber;
+          possibleLines.push(lineNumber);
         } else {
           node.body && walkDeeper(node.body, st);
         }
@@ -245,7 +245,7 @@ export function checkInfiniteLoop(code: string): number {
     },
   );
 
-  return missingAwaitLine;
+  return possibleLines;
 }
 
 interface ParseDepsResult {

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -231,8 +231,13 @@ export function checkInfiniteLoop(code: string): number {
     {},
     {
       WhileStatement: (node: Node, st: unknown, walkDeeper: walk.WalkerCallback<any>) => {
-        if (nodeHasTrueTest(node.test) && !hasAwait(node)) {
-          missingAwaitLine = (code.slice(0, node.start).match(/\n/g) || []).length + 1;
+				const previousLines = code.slice(0, node.start).trimEnd().split("\n");
+				const lineNumber = previousLines.length + 1;
+				if (previousLines[previousLines.length - 1].match(/^\s*\/\/\s*@ignore-infinite/)) {
+					return;
+				}
+				if (nodeHasTrueTest(node.test) && !hasAwait(node)) {
+          missingAwaitLine = lineNumber;
         } else {
           node.body && walkDeeper(node.body, st);
         }

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -116,25 +116,23 @@ function Root(props: IProps): React.ReactElement {
     if (editorRef.current === null || currentScript === null) return;
     if (!decorations) decorations = editorRef.current.createDecorationsCollection();
     if (!currentScript.path.endsWith(".js")) return;
-    const awaitWarning = checkInfiniteLoop(newCode);
-    if (awaitWarning !== -1) {
-      decorations.set([
-        {
-          range: {
-            startLineNumber: awaitWarning,
-            startColumn: 1,
-            endLineNumber: awaitWarning,
-            endColumn: 10,
-          },
-          options: {
-            isWholeLine: true,
-            glyphMarginClassName: "myGlyphMarginClass",
-            glyphMarginHoverMessage: {
-              value: "Possible infinite loop, await something.",
-            },
-          },
-        },
-      ]);
+    const possibleLines = checkInfiniteLoop(newCode);
+    if (possibleLines.length !== 0) {
+      decorations.set(possibleLines.map(awaitWarning => ({
+				range: {
+					startLineNumber: awaitWarning,
+					startColumn: 1,
+					endLineNumber: awaitWarning,
+					endColumn: 10,
+				},
+				options: {
+					isWholeLine: true,
+					glyphMarginClassName: "myGlyphMarginClass",
+					glyphMarginHoverMessage: {
+						value: "Possible infinite loop, await something or ignore it with '// @ignore-infinite' above the loop.",
+					},
+				},
+      })));
     } else decorations.clear();
   }
 

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -130,7 +130,7 @@ function Root(props: IProps): React.ReactElement {
             isWholeLine: true,
             glyphMarginClassName: "myGlyphMarginClass",
             glyphMarginHoverMessage: {
-              value: "Possible infinite loop, await something or ignore it with '// @ignore-infinite' above the loop.",
+              value: "Possible infinite loop, await something. If this is a false-positive, use `// @ignore-infinite` to suppress.",
             },
           },
         })),

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -130,7 +130,8 @@ function Root(props: IProps): React.ReactElement {
             isWholeLine: true,
             glyphMarginClassName: "myGlyphMarginClass",
             glyphMarginHoverMessage: {
-              value: "Possible infinite loop, await something. If this is a false-positive, use `// @ignore-infinite` to suppress.",
+              value:
+                "Possible infinite loop, await something. If this is a false-positive, use `// @ignore-infinite` to suppress.",
             },
           },
         })),

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -118,21 +118,23 @@ function Root(props: IProps): React.ReactElement {
     if (!currentScript.path.endsWith(".js")) return;
     const possibleLines = checkInfiniteLoop(newCode);
     if (possibleLines.length !== 0) {
-      decorations.set(possibleLines.map(awaitWarning => ({
-				range: {
-					startLineNumber: awaitWarning,
-					startColumn: 1,
-					endLineNumber: awaitWarning,
-					endColumn: 10,
-				},
-				options: {
-					isWholeLine: true,
-					glyphMarginClassName: "myGlyphMarginClass",
-					glyphMarginHoverMessage: {
-						value: "Possible infinite loop, await something or ignore it with '// @ignore-infinite' above the loop.",
-					},
-				},
-      })));
+      decorations.set(
+        possibleLines.map((awaitWarning) => ({
+          range: {
+            startLineNumber: awaitWarning,
+            startColumn: 1,
+            endLineNumber: awaitWarning,
+            endColumn: 10,
+          },
+          options: {
+            isWholeLine: true,
+            glyphMarginClassName: "myGlyphMarginClass",
+            glyphMarginHoverMessage: {
+              value: "Possible infinite loop, await something or ignore it with '// @ignore-infinite' above the loop.",
+            },
+          },
+        })),
+      );
     } else decorations.clear();
   }
 


### PR DESCRIPTION
The infinite loop checking the game provides is meant to help newer players find infinite loops that might crash the game.
While this is mostly working, there are some cases, where infinite loops might be intentional. The player might want a never-ending script or an infinite generator.

To improve upon the existing detection system, following functionality has been added:
- Testing for another case, where the while loop will never stop, while (1)
- Excluding any while loops, that have been marked by the player with the comment `// @ignore-infinite`
- Showing multiple infinite while loops in one script.

These changes will help newer players spot infinite loops, while giving the intermediate player the option to disable the checking all together.