### PR TITLE
BLADEBURNER: Fix NaN in getSuccessRange

### DIFF
--- a/src/Bladeburner/Actions/Action.ts
+++ b/src/Bladeburner/Actions/Action.ts
@@ -146,9 +146,19 @@ export abstract class ActionClass {
     let high = real + diff;
     const city = bladeburner.getCurrentCity();
     let r = city.pop / city.popEst;
-    if (Number.isNaN(r)) r = 0;
-    if (r < 1) low *= r;
-    else high *= r;
+    if (Number.isNaN(r)) {
+      r = 0;
+    }
+    if (r < 1) {
+      low *= r;
+    } else {
+      // This happens when the action is Raid, popEst=0, and comms=0.
+      if (high === 0 && r === Infinity) {
+        high = 0;
+      } else {
+        high *= r;
+      }
+    }
     return [clamp(low), clamp(high)];
   }
 

--- a/src/Bladeburner/Actions/Action.ts
+++ b/src/Bladeburner/Actions/Action.ts
@@ -8,6 +8,7 @@ import { BladeburnerConstants } from "../data/Constants";
 import { calculateIntelligenceBonus } from "../../PersonObjects/formulas/intelligence";
 import { BladeMultName } from "../Enums";
 import { getRecordKeys } from "../../Types/Record";
+import { clampNumber } from "../../utils/helpers/clampNumber";
 
 export interface ActionParams {
   desc: string;
@@ -152,12 +153,9 @@ export abstract class ActionClass {
     if (r < 1) {
       low *= r;
     } else {
-      // This happens when the action is Raid, popEst=0, and comms=0.
-      if (high === 0 && r === Infinity) {
-        high = 0;
-      } else {
-        high *= r;
-      }
+      // We need to "clamp" r with "clampNumber" (not "clamp"), otherwise (high *= r) may be NaN. This happens when the
+      // action is Raid, popEst=0, and comms=0.
+      high *= clampNumber(r);
     }
     return [clamp(low), clamp(high)];
   }

--- a/src/Bladeburner/Actions/BlackOperation.ts
+++ b/src/Bladeburner/Actions/BlackOperation.ts
@@ -34,18 +34,20 @@ export class BlackOperation extends ActionClass {
     if (bladeburner.rank < this.reqdRank) return { error: "Insufficient rank" };
     return { available: true };
   }
-  // To be implemented by subtypes
+
   getActionTimePenalty(): number {
     return 1.5;
   }
 
-  getPopulationSuccessFactor(/*inst: Bladeburner, params: ISuccessChanceParams*/): number {
+  getPopulationSuccessFactor(): number {
     return 1;
   }
 
-  getChaosSuccessFactor(/*inst: Bladeburner, params: ISuccessChanceParams*/): number {
+  getChaosSuccessFactor(): number {
     return 1;
   }
+
   getTeamSuccessBonus = operationTeamSuccessBonus;
+
   getActionTypeSkillSuccessBonus = operationSkillSuccessBonus;
 }

--- a/src/Bladeburner/Actions/Operation.ts
+++ b/src/Bladeburner/Actions/Operation.ts
@@ -32,6 +32,7 @@ export class Operation extends LevelableActionClass {
 
   // These functions are shared between operations and blackops, so they are defined outside of Operation
   getTeamSuccessBonus = operationTeamSuccessBonus;
+
   getActionTypeSkillSuccessBonus = operationSkillSuccessBonus;
 
   getChaosSuccessFactor(inst: Bladeburner /*, params: ISuccessChanceParams*/): number {
@@ -45,7 +46,9 @@ export class Operation extends LevelableActionClass {
     return 1;
   }
   getSuccessChance(inst: Bladeburner, person: Person, params: SuccessChanceParams) {
-    if (this.name == BladeOperationName.raid && inst.getCurrentCity().comms <= 0) return 0;
+    if (this.name === BladeOperationName.raid && inst.getCurrentCity().comms <= 0) {
+      return 0;
+    }
     return ActionClass.prototype.getSuccessChance.call(this, inst, person, params);
   }
 
@@ -57,6 +60,7 @@ export class Operation extends LevelableActionClass {
   toJSON(): IReviverValue {
     return this.save("Operation", "teamCount");
   }
+
   loadData(loadedObject: Operation): void {
     this.teamCount = clampInteger(loadedObject.teamCount, 0);
     LevelableActionClass.prototype.loadData.call(this, loadedObject);
@@ -73,6 +77,7 @@ constructorsForReviver.Operation = Operation;
 export const operationSkillSuccessBonus = (inst: Bladeburner) => {
   return inst.getSkillMult(BladeMultName.successChanceOperation);
 };
+
 export function operationTeamSuccessBonus(this: Operation | BlackOperation, inst: Bladeburner) {
   if (this.teamCount && this.teamCount > 0) {
     this.teamCount = Math.min(this.teamCount, inst.teamSize);

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -125,7 +125,7 @@ export class Bladeburner {
   startAction(actionId: ActionIdentifier | null): Attempt<{ message: string }> {
     if (!actionId) {
       this.resetAction();
-      return { success: true, message: "Stopped current bladeburner action" };
+      return { success: true, message: "Stopped current Bladeburner action" };
     }
     if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true)) Player.finishWork(true);
     const action = this.getActionObject(actionId);

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -20,7 +20,7 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
   const getBladeburner = function (ctx: NetscriptContext): Bladeburner {
     const apiAccess = Player.bitNodeN === 7 || Player.sourceFileLvl(7) > 0;
     if (!apiAccess) {
-      throw helpers.errorMessage(ctx, "You have not unlocked the bladeburner API.", "API ACCESS");
+      throw helpers.errorMessage(ctx, "You have not unlocked the Bladeburner API.", "API ACCESS");
     }
     const bladeburner = Player.bladeburner;
     if (!bladeburner)
@@ -112,14 +112,10 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     },
     getActionCurrentTime: (ctx) => () => {
       const bladeburner = getBladeburner(ctx);
-      try {
-        const timecomputed =
-          Math.min(bladeburner.actionTimeCurrent + bladeburner.actionTimeOverflow, bladeburner.actionTimeToComplete) *
-          1000;
-        return timecomputed;
-      } catch (e: unknown) {
-        throw helpers.errorMessage(ctx, String(e));
-      }
+      return (
+        Math.min(bladeburner.actionTimeCurrent + bladeburner.actionTimeOverflow, bladeburner.actionTimeToComplete) *
+        1000
+      );
     },
     getActionEstimatedSuccessChance: (ctx) => (type, name) => {
       const bladeburner = getBladeburner(ctx);


### PR DESCRIPTION
A player reported that their `Raid` operation showed `Estimated success chance: 0.0% ~ NaN%`. This happens when `popEst=0` and `comms=0`. `popEst=0` makes `r=Infinity`, `comms=0` makes `high=0`, and `0*Infinity=NaN`. This PR fixes this problem.