### PR TITLE
IPVGO: Support bonus cycles from offline time

### DIFF
--- a/src/Go/Go.ts
+++ b/src/Go/Go.ts
@@ -11,6 +11,7 @@ export class GoObject {
   currentGame: BoardState = getNewBoardState(7);
   stats: PartialRecord<GoOpponent, OpponentStats> = {};
   nextTurn: Promise<Play> = Promise.resolve({ type: GoPlayType.gameOver, x: null, y: null });
+  storedCycles: number = 0;
 
   prestigeAugmentation() {
     for (const stats of getRecordValues(this.stats)) {
@@ -23,6 +24,16 @@ export class GoObject {
     this.previousGame = null;
     this.currentGame = getNewBoardState(7);
     this.stats = {};
+  }
+
+  /**
+   * Stores offline time that is consumed to speed up the AI.
+   * Only stores offline time if the player has actually been using the mechanic.
+   */
+  storeCycles(offlineCycles: number) {
+    if (this.previousGame) {
+      this.storedCycles += offlineCycles ?? 0;
+    }
   }
 }
 

--- a/src/Go/SaveLoad.ts
+++ b/src/Go/SaveLoad.ts
@@ -21,6 +21,7 @@ type SaveFormat = {
   previousGame: PreviousGameSaveData;
   currentGame: CurrentGameSaveData;
   stats: PartialRecord<GoOpponent, OpponentStats>;
+  storedCycles: number;
 };
 
 export function getGoSave(): SaveFormat {
@@ -40,6 +41,7 @@ export function getGoSave(): SaveFormat {
       passCount: Go.currentGame.passCount,
     },
     stats: Go.stats,
+    storedCycles: Go.storedCycles,
   };
 }
 
@@ -78,6 +80,7 @@ export function loadGo(data: unknown): boolean {
   Go.currentGame = currentGame;
   Go.previousGame = previousGame;
   Go.stats = stats;
+  Go.storeCycles(loadStoredCycles(parsedData.storedCycles));
 
   // If it's the AI's turn, initiate their turn, which will populate nextTurn
   if (currentGame.previousPlayer === GoColor.black && currentGame.ai !== GoOpponent.none) makeAIMove(currentGame);
@@ -177,4 +180,12 @@ function loadSimpleBoard(simpleBoard: unknown, requiredSize?: number): SimpleBoa
     return "Incorrect types or column size while loading a SimpleBoard.";
   }
   return simpleBoard;
+}
+
+function loadStoredCycles(storedCycles: unknown): number {
+  if (!storedCycles || isNaN(+storedCycles)) {
+    return 0;
+  }
+
+  return +storedCycles;
 }

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -57,7 +57,7 @@ export function makeAIMove(boardState: BoardState): Promise<Play> {
       }
 
       // Handle AI making a move
-      await sleep(500);
+      await waitCycle();
       const aiUpdatedBoard = makeMove(boardState, play.x, play.y, GoColor.white);
 
       // Handle the AI breaking. This shouldn't ever happen.
@@ -114,7 +114,7 @@ export async function getMove(
   opponent: GoOpponent,
   rngOverride?: number,
 ): Promise<Play & { type: GoPlayType.move | GoPlayType.pass }> {
-  await sleep(300);
+  await waitCycle();
   const rng = new WHRNG(rngOverride || Player.totalPlaytime);
   const smart = isSmart(opponent, rng.random());
   const moves = getMoveOptions(boardState, player, rng.random(), smart);
@@ -142,9 +142,9 @@ export async function getMove(
     .filter((point) => evaluateIfMoveIsValid(boardState, point.x, point.y, player, false));
 
   const chosenMove = moveOptions[Math.floor(rng.random() * moveOptions.length)];
+  await waitCycle();
 
   if (chosenMove) {
-    await sleep(200);
     //console.debug(`Non-priority move chosen: ${chosenMove.x} ${chosenMove.y}`);
     return { type: GoPlayType.move, x: chosenMove.x, y: chosenMove.y };
   }
@@ -786,7 +786,7 @@ function getMoveOptions(
   };
 
   async function retrieveMoveOption(id: keyof typeof moveOptions): Promise<Move | null> {
-    await sleep(100);
+    await waitCycle();
     if (moveOptions[id] !== undefined) {
       return moveOptions[id] ?? null;
     }
@@ -811,6 +811,18 @@ export function getKomi(opponent: GoOpponent) {
  */
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Spend some time waiting to allow the UI & CSS to render smoothly
+ * If bonus time is available, significantly decrease the length of the wait
+ */
+function waitCycle(): Promise<void> {
+  if (Go.storedCycles > 0) {
+    Go.storedCycles -= 1;
+    return sleep(40);
+  }
+  return sleep(200);
 }
 
 export function showWorldDemon() {

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -44,6 +44,7 @@ import { setupUncaughtPromiseHandler } from "./UncaughtPromiseHandler";
 import { Button, Typography } from "@mui/material";
 import { SnackbarEvents } from "./ui/React/Snackbar";
 import { SaveData } from "./types";
+import { Go } from "./Go/Go";
 
 /** Game engine. Handles the main game loop. */
 const Engine: {
@@ -329,6 +330,8 @@ const Engine: {
 
       // Bladeburner offline progress
       if (Player.bladeburner) Player.bladeburner.storeCycles(numCyclesOffline);
+
+      Go.storeCycles(numCyclesOffline);
 
       staneksGift.process(numCyclesOffline);
 

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -45,6 +45,7 @@ exports[`Check Save File Continuity GoSave continuity 1`] = `
   },
   "previousGame": null,
   "stats": {},
+  "storedCycles": 0,
 }
 `;
 


### PR DESCRIPTION
Add cycles spent offline to the Go object, which will be consumed to speed up the AI's response time. Offline time has been requested by a number of people, since the feature only gains its bonuses when the game is actually running. 

The exact amount of bonus time gained, and the resulting AI speed increase, can be tweaked for balance purposes as needed.

Offline time is only awarded if the player has actually completed a Go game before, it does not build up passively otherwise.