### PR TITLE
MISC:  Updated Grafting finish message to remove typo

### DIFF
--- a/src/Work/GraftingWork.tsx
+++ b/src/Work/GraftingWork.tsx
@@ -56,7 +56,7 @@ export class GraftingWork extends Work {
         dialogBoxCreate(
           <>
             You've finished grafting {augName}.<br />
-            The augmentation has been applied to your body{" "}
+            The augmentation has been applied to your body
             {Player.hasAugmentation(AugmentationName.CongruityImplant, true) ? "." : ", but you feel a bit off."}
           </>,
         );


### PR DESCRIPTION
When finishing Grafting you receive a completion message that changes based on if you have Congruity installed.
This has caused a bug report.

Removed the purposeful {" "} and everything looks normal now.

Tested grafting with and without Congruity.