### PR TITLE
BUGFIX: Fix corrupted save in Steam cloud

### DIFF
--- a/electron/storage.js
+++ b/electron/storage.js
@@ -192,9 +192,9 @@ async function pushSaveDataToSteamCloud(saveData, currentPlayerId) {
    *
    * Instead of implementing it, the old code (encoding in base64) is used here for backward compatibility.
    */
-  const content = saveData.toString("base64");
-  log.debug(`Uncompressed: ${saveData.length} bytes`);
-  log.debug(`Compressed: ${content.length} bytes`);
+  const content = Buffer.from(saveData).toString("base64");
+  log.debug(`saveData: ${saveData.length} bytes`);
+  log.debug(`Base64 string of saveData: ${content.length} bytes`);
   log.debug(`Saving to Steam Cloud as ${steamSaveName}`);
 
   try {


### PR DESCRIPTION
This PR fixes a bug that creates a corrupted save in the Steam cloud.

In old version:
```js
const buffer = Buffer.from(base64save, "base64");
const compressedBuffer = await gzip(buffer);
const content = compressedBuffer.toString("base64");
```
We decoded the base64 string of save data, compressed it, and then called `toString("base64")` on a NodeJs's Buffer to get a base64 string of compressed save data.

In current version:
```js
const content = saveData.toString("base64");
```
`saveData` is save data that has been compressed, so we just need to convert it to a base64 string. However, `saveData` here is not a Buffer, it's a Uint8Array. Calling `toString("base64")` will not convert it to a base64 string, so we need to wrap it in `Buffer.from`.