### PR TITLE
MISC: Change error message when spawning on an invalid server

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -737,11 +737,11 @@ export const ns: InternalAPI<NSFull> = {
       const args = helpers.scriptArgs(ctx, _args);
       setTimeout(() => {
         const scriptServer = GetServer(ctx.workerScript.hostname);
-        if (scriptServer == null) {
-          throw helpers.errorMessage(ctx, "Could not find server. This is a bug. Report to dev");
+        if (scriptServer === null) {
+          throw helpers.errorMessage(ctx, `Cannot find server ${ctx.workerScript.hostname}`);
         }
 
-        return runScriptFromScript("spawn", scriptServer, path, args, ctx.workerScript, runOpts);
+        runScriptFromScript("spawn", scriptServer, path, args, ctx.workerScript, runOpts);
       }, runOpts.spawnDelay);
 
       helpers.log(ctx, () => `Will execute '${path}' in ${runOpts.spawnDelay} milliseconds`);


### PR DESCRIPTION
The error message says that it's a bug, but it can happen in a normal situation.

dummy.js
```js
/** @param {NS} ns */
export async function main(ns) {
  if (ns.args[0] === "start") {
    ns.spawn("dummy.js", { spawnDelay: 2000 });
  }
}
```

test.js
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.purchaseServer("pserv-0", 8);
  ns.scp("dummy.js", "pserv-0", "home");
  ns.exec("dummy.js", "pserv-0", 1, "start");
  await ns.sleep(1000);
  ns.deleteServer("pserv-0");
}
```