### PR TITLE
UI: Remove sleeve message when quitting job from a script

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -747,7 +747,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     quitJob: (ctx) => (_companyName) => {
       helpers.checkSingularityAccess(ctx);
       const companyName = getEnumHelper("CompanyName").nsGetMember(ctx, _companyName);
-      Player.quitJob(companyName);
+      Player.quitJob(companyName, true);
     },
     getCompanyRep: (ctx) => (_companyName) => {
       helpers.checkSingularityAccess(ctx);

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -361,14 +361,16 @@ export function getNextCompanyPosition(
   return pos;
 }
 
-export function quitJob(this: PlayerObject, company: CompanyName): void {
+export function quitJob(this: PlayerObject, company: CompanyName, suppressDialog?: boolean): void {
   if (isCompanyWork(this.currentWork) && this.currentWork.companyName === company) {
     this.finishWork(true);
   }
   for (const sleeve of this.sleeves) {
     if (sleeve.currentWork?.type === SleeveWorkType.COMPANY && sleeve.currentWork.companyName === company) {
       sleeve.stopWork();
-      dialogBoxCreate(`You quit ${company} while one of your sleeves was working there. The sleeve is now idle.`);
+      if (!suppressDialog) {
+        dialogBoxCreate(`You quit ${company} while one of your sleeves was working there. The sleeve is now idle.`);
+      }
     }
   }
   delete this.jobs[company];


### PR DESCRIPTION
Currently when you quit a job while one of your sleeves is working there, the game gives you a popup saying that sleeve is now set to idle. This PR changes that to only happen when you quit your job manually, not when it's done from a script, in line with how other singularity functions work.