### PR TITLE
BUGFIX: BB Sleeves cannot be assigned to contract programmatically

### DIFF
--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -238,24 +238,24 @@ export function NetscriptSleeve(): InternalAPI<NetscriptSleeve> {
       const action = helpers.string(ctx, "action", _action);
       checkSleeveAPIAccess(ctx);
       checkSleeveNumber(ctx, sleeveNumber);
-      let ctract = undefined;
+      let contractName = undefined;
       if (action === "Take on contracts") {
-        const contract = getEnumHelper("BladeContractName").nsGetMember(ctx, _contract);
-        ctract = helpers.string(ctx, "contract", _contract);
+        const contractEnum = getEnumHelper("BladeContractName").nsGetMember(ctx, _contract);
+        contractName = helpers.string(ctx, "contract", _contract);
         for (let i = 0; i < Player.sleeves.length; ++i) {
           if (i === sleeveNumber) continue;
           const otherWork = Player.sleeves[i].currentWork;
-          if (otherWork?.type === SleeveWorkType.BLADEBURNER && otherWork.actionId.name === contract) {
+          if (otherWork?.type === SleeveWorkType.BLADEBURNER && otherWork.actionId.name === contractEnum) {
             throw helpers.errorMessage(
               ctx,
               `Sleeve ${sleeveNumber} cannot take on contracts because Sleeve ${i} is already performing that action.`,
             );
           }
         }
-        const actionId: ActionIdentifier = { type: BladeActionType.contract, name: contract };
+        const actionId: ActionIdentifier = { type: BladeActionType.contract, name: contractEnum };
         Player.sleeves[sleeveNumber].startWork(new SleeveBladeburnerWork({ actionId }));
       }
-      return Player.sleeves[sleeveNumber].bladeburner(action, ctract);
+      return Player.sleeves[sleeveNumber].bladeburner(action, contractName);
     },
   };
 

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -238,8 +238,10 @@ export function NetscriptSleeve(): InternalAPI<NetscriptSleeve> {
       const action = helpers.string(ctx, "action", _action);
       checkSleeveAPIAccess(ctx);
       checkSleeveNumber(ctx, sleeveNumber);
+      let ctract = undefined;
       if (action === "Take on contracts") {
         const contract = getEnumHelper("BladeContractName").nsGetMember(ctx, _contract);
+        ctract = helpers.string(ctx, "contract", _contract);
         for (let i = 0; i < Player.sleeves.length; ++i) {
           if (i === sleeveNumber) continue;
           const otherWork = Player.sleeves[i].currentWork;
@@ -253,8 +255,8 @@ export function NetscriptSleeve(): InternalAPI<NetscriptSleeve> {
         const actionId: ActionIdentifier = { type: BladeActionType.contract, name: contract };
         Player.sleeves[sleeveNumber].startWork(new SleeveBladeburnerWork({ actionId }));
       }
-
-      return Player.sleeves[sleeveNumber].bladeburner(action);
+      //return Player.sleeves[sleeveNumber].bladeburner(action);
+      return Player.sleeves[sleeveNumber].bladeburner(action, ctract);
     },
   };
 

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -255,7 +255,6 @@ export function NetscriptSleeve(): InternalAPI<NetscriptSleeve> {
         const actionId: ActionIdentifier = { type: BladeActionType.contract, name: contract };
         Player.sleeves[sleeveNumber].startWork(new SleeveBladeburnerWork({ actionId }));
       }
-      //return Player.sleeves[sleeveNumber].bladeburner(action);
       return Player.sleeves[sleeveNumber].bladeburner(action, ctract);
     },
   };


### PR DESCRIPTION
Noticed that ns.sleeve.setToBladeburnerAction(1, "Take on contracts", "Tracking") (all contracts) was always returning false.  Tracked things down to a missing contracts parameter.

Added the parameter.
Tested with an alternating sleeve script.  Worked perfectly for all contracts, infiltration and training
