### PR TITLE
BUGFIX: Fix hidden debt of exp at level 1

### DIFF
--- a/src/PersonObjects/formulas/skill.ts
+++ b/src/PersonObjects/formulas/skill.ts
@@ -10,6 +10,9 @@ export function calculateSkill(exp: number, mult = 1): number {
 }
 
 export function calculateExp(skill: number, mult = 1): number {
+  if (skill === 1) {
+    return 0;
+  }
   const value = Math.exp((skill / mult + 200) / 32) - 534.6;
   return clampNumber(value, 0);
 }

--- a/src/PersonObjects/formulas/skill.ts
+++ b/src/PersonObjects/formulas/skill.ts
@@ -10,9 +10,6 @@ export function calculateSkill(exp: number, mult = 1): number {
 }
 
 export function calculateExp(skill: number, mult = 1): number {
-  if (skill === 1) {
-    return 0;
-  }
   const value = Math.exp((skill / mult + 200) / 32) - 534.6;
   return clampNumber(value, 0);
 }

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -25,10 +25,23 @@ import { CONSTANTS } from "./Constants";
 import { LogBoxClearEvents } from "./ui/React/LogBoxManager";
 import { initCircadianModulator } from "./Augmentation/Augmentations";
 import { Go } from "./Go/Go";
+import { calculateExp } from "./PersonObjects/formulas/skill";
+import { currentNodeMults } from "./BitNode/BitNodeMultipliers";
 
 const BitNode8StartingMoney = 250e6;
 function delayedDialog(message: string) {
   setTimeout(() => dialogBoxCreate(message), 200);
+}
+
+function setInitialExpForPlayer() {
+  Player.exp.hacking = calculateExp(1, Player.mults.hacking * currentNodeMults.HackingLevelMultiplier);
+  Player.exp.strength = calculateExp(1, Player.mults.strength * currentNodeMults.StrengthLevelMultiplier);
+  Player.exp.defense = calculateExp(1, Player.mults.defense * currentNodeMults.DefenseLevelMultiplier);
+  Player.exp.dexterity = calculateExp(1, Player.mults.dexterity * currentNodeMults.DexterityLevelMultiplier);
+  Player.exp.agility = calculateExp(1, Player.mults.agility * currentNodeMults.AgilityLevelMultiplier);
+  Player.exp.charisma = calculateExp(1, Player.mults.charisma * currentNodeMults.CharismaLevelMultiplier);
+  Player.updateSkillLevels();
+  Player.hp.current = Player.hp.max;
 }
 
 // Prestige by purchasing augmentation
@@ -100,7 +113,6 @@ export function prestigeAugmentation(): void {
   }
   Player.reapplyAllAugmentations();
   Player.reapplyAllSourceFiles();
-  Player.hp.current = Player.hp.max;
 
   staneksGift.prestigeAugmentation();
 
@@ -173,6 +185,8 @@ export function prestigeAugmentation(): void {
   resetPidCounter();
   ProgramsSeen.clear();
   InvitationsSeen.clear();
+
+  setInitialExpForPlayer();
 }
 
 // Prestige by destroying Bit Node and gaining a Source File
@@ -314,4 +328,6 @@ export function prestigeSourceFile(isFlume: boolean): void {
   // Clear recent scripts
   recentScripts.splice(0, recentScripts.length);
   resetPidCounter();
+
+  setInitialExpForPlayer();
 }


### PR DESCRIPTION
The player's stat levels start at 1, but the respective exp points start at 0. This creates a weird hidden "debt" of exp at level 1 when mult is smaller than ~0.9914716399982745. It was reported in #189.

Reproducible test case:
- Load a clean save file (Options -> Delete Save).
- Use dev menu to add SF 1.1 (simulate a normal save file that beats BN 1.1).
- Bitflume to BN 10.1.
- We have:
  - `calculateExp(1, Player.mults.hacking * currentNodeMults.HackingLevelMultiplier)` = 24.816093628051703
  - `calculateExp(2, Player.mults.hacking * currentNodeMults.HackingLevelMultiplier)` = 69.52860629547718

As we can see with the UI, the player must pay off the hidden "debt" of level 1. This is confusing for the player. This PR fixes this problem.

Please note that this PR does not fix/change the current formula(s) or how exp/skill works (e.g., level 1->2 is harder than level 2->3). It only "fixes" the problem by returning 0 when skill is 1. It's exactly how it works internally (it needs 0 exp to get to level 1). After applying it, level 1->2 still needs 69.52860629547718.

Fixes #189.