### PR TITLE
DOC: remove redundant `@remarks` for sqlinject() function

### DIFF
--- a/markdown/bitburner.ns.sqlinject.md
+++ b/markdown/bitburner.ns.sqlinject.md
@@ -26,6 +26,8 @@ void
 
 RAM cost: 0.05 GB
 
+Runs the SQLInject.exe program on the target server. SQLInject.exe must exist on your home computer.
+
 ## Example
 
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6110,7 +6110,6 @@ export interface NS {
    * ```js
    * ns.sqlinject("foodnstuff");
    * ```
-   * @remarks RAM cost: 0.05 GB
    * @param host - Hostname of the target server.
    */
   sqlinject(host: string): void;


### PR DESCRIPTION
This removes the redundant `@remarks` from the TS doc, and doing so fixes the actual doc being generated correctly.