### PR TITLE
AUGMENTATIONS: Use startingMoney and programs from augmentation definition when prestiging

### DIFF
--- a/src/Augmentation/Augmentation.ts
+++ b/src/Augmentation/Augmentation.ts
@@ -195,6 +195,12 @@ export class Augmentation {
   // The Player/Person classes
   mults: Multipliers = defaultMultipliers();
 
+  // Amount of money given to the Player when prestiging with this augmentation.
+  startingMoney: number;
+
+  // Array of programs to be given to the player when prestiging with this augmentation.
+  programs: CompletedProgramName[];
+
   // Factions that offer this aug.
   factions: FactionName[] = [];
 
@@ -218,6 +224,9 @@ export class Augmentation {
       const mult = params[multName];
       if (mult) this.mults[multName] = mult;
     }
+
+    this.startingMoney = params.startingMoney ?? 0;
+    this.programs = params.programs ?? [];
 
     if (params.stats === undefined)
       this.stats = generateStatsDescription(this.mults, params.programs, params.startingMoney);

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -1,4 +1,5 @@
 import { AugmentationName, CityName, CompletedProgramName, FactionName, LiteratureName, CompanyName } from "@enums";
+import { Augmentations } from "./Augmentation/Augmentations";
 import { initBitNodeMultipliers } from "./BitNode/BitNode";
 import { Companies } from "./Company/Companies";
 import { resetIndustryResearchTrees } from "./Corporation/data/IndustryData";
@@ -60,19 +61,14 @@ export function prestigeAugmentation(): void {
   AddToAllServers(homeComp);
   prestigeHomeComputer(homeComp);
 
-  if (Player.hasAugmentation(AugmentationName.Neurolink, true)) {
-    homeComp.programs.push(CompletedProgramName.ftpCrack);
-    homeComp.programs.push(CompletedProgramName.relaySmtp);
+  // Receive starting money and programs from installed augmentations
+  for (const ownedAug of Player.augmentations) {
+    const aug = Augmentations[ownedAug.name];
+    Player.gainMoney(aug.startingMoney, "other");
+    for (const program of aug.programs) {
+      homeComp.programs.push(program);
+    }
   }
-  if (Player.hasAugmentation(AugmentationName.CashRoot, true)) {
-    Player.setMoney(1e6);
-    homeComp.programs.push(CompletedProgramName.bruteSsh);
-  }
-  if (Player.hasAugmentation(AugmentationName.PCMatrix, true)) {
-    homeComp.programs.push(CompletedProgramName.deepScan1);
-    homeComp.programs.push(CompletedProgramName.autoLink);
-  }
-
   if (Player.sourceFileLvl(5) > 0 || Player.bitNodeN === 5) {
     homeComp.programs.push(CompletedProgramName.formulas);
   }


### PR DESCRIPTION
[Reported on Reddit](https://www.reddit.com/r/Bitburner/comments/1cxrqmx/is_this_a_bug_i_should_report/): The `BigDsBigBrain` augmentation includes definitions for `startingMoney` and `programs`, but the prestige function does not check these definitions. The augmentations encountered in normal gameplay all have hard-coded handlers in the prestige function.

This PR uses the values in the augmentation definition to give the player money and programs during prestige.

A small change in behavior is that CashRoot Starter Kit now results in $1,000,000 (from aug) + $1,000 (base) + $151 (donations), instead of a flat $1,000,000. And the money from CashRoot is now tracked by the money source tracker. Does it make sense for this money source to be tracked?