### PR TITLE
UI: Show BitNode multipliers in BN 5.1

### DIFF
--- a/src/Augmentation/ui/PlayerMultipliers.tsx
+++ b/src/Augmentation/ui/PlayerMultipliers.tsx
@@ -28,9 +28,10 @@ function customFormatPercent(value: number): string {
 }
 
 function BitNodeModifiedStats(props: IBitNodeModifiedStatsProps): React.ReactElement {
-  // If player doesn't have SF5 or if the property isn't affected by BitNode mults
-  if (props.mult === 1 || Player.sourceFileLvl(5) === 0)
+  // If the player doesn't have access to SF5 feature or if the property isn't affected by BitNode mults
+  if (props.mult === 1 || (Player.bitNodeN !== 5 && Player.sourceFileLvl(5) === 0)) {
     return <Typography color={props.color}>{customFormatPercent(props.base)}</Typography>;
+  }
 
   return (
     <Typography color={props.color}>

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -229,8 +229,6 @@ export function CharacterStats(): React.ReactElement {
   }
   timeRows.push(["Total", convertTimeMsToTimeElapsedString(Player.totalPlaytime)]);
 
-  let showBitNodeMults = false;
-  if (Player.sourceFileLvl(5) > 0) showBitNodeMults = true;
   return (
     <Container maxWidth="lg" disableGutters sx={{ mx: 0 }}>
       <Typography variant="h4">Stats</Typography>
@@ -592,7 +590,7 @@ export function CharacterStats(): React.ReactElement {
 
       <CurrentBitNode />
 
-      {showBitNodeMults && (
+      {(Player.bitNodeN === 5 || Player.sourceFileLvl(5) > 0) && (
         <Paper sx={{ p: 1, mb: 1 }}>
           <Typography variant="h5">BitNode Multipliers</Typography>
           <BitNodeMultipliersDisplay n={Player.bitNodeN} />


### PR DESCRIPTION
We always let the player use BN's new features when they are in that BN. However, when they are BN 5.1, they cannot see the BN multipliers in some places. This PR fixes that problem.

Screenshots:
![1](https://github.com/bitburner-official/bitburner-src/assets/152669316/5172619f-6338-42c7-8485-3901edc7c6fc)

![2](https://github.com/bitburner-official/bitburner-src/assets/152669316/e08f494f-b9a2-4fc4-a27c-b17f9c68efa1)
