### PR TITLE
INFILTRATION: Handle automated infiltration

### DIFF
--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -97,7 +97,11 @@ export function Game(props: GameProps): React.ReactElement {
       if (options?.automated) {
         damage = Player.hp.current;
         setTimeout(() => {
-          SnackbarEvents.emit("You were hospitalized. Do not try to automate infiltration!", ToastVariant.WARNING, 5000);
+          SnackbarEvents.emit(
+            "You were hospitalized. Do not try to automate infiltration!",
+            ToastVariant.WARNING,
+            5000,
+          );
         }, 500);
       }
       if (Player.takeDamage(damage)) {

--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -1,6 +1,6 @@
 import { Button, Container, Paper, Typography } from "@mui/material";
 import React, { useCallback, useState } from "react";
-import { FactionName } from "@enums";
+import { FactionName, ToastVariant } from "@enums";
 import { Router } from "../../ui/GameRoot";
 import { Page } from "../../ui/Router";
 import { Player } from "@player";
@@ -15,6 +15,7 @@ import { SlashGame } from "./SlashGame";
 import { Victory } from "./Victory";
 import { WireCuttingGame } from "./WireCuttingGame";
 import { calculateDamageAfterFailingInfiltration } from "../utils";
+import { SnackbarEvents } from "../../ui/React/Snackbar";
 
 type GameProps = {
   StartingDifficulty: number;
@@ -91,11 +92,14 @@ export function Game(props: GameProps): React.ReactElement {
       setStage(Stage.Countdown);
       pushResult(false);
       Player.receiveRumor(FactionName.ShadowsOfAnarchy);
-      // Kill the player immediately if they use automation, so
-      // it's clear they're not meant to
-      const damage = options?.automated
-        ? Player.hp.current
-        : calculateDamageAfterFailingInfiltration(props.StartingDifficulty);
+      let damage = calculateDamageAfterFailingInfiltration(props.StartingDifficulty);
+      // Kill the player immediately if they use automation, so it's clear they're not meant to
+      if (options?.automated) {
+        damage = Player.hp.current;
+        setTimeout(() => {
+          SnackbarEvents.emit("You was hospitalized. Do not try to automate infiltration!", ToastVariant.WARNING, 5000);
+        }, 500);
+      }
       if (Player.takeDamage(damage)) {
         Router.toPage(Page.City);
         return;

--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -97,7 +97,7 @@ export function Game(props: GameProps): React.ReactElement {
       if (options?.automated) {
         damage = Player.hp.current;
         setTimeout(() => {
-          SnackbarEvents.emit("You was hospitalized. Do not try to automate infiltration!", ToastVariant.WARNING, 5000);
+          SnackbarEvents.emit("You were hospitalized. Do not try to automate infiltration!", ToastVariant.WARNING, 5000);
         }, 500);
       }
       if (Player.takeDamage(damage)) {

--- a/src/Infiltration/ui/KeyHandler.tsx
+++ b/src/Infiltration/ui/KeyHandler.tsx
@@ -1,16 +1,18 @@
 import React, { useEffect } from "react";
 
 interface IProps {
-  onKeyDown: (this: Document, event: KeyboardEvent) => void;
+  onKeyDown: (event: KeyboardEvent) => void;
   onFailure: (options?: { automated: boolean }) => void;
 }
 
 export function KeyHandler(props: IProps): React.ReactElement {
   useEffect(() => {
-    function press(this: Document, event: KeyboardEvent): void {
-      if (!event.isTrusted) return;
-      const f = props.onKeyDown.bind(this);
-      f(event);
+    function press(event: KeyboardEvent): void {
+      if (!event.isTrusted || !(event instanceof KeyboardEvent)) {
+        props.onFailure({ automated: true });
+        return;
+      }
+      props.onKeyDown(event);
     }
     document.addEventListener("keydown", press);
     return () => document.removeEventListener("keydown", press);


### PR DESCRIPTION
Infiltration has never been balanced to be played by an automation script. In our code base, we prohibit it with the checks in `src\Infiltration\ui\Game.tsx` and `src\Infiltration\ui\KeyHandler.tsx`, but our checks are wrong:
- `press`: It does not check if `event` is a "real" event or a synthetic one.
- `press`: It does not call `onFailure({ automated: true })`, so the check `options?.automated` in `onFailure` is useless.

With these bugs, our standpoint on automated infiltration is weird. We prohibit it, but we don't do anything to prevent it. There are 3 ways to deal with it:
- Fix those bugs. Make it clear that infiltration is a non-automatic feature. [1]
- Balance it properly and allow it [2]. For example, we can add special restrictions if we detect automation:
  - Lower reward.
  - Random chance of failure + higher damage.
- Revamp infiltration from scratch. [3]

[3] is a big overhaul, so that's not the job of this PR. This PR uses [1]. This is a controversial change because the automated infiltration script is widespread, and many people like it. If the maintainers want, I will change it to [2].