### PR TITLE
IPVGO: Fix mismatch in board size options on save loader [save corruption bugfix]

### DIFF
--- a/src/Go/Constants.ts
+++ b/src/Go/Constants.ts
@@ -68,7 +68,7 @@ export const opponentDetails = {
   },
 };
 
-export const boardSizes = [5, 7, 9, 13];
+export const boardSizes = [5, 7, 9, 13, 19];
 
 export const columnIndexes = "ABCDEFGHJKLMNOPQRSTUVWXYZ";
 

--- a/src/Go/ui/GoSubnetSearch.tsx
+++ b/src/Go/ui/GoSubnetSearch.tsx
@@ -18,7 +18,7 @@ interface IProps {
   cancel: () => void;
   showInstructions: () => void;
 }
-const boardSizeOptions = boardSizes.filter(size => size !== 19);
+const boardSizeOptions = boardSizes.filter((size) => size !== 19);
 
 export const GoSubnetSearch = ({ open, search, cancel, showInstructions }: IProps): React.ReactElement => {
   const classes = boardStyles();

--- a/src/Go/ui/GoSubnetSearch.tsx
+++ b/src/Go/ui/GoSubnetSearch.tsx
@@ -18,6 +18,7 @@ interface IProps {
   cancel: () => void;
   showInstructions: () => void;
 }
+const boardSizeOptions = boardSizes.filter(size => size !== 19);
 
 export const GoSubnetSearch = ({ open, search, cancel, showInstructions }: IProps): React.ReactElement => {
   const classes = boardStyles();
@@ -88,7 +89,7 @@ export const GoSubnetSearch = ({ open, search, cancel, showInstructions }: IProp
             <Typography>????</Typography>
           ) : (
             <Select value={`${boardSize}`} onChange={changeBoardSize} sx={{ mr: 1 }}>
-              {boardSizes.map((size) => (
+              {boardSizeOptions.map((size) => (
                 <MenuItem key={size} value={size}>
                   {size}x{size}
                 </MenuItem>


### PR DESCRIPTION
Closes #1352 

This resolves an issue where player saves can fail to load if they last saved while playing against the secret opponent. The board size checks on the savedata fail when seeing the secret opponent's unusual board.