### PR TITLE
UI: change time elapsed to time remaining for programs and grafting

### DIFF
--- a/src/Work/CreateProgramWork.ts
+++ b/src/Work/CreateProgramWork.ts
@@ -64,8 +64,8 @@ export class CreateProgramWork extends Work {
     skillMult *= focusBonus;
     //Skill multiplier directly applied to "time worked"
     this.cyclesWorked += cycles;
-    this.unitCompleted += CONSTANTS.MilliPerCycle * cycles * skillMult;
     this.unitRate = CONSTANTS.MilliPerCycle * cycles * skillMult;
+    this.unitCompleted += this.unitRate;
 
     if (this.unitCompleted >= this.unitNeeded()) {
       return true;

--- a/src/Work/CreateProgramWork.ts
+++ b/src/Work/CreateProgramWork.ts
@@ -21,10 +21,11 @@ export class CreateProgramWork extends Work {
   programName: CompletedProgramName;
   // amount of effective work completed on the program (time boosted by skills).
   unitCompleted: number;
-
+  unitRate: number;
   constructor(params?: CreateProgramWorkParams) {
     super(WorkType.CREATE_PROGRAM, params?.singularity ?? true);
     this.unitCompleted = 0;
+    this.unitRate = 0;
     this.programName = params?.programName ?? CompletedProgramName.bruteSsh;
 
     if (params) {
@@ -64,6 +65,7 @@ export class CreateProgramWork extends Work {
     //Skill multiplier directly applied to "time worked"
     this.cyclesWorked += cycles;
     this.unitCompleted += CONSTANTS.MilliPerCycle * cycles * skillMult;
+    this.unitRate = CONSTANTS.MilliPerCycle * cycles * skillMult;
 
     if (this.unitCompleted >= this.unitNeeded()) {
       return true;

--- a/src/Work/GraftingWork.tsx
+++ b/src/Work/GraftingWork.tsx
@@ -39,8 +39,8 @@ export class GraftingWork extends Work {
   process(cycles: number): boolean {
     const focusBonus = Player.focusPenalty();
     this.cyclesWorked += cycles;
-    this.unitCompleted += CONSTANTS.MilliPerCycle * cycles * graftingIntBonus() * focusBonus;
     this.unitRate = CONSTANTS.MilliPerCycle * cycles * graftingIntBonus() * focusBonus;
+    this.unitCompleted += this.unitRate;
     return this.unitCompleted >= this.unitNeeded();
   }
 

--- a/src/Work/GraftingWork.tsx
+++ b/src/Work/GraftingWork.tsx
@@ -21,10 +21,12 @@ interface GraftingWorkParams {
 export class GraftingWork extends Work {
   augmentation: AugmentationName;
   unitCompleted: number;
+  unitRate: number;
 
   constructor(params?: GraftingWorkParams) {
     super(WorkType.GRAFTING, params?.singularity ?? true);
     this.unitCompleted = 0;
+    this.unitRate = 0;
     this.augmentation = params?.augmentation ?? AugmentationName.Targeting1;
     const gAugs = GraftableAugmentations();
     if (params) Player.loseMoney(gAugs[this.augmentation].cost, "augmentations");
@@ -38,7 +40,7 @@ export class GraftingWork extends Work {
     const focusBonus = Player.focusPenalty();
     this.cyclesWorked += cycles;
     this.unitCompleted += CONSTANTS.MilliPerCycle * cycles * graftingIntBonus() * focusBonus;
-
+    this.unitRate = CONSTANTS.MilliPerCycle * cycles * graftingIntBonus() * focusBonus;
     return this.unitCompleted >= this.unitNeeded();
   }
 

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -286,7 +286,7 @@ export function WorkInProgressRoot(): React.ReactElement {
   if (isCreateProgramWork(Player.currentWork)) {
     const create = Player.currentWork;
     const completion = (create.unitCompleted / create.unitNeeded()) * 100;
-    const rate = ((create.unitNeeded() - create.unitCompleted) / create.unitRate) * CONSTANTS.MilliPerCycle;
+    const remainingTime = ((create.unitNeeded() - create.unitCompleted) / create.unitRate) * CONSTANTS.MilliPerCycle;
     workInfo = {
       buttons: {
         cancel: () => {
@@ -305,7 +305,7 @@ export function WorkInProgressRoot(): React.ReactElement {
       ),
 
       progress: {
-        remaining: rate,
+        remaining: remainingTime,
         percentage: completion,
       },
 
@@ -316,7 +316,7 @@ export function WorkInProgressRoot(): React.ReactElement {
 
   if (isGraftingWork(Player.currentWork)) {
     const graftWork = Player.currentWork;
-    const rate = ((graftWork.unitNeeded() - graftWork.unitCompleted) / graftWork.unitRate) * CONSTANTS.MilliPerCycle;
+    const remainingTime = ((graftWork.unitNeeded() - graftWork.unitCompleted) / graftWork.unitRate) * CONSTANTS.MilliPerCycle;
     workInfo = {
       buttons: {
         cancel: () => {
@@ -335,7 +335,7 @@ export function WorkInProgressRoot(): React.ReactElement {
       ),
 
       progress: {
-        remaining: rate,
+        remaining: remainingTime,
         percentage: (graftWork.unitCompleted / graftWork.unitNeeded()) * 100,
       },
 

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -316,7 +316,8 @@ export function WorkInProgressRoot(): React.ReactElement {
 
   if (isGraftingWork(Player.currentWork)) {
     const graftWork = Player.currentWork;
-    const remainingTime = ((graftWork.unitNeeded() - graftWork.unitCompleted) / graftWork.unitRate) * CONSTANTS.MilliPerCycle;
+    const remainingTime =
+      ((graftWork.unitNeeded() - graftWork.unitCompleted) / graftWork.unitRate) * CONSTANTS.MilliPerCycle;
     workInfo = {
       buttons: {
         cancel: () => {

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -305,7 +305,7 @@ export function WorkInProgressRoot(): React.ReactElement {
       ),
 
       progress: {
-        remaining: rate, //create.cyclesWorked * CONSTANTS.MilliPerCycle,
+        remaining: rate,
         percentage: completion,
       },
 
@@ -335,7 +335,7 @@ export function WorkInProgressRoot(): React.ReactElement {
       ),
 
       progress: {
-        remaining: rate, //graftWork.cyclesWorked * CONSTANTS.MilliPerCycle,
+        remaining: rate,
         percentage: (graftWork.unitCompleted / graftWork.unitNeeded()) * 100,
       },
 

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -286,7 +286,7 @@ export function WorkInProgressRoot(): React.ReactElement {
   if (isCreateProgramWork(Player.currentWork)) {
     const create = Player.currentWork;
     const completion = (create.unitCompleted / create.unitNeeded()) * 100;
-
+    const rate = ((create.unitNeeded() - create.unitCompleted) / create.unitRate) * CONSTANTS.MilliPerCycle;
     workInfo = {
       buttons: {
         cancel: () => {
@@ -305,7 +305,7 @@ export function WorkInProgressRoot(): React.ReactElement {
       ),
 
       progress: {
-        elapsed: create.cyclesWorked * CONSTANTS.MilliPerCycle,
+        remaining: rate, //create.cyclesWorked * CONSTANTS.MilliPerCycle,
         percentage: completion,
       },
 
@@ -316,7 +316,7 @@ export function WorkInProgressRoot(): React.ReactElement {
 
   if (isGraftingWork(Player.currentWork)) {
     const graftWork = Player.currentWork;
-
+    const rate = ((graftWork.unitNeeded() - graftWork.unitCompleted) / graftWork.unitRate) * CONSTANTS.MilliPerCycle;
     workInfo = {
       buttons: {
         cancel: () => {
@@ -335,7 +335,7 @@ export function WorkInProgressRoot(): React.ReactElement {
       ),
 
       progress: {
-        elapsed: graftWork.cyclesWorked * CONSTANTS.MilliPerCycle,
+        remaining: rate, //graftWork.cyclesWorked * CONSTANTS.MilliPerCycle,
         percentage: (graftWork.unitCompleted / graftWork.unitNeeded()) * 100,
       },
 


### PR DESCRIPTION
Current Program/Grafting behavior is to show how long you've been doing the action which isn't useful

![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/ab692fbb-e644-485d-9c0c-11b1b03135dc)

I calculated the current rate of which the completion of the workTask was being done and added it to the object, and then used that to predict the time remaining for the task

![image](https://github.com/bitburner-official/bitburner-src/assets/147098375/34fb2a31-8a2e-472b-aa59-6f138891aaa0)

Its accurate at the point of consumption, but since other factors can effect how long it takes (lack of focus, more hacking skill, more int) I'm wondering if I need to add "estimated" to the dialog or not.