### PR TITLE
BUGFIX: Correct BN10 Sleeve starting Shock

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -139,7 +139,7 @@ export function prestigeSourceFile(this: PlayerObject): void {
 
   if (this.bitNodeN === 10) {
     for (let i = 0; i < this.sleeves.length; i++) {
-      this.sleeves[i].shock = Math.max(25, this.sleeves[i].shock);
+      this.sleeves[i].shock = Math.min(25, this.sleeves[i].shock);
       this.sleeves[i].sync = Math.max(25, this.sleeves[i].sync);
     }
   }


### PR DESCRIPTION
Looks like an old bug that was supposed to make Shock be maxed at 25 used the wrong math expression, probably copied from the sync expression.

Not sure if sync should really start so low for BN10 in order to get the player a better start with the sleeve.