### PR TITLE
CORPORATION: Don't check access for `getConstants`

### DIFF
--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -588,8 +588,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
     ...warehouseAPI,
     ...officeAPI,
     hasCorporation: () => () => !!Player.corporation,
-    getConstants: (ctx) => () => {
-      checkAccess(ctx);
+    getConstants: () => () => {
       /* TODO 2.2: possibly just rework the whole corp constants structure to be more readable, and just use
        *           structuredClone to provide it directly to player.
        * TODO 2.2: Roll product information into industriesData, there's no reason to look up a product separately */


### PR DESCRIPTION
I think it is reasonable to want to call `getConstants` before creating a corporation. I also couldn't find a technical reason to disallow it.
