### PR TITLE
BLADEBURNER: Remove unused code

### DIFF
--- a/src/Bladeburner/ui/ContractElem.tsx
+++ b/src/Bladeburner/ui/ContractElem.tsx
@@ -10,7 +10,6 @@ import { Autolevel } from "./Autolevel";
 import { formatBigNumber } from "../../ui/formatNumber";
 import { Paper, Typography } from "@mui/material";
 import { useRerender } from "../../ui/React/hooks";
-import { getEnumHelper } from "../../utils/EnumHelper";
 import { ActionHeader } from "./ActionHeader";
 
 interface ContractElemProps {
@@ -20,8 +19,6 @@ interface ContractElemProps {
 
 export function ContractElem({ bladeburner, action }: ContractElemProps): React.ReactElement {
   const rerender = useRerender();
-  // Temp special return
-  if (!getEnumHelper("BladeContractName").isMember(action.name)) return <></>;
   const isActive = action.name === bladeburner.action?.name;
   const actionTime = action.getActionTime(bladeburner, Player);
 

--- a/src/utils/EnumHelper.ts
+++ b/src/utils/EnumHelper.ts
@@ -26,7 +26,7 @@ class EnumHelper<EnumObj extends object, EnumMember extends Member<EnumObj> & st
     this.valueSet = new Set(this.valueArray);
     this.fuzzMap = new Map(this.valueArray.map((val) => [val.toLowerCase().replace(/[ -]+/g, ""), val]));
   }
-  /** Provide a boolean indication for whether a  */
+  /** Provide a boolean indication for whether a value is a member of an enum */
   isMember(toValidate: unknown): toValidate is EnumMember {
     // Asserting that Set.has actually takes in arbitrary values, which it does.
     return (this.valueSet.has as (value: unknown) => boolean)(toValidate);


### PR DESCRIPTION
The special check in `ContractElem` is useless now. It's the temporary code that Snarling added when they refactored the Bladeburner code (75833d9af52fd7446b701f7113fddbddec5be64e).