### PR TITLE
BUGFIX: fix relative imports

### DIFF
--- a/markdown/bitburner.sleeve.md
+++ b/markdown/bitburner.sleeve.md
@@ -37,5 +37,5 @@ If you are not in BitNode-10, then you must have Source-File 10 in order to use 
 |  [setToShockRecovery(sleeveNumber)](./bitburner.sleeve.settoshockrecovery.md) | Set a sleeve to shock recovery. |
 |  [setToSynchronize(sleeveNumber)](./bitburner.sleeve.settosynchronize.md) | Set a sleeve to synchronize. |
 |  [setToUniversityCourse(sleeveNumber, university, className)](./bitburner.sleeve.settouniversitycourse.md) | Set a sleeve to take a class at a university. |
-|  [travel(sleeveNumber, city)](./bitburner.sleeve.travel.md) | Make a sleeve travel to another city. |
+|  [travel(sleeveNumber, city)](./bitburner.sleeve.travel.md) | Make a sleeve travel to another city. The cost for using this function is the same as for a player. |
 

--- a/markdown/bitburner.sleeve.travel.md
+++ b/markdown/bitburner.sleeve.travel.md
@@ -4,7 +4,7 @@
 
 ## Sleeve.travel() method
 
-Make a sleeve travel to another city.
+Make a sleeve travel to another city. The cost for using this function is the same as for a player.
 
 **Signature:**
 

--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -8,7 +8,6 @@ import { parse } from "acorn";
 import { LoadedModule, ScriptURL, ScriptModule } from "./Script/LoadedModule";
 import { Script } from "./Script/Script";
 import { ScriptFilePath, resolveScriptFilePath } from "./Paths/ScriptFilePath";
-import { root } from "./Paths/Directory";
 
 // Acorn type def is straight up incomplete so we have to fill with our own.
 export type Node = any;
@@ -125,7 +124,7 @@ function generateLoadedModule(script: Script, scripts: Map<ScriptFilePath, Scrip
   let newCode = script.code;
   // Loop through each node and replace the script name with a blob url.
   for (const node of importNodes) {
-    const filename = resolveScriptFilePath(node.filename, root, ".js");
+    const filename = resolveScriptFilePath(node.filename, script.filename, ".js");
     if (!filename) throw new Error(`Failed to parse import: ${node.filename}`);
 
     // Find the corresponding script.
@@ -149,6 +148,7 @@ function generateLoadedModule(script: Script, scripts: Map<ScriptFilePath, Scrip
     // script dedupe properly.
     const adjustedCode = newCode + `\n//# sourceURL=${script.server}/${script.filename}`;
     // At this point we have the full code and can construct a new blob / assign the URL.
+
     const url = URL.createObjectURL(makeScriptBlob(adjustedCode)) as ScriptURL;
     const module = config.doImport(url).catch((e) => {
       script.invalidateModule();

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -15,7 +15,6 @@ import { Script } from "./Script";
 import { Node } from "../NetscriptJSEvaluator";
 import { ScriptFilePath, resolveScriptFilePath } from "../Paths/ScriptFilePath";
 import { root } from "../Paths/Directory";
-import { FilePath, resolveFilePath } from "../Paths/FilePath";
 
 export interface RamUsageEntry {
   type: "ns" | "dom" | "fn" | "misc";
@@ -57,11 +56,14 @@ function getNumericCost(cost: number | (() => number)): number {
  * Parses code into an AST and walks through it recursively to calculate
  * RAM usage. Also accounts for imported modules.
  * @param otherScripts - All other scripts on the server. Used to account for imported scripts
- * @param code - The code being parsed */
+ * @param code - The code being parsed
+ * @param scriptname - The name of the script that ram needs to be added to
+ * */
+
 function parseOnlyRamCalculate(
   otherScripts: Map<ScriptFilePath, Script>,
   code: string,
-  mainFileName: FilePath,
+  scriptname: ScriptFilePath,
   ns1?: boolean,
 ): RamCalculation {
   /**
@@ -83,7 +85,7 @@ function parseOnlyRamCalculate(
   const parseQueue: string[] = [];
   // Parses a chunk of code with a given module name, and updates parseQueue and dependencyMap.
   function parseCode(code: string, moduleName: string): void {
-    const result = parseOnlyCalculateDeps(code, mainFileName, moduleName);
+    const result = parseOnlyCalculateDeps(code, scriptname, moduleName);
     completedParses.add(moduleName);
 
     // Add any additional modules to the parse queue;
@@ -265,7 +267,7 @@ interface ParseDepsResult {
  * for RAM usage calculations. It also returns an array of additional modules
  * that need to be parsed (i.e. are 'import'ed scripts).
  */
-function parseOnlyCalculateDeps(code: string, filename: FilePath, currentModule: string): ParseDepsResult {
+function parseOnlyCalculateDeps(code: string, filename: ScriptFilePath, currentModule: string): ParseDepsResult {
   const ast = parse(code, { sourceType: "module", ecmaVersion: "latest" });
   // Everything from the global scope goes in ".". Everything else goes in ".function", where only
   // the outermost layer of functions counts.
@@ -344,7 +346,11 @@ function parseOnlyCalculateDeps(code: string, filename: FilePath, currentModule:
     Object.assign(
       {
         ImportDeclaration: (node: Node, st: State) => {
-          const importModuleName = resolveFilePath(node.source.value, filename) as FilePath;
+          const importModuleName = resolveScriptFilePath(node.source.value, filename, ".js");
+          if (!importModuleName)
+            throw new Error(
+              `ScriptFilePath couldnt be resolved in ImportDeclaration. Value: ${node.source.value}  ScriptFilePath: ${filename}`,
+            );
           additionalModules.push(importModuleName);
 
           // This module's global scope refers to that module's global scope, no matter how we
@@ -403,17 +409,18 @@ function parseOnlyCalculateDeps(code: string, filename: FilePath, currentModule:
 /**
  * Calculate's a scripts RAM Usage
  * @param {string} code - The script's code
+ * @param {ScriptFilePath} scriptname - The script's name. Used to resolve relative paths
  * @param {Script[]} otherScripts - All other scripts on the server.
  *                                  Used to account for imported scripts
  */
 export function calculateRamUsage(
   code: string,
-  scriptName: FilePath,
+  scriptname: ScriptFilePath,
   otherScripts: Map<ScriptFilePath, Script>,
   ns1?: boolean,
 ): RamCalculation {
   try {
-    return parseOnlyRamCalculate(otherScripts, code, scriptName, ns1);
+    return parseOnlyRamCalculate(otherScripts, code, scriptname, ns1);
   } catch (e) {
     return {
       errorCode: RamCalculationErrorCode.SyntaxError,

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -70,7 +70,7 @@ function parseOnlyRamCalculate(
   /**
    * Maps dependent identifiers to their dependencies.
    *
-   * The initial identifier is __SPECIAL_INITIAL_MODULE__.__GLOBAL__.
+   * The initial identifier is <name of the main script>.__GLOBAL__.
    * It depends on all the functions declared in the module, all the global scopes
    * of its imports, and any identifiers referenced in this global scope. Each
    * function depends on all the identifiers referenced internally.

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -114,7 +114,7 @@ function parseOnlyRamCalculate(
     if (!script) {
       return {
         errorCode: RamCalculationErrorCode.ImportError,
-        errorMessage: `File:"${nextModule}" not found on server: ${server}`,
+        errorMessage: `File: "${nextModule}" not found on server: ${server}`,
       };
     }
 

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -15,6 +15,7 @@ import { Script } from "./Script";
 import { Node } from "../NetscriptJSEvaluator";
 import { ScriptFilePath, resolveScriptFilePath } from "../Paths/ScriptFilePath";
 import { root } from "../Paths/Directory";
+import { FilePath, resolveFilePath } from "../Paths/FilePath";
 
 export interface RamUsageEntry {
   type: "ns" | "dom" | "fn" | "misc";
@@ -57,7 +58,12 @@ function getNumericCost(cost: number | (() => number)): number {
  * RAM usage. Also accounts for imported modules.
  * @param otherScripts - All other scripts on the server. Used to account for imported scripts
  * @param code - The code being parsed */
-function parseOnlyRamCalculate(otherScripts: Map<ScriptFilePath, Script>, code: string, ns1?: boolean): RamCalculation {
+function parseOnlyRamCalculate(
+  otherScripts: Map<ScriptFilePath, Script>,
+  code: string,
+  mainFileName: FilePath,
+  ns1?: boolean,
+): RamCalculation {
   /**
    * Maps dependent identifiers to their dependencies.
    *
@@ -77,7 +83,7 @@ function parseOnlyRamCalculate(otherScripts: Map<ScriptFilePath, Script>, code: 
   const parseQueue: string[] = [];
   // Parses a chunk of code with a given module name, and updates parseQueue and dependencyMap.
   function parseCode(code: string, moduleName: string): void {
-    const result = parseOnlyCalculateDeps(code, moduleName);
+    const result = parseOnlyCalculateDeps(code, mainFileName, moduleName);
     completedParses.add(moduleName);
 
     // Add any additional modules to the parse queue;
@@ -259,7 +265,7 @@ interface ParseDepsResult {
  * for RAM usage calculations. It also returns an array of additional modules
  * that need to be parsed (i.e. are 'import'ed scripts).
  */
-function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsResult {
+function parseOnlyCalculateDeps(code: string, filename: FilePath, currentModule: string): ParseDepsResult {
   const ast = parse(code, { sourceType: "module", ecmaVersion: "latest" });
   // Everything from the global scope goes in ".". Everything else goes in ".function", where only
   // the outermost layer of functions counts.
@@ -338,7 +344,7 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsR
     Object.assign(
       {
         ImportDeclaration: (node: Node, st: State) => {
-          const importModuleName = node.source.value;
+          const importModuleName = resolveFilePath(node.source.value, filename) as FilePath;
           additionalModules.push(importModuleName);
 
           // This module's global scope refers to that module's global scope, no matter how we
@@ -402,11 +408,12 @@ function parseOnlyCalculateDeps(code: string, currentModule: string): ParseDepsR
  */
 export function calculateRamUsage(
   code: string,
+  scriptName: FilePath,
   otherScripts: Map<ScriptFilePath, Script>,
   ns1?: boolean,
 ): RamCalculation {
   try {
-    return parseOnlyRamCalculate(otherScripts, code, ns1);
+    return parseOnlyRamCalculate(otherScripts, code, scriptName, ns1);
   } catch (e) {
     return {
       errorCode: RamCalculationErrorCode.SyntaxError,

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -14,7 +14,6 @@ import { RamCosts, RamCostConstants } from "../Netscript/RamCostGenerator";
 import { Script } from "./Script";
 import { Node } from "../NetscriptJSEvaluator";
 import { ScriptFilePath, resolveScriptFilePath } from "../Paths/ScriptFilePath";
-import { root } from "../Paths/Directory";
 
 export interface RamUsageEntry {
   type: "ns" | "dom" | "fn" | "misc";
@@ -82,10 +81,10 @@ function parseOnlyRamCalculate(
   const completedParses = new Set();
 
   // Scripts we've discovered that need to be parsed.
-  const parseQueue: string[] = [];
+  const parseQueue: ScriptFilePath[] = [];
   // Parses a chunk of code with a given module name, and updates parseQueue and dependencyMap.
-  function parseCode(code: string, moduleName: string): void {
-    const result = parseOnlyCalculateDeps(code, scriptname, moduleName);
+  function parseCode(code: string, moduleName: string, filename: ScriptFilePath): void {
+    const result = parseOnlyCalculateDeps(code, moduleName, filename, ns1);
     completedParses.add(moduleName);
 
     // Add any additional modules to the parse queue;
@@ -101,7 +100,7 @@ function parseOnlyRamCalculate(
 
   // Parse the initial module, which is the "main" script that is being run
   const initialModule = "__SPECIAL_INITIAL_MODULE__";
-  parseCode(code, initialModule);
+  parseCode(code, initialModule, scriptname);
 
   // Process additional modules, which occurs if the "main" script has any imports
   while (parseQueue.length > 0) {
@@ -110,16 +109,18 @@ function parseOnlyRamCalculate(
     if (nextModule.startsWith("https://") || nextModule.startsWith("http://")) continue;
 
     // Using root as the path base right now. Difficult to implement
-    const filename = resolveScriptFilePath(nextModule, root, ns1 ? ".script" : ".js");
-    if (!filename) {
+    if (!nextModule) {
       return { errorCode: RamCalculationErrorCode.ImportError, errorMessage: `Invalid import path: "${nextModule}"` };
     }
-    const script = otherScripts.get(filename);
+    const script = otherScripts.get(nextModule);
     if (!script) {
-      return { errorCode: RamCalculationErrorCode.ImportError, errorMessage: `No such file on server: "${filename}"` };
+      return {
+        errorCode: RamCalculationErrorCode.ImportError,
+        errorMessage: `No such file on server: "${nextModule}"`,
+      };
     }
 
-    parseCode(script.code, nextModule);
+    parseCode(script.code, nextModule, nextModule);
   }
 
   // Finally, walk the reference map and generate a ram cost. The initial set of keys to scan
@@ -258,7 +259,7 @@ export function checkInfiniteLoop(code: string): number[] {
 
 interface ParseDepsResult {
   dependencyMap: Record<string, Set<string> | undefined>;
-  additionalModules: string[];
+  additionalModules: ScriptFilePath[];
 }
 
 /**
@@ -267,7 +268,12 @@ interface ParseDepsResult {
  * for RAM usage calculations. It also returns an array of additional modules
  * that need to be parsed (i.e. are 'import'ed scripts).
  */
-function parseOnlyCalculateDeps(code: string, filename: ScriptFilePath, currentModule: string): ParseDepsResult {
+function parseOnlyCalculateDeps(
+  code: string,
+  currentModule: string,
+  currentscript: ScriptFilePath,
+  ns1?: boolean,
+): ParseDepsResult {
   const ast = parse(code, { sourceType: "module", ecmaVersion: "latest" });
   // Everything from the global scope goes in ".". Everything else goes in ".function", where only
   // the outermost layer of functions counts.
@@ -279,7 +285,7 @@ function parseOnlyCalculateDeps(code: string, filename: ScriptFilePath, currentM
   // Filled when we import names from other modules.
   const internalToExternal: Record<string, string | undefined> = {};
 
-  const additionalModules: string[] = [];
+  const additionalModules: ScriptFilePath[] = [];
 
   // References get added pessimistically. They are added for thisModule.name, name, and for
   // any aliases.
@@ -346,10 +352,10 @@ function parseOnlyCalculateDeps(code: string, filename: ScriptFilePath, currentM
     Object.assign(
       {
         ImportDeclaration: (node: Node, st: State) => {
-          const importModuleName = resolveScriptFilePath(node.source.value, filename, ".js");
+          const importModuleName = resolveScriptFilePath(node.source.value, currentscript, ns1 ? ".script" : ".js");
           if (!importModuleName)
             throw new Error(
-              `ScriptFilePath couldnt be resolved in ImportDeclaration. Value: ${node.source.value}  ScriptFilePath: ${filename}`,
+              `ScriptFilePath couldnt be resolved in ImportDeclaration. Value: ${node.source.value}  ScriptFilePath: ${currentscript}`,
             );
           additionalModules.push(importModuleName);
 

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -14,6 +14,7 @@ import { RamCosts, RamCostConstants } from "../Netscript/RamCostGenerator";
 import { Script } from "./Script";
 import { Node } from "../NetscriptJSEvaluator";
 import { ScriptFilePath, resolveScriptFilePath } from "../Paths/ScriptFilePath";
+import { ServerName } from "../Types/strings";
 
 export interface RamUsageEntry {
   type: "ns" | "dom" | "fn" | "misc";
@@ -57,12 +58,13 @@ function getNumericCost(cost: number | (() => number)): number {
  * @param otherScripts - All other scripts on the server. Used to account for imported scripts
  * @param code - The code being parsed
  * @param scriptname - The name of the script that ram needs to be added to
+ * @param server - Servername of the scripts for Error Message
  * */
-
 function parseOnlyRamCalculate(
   otherScripts: Map<ScriptFilePath, Script>,
   code: string,
   scriptname: ScriptFilePath,
+  server: ServerName,
   ns1?: boolean,
 ): RamCalculation {
   /**
@@ -83,8 +85,8 @@ function parseOnlyRamCalculate(
   // Scripts we've discovered that need to be parsed.
   const parseQueue: ScriptFilePath[] = [];
   // Parses a chunk of code with a given module name, and updates parseQueue and dependencyMap.
-  function parseCode(code: string, moduleName: string, filename: ScriptFilePath): void {
-    const result = parseOnlyCalculateDeps(code, moduleName, filename, ns1);
+  function parseCode(code: string, moduleName: ScriptFilePath): void {
+    const result = parseOnlyCalculateDeps(code, moduleName, ns1);
     completedParses.add(moduleName);
 
     // Add any additional modules to the parse queue;
@@ -99,8 +101,8 @@ function parseOnlyRamCalculate(
   }
 
   // Parse the initial module, which is the "main" script that is being run
-  const initialModule = "__SPECIAL_INITIAL_MODULE__";
-  parseCode(code, initialModule, scriptname);
+  const initialModule = scriptname;
+  parseCode(code, initialModule);
 
   // Process additional modules, which occurs if the "main" script has any imports
   while (parseQueue.length > 0) {
@@ -108,23 +110,19 @@ function parseOnlyRamCalculate(
     if (nextModule === undefined) throw new Error("nextModule should not be undefined");
     if (nextModule.startsWith("https://") || nextModule.startsWith("http://")) continue;
 
-    // Using root as the path base right now. Difficult to implement
-    if (!nextModule) {
-      return { errorCode: RamCalculationErrorCode.ImportError, errorMessage: `Invalid import path: "${nextModule}"` };
-    }
     const script = otherScripts.get(nextModule);
     if (!script) {
       return {
         errorCode: RamCalculationErrorCode.ImportError,
-        errorMessage: `No such file on server: "${nextModule}"`,
+        errorMessage: `File:"${nextModule}" not found on server: ${server}`,
       };
     }
 
-    parseCode(script.code, nextModule, nextModule);
+    parseCode(script.code, nextModule);
   }
 
   // Finally, walk the reference map and generate a ram cost. The initial set of keys to scan
-  // are those that start with __SPECIAL_INITIAL_MODULE__.
+  // are those that start with the name of the main script.
   let ram = RamCostConstants.Base;
   const detailedCosts: RamUsageEntry[] = [{ type: "misc", name: "baseCost", cost: RamCostConstants.Base }];
   const unresolvedRefs = Object.keys(dependencyMap).filter((s) => s.startsWith(initialModule));
@@ -268,12 +266,7 @@ interface ParseDepsResult {
  * for RAM usage calculations. It also returns an array of additional modules
  * that need to be parsed (i.e. are 'import'ed scripts).
  */
-function parseOnlyCalculateDeps(
-  code: string,
-  currentModule: string,
-  currentscript: ScriptFilePath,
-  ns1?: boolean,
-): ParseDepsResult {
+function parseOnlyCalculateDeps(code: string, currentModule: ScriptFilePath, ns1?: boolean): ParseDepsResult {
   const ast = parse(code, { sourceType: "module", ecmaVersion: "latest" });
   // Everything from the global scope goes in ".". Everything else goes in ".function", where only
   // the outermost layer of functions counts.
@@ -352,11 +345,12 @@ function parseOnlyCalculateDeps(
     Object.assign(
       {
         ImportDeclaration: (node: Node, st: State) => {
-          const importModuleName = resolveScriptFilePath(node.source.value, currentscript, ns1 ? ".script" : ".js");
+          const importModuleName = resolveScriptFilePath(node.source.value, currentModule, ns1 ? ".script" : ".js");
           if (!importModuleName)
             throw new Error(
-              `ScriptFilePath couldnt be resolved in ImportDeclaration. Value: ${node.source.value}  ScriptFilePath: ${currentscript}`,
+              `ScriptFilePath couldnt be resolved in ImportDeclaration. Value: ${node.source.value}  ScriptFilePath: ${currentModule}`,
             );
+
           additionalModules.push(importModuleName);
 
           // This module's global scope refers to that module's global scope, no matter how we
@@ -418,15 +412,18 @@ function parseOnlyCalculateDeps(
  * @param {ScriptFilePath} scriptname - The script's name. Used to resolve relative paths
  * @param {Script[]} otherScripts - All other scripts on the server.
  *                                  Used to account for imported scripts
+ * @param {ServerName} server - Servername of the scripts for Error Message
+ * @param {boolean} ns1 - Deprecated: is the fileExtension .script or .js
  */
 export function calculateRamUsage(
   code: string,
   scriptname: ScriptFilePath,
   otherScripts: Map<ScriptFilePath, Script>,
+  server: ServerName,
   ns1?: boolean,
 ): RamCalculation {
   try {
-    return parseOnlyRamCalculate(otherScripts, code, scriptname, ns1);
+    return parseOnlyRamCalculate(otherScripts, code, scriptname, server, ns1);
   } catch (e) {
     return {
       errorCode: RamCalculationErrorCode.SyntaxError,

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -73,7 +73,7 @@ export class Script implements ContentFile {
    * @param {Script[]} otherScripts - Other scripts on the server. Used to process imports
    */
   updateRamUsage(otherScripts: Map<ScriptFilePath, Script>): void {
-    const ramCalc = calculateRamUsage(this.code, otherScripts, this.filename.endsWith(".script"));
+    const ramCalc = calculateRamUsage(this.code, this.filename, otherScripts, this.filename.endsWith(".script"));
     if (ramCalc.cost && ramCalc.cost >= RamCostConstants.Base) {
       this.ramUsage = roundToTwo(ramCalc.cost);
       this.ramUsageEntries = ramCalc.entries as RamUsageEntry[];

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -73,7 +73,13 @@ export class Script implements ContentFile {
    * @param {Script[]} otherScripts - Other scripts on the server. Used to process imports
    */
   updateRamUsage(otherScripts: Map<ScriptFilePath, Script>): void {
-    const ramCalc = calculateRamUsage(this.code, this.filename, otherScripts, this.filename.endsWith(".script"));
+    const ramCalc = calculateRamUsage(
+      this.code,
+      this.filename,
+      otherScripts,
+      this.server,
+      this.filename.endsWith(".script"),
+    );
     if (ramCalc.cost && ramCalc.cost >= RamCostConstants.Base) {
       this.ramUsage = roundToTwo(ramCalc.cost);
       this.ramUsageEntries = ramCalc.entries as RamUsageEntry[];

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -44,7 +44,7 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
       setRamEntries([["N/A", ""]]);
       return;
     }
-    const ramUsage = calculateRamUsage(newCode, scriptname, server.scripts);
+    const ramUsage = calculateRamUsage(newCode, scriptname, server.scripts, server.hostname);
     if (ramUsage.cost && ramUsage.cost > 0) {
       const entries = ramUsage.entries?.sort((a, b) => b.cost - a.cost) ?? [];
       const entriesDisp = [];

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -8,12 +8,14 @@ import { useBoolean } from "../../ui/React/hooks";
 import { BaseServer } from "../../Server/BaseServer";
 
 import { Options } from "./Options";
-import { FilePath } from "src/Paths/FilePath";
+import { FilePath } from "../../Paths/FilePath";
+import { resolveScriptFilePath } from "../../Paths/ScriptFilePath";
+import { root } from "../../Paths/Directory";
 
 export interface ScriptEditorContextShape {
   ram: string;
   ramEntries: string[][];
-  updateRAM: (newCode: string | null, filename: FilePath, server: BaseServer | null) => void;
+  updateRAM: (newCode: string | null, filename: FilePath | null, server: BaseServer | null) => void;
 
   isUpdatingRAM: boolean;
   startUpdatingRAM: () => void;
@@ -29,8 +31,15 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
   const [ram, setRAM] = useState("RAM: ???");
   const [ramEntries, setRamEntries] = useState<string[][]>([["???", ""]]);
 
-  const updateRAM: ScriptEditorContextShape["updateRAM"] = (newCode, scriptname, server) => {
-    if (newCode === null || server === null) {
+  const updateRAM: ScriptEditorContextShape["updateRAM"] = (newCode, filename, server) => {
+    if (newCode === null || filename === null || server === null) {
+      setRAM("N/A");
+      setRamEntries([["N/A", ""]]);
+      return;
+    }
+    //temp duplication to turn FilePath into ScriptFilePath
+    const scriptname = resolveScriptFilePath(filename, root, ".js");
+    if (!scriptname) {
       setRAM("N/A");
       setRamEntries([["N/A", ""]]);
       return;

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -8,11 +8,12 @@ import { useBoolean } from "../../ui/React/hooks";
 import { BaseServer } from "../../Server/BaseServer";
 
 import { Options } from "./Options";
+import { FilePath } from "src/Paths/FilePath";
 
 export interface ScriptEditorContextShape {
   ram: string;
   ramEntries: string[][];
-  updateRAM: (newCode: string | null, server: BaseServer | null) => void;
+  updateRAM: (newCode: string | null, filename: FilePath, server: BaseServer | null) => void;
 
   isUpdatingRAM: boolean;
   startUpdatingRAM: () => void;
@@ -28,14 +29,13 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
   const [ram, setRAM] = useState("RAM: ???");
   const [ramEntries, setRamEntries] = useState<string[][]>([["???", ""]]);
 
-  const updateRAM: ScriptEditorContextShape["updateRAM"] = (newCode, server) => {
+  const updateRAM: ScriptEditorContextShape["updateRAM"] = (newCode, scriptname, server) => {
     if (newCode === null || server === null) {
       setRAM("N/A");
       setRamEntries([["N/A", ""]]);
       return;
     }
-
-    const ramUsage = calculateRamUsage(newCode, server.scripts);
+    const ramUsage = calculateRamUsage(newCode, scriptname, server.scripts);
     if (ramUsage.cost && ramUsage.cost > 0) {
       const entries = ramUsage.entries?.sort((a, b) => b.cost - a.cost) ?? [];
       const entriesDisp = [];

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -31,7 +31,7 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
   const [ramEntries, setRamEntries] = useState<string[][]>([["???", ""]]);
 
   const updateRAM: ScriptEditorContextShape["updateRAM"] = (newCode, filename, server) => {
-    if (newCode === null || filename === null || server === null || !hasScriptExtension(filename)) {
+    if (newCode == null || filename == null || server == null || !hasScriptExtension(filename)) {
       setRAM("N/A");
       setRamEntries([["N/A", ""]]);
       return;

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -9,8 +9,7 @@ import { BaseServer } from "../../Server/BaseServer";
 
 import { Options } from "./Options";
 import { FilePath } from "../../Paths/FilePath";
-import { resolveScriptFilePath } from "../../Paths/ScriptFilePath";
-import { root } from "../../Paths/Directory";
+import { hasScriptExtension } from "../../Paths/ScriptFilePath";
 
 export interface ScriptEditorContextShape {
   ram: string;
@@ -32,19 +31,12 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
   const [ramEntries, setRamEntries] = useState<string[][]>([["???", ""]]);
 
   const updateRAM: ScriptEditorContextShape["updateRAM"] = (newCode, filename, server) => {
-    if (newCode === null || filename === null || server === null) {
+    if (newCode === null || filename === null || server === null || !hasScriptExtension(filename)) {
       setRAM("N/A");
       setRamEntries([["N/A", ""]]);
       return;
     }
-    //temp duplication to turn FilePath into ScriptFilePath
-    const scriptname = resolveScriptFilePath(filename, root, ".js");
-    if (!scriptname) {
-      setRAM("N/A");
-      setRamEntries([["N/A", ""]]);
-      return;
-    }
-    const ramUsage = calculateRamUsage(newCode, scriptname, server.scripts, server.hostname);
+    const ramUsage = calculateRamUsage(newCode, filename, server.scripts, server.hostname);
     if (ramUsage.cost && ramUsage.cost > 0) {
       const entries = ramUsage.entries?.sort((a, b) => b.cost - a.cost) ?? [];
       const entriesDisp = [];

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -140,11 +140,10 @@ function Root(props: IProps): React.ReactElement {
   }
 
   const debouncedCodeParsing = debounce((newCode: string) => {
-    if (!currentScript) return;
     infLoop(newCode);
     updateRAM(
       !currentScript || currentScript.isTxt ? null : newCode,
-      currentScript.path,
+      currentScript?.path ?? null,
       currentScript && GetServer(currentScript.hostname),
     );
     finishUpdatingRAM();

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -140,9 +140,11 @@ function Root(props: IProps): React.ReactElement {
   }
 
   const debouncedCodeParsing = debounce((newCode: string) => {
+    if (!currentScript) return;
     infLoop(newCode);
     updateRAM(
       !currentScript || currentScript.isTxt ? null : newCode,
+      currentScript.path,
       currentScript && GetServer(currentScript.hostname),
     );
     finishUpdatingRAM();

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -143,7 +143,7 @@ function Root(props: IProps): React.ReactElement {
     infLoop(newCode);
     updateRAM(
       !currentScript || currentScript.isTxt ? null : newCode,
-      currentScript?.path ?? null,
+      currentScript && currentScript.path,
       currentScript && GetServer(currentScript.hostname),
     );
     finishUpdatingRAM();

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -9,6 +9,7 @@ import { calculateRamUsage } from "../../../src/Script/RamCalculations";
 import { ns } from "../../../src/NetscriptFunctions";
 import { InternalAPI } from "src/Netscript/APIWrapper";
 import { Singularity } from "@nsdefs";
+import { ScriptFilePath } from "src/Paths/ScriptFilePath";
 
 type PotentiallyAsyncFunction = (arg?: unknown) => { catch?: PotentiallyAsyncFunction };
 
@@ -71,13 +72,15 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
     extraLayerCost = 0,
   ) {
     const code = `${fnPath.join(".")}();\n`.repeat(3);
+    const filename = "testfile.js" as ScriptFilePath;
     const fnName = fnPath[fnPath.length - 1];
+    const server = "testserver";
 
     //check imported getRamCost fn vs. expected ram from test
     expect(getRamCost(fnPath, true)).toEqual(expectedRamCost);
 
     // Static ram check
-    const staticCost = calculateRamUsage(code, new Map()).cost;
+    const staticCost = calculateRamUsage(code, filename, new Map(), server).cost;
     expect(staticCost).toBeCloseTo(Math.min(baseCost + expectedRamCost + extraLayerCost, maxCost));
 
     // reset workerScript for dynamic check

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -385,14 +385,14 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
               return testRelativeAgain(ns)
           }
         `;
-      const libOneScript = new Script(libNameOne, libCodeOne);
+      const libScriptOne = new Script(libNameOne, libCodeOne);
 
       const libCodeTwo = `
           export function testRelativeAgain(ns) {
               return ns.hack("n00dles")
           }
         `;
-      const libTwoScript = new Script(libNameTwo, libCodeTwo);
+      const libScriptTwo = new Script(libNameTwo, libCodeTwo);
 
       const code = `
           import { testRelative } from "./libTestOne";
@@ -405,8 +405,8 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         code,
         folderFilename,
         new Map([
-          [libNameOne, libOneScript],
-          [libNameTwo, libTwoScript],
+          [libNameOne, libScriptOne],
+          [libNameTwo, libScriptTwo],
         ]),
         server,
       ).cost;
@@ -437,7 +437,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
               return ns.grow("n00dles")
           }
         `;
-      const libScriptThree = new Script(fail_libNameTwo, fail_libCodeTwo);
+      const fail_libScriptTwo = new Script(fail_libNameTwo, fail_libCodeTwo);
 
       const code = `
           import { testRelative } from "foo/libTestOne";
@@ -452,7 +452,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         new Map([
           [libNameOne, libScriptOne],
           [libNameTwo, libScriptTwo],
-          [fail_libNameTwo, libScriptThree],
+          [fail_libNameTwo, fail_libScriptTwo],
         ]),
         server,
       ).cost;

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -12,6 +12,7 @@ const HacknetCost = 4;
 const MaxCost = 1024;
 
 const filename = "testfile.js" as ScriptFilePath;
+const folderFilename = "test/testfile.js" as ScriptFilePath;
 const server = "testserver";
 describe("Parsing NetScript code to work out static RAM costs", function () {
   jest.spyOn(console, "error").mockImplementation(() => {});
@@ -350,6 +351,112 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         server,
       ).cost;
       expectCost(calculated, GrowCost);
+    });
+
+    it("Importing with a relative path - One Layer Deep", async function () {
+      const libCode = `
+          export async function testRelative(ns) {
+              await ns.hack("n00dles")
+          }
+        `;
+      const lib = new Script("test/libTest.js" as ScriptFilePath, libCode);
+      const code = `
+          import { testRelative } from "./libTest";
+
+          export async function main(ns) {
+            await testRelative(ns)
+          }
+        `;
+      const calculated = calculateRamUsage(
+        code,
+        folderFilename,
+        new Map([["test/libTest.js" as ScriptFilePath, lib]]),
+        server,
+      ).cost;
+      expectCost(calculated, HackCost);
+    });
+    it("Importing with a relative path - Two Layer Deep", async function () {
+      const libNameOne = "test/libTestOne.js" as ScriptFilePath;
+      const libNameTwo = "test/libTestTwo.js" as ScriptFilePath;
+
+      const libCodeOne = `
+          import { testRelativeAgain } from "./libTestTwo";
+          export function testRelative(ns) {
+              return testRelativeAgain(ns)
+          }
+        `;
+      const libOneScript = new Script(libNameOne, libCodeOne);
+
+      const libCodeTwo = `
+          export function testRelativeAgain(ns) {
+              return ns.hack("n00dles")
+          }
+        `;
+      const libTwoScript = new Script(libNameTwo, libCodeTwo);
+
+      const code = `
+          import { testRelative } from "./libTestOne";
+
+          export async function main(ns) {
+            await testRelative(ns)
+          }
+        `;
+      const calculated = calculateRamUsage(
+        code,
+        folderFilename,
+        new Map([
+          [libNameOne, libOneScript],
+          [libNameTwo, libTwoScript],
+        ]),
+        server,
+      ).cost;
+      expectCost(calculated, HackCost);
+    });
+    it("Importing with a relative path - possible path conflict", async function () {
+      const libNameOne = "foo/libTestOne.js" as ScriptFilePath;
+      const libNameTwo = "foo/libTestTwo.js" as ScriptFilePath;
+      const fail_libNameTwo = "test/libTestTwo.js" as ScriptFilePath;
+
+      const libCodeOne = `
+          import { testRelativeAgain } from "./libTestTwo";
+          export function testRelative(ns) {
+              return testRelativeAgain(ns)
+          }
+        `;
+      const libScriptOne = new Script(libNameOne, libCodeOne);
+
+      const libCodeTwo = `
+          export function testRelativeAgain(ns) {
+              return ns.hack("n00dles")
+          }
+        `;
+      const libScriptTwo = new Script(libNameTwo, libCodeTwo);
+
+      const fail_libCodeTwo = `
+          export function testRelativeAgain(ns) {
+              return ns.grow("n00dles")
+          }
+        `;
+      const libScriptThree = new Script(fail_libNameTwo, fail_libCodeTwo);
+
+      const code = `
+          import { testRelative } from "foo/libTestOne";
+
+          export async function main(ns) {
+            await testRelative(ns)
+          }
+        `;
+      const calculated = calculateRamUsage(
+        code,
+        folderFilename,
+        new Map([
+          [libNameOne, libScriptOne],
+          [libNameTwo, libScriptTwo],
+          [fail_libNameTwo, libScriptThree],
+        ]),
+        server,
+      ).cost;
+      expectCost(calculated, HackCost);
     });
   });
 });

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -415,7 +415,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
     it("Importing with a relative path - possible path conflict", async function () {
       const libNameOne = "foo/libTestOne.js" as ScriptFilePath;
       const libNameTwo = "foo/libTestTwo.js" as ScriptFilePath;
-      const fail_libNameTwo = "test/libTestTwo.js" as ScriptFilePath;
+      const incorrect_libNameTwo = "test/libTestTwo.js" as ScriptFilePath;
 
       const libCodeOne = `
           import { testRelativeAgain } from "./libTestTwo";
@@ -432,12 +432,12 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         `;
       const libScriptTwo = new Script(libNameTwo, libCodeTwo);
 
-      const fail_libCodeTwo = `
+      const incorrect_libCodeTwo = `
           export function testRelativeAgain(ns) {
               return ns.grow("n00dles")
           }
         `;
-      const fail_libScriptTwo = new Script(fail_libNameTwo, fail_libCodeTwo);
+      const incorrect_libScriptTwo = new Script(incorrect_libNameTwo, incorrect_libCodeTwo);
 
       const code = `
           import { testRelative } from "foo/libTestOne";
@@ -452,7 +452,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         new Map([
           [libNameOne, libScriptOne],
           [libNameTwo, libScriptTwo],
-          [fail_libNameTwo, fail_libScriptTwo],
+          [incorrect_libNameTwo, incorrect_libScriptTwo],
         ]),
         server,
       ).cost;

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -10,6 +10,9 @@ const GrowCost = 0.15;
 const SleeveGetTaskCost = 4;
 const HacknetCost = 4;
 const MaxCost = 1024;
+
+const filename = "testfile.js" as ScriptFilePath;
+const server = "testserver";
 describe("Parsing NetScript code to work out static RAM costs", function () {
   jest.spyOn(console, "error").mockImplementation(() => {});
   /** Tests numeric equality, allowing for floating point imprecision - and includes script base cost */
@@ -24,7 +27,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
       const code = `
         export async function main(ns) { }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, 0);
     });
 
@@ -34,7 +37,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.print("Slum snakes r00l!");
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, 0);
     });
 
@@ -44,7 +47,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.hack("joesguns");
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -54,7 +57,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await X.hack("joesguns");
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -65,7 +68,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.hack("joesguns");
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -76,7 +79,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.grow("joesguns");
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HackCost + GrowCost);
     });
 
@@ -89,7 +92,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await ns.hack("joesguns");
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -104,7 +107,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           async doHacking() { await this.ns.hack("joesguns"); }
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -119,7 +122,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           async doHacking() { await this.#ns.hack("joesguns"); }
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HackCost);
     });
   });
@@ -132,7 +135,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         }
         function get() { return 0; }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, 0);
     });
 
@@ -143,7 +146,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         }
         function purchaseNode() { return 0; }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       // Works at present, because the parser checks the namespace only, not the function name
       expectCost(calculated, 0);
     });
@@ -156,7 +159,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
         }
         function getTask() { return 0; }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, 0);
     });
   });
@@ -168,7 +171,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.hacknet.purchaseNode(0);
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, HacknetCost);
     });
 
@@ -178,7 +181,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ns.sleeve.getTask(3);
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, SleeveGetTaskCost);
     });
   });
@@ -196,7 +199,12 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           dummy();
         }
       `;
-      const calculated = calculateRamUsage(code, new Map([["libTest.js" as ScriptFilePath, lib]])).cost;
+      const calculated = calculateRamUsage(
+        code,
+        filename,
+        new Map([["libTest.js" as ScriptFilePath, lib]]),
+        server,
+      ).cost;
       expectCost(calculated, 0);
     });
 
@@ -212,7 +220,12 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await doHack(ns);
         }
       `;
-      const calculated = calculateRamUsage(code, new Map([["libTest.js" as ScriptFilePath, lib]])).cost;
+      const calculated = calculateRamUsage(
+        code,
+        filename,
+        new Map([["libTest.js" as ScriptFilePath, lib]]),
+        server,
+      ).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -229,7 +242,12 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await doHack(ns);
         }
       `;
-      const calculated = calculateRamUsage(code, new Map([["libTest.js" as ScriptFilePath, lib]])).cost;
+      const calculated = calculateRamUsage(
+        code,
+        filename,
+        new Map([["libTest.js" as ScriptFilePath, lib]]),
+        server,
+      ).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -246,7 +264,12 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await test.doHack(ns);
         }
       `;
-      const calculated = calculateRamUsage(code, new Map([["libTest.js" as ScriptFilePath, lib]])).cost;
+      const calculated = calculateRamUsage(
+        code,
+        filename,
+        new Map([["libTest.js" as ScriptFilePath, lib]]),
+        server,
+      ).cost;
       expectCost(calculated, HackCost + GrowCost);
     });
 
@@ -267,7 +290,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           ${lines.join("\n")};
         }
       `;
-      const calculated = calculateRamUsage(code, new Map()).cost;
+      const calculated = calculateRamUsage(code, filename, new Map(), server).cost;
       expectCost(calculated, MaxCost);
     });
 
@@ -289,7 +312,12 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           await test.doHack(ns);
         }
       `;
-      const calculated = calculateRamUsage(code, new Map([["libTest.js" as ScriptFilePath, lib]])).cost;
+      const calculated = calculateRamUsage(
+        code,
+        filename,
+        new Map([["libTest.js" as ScriptFilePath, lib]]),
+        server,
+      ).cost;
       expectCost(calculated, HackCost);
     });
 
@@ -315,7 +343,12 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
             await growerInstance.doGrow();
           }
         `;
-      const calculated = calculateRamUsage(code, new Map([["libTest.js" as ScriptFilePath, lib]])).cost;
+      const calculated = calculateRamUsage(
+        code,
+        filename,
+        new Map([["libTest.js" as ScriptFilePath, lib]]),
+        server,
+      ).cost;
       expectCost(calculated, GrowCost);
     });
   });


### PR DESCRIPTION
Snarling added relative pathing a while back 
but currently for imports it only works partially

the only part that works is in the editor when hovered over the import 
![image](https://github.com/bitburner-official/bitburner-src/assets/115591472/e5180d20-cab1-42ff-8f29-f009fc01ab8a)

neither the ram calculation nor the compiler uses the relative path

this pr/draw attempts to fix this

caveats:
i havent done much testing with this only used the testscripts ill provide at the end
and variable names are temporary

i just want to get feedback first because this touches sensible areas of the codebase

```js
// test/test2.js
import { test3 } from "test1.js"
/** @param {NS} ns */
export async function main(ns) {
  ns.tprint(test3())
}
// test/test1.js
export function test3(){
  return "test"
}
```