### PR TITLE
MISC: Fix wrong help text of cd command

### DIFF
--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -148,7 +148,7 @@ export const HelpTexts: Record<string, string[]> = {
   cd: [
     "Usage: cd [dir]",
     " ",
-    "Change to the specified directory. If you change to a directory that does not exist, it will not be created. Examples:",
+    "Change to the specified directory. You cannot change to a directory that does not exist. Examples:",
     " ",
     "    cd scripts/hacking",
     " ",

--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -148,8 +148,7 @@ export const HelpTexts: Record<string, string[]> = {
   cd: [
     "Usage: cd [dir]",
     " ",
-    "Change to the specified directory. Note that this works even for directories that don't exist. If you ",
-    "change to a directory that does not exist, it will not be 'created'. Examples:",
+    "Change to the specified directory. If you change to a directory that does not exist, it will not be created. Examples:",
     " ",
     "    cd scripts/hacking",
     " ",


### PR DESCRIPTION
> Note that this works even for directories that don't exist.

This is wrong. If the directory does not exist, `cd` will print an error.

> If you change to a directory that does not exist, it will not be created.

This is a really weird description for `cd`. Is there anybody expecting `cd` to create a non-existent directory? I'm not sure if we should keep it, so I did not change or remove it.