### PR TITLE
UI: Remember last position of documentation pages

### DIFF
--- a/src/ui/MD/MD.tsx
+++ b/src/ui/MD/MD.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import { TableHead } from "@mui/material";
 import remarkGfm from "remark-gfm";
@@ -7,8 +7,20 @@ import { code, Pre } from "./code";
 import { A } from "./a";
 import remarkMath from "remark-math";
 import rehypeMathjax from "rehype-mathjax/svg";
+import { FilePath } from "../../Paths/FilePath";
+import { getPage } from "../../Documentation/root";
 
-export function MD(props: { md: string }): React.ReactElement {
+export function MD(props: { pageFilePath: FilePath; top: number }): React.ReactElement {
+  const pageContent = getPage(props.pageFilePath);
+
+  useEffect(() => {
+    // This is a workaround. window.scrollTo does not work when we switch from Documentation tab to another tab, then
+    // switch back.
+    setTimeout(() => {
+      window.scrollTo({ top: props.top, behavior: "instant" });
+    }, 0);
+  });
+
   return (
     <ReactMarkdown
       components={{
@@ -34,7 +46,7 @@ export function MD(props: { md: string }): React.ReactElement {
       remarkPlugins={[remarkGfm, remarkMath]}
       rehypePlugins={[rehypeMathjax]}
     >
-      {props.md}
+      {String(pageContent)}
     </ReactMarkdown>
   );
 }

--- a/src/ui/React/Documentation.tsx
+++ b/src/ui/React/Documentation.tsx
@@ -9,6 +9,8 @@ export const Navigator = React.createContext<Navigator>({ navigate: () => undefi
 
 export const useNavigator = (): Navigator => useContext(Navigator);
 
+export const windowTopPositionOfPages = new Map<FilePath, number>();
+
 interface History {
   pages: FilePath[];
   page: FilePath;
@@ -59,13 +61,22 @@ export const HistoryProvider = (props: React.PropsWithChildren<object>): React.R
     page: defaultPage,
     pages: [],
     push(p: FilePath) {
-      setHistory((h) => onPush(h, p));
+      setHistory((h) => {
+        windowTopPositionOfPages.set(h.page, window.scrollY);
+        return onPush(h, p);
+      });
     },
     pop() {
-      setHistory((h) => onPop(h));
+      setHistory((h) => {
+        windowTopPositionOfPages.set(h.page, window.scrollY);
+        return onPop(h);
+      });
     },
     home() {
-      setHistory((h) => onHome(h));
+      setHistory((h) => {
+        windowTopPositionOfPages.set(h.page, window.scrollY);
+        return onHome(h);
+      });
     },
   });
   return <Provider value={history}>{props.children}</Provider>;


### PR DESCRIPTION
We always scroll the page to (0, 0). This is annoying when the player tries to switch between different documentation pages or game tabs. This PR fixes it.

I also make a change to "Back" and "Home" buttons. They are fixed at the top of the page now. The player can go back to the previous page or the home page without scrolling to the top of the page.