### PR TITLE
MISC: Fix support of react-refresh-webpack-plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = (env, argv) => {
   const isDevServer = (env || {}).devServer === true;
   const runInContainer = (env || {}).runInContainer === true;
   const isDevelopment = argv.mode === "development";
-  const isFastRefresh = argv.fast === "true";
+  const enableReactRefresh = (env || {}).enableReactRefresh === true;
   const outputDirectory = "dist";
   const entry = "./src/index.tsx";
 
@@ -126,7 +126,7 @@ module.exports = (env, argv) => {
           columns: true,
           module: true,
         }),
-      isFastRefresh && new ReactRefreshWebpackPlugin(),
+      enableReactRefresh && new ReactRefreshWebpackPlugin(),
     ].filter(Boolean),
     target: "web",
     entry: entry,
@@ -143,7 +143,7 @@ module.exports = (env, argv) => {
           use: {
             loader: "babel-loader",
             options: {
-              plugins: [isFastRefresh && require.resolve("react-refresh/babel")].filter(Boolean),
+              plugins: [enableReactRefresh && require.resolve("react-refresh/babel")].filter(Boolean),
               cacheDirectory: true,
             },
           },


### PR DESCRIPTION
In 62cd8ffcc6f5815749800f3fd4e344a2da42d7e4, we added `const isFastRefresh = argv.fast === "true"` to check if we want to enable `react-refresh-webpack-plugin`. That check was fine because we used `webpack-dev-server` CLI. When we switched to `webpack` CLI, we could not use `--fast true` anymore. If we use `--customOption optionValue` syntax, `webpack` CLI will throw the error `Error: Unknown option '--customOption'`. In order to pass a custom option to `webpack`, we need to use `--env`.

Example: `webpack serve --progress --env devServer --mode development --env enableReactRefresh`.