### PR TITLE
IPVGO: Fix displayed mult to match the actual bonus of SF 14.1

### DIFF
--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -561,7 +561,7 @@ export function CharacterStats(): React.ReactElement {
                 rows={[
                   {
                     mult: "IPvGO Node Power bonus",
-                    value: Player.sourceFileLvl(14) ? 1.25 * currentNodeMults.GoPower : currentNodeMults.GoPower,
+                    value: Player.sourceFileLvl(14) ? 2 * currentNodeMults.GoPower : currentNodeMults.GoPower,
                   },
                   {
                     mult: "IPvGO Max Favor",


### PR DESCRIPTION
Ensure the correct bonus from Source-File 14.1 is shown on the mults screen