### PR TITLE
MISC: Blade Burner API access and Blades Simulacrum update

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -198,13 +198,14 @@ export function initBitNodes() {
         <br />
         <br />
         In this BitNode you will be able to access the {FactionName.Bladeburners} Division at the NSA, which provides a
-        new mechanic for progression.
+        new mechanic for progression and through the {FactionName.Bladeburners} API, which allows you to access{" "}
+        {FactionName.Bladeburners} functionality through Netscript.
         <br />
         <br />
         Destroying this BitNode will give you Source-File 6, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File allows you to access the NSA's {FactionName.Bladeburners} Division
-        in other BitNodes. In addition, this Source-File will raise both the level and experience gain rate of all your
-        combat stats by:
+        level up to a maximum of 3. This Source-File allows you to access the {FactionName.Bladeburners} through the NSA
+        and the API. In addition, this Source-File will raise both the level and experience gain rate of all your combat
+        stats by:
         <br />
         <br />
         Level 1: 8%
@@ -229,14 +230,14 @@ export function initBitNodes() {
         models that were stronger, faster, and more intelligent than the humans that had created them.
         <br />
         <br />
-        In this BitNode you will be able to access the {FactionName.Bladeburners} API, which allows you to access{" "}
+        In this BitNode you will be able to access the {FactionName.Bladeburners} Division at the NSA, which provides a
+        new mechanic for progression and through the {FactionName.Bladeburners} API, which allows you to access{" "}
         {FactionName.Bladeburners} functionality through Netscript.
         <br />
         <br />
         Destroying this BitNode will give you Source-File 7, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File allows you to access the {FactionName.Bladeburners} Netscript API
-        in other BitNodes. In addition, this Source-File will increase all of your {FactionName.Bladeburners}{" "}
-        multipliers by:
+        level up to a maximum of 3. This Source-File allows you to access the {FactionName.Bladeburners} through the NSA
+        and the API. In addition, this Source-File will increase all of your {FactionName.Bladeburners} multipliers by:
         <br />
         <br />
         Level 1: 8%
@@ -244,6 +245,8 @@ export function initBitNodes() {
         Level 2: 12%
         <br />
         Level 3: 14%
+        <br />
+        Level 3: Start with Blades Simulacrum augmentation
       </>
     ),
   );

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -18,7 +18,8 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     return;
   };
   const getBladeburner = function (ctx: NetscriptContext): Bladeburner {
-    const apiAccess = Player.bitNodeN === 7 || Player.sourceFileLvl(7) > 0;
+    const apiAccess =
+      Player.bitNodeN === 6 || Player.sourceFileLvl(6) > 0 || Player.bitNodeN === 7 || Player.sourceFileLvl(7) > 0;
     if (!apiAccess) {
       throw helpers.errorMessage(ctx, "You have not unlocked the Bladeburner API.", "API ACCESS");
     }

--- a/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
@@ -1,4 +1,5 @@
 import { Bladeburner } from "../../Bladeburner/Bladeburner";
+import { AugmentationName } from "@enums";
 
 import type { PlayerObject } from "./PlayerObject";
 
@@ -9,4 +10,11 @@ export function canAccessBladeburner(this: PlayerObject): boolean {
 export function startBladeburner(this: PlayerObject): void {
   this.bladeburner = new Bladeburner();
   this.bladeburner.init();
+  // Give Blades Simulacrum if you have unlocked it
+  if (this.sourceFileLvl(7) >= 3) {
+    this.augmentations.push({
+      name: AugmentationName.BladesSimulacrum,
+      level: 1,
+    });
+  }
 }


### PR DESCRIPTION
As per a conversation in Dev:
https://discord.com/channels/415207508303544321/459097632896188436/1251988703132254229

This update unlocked the Blade Burner API upon completion of, and while you are within BN's 6 and 7.
The BN descriptions have been updated to show this change.

As well, the Blades Simulacrum augment is now a reward for completing BN 7.3.  It is only given upon first initialization of Blade Burner.

Looking for conversation around what the BN description should be changed to.

Text changes in the BN's posted as well
![BN7Screenshot 2024-06-17 210216](https://github.com/bitburner-official/bitburner-src/assets/148732459/075fa4de-22e5-478f-87c4-a8e451dbb691)
![BN6Screenshot 2024-06-17 210151](https://github.com/bitburner-official/bitburner-src/assets/148732459/dfe56cf5-2a9c-4fd2-8804-a02e2b34d97d)
