### PR TITLE
ELECTRON: Fix error with symbolic link

### DIFF
--- a/electron/fileError.html
+++ b/electron/fileError.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bitburner</title>
+    <style>
+      body {
+        background-color: black;
+        color: #0c0;
+        margin: 0;
+      }
+
+      div {
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      h1 {
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Attempts to access local files outside the normal game environment will be directed to this file.</h1>
+    </div>
+  </body>
+</html>

--- a/electron/fileError.txt
+++ b/electron/fileError.txt
@@ -1,1 +1,0 @@
-Attempts to access local files outside the normal game environment will be directed to this file.


### PR DESCRIPTION
Some players reported that the Steam app only shows a black screen. When I check their logs and their setups, I see that they use a symbolic link to link their game folder. For example, let's say that their game folder is at `D:\Games\Steams\Bitburner\`, they create a symbolic link at `E:\GameData\Bitburner\` that points to their game folder, then launch the exe file at `E:\GameData\Bitburner\bitburner.exe`. The code in `protocol.interceptFileProtocol` won't be able to handle this case. `url` and `filePath` point to the symbolic link (`E:\GameData\Bitburner\`), but `__dirname` points to the real path (`D:\Games\Steams\Bitburner\`), so `relativePath` is wrong. This PR fixes this problem.

Other changes:

`((method === "GET" && relativePath.startsWith("dist")) || relativePath.match(/^[a-zA-Z-_]*\.html/))` is changed to `(method === "GET" && (relativePath.startsWith("dist") || relativePath.match(/^[a-zA-Z-_]*\.html/)))`.

I convert `fileError.txt` to `fileError.html`. When we return the plain text in `fileError.txt`, it's wrapped like this:
```html
<html>
  <head>
    <meta name="color-scheme" content="light dark" />
  </head>
  <body>
    <pre style="word-wrap: break-word; white-space: pre-wrap">
Attempts to access local files outside the normal game environment will be directed to this file.
</pre
    >
  </body>
</html>
```
The player cannot see the text because its color is the same as the background color.

Tested on Windows.