### PR TITLE
BLADEBURNER: Fix wrong tooltip description in ActionLevel

### DIFF
--- a/src/Bladeburner/ui/ActionLevel.tsx
+++ b/src/Bladeburner/ui/ActionLevel.tsx
@@ -7,6 +7,7 @@ import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 
 import { BladeburnerConstants } from "../data/Constants";
+import { Contract } from "../Actions";
 
 interface ActionLevelProps {
   action: LevelableAction;
@@ -18,6 +19,11 @@ interface ActionLevelProps {
 export function ActionLevel({ action, isActive, bladeburner, rerender }: ActionLevelProps): React.ReactElement {
   const canIncrease = action.level < action.maxLevel;
   const canDecrease = action.level > 1;
+  const successesNeededForNextLevel = action.getSuccessesNeededForNextLevel(
+    action instanceof Contract
+      ? BladeburnerConstants.ContractSuccessesPerLevel
+      : BladeburnerConstants.OperationSuccessesPerLevel,
+  );
 
   function increaseLevel(): void {
     if (!canIncrease) return;
@@ -36,21 +42,7 @@ export function ActionLevel({ action, isActive, bladeburner, rerender }: ActionL
   return (
     <Box display="flex" flexDirection="row" alignItems="center">
       <Box display="flex">
-        <Tooltip
-          title={
-            action.constructor.name === "Contract" ? (
-              <Typography>
-                {action.getSuccessesNeededForNextLevel(BladeburnerConstants.ContractSuccessesPerLevel)} successes needed
-                for next level
-              </Typography>
-            ) : (
-              <Typography>
-                {action.getSuccessesNeededForNextLevel(BladeburnerConstants.OperationSuccessesPerLevel)} successes
-                needed for next level
-              </Typography>
-            )
-          }
-        >
+        <Tooltip title={<Typography>{successesNeededForNextLevel} successes needed for next level</Typography>}>
           <Typography>
             Level: {action.level} / {action.maxLevel}
           </Typography>


### PR DESCRIPTION
In `src\Bladeburner\ui\ActionLevel.tsx`, we use `action.constructor.name === "Contract"` to check if the action is a `Contract`. This is wrong because when Webpack minifies the bundle code, the constructor name will be changed too.

How to reproduce this bug (you must test it on a production build):
- Load a clean save.
- Join Bladeburner.
- Do Tracking contract until it's level 2.
- Hover the mouse over `Level: 2 / 2`. It will show `6 successes needed for next level`. `6` is the wrong value.

Fixes #831.