### PR TITLE
BUGFIX: Engine does not send all faction invitations

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -162,9 +162,8 @@ const Engine: {
   checkCounters: function () {
     if (Engine.Counters.checkFactionInvitations <= 0) {
       const invitedFactions = Player.checkForFactionInvitations();
-      if (invitedFactions.length > 0) {
-        const randFaction = invitedFactions[Math.floor(Math.random() * invitedFactions.length)];
-        inviteToFaction(randFaction);
+      for (const invitedFaction of invitedFactions) {
+        inviteToFaction(invitedFaction);
       }
       Engine.Counters.checkFactionInvitations = 100;
     }


### PR DESCRIPTION
When the player calls `ns.singularity.checkFactionInvitations`, they expect that the returned value is the array of factions for which they satisfy conditions. However, the game engine sends only 1 invitation of a random faction in that array. This behavior does not make sense to me.