### PR TITLE
SLEEVES: Add missing faction check when installing through API

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -274,6 +274,9 @@ export class Sleeve extends Person implements SleevePerson {
     // Verify that this sleeve does not already have that augmentation.
     if (this.hasAugmentation(aug.name)) return false;
 
+    // Verify that the augmentation is available for purchase.
+    if (!this.findPurchasableAugs().includes(aug)) return false;
+
     Player.loseMoney(aug.baseCost, "sleeves");
     this.installAugmentation(aug);
     return true;


### PR DESCRIPTION
Per title.

To verify the behavior, try the following:

```js
ns.sleeve.purchaseSleeveAug(0, `Stanek's Gift - Serenity`);
```