### PR TITLE
SLEEVE: Add funds check for sleeve travel

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -256,6 +256,10 @@ export class Sleeve extends Person implements SleevePerson {
 
   /** Travel to another City. Costs money from player */
   travel(newCity: CityName): boolean {
+    if (!Player.canAfford(CONSTANTS.TravelCost)) {
+      return false;
+    }
+
     Player.loseMoney(CONSTANTS.TravelCost, "sleeves");
     this.city = newCity;
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4473,7 +4473,7 @@ export interface Sleeve {
   setToGymWorkout(sleeveNumber: number, gymName: string, stat: string): boolean;
 
   /**
-   * Make a sleeve travel to another city.
+   * Make a sleeve travel to another city. The cost for using this function is the same as for a player.
    * @remarks
    * RAM cost: 4 GB
    *


### PR DESCRIPTION
This makes sleeve travel consistent with player travel behaviour. This also makes the function description more truthful in that it is now possible to return false.

This does affect game balance by making the debt achievement no longer possible by using sleeve travel; other methods exist.

Closes #991 