### PR TITLE
MISC: Make spawn able to have 0 delay

### DIFF
--- a/markdown/bitburner.ns.spawn.md
+++ b/markdown/bitburner.ns.spawn.md
@@ -30,6 +30,8 @@ RAM cost: 2 GB
 
 Terminates the current script, and then after a defined delay it will execute the newly-specified script. The purpose of this function is to execute a new script without being constrained by the RAM usage of the current one. This function can only be used to run scripts on the local server.
 
+The delay specified can be 0; in this case the new script will synchronously replace the old one. (There will not be any opportunity for other scripts to use up the RAM in-between.)
+
 Because this function immediately terminates the script, it does not have a return value.
 
 Running this function with 0 or fewer threads will cause a runtime error.

--- a/markdown/bitburner.spawnoptions.md
+++ b/markdown/bitburner.spawnoptions.md
@@ -16,5 +16,5 @@ interface SpawnOptions extends RunOptions
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [spawnDelay?](./bitburner.spawnoptions.spawndelay.md) |  | number | _(Optional)_ Number of milliseconds to delay before spawning script, defaults to 10000 (10s). Must be a positive integer. |
+|  [spawnDelay?](./bitburner.spawnoptions.spawndelay.md) |  | number | _(Optional)_ Number of milliseconds to delay before spawning script, defaults to 10000 (10s). Must be a non-negative integer. If 0, the script will be spawned synchronously. |
 

--- a/markdown/bitburner.spawnoptions.spawndelay.md
+++ b/markdown/bitburner.spawnoptions.spawndelay.md
@@ -4,7 +4,7 @@
 
 ## SpawnOptions.spawnDelay property
 
-Number of milliseconds to delay before spawning script, defaults to 10000 (10s). Must be a positive integer.
+Number of milliseconds to delay before spawning script, defaults to 10000 (10s). Must be a non-negative integer. If 0, the script will be spawned synchronously.
 
 **Signature:**
 

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -93,7 +93,7 @@ export interface CompleteRunOptions {
 }
 /** SpawnOptions with non-optional, type-validated members, for passing between internal functions. */
 export interface CompleteSpawnOptions extends CompleteRunOptions {
-  spawnDelay: PositiveInteger;
+  spawnDelay: number;
 }
 /** HGWOptions with non-optional, type-validated members, for passing between internal functions. */
 export interface CompleteHGWOptions {
@@ -189,11 +189,16 @@ function runOptions(ctx: NetscriptContext, threadOrOption: unknown): CompleteRun
 }
 
 function spawnOptions(ctx: NetscriptContext, threadOrOption: unknown): CompleteSpawnOptions {
-  const result: CompleteSpawnOptions = { spawnDelay: 10000 as PositiveInteger, ...runOptions(ctx, threadOrOption) };
+  const result: CompleteSpawnOptions = { spawnDelay: 10000, ...runOptions(ctx, threadOrOption) };
   if (typeof threadOrOption !== "object" || !threadOrOption) return result;
   // Safe assertion since threadOrOption type has been narrowed to a non-null object
   const { spawnDelay } = threadOrOption as Unknownify<CompleteSpawnOptions>;
-  if (spawnDelay !== undefined) result.spawnDelay = positiveInteger(ctx, "spawnDelayMsec", spawnDelay);
+  if (spawnDelay !== undefined) {
+    result.spawnDelay = number(ctx, "spawnDelay", spawnDelay);
+    if (result.spawnDelay < 0) {
+      throw errorMessage(ctx, `spawnDelay must be non-negative, got ${spawnDelay}`);
+    }
+  }
   return result;
 }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -283,7 +283,10 @@ interface RunOptions {
 
 /** @public */
 interface SpawnOptions extends RunOptions {
-  /** Number of milliseconds to delay before spawning script, defaults to 10000 (10s). Must be a positive integer. */
+  /**
+   * Number of milliseconds to delay before spawning script, defaults to 10000 (10s).
+   * Must be a non-negative integer. If 0, the script will be spawned synchronously.
+   */
   spawnDelay?: number;
 }
 
@@ -6260,6 +6263,9 @@ export interface NS {
    * newly-specified script. The purpose of this function is to execute a new script without being
    * constrained by the RAM usage of the current one. This function can only be used to run scripts
    * on the local server.
+   *
+   * The delay specified can be 0; in this case the new script will synchronously replace
+   * the old one. (There will not be any opportunity for other scripts to use up the RAM in-between.)
    *
    * Because this function immediately terminates the script, it does not have a return value.
    *


### PR DESCRIPTION
This eliminates a hole where spawn was unrelaible, because other scripts could jump in and steal the RAM. It's not an API break, because 0 used to be an invalid value.

```
run eval.js --tail "ns.spawn('eval.js', {spawnDelay: 1}, 4); ns.tprint('foo')"
run eval.js --tail "ns.spawn('eval.js', {spawnDelay: 0}, 4); ns.tprint('foo')"
```
![image](https://github.com/bitburner-official/bitburner-src/assets/459704/65e6022c-c11f-419a-afce-397fd5171552)

Also tested that negative values are invalid.