### PR TITLE
BUGFIX: bladeburner.getActionRepGain: mark level param as optional in signature

### DIFF
--- a/markdown/bitburner.bladeburner.getactionrepgain.md
+++ b/markdown/bitburner.bladeburner.getactionrepgain.md
@@ -9,7 +9,7 @@ Get the reputation gain of an action.
 **Signature:**
 
 ```typescript
-getActionRepGain(type: string, name: string, level: number): number;
+getActionRepGain(type: string, name: string, level?: number): number;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ getActionRepGain(type: string, name: string, level: number): number;
 |  --- | --- | --- |
 |  type | string | Type of action. |
 |  name | string | Name of action. Must be an exact match. |
-|  level | number | Optional number. Action level at which to calculate the gain. Will be the action's current level if not given. |
+|  level | number | _(Optional)_ Optional number. Action level at which to calculate the gain. Will be the action's current level if not given. |
 
 **Returns:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3132,7 +3132,7 @@ export interface Bladeburner {
    * @param level - Optional number. Action level at which to calculate the gain. Will be the action's current level if not given.
    * @returns Average Bladeburner reputation gain for successfully completing the specified action.
    */
-  getActionRepGain(type: string, name: string, level: number): number;
+  getActionRepGain(type: string, name: string, level?: number): number;
 
   /**
    * Get action count remaining.


### PR DESCRIPTION
This parameter is documented as optional, but the signature is causing my TypeScript compilation to complain. Making this change in my own `NetscriptDefinitions.d.ts` stops the compilation error and the game seems to work fine 😄

Please let me know if I missed something from the contribution process. Thank you for an excellent game!