### PR TITLE
MISC: Use camel case for CSS properties

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -77,8 +77,8 @@ const htmlLocation = location;
 
 const useStyles = makeStyles()((theme: Theme) => ({
   root: {
-    "-ms-overflow-style": "none" /* for Internet Explorer, Edge */,
-    "scrollbar-width": "none" /* for Firefox */,
+    msOverflowStyle: "none" /* for Internet Explorer, Edge */,
+    scrollbarWidth: "none" /* for Firefox */,
     margin: theme.spacing(0),
     flexGrow: 1,
     padding: "8px",


### PR DESCRIPTION
When we load the game, we can see these warnings:
```
Using kebab-case for css properties in objects is not supported. Did you mean msOverflowStyle?
Using kebab-case for css properties in objects is not supported. Did you mean scrollbarWidth?
```

Quote from Emotion's documentation:
> Instead of writing css properties in `kebab-case` like regular css, you write them in `camelCase`, for example `background-color` would be `backgroundColor`.

Reference: https://emotion.sh/docs/object-styles

This PR fixes this problem.
