### PR TITLE
IPVGO: Fix outdated docs

### DIFF
--- a/markdown/bitburner.go.makemove.md
+++ b/markdown/bitburner.go.makemove.md
@@ -30,7 +30,7 @@ makeMove(
 
 Promise&lt;{ type: "move" \| "pass" \| "gameOver"; x: number \| null; y: number \| null; }&gt;
 
-a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
 
 ## Remarks
 

--- a/markdown/bitburner.go.passturn.md
+++ b/markdown/bitburner.go.passturn.md
@@ -21,7 +21,7 @@ passTurn(): Promise<{
 
 Promise&lt;{ type: "move" \| "pass" \| "gameOver"; x: number \| null; y: number \| null; }&gt;
 
-a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
 
 ## Remarks
 

--- a/markdown/bitburner.sleeve.md
+++ b/markdown/bitburner.sleeve.md
@@ -37,5 +37,5 @@ If you are not in BitNode-10, then you must have Source-File 10 in order to use 
 |  [setToShockRecovery(sleeveNumber)](./bitburner.sleeve.settoshockrecovery.md) | Set a sleeve to shock recovery. |
 |  [setToSynchronize(sleeveNumber)](./bitburner.sleeve.settosynchronize.md) | Set a sleeve to synchronize. |
 |  [setToUniversityCourse(sleeveNumber, university, className)](./bitburner.sleeve.settouniversitycourse.md) | Set a sleeve to take a class at a university. |
-|  [travel(sleeveNumber, city)](./bitburner.sleeve.travel.md) | Make a sleeve travel to another city. |
+|  [travel(sleeveNumber, city)](./bitburner.sleeve.travel.md) | Make a sleeve travel to another city. The cost for using this function is the same as for a player. |
 

--- a/markdown/bitburner.sleeve.travel.md
+++ b/markdown/bitburner.sleeve.travel.md
@@ -4,7 +4,7 @@
 
 ## Sleeve.travel() method
 
-Make a sleeve travel to another city.
+Make a sleeve travel to another city. The cost for using this function is the same as for a player.
 
 **Signature:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3969,7 +3969,7 @@ export interface Go {
    * @remarks
    * RAM cost: 4 GB
    *
-   * @returns a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+   * @returns a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
    */
   makeMove(
     x: number,
@@ -3987,7 +3987,7 @@ export interface Go {
    * This can also be used if you pick up the game in a state where the opponent needs to play next. For example: if BitBurner was
    * closed while waiting for the opponent to make a move, you may need to call passTurn() to get them to play their move on game start.
    *
-   * @returns a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+   * @returns a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
    *
    * @remarks
    * RAM cost: 0 GB
@@ -4205,7 +4205,7 @@ export interface Go {
   cheat: {
     /**
      * Returns your chance of successfully playing one of the special moves in the ns.go.cheat API.
-     * Scales with your crime success rate stat. Caps at 80%.
+     * Scales with your crime success rate stat.
      *
      * Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a
      * small (~10%) chance you will instantly be ejected from the subnet.
@@ -4227,7 +4227,7 @@ export interface Go {
      * RAM cost: 8 GB
      * Requires Bitnode 14.2 to use
      *
-     * @returns a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+     * @returns a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
      */
     removeRouter(
       x: number,
@@ -4250,7 +4250,7 @@ export interface Go {
      * RAM cost: 8 GB
      * Requires Bitnode 14.2 to use
      *
-     * @returns a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+     * @returns a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
      */
     playTwoMoves(
       x1: number,
@@ -4275,7 +4275,7 @@ export interface Go {
      * RAM cost: 8 GB
      * Requires Bitnode 14.2 to use
      *
-     * @returns a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+     * @returns a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
      */
     repairOfflineNode(
       x: number,
@@ -4299,7 +4299,7 @@ export interface Go {
      * RAM cost: 8 GB
      * Requires Bitnode 14.2 to use
      *
-     * @returns a promise that contains if your move was valid and successful, the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
+     * @returns a promise that contains the opponent move's x and y coordinates (or pass) in response, or an indication if the game has ended
      */
     destroyNode(
       x: number,


### PR DESCRIPTION
Remove reference to 80% cheat success cap that was removed

Remove references to move success result in promise return values for makeMove, pass, cheat, etc