### PR TITLE
BUGFIX: Fix manual hack exploit

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -24,7 +24,6 @@ export const CONSTANTS: {
   IntelligenceCrimeBaseExpGain: number;
   IntelligenceProgramBaseExpGain: number;
   IntelligenceGraftBaseExpGain: number;
-  IntelligenceTerminalHackBaseExpGain: number;
   IntelligenceSingFnBaseExpGain: number;
   MillisecondsPer20Hours: number;
   GameCyclesPer20Hours: number;
@@ -101,7 +100,6 @@ export const CONSTANTS: {
   IntelligenceCrimeBaseExpGain: 0.05,
   IntelligenceProgramBaseExpGain: 0.1, // Program required hack level divided by this to determine int exp gain
   IntelligenceGraftBaseExpGain: 0.05,
-  IntelligenceTerminalHackBaseExpGain: 200, // Hacking exp divided by this to determine int exp gain
   IntelligenceSingFnBaseExpGain: 1.5,
 
   // Time-related constants

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -225,6 +225,9 @@ export class Terminal {
       server.moneyAvailable -= moneyGained;
       Player.gainMoney(moneyGained, "hacking");
       Player.gainHackingExp(expGainedOnSuccess);
+      if (expGainedOnSuccess > 1) {
+        Player.gainIntelligenceExp(Math.log10(expGainedOnSuccess));
+      }
 
       const oldSec = server.hackDifficulty;
       server.fortify(ServerConstants.ServerFortifyAmount);

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -226,7 +226,7 @@ export class Terminal {
       Player.gainMoney(moneyGained, "hacking");
       Player.gainHackingExp(expGainedOnSuccess);
       if (expGainedOnSuccess > 1) {
-        Player.gainIntelligenceExp(Math.log10(expGainedOnSuccess));
+        Player.gainIntelligenceExp(4 * Math.log10(expGainedOnSuccess));
       }
 
       const oldSec = server.hackDifficulty;

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -211,7 +211,7 @@ export class Terminal {
         Router.toPage(Page.BitVerse, { flume: false, quick: false });
         return;
       }
-      // Manunally check for faction invites
+      // Manually check for faction invitations
       Engine.Counters.checkFactionInvitations = 0;
       Engine.checkCounters();
 
@@ -225,7 +225,6 @@ export class Terminal {
       server.moneyAvailable -= moneyGained;
       Player.gainMoney(moneyGained, "hacking");
       Player.gainHackingExp(expGainedOnSuccess);
-      Player.gainIntelligenceExp(expGainedOnSuccess / CONSTANTS.IntelligenceTerminalHackBaseExpGain);
 
       const oldSec = server.hackDifficulty;
       server.fortify(ServerConstants.ServerFortifyAmount);


### PR DESCRIPTION
When a player hacks a server manually via the terminal, their gain of intelligence exp is based on the gain of hacking exp. This is an oversight in the balance of intelligence gain. It's very easy to gain hacking exp, but intelligence exp is supposed to be incredibly hard to gain. This PR removes the gain of intelligence exp in this case. The reasons are:
- Manually hacking gains intelligence exp, but manually growing/weakening does not.
- The gain rate is absurd. With money from Corporation, I can farm intelligence from 0 to ~750 in ~1-2 hours and 0 to ~800 in < 10 hours.

We can nerf the gain by using a logarithm function, but it's very hard to create a function that generates meaningful exp at a low hacking exp multiplier (it's worth hacking manually to gain intelligence exp) while avoiding exploits at a high hacking exp multiplier.