### PR TITLE
BLADEBURNER: fix signature and documentation for getTeamSize

### DIFF
--- a/markdown/bitburner.bladeburner.getteamsize.md
+++ b/markdown/bitburner.bladeburner.getteamsize.md
@@ -9,15 +9,15 @@ Get team size.
 **Signature:**
 
 ```typescript
-getTeamSize(type: string, name: string): number;
+getTeamSize(type?: string, name?: string): number;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  type | string | Type of action. |
-|  name | string | Name of action. Must be an exact match. |
+|  type | string | _(Optional)_ Type of action. |
+|  name | string | _(Optional)_ Name of action. Must be an exact match. |
 
 **Returns:**
 
@@ -29,7 +29,7 @@ Number of Bladeburner team members that were assigned to the specified action.
 
 RAM cost: 4 GB
 
-Returns the number of Bladeburner team members you have assigned to the specified action.
+Returns the number of available Bladeburner team members. You can also pass the type and name of an action to get the number of Bladeburner team members you have assigned to the specified action.
 
 Setting a team is only applicable for Operations and BlackOps. This function will return 0 for other action types.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3321,7 +3321,9 @@ export interface Bladeburner {
    * @remarks
    * RAM cost: 4 GB
    *
-   * Returns the number of Bladeburner team members you have assigned to the specified action.
+   * Returns the number of available Bladeburner team members.
+   * You can also pass the type and name of an action to get the number of
+   * Bladeburner team members you have assigned to the specified action.
    *
    * Setting a team is only applicable for Operations and BlackOps. This function will return 0 for other action types.
    *
@@ -3329,7 +3331,7 @@ export interface Bladeburner {
    * @param name - Name of action. Must be an exact match.
    * @returns Number of Bladeburner team members that were assigned to the specified action.
    */
-  getTeamSize(type: string, name: string): number;
+  getTeamSize(type?: string, name?: string): number;
 
   /**
    * Set team size.


### PR DESCRIPTION
[Calling this method without parameters](https://github.com/mrsimo/bitburner-src/blob/d7583455c6dda6d7602574ce393f7dbf54c71069/src/NetscriptFunctions/Bladeburner.ts#L218) is the only way I've found to get the available team size. This is a proposal to update the signature and the documentation. Modifying my local `NetscriptDefinitions.d.ts` compiles the TypeScript without errors.