### PR TITLE
MISC: Change type of location parameter/property

### DIFF
--- a/markdown/bitburner.infiltration.getinfiltration.md
+++ b/markdown/bitburner.infiltration.getinfiltration.md
@@ -9,14 +9,14 @@ Get all infiltrations with difficulty, location and rewards.
 **Signature:**
 
 ```typescript
-getInfiltration(location: string): InfiltrationLocation;
+getInfiltration(location: LocationName | `${LocationName}`): InfiltrationLocation;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  location | string |  |
+|  location | [LocationName](./bitburner.locationname.md) \| \`${[LocationName](./bitburner.locationname.md)<!-- -->}\` |  |
 
 **Returns:**
 

--- a/markdown/bitburner.player.location.md
+++ b/markdown/bitburner.player.location.md
@@ -7,5 +7,5 @@
 **Signature:**
 
 ```typescript
-location: string;
+location: LocationName;
 ```

--- a/markdown/bitburner.player.md
+++ b/markdown/bitburner.player.md
@@ -20,7 +20,7 @@ interface Player extends Person
 |  [factions](./bitburner.player.factions.md) |  | string\[\] |  |
 |  [jobs](./bitburner.player.jobs.md) |  | Partial&lt;Record&lt;[CompanyName](./bitburner.companyname.md)<!-- -->, [JobName](./bitburner.jobname.md)<!-- -->&gt;&gt; |  |
 |  [karma](./bitburner.player.karma.md) |  | number |  |
-|  [location](./bitburner.player.location.md) |  | string |  |
+|  [location](./bitburner.player.location.md) |  | [LocationName](./bitburner.locationname.md) |  |
 |  [money](./bitburner.player.money.md) |  | number |  |
 |  [numPeopleKilled](./bitburner.player.numpeoplekilled.md) |  | number |  |
 |  [totalPlaytime](./bitburner.player.totalplaytime.md) |  | number |  |

--- a/markdown/bitburner.singularity.gotolocation.md
+++ b/markdown/bitburner.singularity.gotolocation.md
@@ -9,14 +9,14 @@ Go to a location.
 **Signature:**
 
 ```typescript
-goToLocation(locationName: string): boolean;
+goToLocation(locationName: LocationName | `${LocationName}`): boolean;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  locationName | string | Name of the location. |
+|  locationName | [LocationName](./bitburner.locationname.md) \| \`${[LocationName](./bitburner.locationname.md)<!-- -->}\` | Name of the location. |
 
 **Returns:**
 

--- a/markdown/bitburner.sleeve.md
+++ b/markdown/bitburner.sleeve.md
@@ -37,5 +37,5 @@ If you are not in BitNode-10, then you must have Source-File 10 in order to use 
 |  [setToShockRecovery(sleeveNumber)](./bitburner.sleeve.settoshockrecovery.md) | Set a sleeve to shock recovery. |
 |  [setToSynchronize(sleeveNumber)](./bitburner.sleeve.settosynchronize.md) | Set a sleeve to synchronize. |
 |  [setToUniversityCourse(sleeveNumber, university, className)](./bitburner.sleeve.settouniversitycourse.md) | Set a sleeve to take a class at a university. |
-|  [travel(sleeveNumber, city)](./bitburner.sleeve.travel.md) | Make a sleeve travel to another city. |
+|  [travel(sleeveNumber, city)](./bitburner.sleeve.travel.md) | Make a sleeve travel to another city. The cost for using this function is the same as for a player. |
 

--- a/markdown/bitburner.sleeve.travel.md
+++ b/markdown/bitburner.sleeve.travel.md
@@ -4,7 +4,7 @@
 
 ## Sleeve.travel() method
 
-Make a sleeve travel to another city.
+Make a sleeve travel to another city. The cost for using this function is the same as for a player.
 
 **Signature:**
 

--- a/markdown/bitburner.studytask.location.md
+++ b/markdown/bitburner.studytask.location.md
@@ -7,5 +7,5 @@
 **Signature:**
 
 ```typescript
-location: string;
+location: LocationName | `${LocationName}`;
 ```

--- a/markdown/bitburner.studytask.md
+++ b/markdown/bitburner.studytask.md
@@ -22,6 +22,6 @@ An object representing the current study task
 |  --- | --- | --- | --- |
 |  [classType](./bitburner.studytask.classtype.md) |  | string |  |
 |  [cyclesWorked](./bitburner.studytask.cyclesworked.md) |  | number |  |
-|  [location](./bitburner.studytask.location.md) |  | string |  |
+|  [location](./bitburner.studytask.location.md) |  | [LocationName](./bitburner.locationname.md) \| \`${[LocationName](./bitburner.locationname.md)<!-- -->}\` |  |
 |  [type](./bitburner.studytask.type.md) |  | "CLASS" |  |
 

--- a/markdown/bitburner.workformulas.gymgains.md
+++ b/markdown/bitburner.workformulas.gymgains.md
@@ -7,7 +7,7 @@
 **Signature:**
 
 ```typescript
-gymGains(person: Person, gymType: GymType | `${GymType}`, locationName: string): WorkStats;
+gymGains(person: Person, gymType: GymType | `${GymType}`, locationName: LocationName | `${LocationName}`): WorkStats;
 ```
 
 ## Parameters
@@ -16,7 +16,7 @@ gymGains(person: Person, gymType: GymType | `${GymType}`, locationName: string):
 |  --- | --- | --- |
 |  person | [Person](./bitburner.person.md) |  |
 |  gymType | [GymType](./bitburner.gymtype.md) \| \`${[GymType](./bitburner.gymtype.md)<!-- -->}\` |  |
-|  locationName | string |  |
+|  locationName | [LocationName](./bitburner.locationname.md) \| \`${[LocationName](./bitburner.locationname.md)<!-- -->}\` |  |
 
 **Returns:**
 

--- a/markdown/bitburner.workformulas.universitygains.md
+++ b/markdown/bitburner.workformulas.universitygains.md
@@ -10,7 +10,7 @@
 universityGains(
     person: Person,
     classType: UniversityClassType | `${UniversityClassType}`,
-    locationName: string,
+    locationName: LocationName | `${LocationName}`,
   ): WorkStats;
 ```
 
@@ -20,7 +20,7 @@ universityGains(
 |  --- | --- | --- |
 |  person | [Person](./bitburner.person.md) |  |
 |  classType | [UniversityClassType](./bitburner.universityclasstype.md) \| \`${[UniversityClassType](./bitburner.universityclasstype.md)<!-- -->}\` |  |
-|  locationName | string |  |
+|  locationName | [LocationName](./bitburner.locationname.md) \| \`${[LocationName](./bitburner.locationname.md)<!-- -->}\` |  |
 
 **Returns:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -47,7 +47,7 @@ interface Player extends Person {
   jobs: Partial<Record<CompanyName, JobName>>;
   factions: string[];
   totalPlaytime: number;
-  location: string;
+  location: LocationName;
   karma: number;
 }
 
@@ -1611,7 +1611,7 @@ export interface StudyTask {
   type: "CLASS";
   cyclesWorked: number;
   classType: string;
-  location: string;
+  location: LocationName | `${LocationName}`;
 }
 /**
  * Company Work
@@ -2460,7 +2460,7 @@ export interface Singularity {
    * @param locationName - Name of the location.
    * @returns True if the player was moved there, false otherwise.
    */
-  goToLocation(locationName: string): boolean;
+  goToLocation(locationName: LocationName | `${LocationName}`): boolean;
 
   /**
    * Get the current server.
@@ -4657,12 +4657,12 @@ interface WorkFormulas {
   /** @returns The WorkStats gained when completing one instance of the specified crime. */
   crimeGains(person: Person, crimeType: CrimeType | `${CrimeType}`): WorkStats;
   /** @returns The WorkStats applied every game cycle (200ms) by taking the specified gym class. */
-  gymGains(person: Person, gymType: GymType | `${GymType}`, locationName: string): WorkStats;
+  gymGains(person: Person, gymType: GymType | `${GymType}`, locationName: LocationName | `${LocationName}`): WorkStats;
   /** @returns The WorkStats applied every game cycle (200ms) by taking the specified university class. */
   universityGains(
     person: Person,
     classType: UniversityClassType | `${UniversityClassType}`,
-    locationName: string,
+    locationName: LocationName | `${LocationName}`,
   ): WorkStats;
   /** @returns The WorkStats applied every game cycle (200ms) by performing the specified faction work. */
   factionGains(person: Person, workType: FactionWorkType | `${FactionWorkType}`, favor: number): WorkStats;
@@ -5179,7 +5179,7 @@ interface Infiltration {
    *
    * @returns Infiltration data for given location.
    */
-  getInfiltration(location: string): InfiltrationLocation;
+  getInfiltration(location: LocationName | `${LocationName}`): InfiltrationLocation;
 }
 
 /**


### PR DESCRIPTION
We use `string` for the type of location/locationName in `NetscriptDefinitions.d.ts`. This PR changes it to `LocationName`.