### PR TITLE
DOCUMENTATION: Faction work description update

### DIFF
--- a/src/Faction/ui/FactionRoot.tsx
+++ b/src/Faction/ui/FactionRoot.tsx
@@ -31,18 +31,18 @@ type FactionRootProps = {
 const hackingContractsInfo =
   "Complete hacking contracts for your faction. " +
   "Your effectiveness, which determines how much " +
-  "reputation you gain for this faction, is based on your hacking skill. " +
+  "reputation you gain for this faction, is based completely on your hacking skill. " +
   "You will gain hacking exp.";
 const fieldWorkInfo =
   "Carry out field missions for your faction. " +
   "Your effectiveness, which determines how much " +
-  "reputation you gain for this faction, is based on all of your stats. " +
+  "reputation you gain for this faction, is based on all of your stats equally . " +
   "You will gain exp for all stats.";
 const securityWorkInfo =
   "Serve in a security detail for your faction. " +
   "Your effectiveness, which determines how much " +
-  "reputation you gain for this faction, is based on your combat stats. " +
-  "You will gain exp for all combat stats.";
+  "reputation you gain for this faction, is based on your combat stats and your hacking skill. " +
+  "You will gain exp for all combat stats and hacking.";
 const augmentationsInfo =
   "As your reputation with this faction rises, you will " +
   "unlock Augmentations, which you can purchase to enhance " +


### PR DESCRIPTION
- made it clearer security gives hacking exp, and utilises it too
- clarified weighting of stats for hacking/field work

Alternative options:
- remove hacking from security work
- spell out weightings even more explicitly

Original issue involved exp-boosting augments to add to confusion regarding exp ratios, I view this as natural player learning through experimentation - hopefully proposed changes here are sufficient to better understand faction work.

Closes #18
