### PR TITLE
API: Get Sleeve Success at BB tasks through existing commands

### DIFF
--- a/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
+++ b/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
@@ -9,7 +9,7 @@ Get estimate success chance of an action.
 **Signature:**
 
 ```typescript
-getActionEstimatedSuccessChance(type: string, name: string, sleeve: number = undefined): [number, number];
+getActionEstimatedSuccessChance(type: string, name: string, sleeve?: number): [number, number];
 ```
 
 ## Parameters

--- a/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
+++ b/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
@@ -9,7 +9,7 @@ Get estimate success chance of an action.
 **Signature:**
 
 ```typescript
-getActionEstimatedSuccessChance(type: string, name: string): [number, number];
+getActionEstimatedSuccessChance(type: string, name: string, sleeve = undefined): [number, number];
 ```
 
 ## Parameters
@@ -18,6 +18,7 @@ getActionEstimatedSuccessChance(type: string, name: string): [number, number];
 |  --- | --- | --- |
 |  type | string | Type of action. |
 |  name | string | Name of action. Must be an exact match. |
+|  sleeve | (not declared) | _(Optional)_ Optional. Sleeve number to check for success. |
 
 **Returns:**
 

--- a/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
+++ b/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
@@ -9,7 +9,7 @@ Get estimate success chance of an action.
 **Signature:**
 
 ```typescript
-getActionEstimatedSuccessChance(type: string, name: string, sleeve = undefined): [number, number];
+getActionEstimatedSuccessChance(type: string, name: string, sleeve: number = undefined): [number, number];
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ getActionEstimatedSuccessChance(type: string, name: string, sleeve = undefined):
 |  --- | --- | --- |
 |  type | string | Type of action. |
 |  name | string | Name of action. Must be an exact match. |
-|  sleeve | (not declared) | _(Optional)_ Optional. Sleeve number to check for success. |
+|  sleeve | number | _(Optional)_ Optional. Sleeve number to check for success. |
 
 **Returns:**
 

--- a/markdown/bitburner.bladeburner.md
+++ b/markdown/bitburner.bladeburner.md
@@ -24,7 +24,7 @@ You have to be employed in the Bladeburner division and be in BitNode-7 or have 
 |  [getActionCountRemaining(type, name)](./bitburner.bladeburner.getactioncountremaining.md) | Get action count remaining. |
 |  [getActionCurrentLevel(type, name)](./bitburner.bladeburner.getactioncurrentlevel.md) | Get the current level of an action. |
 |  [getActionCurrentTime()](./bitburner.bladeburner.getactioncurrenttime.md) | Get the time elapsed on current action. |
-|  [getActionEstimatedSuccessChance(type, name)](./bitburner.bladeburner.getactionestimatedsuccesschance.md) | Get estimate success chance of an action. |
+|  [getActionEstimatedSuccessChance(type, name, sleeve)](./bitburner.bladeburner.getactionestimatedsuccesschance.md) | Get estimate success chance of an action. |
 |  [getActionMaxLevel(type, name)](./bitburner.bladeburner.getactionmaxlevel.md) | Get the maximum level of an action. |
 |  [getActionRepGain(type, name, level)](./bitburner.bladeburner.getactionrepgain.md) | Get the reputation gain of an action. |
 |  [getActionSuccesses(type, name)](./bitburner.bladeburner.getactionsuccesses.md) | Get action successes. |

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -11,6 +11,7 @@ import { getEnumHelper } from "../utils/EnumHelper";
 import { Skills } from "../Bladeburner/data/Skills";
 import { assertString } from "../Netscript/TypeAssertion";
 import { BlackOperations, blackOpsArray } from "../Bladeburner/data/BlackOperations";
+import { checkSleeveAPIAccess, checkSleeveNumber } from "../NetscriptFunctions/Sleeve";
 
 export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
   const checkBladeburnerAccess = function (ctx: NetscriptContext): void {
@@ -27,22 +28,6 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
       throw helpers.errorMessage(ctx, "You must be a member of the Bladeburner division to use this API.");
     return bladeburner;
   };
-  const checkSleeveAPIAccess = function (ctx: NetscriptContext) {
-    if (Player.bitNodeN !== 10 && !Player.sourceFileLvl(10)) {
-      throw helpers.errorMessage(
-        ctx,
-        "You do not currently have access to the Sleeve API. This is either because you are not in BitNode-10 or because you do not have Source-File 10",
-      );
-    }
-  };
-  const checkSleeveNumber = function (ctx: NetscriptContext, sleeveNumber: number) {
-    if (sleeveNumber >= Player.sleeves.length || sleeveNumber < 0) {
-      const msg = `Invalid sleeve number: ${sleeveNumber}`;
-      helpers.log(ctx, () => msg);
-      throw helpers.errorMessage(ctx, msg);
-    }
-  };
-
   function getAction(ctx: NetscriptContext, type: unknown, name: unknown): Action {
     const bladeburner = Player.bladeburner;
     assertString(ctx, "type", type);
@@ -135,7 +120,7 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     getActionEstimatedSuccessChance: (ctx) => (type, name, _sleeve) => {
       const bladeburner = getBladeburner(ctx);
       const action = getAction(ctx, type, name);
-      if (_sleeve !== undefined) {
+      if (_sleeve != null) {
         checkSleeveAPIAccess(ctx);
         const sleeveNumber = helpers.number(ctx, "sleeve", _sleeve);
         checkSleeveNumber(ctx, sleeveNumber);

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -16,24 +16,24 @@ import { getAugCost } from "../Augmentation/AugmentationHelpers";
 import { Factions } from "../Faction/Factions";
 import { SleeveWorkType } from "../PersonObjects/Sleeve/Work/Work";
 
+export const checkSleeveAPIAccess = function (ctx: NetscriptContext) {
+  if (Player.bitNodeN !== 10 && !Player.sourceFileLvl(10)) {
+    throw helpers.errorMessage(
+      ctx,
+      "You do not currently have access to the Sleeve API. This is either because you are not in BitNode-10 or because you do not have Source-File 10",
+    );
+  }
+};
+
+export const checkSleeveNumber = function (ctx: NetscriptContext, sleeveNumber: number) {
+  if (sleeveNumber >= Player.sleeves.length || sleeveNumber < 0) {
+    const msg = `Invalid sleeve number: ${sleeveNumber}`;
+    helpers.log(ctx, () => msg);
+    throw helpers.errorMessage(ctx, msg);
+  }
+};
+
 export function NetscriptSleeve(): InternalAPI<NetscriptSleeve> {
-  const checkSleeveAPIAccess = function (ctx: NetscriptContext) {
-    if (Player.bitNodeN !== 10 && !Player.sourceFileLvl(10)) {
-      throw helpers.errorMessage(
-        ctx,
-        "You do not currently have access to the Sleeve API. This is either because you are not in BitNode-10 or because you do not have Source-File 10",
-      );
-    }
-  };
-
-  const checkSleeveNumber = function (ctx: NetscriptContext, sleeveNumber: number) {
-    if (sleeveNumber >= Player.sleeves.length || sleeveNumber < 0) {
-      const msg = `Invalid sleeve number: ${sleeveNumber}`;
-      helpers.log(ctx, () => msg);
-      throw helpers.errorMessage(ctx, msg);
-    }
-  };
-
   const sleeveFunctions: InternalAPI<NetscriptSleeve> = {
     getNumSleeves: (ctx) => () => {
       checkSleeveAPIAccess(ctx);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3117,7 +3117,7 @@ export interface Bladeburner {
    * @param sleeve - Optional.  Sleeve number to check for success.
    * @returns Estimated success chance for the specified action.
    */
-  getActionEstimatedSuccessChance(type: string, name: string, sleeve: number = undefined): [number, number];
+  getActionEstimatedSuccessChance(type: string, name: string, sleeve?: number): [number, number];
 
   /**
    * Get the reputation gain of an action.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3117,7 +3117,7 @@ export interface Bladeburner {
    * @param sleeve - Optional.  Sleeve number to check for success.
    * @returns Estimated success chance for the specified action.
    */
-  getActionEstimatedSuccessChance(type: string, name: string, sleeve = undefined): [number, number];
+  getActionEstimatedSuccessChance(type: string, name: string, sleeve: number = undefined): [number, number];
 
   /**
    * Get the reputation gain of an action.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3114,9 +3114,10 @@ export interface Bladeburner {
    *
    * @param type - Type of action.
    * @param name - Name of action. Must be an exact match.
+   * @param sleeve - Optional.  Sleeve number to check for success.
    * @returns Estimated success chance for the specified action.
    */
-  getActionEstimatedSuccessChance(type: string, name: string): [number, number];
+  getActionEstimatedSuccessChance(type: string, name: string, sleeve = undefined): [number, number];
 
   /**
    * Get the reputation gain of an action.


### PR DESCRIPTION
Tweaked the existing BB command of getActionEstimatedSuccessChance(type, name) to also take an optional sleeve number.  With the number added it will return the sleeves success high and low chance of contracts only, (Tracking, Investigation, Bounty Hunter) returning [0, 0] otherwise.

This does not break any existing scripts as it's an optional parameter.

Tested with my sleeve 0 and verified that I received different numbers for myself and my sleeve.