### PR TITLE
EDITOR: Fixed vim mode not being set when using the respective command

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -80,8 +80,6 @@ export function ScriptEditorContextProvider({ children }: { children: React.Reac
     cursorBlinking: Settings.MonacoCursorBlinking,
   });
 
-  console.log("Context Vim", options.vim, Settings.MonacoVim);
-
   function saveOptions(options: Options) {
     console.log("Saving Vim", options.vim, Settings.MonacoVim);
     setOptions(options);

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -24,7 +24,7 @@ export interface ScriptEditorContextShape {
 
 const ScriptEditorContext = React.createContext({} as ScriptEditorContextShape);
 
-export function ScriptEditorContextProvider({ children, vim }: { children: React.ReactNode; vim: boolean }) {
+export function ScriptEditorContextProvider({ children }: { children: React.ReactNode }) {
   const [ram, setRAM] = useState("RAM: ???");
   const [ramEntries, setRamEntries] = useState<string[][]>([["???", ""]]);
 
@@ -75,12 +75,15 @@ export function ScriptEditorContextProvider({ children, vim }: { children: React
     fontSize: Settings.MonacoFontSize,
     fontLigatures: Settings.MonacoFontLigatures,
     wordWrap: Settings.MonacoWordWrap,
-    vim: vim || Settings.MonacoVim,
+    vim: Settings.MonacoVim,
     cursorStyle: Settings.MonacoCursorStyle,
     cursorBlinking: Settings.MonacoCursorBlinking,
   });
 
+  console.log("Context Vim", options.vim, Settings.MonacoVim);
+
   function saveOptions(options: Options) {
+    console.log("Saving Vim", options.vim, Settings.MonacoVim);
     setOptions(options);
     Settings.MonacoTheme = options.theme;
     Settings.MonacoInsertSpaces = options.insertSpaces;

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -35,7 +35,6 @@ interface IProps {
   // Map of filename -> code
   files: Map<ContentFilePath, string>;
   hostname: string;
-  vim: boolean;
 }
 const openScripts: OpenScript[] = [];
 let currentScript: OpenScript | null = null;
@@ -422,7 +421,7 @@ function Root(props: IProps): React.ReactElement {
 // Called every time script editor is opened
 export function ScriptEditorRoot(props: IProps) {
   return (
-    <ScriptEditorContextProvider vim={props.vim}>
+    <ScriptEditorContextProvider>
       <Root {...props} />
     </ScriptEditorContextProvider>
   );

--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -1,17 +1,14 @@
 import React from "react";
 import { Theme } from "@mui/material/styles";
 
-import { hasTextExtension, type TextFilePath } from "../../Paths/TextFilePath";
+import { type TextFilePath } from "../../Paths/TextFilePath";
 import type { ContractFilePath } from "../../Paths/ContractFilePath";
 import type { ProgramFilePath } from "../../Paths/ProgramFilePath";
-import type { ContentFilePath } from "../../Paths/ContentFile";
 import type { ScriptFilePath } from "../../Paths/ScriptFilePath";
 
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 import { BaseServer } from "../../Server/BaseServer";
-import { Router } from "../../ui/GameRoot";
-import { Page } from "../../ui/Router";
 import { Terminal } from "../../Terminal";
 import libarg from "arg";
 import { showLiterature } from "../../Literature/LiteratureHelpers";
@@ -25,6 +22,7 @@ import {
   root,
 } from "../../Paths/Directory";
 import { isMember } from "../../utils/EnumHelper";
+import { commonEditor } from "./common/editor";
 
 export function ls(args: (string | number | boolean)[], server: BaseServer): void {
   interface LSFlags {
@@ -134,16 +132,7 @@ export function ls(args: (string | number | boolean)[], server: BaseServer): voi
     )();
     const fullPath = combinePath(baseDirectory, props.path);
     function onClick() {
-      let content;
-      if (hasTextExtension(fullPath)) {
-        content = server.textFiles.get(fullPath)?.content ?? "";
-      } else {
-        content = server.scripts.get(fullPath)?.content ?? "";
-      }
-      const files = new Map<ContentFilePath, string>();
-      const options = { hostname: server.hostname };
-      files.set(fullPath, content);
-      Router.toPage(Page.ScriptEditor, { files, options });
+      commonEditor("ls", { args: [fullPath], server }, { hostname: server.hostname });
     }
     return (
       <span>

--- a/src/Terminal/commands/nano.ts
+++ b/src/Terminal/commands/nano.ts
@@ -1,7 +1,9 @@
+import { Settings } from "../../Settings/Settings";
 import { BaseServer } from "../../Server/BaseServer";
 
 import { commonEditor } from "./common/editor";
 
 export function nano(args: (string | number | boolean)[], server: BaseServer): void {
+  Settings.MonacoVim = false;
   return commonEditor("nano", { args, server });
 }

--- a/src/Terminal/commands/vim.ts
+++ b/src/Terminal/commands/vim.ts
@@ -1,7 +1,9 @@
+import { Settings } from "../../Settings/Settings";
 import { BaseServer } from "../../Server/BaseServer";
 
 import { commonEditor } from "./common/editor";
 
 export function vim(args: (string | number | boolean)[], server: BaseServer): void {
-  return commonEditor("vim", { args, server }, { vim: true });
+  Settings.MonacoVim = true;
+  return commonEditor("vim", { args, server });
 }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -247,7 +247,6 @@ export function GameRoot(): React.ReactElement {
         <ScriptEditorRoot
           files={pageWithContext.files ?? new Map()}
           hostname={pageWithContext.options?.hostname ?? Player.getCurrentServer().hostname}
-          vim={!!pageWithContext.options?.vim}
         />
       );
       break;

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -89,7 +89,6 @@ export type PageWithContext =
   | { page: SimplePage };
 
 export interface ScriptEditorRouteOptions {
-  vim?: boolean;
   hostname?: string;
 }
 


### PR DESCRIPTION
### Issue
When opening a script with `nano` or `vim`, the editor setting, whether to use vim, is not overwritten. This means that the initial value, `false` is kept and going to another page and coming back will disable vim. As a side-effect, if the value is `true`, opening a script using `nano` will still enable vim.

### Intended behavior
- Opening a script using `nano` should disable vim mode.
- Opening a script using `vim` should enable vim mode.
- The previously used mode should be kept and only changed when
- - Switching the mode in the editor settings
- - Opening a script with a different command
- Opening a script using `ls` should have no opinion on the mode used

### Changes made
- Removed the `vim` editor option passed between the ScriptEditorRoot and the pages.
- Changed the editor commands to set the mode being used on command to the settings of the editor
- Changed the `ls` command to open the editor similar to the `nano` and `vim` command, ignoring any mode preferences and using the current setting