### PR TITLE
UI: Reverse order of Black Operations list

### DIFF
--- a/src/Bladeburner/ui/BlackOpPage.tsx
+++ b/src/Bladeburner/ui/BlackOpPage.tsx
@@ -14,7 +14,7 @@ interface BlackOpPageProps {
 }
 
 export function BlackOpPage({ bladeburner }: BlackOpPageProps): React.ReactElement {
-  const blackOps = blackOpsArray.slice(0, bladeburner.numBlackOpsComplete + 1);
+  const blackOps = blackOpsArray.slice(0, bladeburner.numBlackOpsComplete + 1).sort((a, b) => b.n - a.n);
 
   return (
     <>

--- a/src/Bladeburner/ui/BlackOpPage.tsx
+++ b/src/Bladeburner/ui/BlackOpPage.tsx
@@ -14,7 +14,7 @@ interface BlackOpPageProps {
 }
 
 export function BlackOpPage({ bladeburner }: BlackOpPageProps): React.ReactElement {
-  const blackOps = blackOpsArray.slice(0, bladeburner.numBlackOpsComplete + 1).sort((a, b) => b.n - a.n);
+  const blackOps = blackOpsArray.slice(0, bladeburner.numBlackOpsComplete + 1).reverse();
 
   return (
     <>


### PR DESCRIPTION
This PR reverses the order of the Black Operations list. It removes the unnecessary scrolling.

Before:
![before](https://github.com/bitburner-official/bitburner-src/assets/152669316/68e3be16-44db-4c8e-9690-4c35081ed02b)

After:
![after](https://github.com/bitburner-official/bitburner-src/assets/152669316/0ef2f9a1-b579-49cf-8ffc-2b9010e9473b)
