### PR TITLE
BUGFIX: Fix wrong HP after calling applyEntropy

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
@@ -6,6 +6,10 @@ import { updateGoMults } from "../../Go/effects/effect";
 import type { PlayerObject } from "./PlayerObject";
 
 export function applyEntropy(this: PlayerObject, stacks = 1): void {
+  // Save the current value of this.hp.
+  const currentHp = this.hp.current;
+  const currentMaxHp = this.hp.max;
+
   // Re-apply all multipliers
   this.reapplyAllAugmentations();
   this.reapplyAllSourceFiles();
@@ -13,4 +17,18 @@ export function applyEntropy(this: PlayerObject, stacks = 1): void {
   this.mults = calculateEntropy(stacks);
   staneksGift.updateMults();
   updateGoMults();
+
+  if (this.hp.max === currentMaxHp) {
+    /**
+     * When the max HP is not changed, the current HP may still be changed after multiple function calls above. We need
+     * to reset hp.current to the saved value.
+     */
+    this.hp.current = currentHp;
+  } else {
+    /**
+     * The ratio of (hp.current / hp.max) may be wrong after multiple function calls above. We need to recalculate
+     * hp.current based on the saved value.
+     */
+    this.hp.current = Math.round(this.hp.max * Math.min(currentHp / currentMaxHp, 1));
+  }
 }

--- a/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectAugmentationMethods.ts
@@ -6,9 +6,8 @@ import { updateGoMults } from "../../Go/effects/effect";
 import type { PlayerObject } from "./PlayerObject";
 
 export function applyEntropy(this: PlayerObject, stacks = 1): void {
-  // Save the current value of this.hp.
-  const currentHp = this.hp.current;
-  const currentMaxHp = this.hp.max;
+  // Save the current HP ratio.
+  const currentHpRatio = this.hp.current / this.hp.max;
 
   // Re-apply all multipliers
   this.reapplyAllAugmentations();
@@ -18,17 +17,9 @@ export function applyEntropy(this: PlayerObject, stacks = 1): void {
   staneksGift.updateMults();
   updateGoMults();
 
-  if (this.hp.max === currentMaxHp) {
-    /**
-     * When the max HP is not changed, the current HP may still be changed after multiple function calls above. We need
-     * to reset hp.current to the saved value.
-     */
-    this.hp.current = currentHp;
-  } else {
-    /**
-     * The ratio of (hp.current / hp.max) may be wrong after multiple function calls above. We need to recalculate
-     * hp.current based on the saved value.
-     */
-    this.hp.current = Math.round(this.hp.max * Math.min(currentHp / currentMaxHp, 1));
-  }
+  /**
+   * The ratio of (hp.current / hp.max) may be wrong after multiple function calls above. We need to recalculate
+   * hp.current based on the saved value.
+   */
+  this.hp.current = Math.round(this.hp.max * Math.min(currentHpRatio, 1));
 }


### PR DESCRIPTION
In `updateSkillLevels`, we recalculate the skill levels of stats based on exp and stats' multipliers. After that, we calculate new values for `hp.current` and `hp.max`. In `applyEntropy`, we change stats' multipliers and call `updateSkillLevels` four times. After that, the HP value is wrong.

Log:
```
regenerateHp before 5 57
regenerateHp after 7 57
new engine update
Error
    at PlayerObject.updateSkillLevels (PersonMethods.ts:136:7)
    at PlayerObject.reapplyAllAugmentations (PlayerObjectGeneralMethods.ts:405:8)
    at PlayerObject.applyEntropy (PlayerObjectAugmentationMethods.ts:18:8)
    at StaneksGift.process (StaneksGift.ts:71:51)
    at Object.updateGame (engine.tsx:106:60)
    at start (engine.tsx:393:14)
updateSkillLevels before 7 57 0.12280701754385964
updateSkillLevels after 4 32 0.125
Error
    at PlayerObject.updateSkillLevels (PersonMethods.ts:136:7)
    at PlayerObject.reapplyAllSourceFiles (PlayerObjectGeneralMethods.ts:421:8)
    at PlayerObject.applyEntropy (PlayerObjectAugmentationMethods.ts:19:8)
    at StaneksGift.process (StaneksGift.ts:71:51)
    at Object.updateGame (engine.tsx:106:60)
    at start (engine.tsx:393:14)
updateSkillLevels before 4 32 0.125
updateSkillLevels after 5 42 0.11904761904761904
Error
    at PlayerObject.updateSkillLevels (PersonMethods.ts:136:7)
    at StaneksGift.updateMults (StaneksGift.ts:221:49)
    at PlayerObject.applyEntropy (PlayerObjectAugmentationMethods.ts:21:58)
    at StaneksGift.process (StaneksGift.ts:71:51)
    at Object.updateGame (engine.tsx:106:60)
    at start (engine.tsx:393:14)
updateSkillLevels before 5 42 0.11904761904761904
updateSkillLevels after 6 54 0.1111111111111111
Error
    at PlayerObject.updateSkillLevels (PersonMethods.ts:136:7)
    at updateGoMults (effect.ts:74:47)
    at PlayerObject.applyEntropy (PlayerObjectAugmentationMethods.ts:22:68)
    at StaneksGift.process (StaneksGift.ts:71:51)
    at Object.updateGame (engine.tsx:106:60)
    at start (engine.tsx:393:14)
updateSkillLevels before 6 54 0.1111111111111111
updateSkillLevels after 6 57 0.10526315789473684
new engine update
```

How to reproduce:
- Load the save file in #1308.
- Kill all scripts and reload.
- Run `run stanek.js`.
- Deal damage to the player.
- Set BB action to Hyperbolic Regeneration Chamber.

Fixes #1308.