### PR TITLE
BUGFIX: Fix negative elapsed time

### DIFF
--- a/src/Script/ScriptHelpers.ts
+++ b/src/Script/ScriptHelpers.ts
@@ -15,7 +15,7 @@ export function scriptCalculateOfflineProduction(runningScript: RunningScript): 
   //The Player object stores the last update time from when we were online
   const thisUpdate = new Date().getTime();
   const lastUpdate = Player.lastUpdate;
-  const timePassed = (thisUpdate - lastUpdate) / 1000; //Seconds
+  const timePassed = Math.max((thisUpdate - lastUpdate) / 1000, 0); //Seconds
 
   //Calculate the "confidence" rating of the script's true production. This is based
   //entirely off of time. We will arbitrarily say that if a script has been running for

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -46,6 +46,10 @@ import { SnackbarEvents } from "./ui/React/Snackbar";
 import { SaveData } from "./types";
 import { Go } from "./Go/Go";
 
+function showWarningAboutSystemClock() {
+  AlertEvents.emit("Warning: The system clock moved backward.");
+}
+
 /** Game engine. Handles the main game loop. */
 const Engine: {
   _lastUpdate: number;
@@ -247,7 +251,13 @@ const Engine: {
       // Calculate the number of cycles have elapsed while offline
       Engine._lastUpdate = new Date().getTime();
       const lastUpdate = Player.lastUpdate;
-      const timeOffline = Engine._lastUpdate - lastUpdate;
+      let timeOffline = Engine._lastUpdate - lastUpdate;
+      if (timeOffline < 0) {
+        timeOffline = 0;
+        setTimeout(() => {
+          showWarningAboutSystemClock();
+        }, 250);
+      }
       const numCyclesOffline = Math.floor(timeOffline / CONSTANTS.MilliPerCycle);
 
       // Calculate the number of chances for a contract the player had whilst offline
@@ -393,6 +403,12 @@ const Engine: {
     // Get time difference
     const _thisUpdate = new Date().getTime();
     let diff = _thisUpdate - Engine._lastUpdate;
+    if (diff < 0) {
+      diff = 0;
+      Engine._lastUpdate = _thisUpdate;
+      Player.lastUpdate = _thisUpdate;
+      showWarningAboutSystemClock();
+    }
     const offset = diff % CONSTANTS.MilliPerCycle;
 
     // Divide this by cycle time to determine how many cycles have elapsed since last update


### PR DESCRIPTION
When the system clock moves backward, the elapsed time is negative. This PR fixes it.

Fixes #1344.