### PR TITLE
EDITOR: Added vim notifications and register view

### DIFF
--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -43,9 +43,10 @@ interface ModalProps {
   onClose: () => void;
   children: React.ReactNode;
   sx?: SxProps<Theme>;
+  removeFocus?: boolean;
 }
 
-export const Modal = ({ open, onClose, children, sx }: ModalProps): React.ReactElement => {
+export const Modal = ({ open, onClose, children, sx, removeFocus = true }: ModalProps): React.ReactElement => {
   const { classes } = useStyles();
   const [content, setContent] = useState(children);
   useEffect(() => {
@@ -55,10 +56,10 @@ export const Modal = ({ open, onClose, children, sx }: ModalProps): React.ReactE
 
   return (
     <M
-      disableRestoreFocus
+      disableRestoreFocus={removeFocus}
       disableScrollLock
       disableEnforceFocus
-      disableAutoFocus
+      disableAutoFocus={removeFocus}
       open={open}
       onClose={onClose}
       closeAfterTransition


### PR DESCRIPTION
This is an addition of #1332.
There, I removed the notifications from vim. Reading further into the `monaco-vim` package, these notifications provide useful information, which can simply be retrieved by reading the text of the html element passed to the status bar.

Any errors with the package will now be displayed as a notification in the status bar. Currently broken functionality of the package, like globals (e.g. `:g/foo`), will result in an error that is displayed in the status bar, instead of leaving the player in the dark.

The registers the package offers would be displayed in a weird way in the status bar, so they have been moved to their own modal. For accessibility, the modal component the game provides has been altered to allow re-enabling the auto-focus. This is to allow the player to close the modal by pressing `Esc`, instead of having to click on the modal once for focus.

I'm not quite sure why the focus is removed by default, except that a focus outline is drawn, which looks a bit weird.