### PR TITLE
BLADEBURNER: Remove percentage-based BB operation population changes

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -788,35 +788,26 @@ export class Bladeburner {
         break;
       case BladeOperationName.sting:
         if (success) {
-          city.changePopulationByPercentage(-0.1, {
-            changeEstEqually: true,
-            nonZero: true,
-          });
+          const change = getRandomIntInclusive(-10, -5);
+          city.changePopulationByCount(change, { estChange: change, estOffset: 0 });
         }
         city.changeChaosByCount(0.1);
         break;
       case BladeOperationName.raid:
         if (success) {
-          city.changePopulationByPercentage(-1, {
-            changeEstEqually: true,
-            nonZero: true,
-          });
+          const change = getRandomIntInclusive(-100, -50);
+          city.changePopulationByCount(change, { estChange: change, estOffset: 0 });
           --city.comms;
         } else {
-          const change = getRandomIntInclusive(-10, -5) / 10;
-          city.changePopulationByPercentage(change, {
-            nonZero: true,
-            changeEstEqually: false,
-          });
+          const change = getRandomIntInclusive(-40, -10);
+          city.changePopulationByCount(change, { estChange: change, estOffset: 0 });
         }
         city.changeChaosByPercentage(getRandomIntInclusive(1, 5));
         break;
       case BladeOperationName.stealthRetirement:
         if (success) {
-          city.changePopulationByPercentage(-0.5, {
-            changeEstEqually: true,
-            nonZero: true,
-          });
+          const change = getRandomIntInclusive(-20, -10);
+          city.changePopulationByCount(change, { estChange: change, estOffset: 0 });
         }
         city.changeChaosByPercentage(getRandomIntInclusive(-3, -1));
         break;


### PR DESCRIPTION
Several of the BB operations currently, on success, reduce the synthoid population in the city by a percentage. This is a problem for two reasons, one mechanical and one fluff:

* Mechanically, these operations can very quickly drop city population, making them practically unusable. This is especially notable in contrast with Assassination/Bounty Hunter/Retirement, which all kill >one< synthoid.
* Fluff-wise, the synthoid population is typically somewhere in the billions, so having an operation that kills 1% means the character has killed tens of millions of them, which is rather _bizarre_.

This PR removes all instances of operations doing that and replaces them with flat numbers that I think make sense for the operation as described:

* Sting: 0.1% -> 5-10
* Raid success: 1% -> 50-100
* Raid failure: 1%-0.5% -> 10-40
* Stealth retirement: 0.5% -> 10-20

This is a buff to BB, because it makes these operations less damaging.