### PR TITLE
CORPORATION: Refactor markup multiplier

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -15,6 +15,7 @@ import { JSONMap, JSONSet } from "../Types/Jsonable";
 import { PartialRecord, getRecordEntries, getRecordKeys, getRecordValues } from "../Types/Record";
 import { Material } from "./Material";
 import { getKeyList } from "../utils/helpers/getKeyList";
+import { calculateMarkupMultiplier } from "./helpers";
 
 interface DivisionParams {
   name: string;
@@ -582,26 +583,13 @@ export class Division {
             }
             mat.uiMarketPrice = sCost;
 
-            // Calculate how much of the material sells (per second)
-            let markup = 1;
-            if (sCost > mat.marketPrice) {
-              //Penalty if difference between sCost and bCost is greater than markup limit
-              if (sCost - mat.marketPrice > markupLimit) {
-                markup = Math.pow(markupLimit / (sCost - mat.marketPrice), 2);
-              }
-            } else if (sCost < mat.marketPrice) {
-              if (sCost <= 0) {
-                markup = 1e12; //Sell everything, essentially discard
-              } else {
-                //Lower prices than market increases sales
-                markup = mat.marketPrice / sCost;
-              }
-            }
+            const markupMultiplier = calculateMarkupMultiplier(sCost, mat.marketPrice, markupLimit);
 
+            // Calculate how much of the material sells (per second)
             mat.maxSellPerCycle =
               (mat.quality + 0.001) *
               marketFactor *
-              markup *
+              markupMultiplier *
               businessFactor *
               corporation.getSalesMult() *
               advertisingFactor *
@@ -920,21 +908,15 @@ export class Division {
             sCost = sellPrice;
           }
           product.uiMarketPrice[city] = sCost;
-          let markup = 1;
-          if (sCost > product.cityData[city].productionCost) {
-            if (sCost - product.cityData[city].productionCost > markupLimit) {
-              markup = markupLimit / (sCost - product.cityData[city].productionCost);
-            }
-          } else if (sCost <= 0) {
-            markup = 1e12; //Sell everything, essentially discard - as materials
-          }
+
+          const markupMultiplier = calculateMarkupMultiplier(sCost, product.cityData[city].productionCost, markupLimit);
 
           product.maxSellAmount =
             0.5 *
             Math.pow(product.cityData[city].effectiveRating, 0.65) *
             marketFactor *
             corporation.getSalesMult() *
-            Math.pow(markup, 2) *
+            markupMultiplier *
             businessFactor *
             advertisingFactor *
             this.getSalesMultiplier();

--- a/src/Corporation/helpers.ts
+++ b/src/Corporation/helpers.ts
@@ -88,3 +88,26 @@ export function issueNewSharesFailureReason(corp: Corporation, numShares: number
 
   return "";
 }
+
+export function calculateMarkupMultiplier(sellingPrice: number, marketPrice: number, markupLimit: number): number {
+  // Sanitize sellingPrice
+  if (!Number.isFinite(sellingPrice)) {
+    return 1;
+  }
+  let markupMultiplier = 1;
+  if (sellingPrice > marketPrice) {
+    // markupMultiplier is a penalty modifier if sellingPrice is greater than the sum of marketPrice and markupLimit.
+    if (sellingPrice > marketPrice + markupLimit) {
+      markupMultiplier = Math.pow(markupLimit / (sellingPrice - marketPrice), 2);
+    }
+  } else {
+    if (sellingPrice <= 0) {
+      // Discard
+      markupMultiplier = 1e12;
+    } else {
+      // markupMultiplier is a bonus modifier if sellingPrice is less than marketPrice.
+      markupMultiplier = marketPrice / sellingPrice;
+    }
+  }
+  return markupMultiplier;
+}

--- a/src/Documentation/doc/advanced/corporation/optimal-selling-price-market-ta2.md
+++ b/src/Documentation/doc/advanced/corporation/optimal-selling-price-market-ta2.md
@@ -63,12 +63,13 @@ $$MarketFactor = Max\left(0.1,{Demand\ast(100 - Competition)}\ast{0.01}\right)$$
 - Division's research bonus: this is always 1. Currently there is not any research that increases the sales bonus.
 - `MarkupMultiplier`: initialize with 1.
   - `SellingPrice` is the selling price that you set.
-  - With materials, if we set `SellingPrice` to 0, `MarkupMultiplier` is $10^{12}$ (check the formula below). Extremely high `MarkupMultiplier` means that we can sell all units, regardless of other factors. This is the fastest way to discard materials.
-  - If `(SellingPrice > MarketPrice + MarkupLimit)`:
-    $$MarkupMultiplier = \left(\frac{MarkupLimit}{SellingPrice - MarketPrice}\right)^{2}$$
-  - If item is material and `SellingPrice` is less than `MarketPrice`:
+  - If we set `SellingPrice` to 0 or a negative number, `MarkupMultiplier` is $10^{12}$ (check the formula below). With an extremely high `MarkupMultiplier`, we can sell all units, regardless of other factors. This is the fastest way to discard stored units.
+  - If `(SellingPrice > MarketPrice)`:
+    - If `(SellingPrice > MarketPrice + MarkupLimit)`:
+      $$MarkupMultiplier = \left(\frac{MarkupLimit}{SellingPrice - MarketPrice}\right)^{2}$$
+  - If `(SellingPrice <= MarketPrice)`:
 
-$$MarkupMultiplier = \begin{cases}\frac{MarketPrice}{SellingPrice}, & SellingPrice > 0 \land SellingPrice < MarketPrice \newline 10^{12}, & SellingPrice \leq 0 \end{cases}$$
+$$MarkupMultiplier = \begin{cases}\frac{MarketPrice}{SellingPrice}, & SellingPrice > 0 \newline 10^{12}, & SellingPrice \leq 0 \end{cases}$$
 
 ## Optimal selling price
 


### PR DESCRIPTION
The markup multiplier can be:
- Penalty modifier: $\left(\frac{MarkupLimit}{SellingPrice - MarketPrice}\right)^{2}$ [1]
- Bonus modifier: $\frac{MarketPrice}{SellingPrice}$ [2]
- $10^{12}$ [3]

For a very long time, only [1] was applicable to both materials and products. It creates 2 problems:
- The player cannot discard products. This is fixed by #1330.
- Products do not get a bonus modifier when the selling price is less than the market price.

This PR "unifies" the logic of the markup multiplier for both materials and products and fixes the above problem.