### PR TITLE
UI: Add RAM checking to tab closure in editor

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -292,6 +292,7 @@ function Root(props: IProps): React.ReactElement {
         editorRef.current.setModel(currentScript.model);
         editorRef.current.setPosition(currentScript.lastPosition);
         editorRef.current.revealLineInCenter(currentScript.lastPosition.lineNumber);
+        parseCode(currentScript.code);
         editorRef.current.focus();
       }
     }


### PR DESCRIPTION
Very minor change to trigger RAM checking on tab closure in the built-in editor. Fixes UI bug described at [discord](https://discord.com/channels/415207508303544321/415213413745164318/1240361787564490854)

Bugged pre-change; note empty script should not have 11.6GB ram cost (previously closed script did):
![ramcost3](https://github.com/bitburner-official/bitburner-src/assets/97335456/daad0df2-a7bf-490d-8056-0618ed20078a)

All things React still scare and confuse me, but I hope this helps.