### PR TITLE
TERMINAL: Fix autocomplete for mixed case strings

### DIFF
--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -60,7 +60,6 @@ function longestCommonStart(strings: string[]): string {
   }
 
   const a1: string = strings[0];
-  const areEqualCaseInsensitive = (a: string, b: string) => a.toUpperCase() === b.toUpperCase();
   for (let i = 0; i < a1.length; ++i) {
     const chr = a1.charAt(i).toUpperCase();
     for (let s = 1; s < strings.length; ++s) {

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -61,19 +61,15 @@ function longestCommonStart(strings: string[]): string {
 
   const a1: string = strings[0];
   const areEqualCaseInsensitive = (a: string, b: string) => a.toUpperCase() === b.toUpperCase();
-  let i;
   for (let i = 0; i < a1.length; ++i) {
     const chr = a1.charAt(i).toUpperCase();
     for (let s = 1; s < strings.length; ++s) {
       if (chr !== strings[s].charAt(i).toUpperCase()) {
         return a1.substring(0, i);
       }
-        break c;
-      }
     }
   }
-return a1;
-  return a1.substring(0, i);
+  return a1;
 }
 
 // Returns whether an array contains entirely of string objects

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -59,14 +59,15 @@ function longestCommonStart(strings: string[]): string {
     return "";
   }
 
-  const A: string[] = strings.concat().sort();
-  const a1: string = A[0];
-  const a2: string = A[A.length - 1];
-  const L: number = a1.length;
-  let i = 0;
+  const a1: string = strings[0];
   const areEqualCaseInsensitive = (a: string, b: string) => a.toUpperCase() === b.toUpperCase();
-  while (i < L && areEqualCaseInsensitive(a1.charAt(i), a2.charAt(i))) {
-    i++;
+  let i;
+  c: for (i = 0; i < a1.length; ++i) {
+    for (let s = 1; s < strings.length; ++s) {
+      if (!areEqualCaseInsensitive(a1.charAt(i), strings[s].charAt(i))) {
+        break c;
+      }
+    }
   }
 
   return a1.substring(0, i);

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -62,14 +62,17 @@ function longestCommonStart(strings: string[]): string {
   const a1: string = strings[0];
   const areEqualCaseInsensitive = (a: string, b: string) => a.toUpperCase() === b.toUpperCase();
   let i;
-  c: for (i = 0; i < a1.length; ++i) {
+  for (let i = 0; i < a1.length; ++i) {
+    const chr = a1.charAt(i).toUpperCase();
     for (let s = 1; s < strings.length; ++s) {
-      if (!areEqualCaseInsensitive(a1.charAt(i), strings[s].charAt(i))) {
+      if (chr !== strings[s].charAt(i).toUpperCase()) {
+        return a1.substring(0, i);
+      }
         break c;
       }
     }
   }
-
+return a1;
   return a1.substring(0, i);
 }
 


### PR DESCRIPTION
Demo at https://yichizhng.github.io/bitburner-src/

To test, try the following:

Create the following files (remember to save them):

```
$ nano abbc.js aBbd.js aBee.js
```

Then type `nano a` and press tab for autocomplete; currently it will autocomplete to `nano aBb`, because the filenames are sorted and then only aBbd.js and abbc.js are considered.