### PR TITLE
BUGFIX: Fix wrong position name in ns.formulas.work.companyGains

### DIFF
--- a/src/NetscriptFunctions/Formulas.ts
+++ b/src/NetscriptFunctions/Formulas.ts
@@ -26,15 +26,7 @@ import {
   calculateGrowTime,
   calculateWeakenTime,
 } from "../Hacking";
-import {
-  CityName,
-  CompletedProgramName,
-  FactionWorkType,
-  GymType,
-  JobName,
-  LocationName,
-  UniversityClassType,
-} from "@enums";
+import { CityName, CompletedProgramName, FactionWorkType, GymType, LocationName, UniversityClassType } from "@enums";
 import { Formulas as IFormulas, Player as IPlayer, Person as IPerson } from "@nsdefs";
 import {
   calculateRespectGain,
@@ -427,12 +419,10 @@ export function NetscriptFormulas(): InternalAPI<IFormulas> {
       companyGains: (ctx) => (_person, _companyName, _positionName, _favor) => {
         checkFormulasAccess(ctx);
         const person = helpers.person(ctx, _person);
-        const positionName = findEnumMember(JobName, helpers.string(ctx, "_positionName", _positionName));
-        if (!positionName) throw new Error(`Invalid company position: ${_positionName}`);
+        const companyName = getEnumHelper("CompanyName").nsGetMember(ctx, _companyName);
+        const company = Companies[companyName];
+        const positionName = getEnumHelper("JobName").nsGetMember(ctx, _positionName);
         const position = CompanyPositions[positionName];
-        const companyName = helpers.string(ctx, "_companyName", _companyName);
-        const company = Object.values(Companies).find((c) => c.name === companyName);
-        if (!company) throw new Error(`Invalid company name: ${companyName}`);
         const favor = helpers.number(ctx, "favor", _favor);
         return calculateCompanyWorkStats(person, company, position, favor);
       },


### PR DESCRIPTION
`findEnumMember` was added in #212. It allows fuzzy matching of player input with enum members. In #596, Snarling added `getEnumHelper` that has many features, including fuzzy matching. Nowadays, we mostly use `getEnumHelper.nsGetMember` instead of `findEnumMember`. In my opinion, this is a good move, because allowing the player to use the "fuzzy" value when calling NS APIs will create potential bugs in the future.

`findEnumMember` is still used in these places:
- `fromJSON` in `src\Work\ClassWork.tsx`. This is fine.
- Singularity API: `ns.singularity.universityCourse` and `ns.singularity.gymWorkout`.
- Formulas API: `ns.formulas.work.gymGains`, `ns.formulas.work.universityGains`, `ns.formulas.work.factionGains`, and `ns.formulas.work.companyGains`.

The usage of `findEnumMember` in `ns.formulas.work.companyGains` creates the bug in #1220. This PR fixes that specific bug.

I also want to discuss changing other APIs that use `findEnumMember` (check the list above). It does not make sense to enforce the check of enum values in most places but to allow "fuzzy" values in other places. For example, in `ns.formulas.work.gymGains`, we check the location name with `getEnumHelper("LocationName").nsGetMember`, but allow the "fuzzy" value for `_classType`.
Technically, this is a breaking change, but I think it's a good one.
@Snarling @d0sboots What are your opinions?

I found many other places that use `.toLowerCase` to accept "fuzzy" values, but I will leave them there and make the change in v3.0.

Fixes #1220.