### PR TITLE
IPVGO: Add defence boost to Tetrads

### DIFF
--- a/src/Go/Constants.ts
+++ b/src/Go/Constants.ts
@@ -39,7 +39,7 @@ export const opponentDetails = {
     description: "Martial AI",
     flavorText:
       "The faction known as Tetrads prefers to get up close and personal. Their combat style excels at circling around and cutting through their opponents, both on and off of the subnets.",
-    bonusDescription: "strength, dex, and agility levels",
+    bonusDescription: "strength, defense, dexterity, and agility levels",
     bonusPower: 0.7,
   },
   [GoOpponent.Daedalus]: {

--- a/src/Go/effects/effect.ts
+++ b/src/Go/effects/effect.ts
@@ -79,6 +79,7 @@ function calculateMults(): Multipliers {
         break;
       case GoOpponent.Tetrads:
         mults.strength *= effect;
+        mults.defense *= effect;
         mults.dexterity *= effect;
         mults.agility *= effect;
         break;


### PR DESCRIPTION
Based on discord [suggestion](https://discordapp.com/channels/415207508303544321/1221920484111814828/1236087482618089492), Tetrads now do all four combat stats.