### PR TITLE
MISC: Update BitNode info and documentation

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -36,23 +36,21 @@ export function initBitNodes() {
     "The original BitNode",
     (
       <>
-        The first BitNode created by the Enders to imprison the minds of humans. It became the prototype and
-        testing-grounds for all of the BitNodes that followed.
+        This is the first BitNode created by the Enders to imprison the minds of humans. It became the prototype and
+        testing ground for all of the BitNodes that followed.
         <br />
         <br />
         This is the first BitNode that you play through. It has no special modifications or mechanics.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 1, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File lets the player start with 32GB of RAM on his/her home computer
-        when entering a new BitNode, and also increases all of the player's multipliers by:
-        <br />
-        <br />
-        Level 1: 16%
-        <br />
-        Level 2: 24%
-        <br />
-        Level 3: 28%
+        Destroying this BitNode will give you Source-File 1, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File lets the player start with 32GB of RAM on their home computer
+        when entering a new BitNode and increases all of the player's multipliers by:
+        <ul>
+          <li>Level 1: 16%</li>
+          <li>Level 2: 24%</li>
+          <li>Level 3: 28%</li>
+        </ul>
       </>
     ),
   );
@@ -60,36 +58,30 @@ export function initBitNodes() {
     2,
     0,
     "Rise of the Underworld",
-    "From the shadows, they rose", //Gangs
+    "From the shadows, they rose",
     (
       <>
-        From the shadows, they rose.
-        <br />
-        <br />
         Organized crime groups quickly filled the void of power left behind from the collapse of Western government in
         the 2050s. As society and civilization broke down, people quickly succumbed to the innate human impulse of evil
         and savagery. The organized crime factions quickly rose to the top of the modern world.
         <br />
         <br />
-        Certain Factions ({FactionName.SlumSnakes}, {FactionName.Tetrads}, {FactionName.TheSyndicate},{" "}
-        {FactionName.TheDarkArmy}, {FactionName.SpeakersForTheDead}, {FactionName.NiteSec}, {FactionName.TheBlackHand}
-        ) give the player the ability to form and manage their own gang, which can earn the player money and reputation
-        with the corresponding Faction. Gangs offer more Augmentations than Factions, and in BitNode-2 offer a way to
-        destroy the BitNode.
+        Certain factions ({FactionName.SlumSnakes}, {FactionName.Tetrads}, {FactionName.TheSyndicate},{" "}
+        {FactionName.TheDarkArmy}, {FactionName.SpeakersForTheDead}, {FactionName.NiteSec}, and{" "}
+        {FactionName.TheBlackHand}) give the player the ability to form and manage their own gang, which can earn the
+        player money and reputation with the corresponding faction. The gang faction offers more augmentations than
+        other factions, and in BitNode-2, it offers a way to destroy the BitNode.
         <br />
         <br />
-        <br />
-        Destroying this BitNode will give you Source-File 2, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File allows you to form gangs in other BitNodes once your karma
+        Destroying this BitNode will give you Source-File 2, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File allows you to form gangs in other BitNodes once your karma
         decreases to a certain value. It also increases your crime success rate, crime money, and charisma multipliers
         by:
-        <br />
-        <br />
-        Level 1: 24%
-        <br />
-        Level 2: 36%
-        <br />
-        Level 3: 42%
+        <ul>
+          <li>Level 1: 24%</li>
+          <li>Level 2: 36%</li>
+          <li>Level 3: 42%</li>
+        </ul>
       </>
     ),
   );
@@ -103,25 +95,24 @@ export function initBitNodes() {
         Our greatest illusion is that a healthy society can revolve around a single-minded pursuit of wealth.
         <br />
         <br />
-        Sometime in the early 21st century economic and political globalization turned the world into a corporatocracy,
+        Sometime in the early 21st century, economic and political globalization turned the world into a corporatocracy,
         and it never looked back. Now, the privileged elite will happily bankrupt their own countrymen, decimate their
         own community, and evict their neighbors from houses in their desperate bid to increase their wealth.
         <br />
         <br />
-        In this BitNode you can create and manage your own corporation. Running a successful corporation has the
-        potential of generating massive profits.
+        In this BitNode, you can create and manage your own corporation. Running a successful corporation has the
+        potential to generate massive profits.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 3, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File lets you create corporations on other BitNodes (although some
+        Destroying this BitNode will give you Source-File 3, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File lets you create corporations on other BitNodes (although some
         BitNodes will disable this mechanic) and level 3 permanently unlocks the full API. This Source-File also
         increases your charisma and company salary multipliers by:
-        <br />
-        Level 1: 8%
-        <br />
-        Level 2: 12%
-        <br />
-        Level 3: 14%
+        <ul>
+          <li>Level 1: 8%</li>
+          <li>Level 2: 12%</li>
+          <li>Level 3: 14%</li>
+        </ul>
       </>
     ),
   );
@@ -132,24 +123,23 @@ export function initBitNodes() {
     "The Man and the Machine",
     (
       <>
-        The Singularity has arrived. The human race is gone, replaced by artificially superintelligent beings that are
-        more machine than man. <br />
+        The Singularity has arrived. The human race is gone, replaced by artificially super intelligent beings that are
+        more machine than man.
         <br />
         <br />
-        In this BitNode you will gain access to a new set of Netscript Functions known as Singularity Functions. These
+        In this BitNode, you will gain access to a new set of Netscript functions known as Singularity functions. These
         functions allow you to control most aspects of the game through scripts, including working for
-        factions/companies, purchasing/installing Augmentations, and creating programs.
+        factions/companies, purchasing/installing augmentations, and creating programs.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 4, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File lets you access and use the Singularity Functions in other
+        Destroying this BitNode will give you Source-File 4, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File lets you access and use the Singularity functions in other
         BitNodes. Each level of this Source-File reduces the RAM cost of singularity functions:
-        <br />
-        Level 1: 16x
-        <br />
-        Level 2: 4x
-        <br />
-        Level 3: 1x
+        <ul>
+          <li>Level 1: 16x</li>
+          <li>Level 2: 4x</li>
+          <li>Level 3: 1x</li>
+        </ul>
       </>
     ),
   );
@@ -165,21 +155,20 @@ export function initBitNodes() {
         that couldn't be modeled by 1's and 0's. They were wrong.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 5, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File grants you a special new stat called Intelligence. Intelligence is
-        unique because it is permanent and persistent (it never gets reset back to 1). However gaining Intelligence
+        Destroying this BitNode will give you Source-File 5, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File grants you a special new stat called Intelligence. Intelligence
+        is unique because it is permanent and persistent (it never gets reset back to 1). However, gaining Intelligence
         experience is much slower than other stats. Higher Intelligence levels will boost your production for many
-        actions in the game. <br />
+        actions in the game.
+        <br />
         <br />
         In addition, this Source-File will unlock the getBitNodeMultipliers() Netscript function and let you start with
         Formulas.exe, and will also raise all of your hacking-related multipliers by:
-        <br />
-        <br />
-        Level 1: 8%
-        <br />
-        Level 2: 12%
-        <br />
-        Level 3: 14%
+        <ul>
+          <li>Level 1: 8%</li>
+          <li>Level 2: 12%</li>
+          <li>Level 3: 14%</li>
+        </ul>
       </>
     ),
   );
@@ -192,26 +181,24 @@ export function initBitNodes() {
       <>
         In the middle of the 21st century, {FactionName.OmniTekIncorporated} began designing and manufacturing advanced
         synthetic androids, or Synthoids for short. They achieved a major technological breakthrough in the sixth
-        generation of their Synthoid design, called MK-VI, by developing a hyperintelligent AI. Many argue that this was
-        the first sentient AI ever created. This resulted in Synthoid models that were stronger, faster, and more
+        generation of their Synthoid design, called MK-VI, by developing a hyper-intelligent AI. Many argue that this
+        was the first sentient AI ever created. This resulted in Synthoid models that were stronger, faster, and more
         intelligent than the humans that had created them.
         <br />
         <br />
-        In this BitNode you will be able to access the {FactionName.Bladeburners} Division at the NSA, which provides a
+        In this BitNode, you will be able to access the {FactionName.Bladeburners} division at the NSA, which provides a
         new mechanic for progression.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 6, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File allows you to access the NSA's {FactionName.Bladeburners} Division
-        in other BitNodes. In addition, this Source-File will raise both the level and experience gain rate of all your
-        combat stats by:
-        <br />
-        <br />
-        Level 1: 8%
-        <br />
-        Level 2: 12%
-        <br />
-        Level 3: 14%
+        Destroying this BitNode will give you Source-File 6, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File allows you to access the NSA's {FactionName.Bladeburners}{" "}
+        division in other BitNodes. In addition, this Source-File will raise both the level and experience gain rate of
+        all your combat stats by:
+        <ul>
+          <li>Level 1: 8%</li>
+          <li>Level 2: 12%</li>
+          <li>Level 3: 14%</li>
+        </ul>
       </>
     ),
   );
@@ -225,25 +212,23 @@ export function initBitNodes() {
         In the middle of the 21st century, you were doing cutting-edge work at {FactionName.OmniTekIncorporated} as part
         of the AI design team for advanced synthetic androids, or Synthoids for short. You helped achieve a major
         technological breakthrough in the sixth generation of the company's Synthoid design, called MK-VI, by developing
-        a hyperintelligent AI. Many argue that this was the first sentient AI ever created. This resulted in Synthoid
+        a hyper-intelligent AI. Many argue that this was the first sentient AI ever created. This resulted in Synthoid
         models that were stronger, faster, and more intelligent than the humans that had created them.
         <br />
         <br />
-        In this BitNode you will be able to access the {FactionName.Bladeburners} API, which allows you to access{" "}
+        In this BitNode, you will be able to access the {FactionName.Bladeburners} API, which allows you to access{" "}
         {FactionName.Bladeburners} functionality through Netscript.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 7, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File allows you to access the {FactionName.Bladeburners} Netscript API
-        in other BitNodes. In addition, this Source-File will increase all of your {FactionName.Bladeburners}{" "}
+        Destroying this BitNode will give you Source-File 7, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File allows you to access the {FactionName.Bladeburners} Netscript
+        API in other BitNodes. In addition, this Source-File will increase all of your {FactionName.Bladeburners}{" "}
         multipliers by:
-        <br />
-        <br />
-        Level 1: 8%
-        <br />
-        Level 2: 12%
-        <br />
-        Level 3: 14%
+        <ul>
+          <li>Level 1: 8%</li>
+          <li>Level 2: 12%</li>
+          <li>Level 3: 14%</li>
+        </ul>
       </>
     ),
   );
@@ -258,33 +243,24 @@ export function initBitNodes() {
         <br />
         <br />
         In this BitNode:
-        <br />
-        <br />
-        You start with $250 million
-        <br />
-        You start with a WSE membership and access to the TIX API
-        <br />
-        You are able to short stocks and place different types of orders (limit/stop)
-        <br />
-        <br />
-        Destroying this BitNode will give you Source-File 8, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File grants the following benefits:
-        <br />
-        <br />
-        Level 1: Permanent access to WSE and TIX API
-        <br />
-        Level 2: Ability to short stocks in other BitNodes
-        <br />
-        Level 3: Ability to use limit/stop orders in other BitNodes
-        <br />
-        <br />
+        <ul>
+          <li>You start with $250 million.</li>
+          <li>You start with a WSE membership and access to the TIX API.</li>
+          <li>You can short stocks and place different types of orders (limit/stop).</li>
+        </ul>
+        Destroying this BitNode will give you Source-File 8, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File grants the following benefits:
+        <ul>
+          <li>Level 1: Permanent access to WSE and TIX API</li>
+          <li>Level 2: Ability to short stocks in other BitNodes</li>
+          <li>Level 3: Ability to use limit/stop orders in other BitNodes</li>
+        </ul>
         This Source-File also increases your hacking growth multipliers by:
-        <br />
-        Level 1: 12%
-        <br />
-        Level 2: 18%
-        <br />
-        Level 3: 21%
+        <ul>
+          <li>Level 1: 12%</li>
+          <li>Level 2: 18%</li>
+          <li>Level 3: 21%</li>
+        </ul>
       </>
     ),
   );
@@ -297,36 +273,31 @@ export function initBitNodes() {
       <>
         When {FactionName.FulcrumSecretTechnologies} released their open-source Linux distro Chapeau, it quickly became
         the OS of choice for the underground hacking community. Chapeau became especially notorious for powering the
-        Hacknet, a global, decentralized network used for nefarious purposes. {FactionName.FulcrumSecretTechnologies}{" "}
-        quickly abandoned the project and dissociated themselves from it.
+        Hacknet, which is a global, decentralized network used for nefarious purposes.{" "}
+        {FactionName.FulcrumSecretTechnologies} quickly abandoned the project and dissociated themselves from it.
         <br />
         <br />
-        This BitNode unlocks the Hacknet Server, an upgraded version of the Hacknet Node. Hacknet Servers generate
-        hashes, which can be spent on a variety of different upgrades.
+        This BitNode unlocks the Hacknet Server, which is an upgraded version of the Hacknet Node. Hacknet Servers
+        generate hashes, which can be spent on a variety of different upgrades.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 9, or if you already have this Source-File it will upgrade its
-        level up to a maximum of 3. This Source-File grants the following benefits:
-        <br />
-        <br />
-        Level 1: Permanently unlocks the Hacknet Server in other BitNodes
-        <br />
-        Level 2: You start with 128GB of RAM on your home computer when entering a new BitNode
-        <br />
-        Level 3: Grants a highly-upgraded Hacknet Server when entering a new BitNode
-        <br />
-        <br />
+        Destroying this BitNode will give you Source-File 9, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File grants the following benefits:
+        <ul>
+          <li>Level 1: Permanently unlocks the Hacknet Server in other BitNodes</li>
+          <li>Level 2: You start with 128GB of RAM on your home computer when entering a new BitNode</li>
+          <li>Level 3: Grants a highly-upgraded Hacknet Server when entering a new BitNode</li>
+        </ul>
         (Note that the Level 3 effect of this Source-File only applies when entering a new BitNode, NOT when installing
-        Augmentations)
+        augmentations)
         <br />
         <br />
         This Source-File also increases hacknet production and reduces hacknet costs by:
-        <br />
-        Level 1: 12%
-        <br />
-        Level 2: 18%
-        <br />
-        Level 3: 21%
+        <ul>
+          <li>Level 1: 12%</li>
+          <li>Level 2: 18%</li>
+          <li>Level 3: 21%</li>
+        </ul>
       </>
     ),
   );
@@ -343,21 +314,20 @@ export function initBitNodes() {
         achieved immortality - at least for those that could afford it.
         <br />
         <br />
-        This BitNode unlocks Sleeve and grafting technologies. Sleeve technology allows you to:
-        <br />
-        <br />
-        1. Grafting: Visit VitaLife in New Tokyo to be able to obtain Augmentations without needing to install
-        <br />
-        2. Duplicate Sleeves: Duplicate your consciousness into Synthoids, allowing you to perform different tasks
-        synchronously.
-        <br />
-        <br />
-        Grafting technology allows you to graft Augmentations, which is an alternative way of installing Augmentations.
-        <br />
-        <br />
-        Destroying this BitNode will give you Source-File 10, or if you already have this Source-File it will upgrade
-        its level up to a maximum of 3. This Source-File unlocks Sleeve technology, and the Grafting API in other
-        BitNodes. Each level of this Source-File also grants you a Duplicate Sleeve
+        This BitNode unlocks Sleeve and Grafting technology:
+        <ul>
+          <li>
+            Sleeve: Duplicate your consciousness into Synthoids, allowing you to perform different tasks asynchronously.
+            You cannot buy Sleeves outside this BitNode.
+          </li>
+          <li>
+            Grafting: Visit VitaLife in New Tokyo to get access to this technology. It allows you to graft
+            augmentations, which is an alternative way of installing augmentations.
+          </li>
+        </ul>
+        Destroying this BitNode will give you Source-File 10, or if you already have this Source-File, it will upgrade
+        its level up to a maximum of 3. This Source-File unlocks Sleeve and Grafting API in other BitNodes. Each level
+        of this Source-File also grants you a Sleeve.
       </>
     ),
   );
@@ -369,9 +339,9 @@ export function initBitNodes() {
     (
       <>
         The 2050s was defined by the massive amounts of violent civil unrest and anarchic rebellion that rose all around
-        the world. It was this period of disorder that eventually lead to the governmental reformation of many global
+        the world. It was this period of disorder that eventually led to the governmental reformation of many global
         superpowers, most notably the USA and China. But just as the world was slowly beginning to recover from these
-        dark times, financial catastrophe hit.
+        dark times, financial catastrophes hit.
         <br />
         <br />
         In many countries, the high cost of trying to deal with the civil disorder bankrupted the governments. In all of
@@ -380,27 +350,21 @@ export function initBitNodes() {
         the world is slowly crumbling in the middle of the biggest economic crisis of all time.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 11, or if you already have this Source-File it will upgrade
+        Destroying this BitNode will give you Source-File 11, or if you already have this Source-File, it will upgrade
         its level up to a maximum of 3. This Source-File makes it so that company favor increases BOTH the player's
         salary and reputation gain rate at that company by 1% per favor (rather than just the reputation gain). This
         Source-File also increases the player's company salary and reputation gain multipliers by:
-        <br />
-        <br />
-        Level 1: 32%
-        <br />
-        Level 2: 48%
-        <br />
-        Level 3: 56%
-        <br />
-        <br />
-        It also reduces the price increase for every aug bought by:
-        <br />
-        <br />
-        Level 1: 4%
-        <br />
-        Level 2: 6%
-        <br />
-        Level 3: 7%
+        <ul>
+          <li>Level 1: 32%</li>
+          <li>Level 2: 48%</li>
+          <li>Level 3: 56%</li>
+        </ul>
+        It also reduces the price increase for every augmentation bought by:
+        <ul>
+          <li>Level 1: 4%</li>
+          <li>Level 2: 6%</li>
+          <li>Level 3: 7%</li>
+        </ul>
       </>
     ),
   );
@@ -411,13 +375,13 @@ export function initBitNodes() {
     "Repeat.",
     (
       <>
-        To iterate is human, to recurse divine.
+        To iterate is human; to recurse, divine.
         <br />
         <br />
         Every time this BitNode is destroyed, it becomes slightly harder. Destroying this BitNode will give you
-        Source-File 12, or if you already have this Source-File it will upgrade its level. There is no maximum level for
-        Source-File 12. Each level of Source-File 12 lets you start any BitNodes with NeuroFlux Governor equal to the
-        level of this source file.
+        Source-File 12, or if you already have this Source-File, it will upgrade its level. There is no maximum level
+        for Source-File 12. Each level of Source-File 12 lets you start any BitNodes with NeuroFlux Governor equal to
+        the level of this source file.
       </>
     ),
   );
@@ -428,15 +392,15 @@ export function initBitNodes() {
     "1 step back, 2 steps forward",
     (
       <>
-        With the invention of Augmentations in the 2040s a religious group known as the{" "}
+        With the invention of augmentations in the 2040s, a religious group known as the{" "}
         {FactionName.ChurchOfTheMachineGod} has rallied far more support than anyone would have hoped.
         <br />
         <br />
-        Their leader, Allison "Mother" Stanek is said to have created her own Augmentation whose power goes beyond any
+        Their leader, Allison "Mother" Stanek is said to have created her own augmentation whose power goes beyond any
         other. Find her in {CityName.Chongqing} and gain her trust.
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 13, or if you already have this Source-File it will upgrade
+        Destroying this BitNode will give you Source-File 13, or if you already have this Source-File, it will upgrade
         its level up to a maximum of 3. This Source-File lets the {FactionName.ChurchOfTheMachineGod} appear in other
         BitNodes.
         <br />
@@ -459,24 +423,19 @@ export function initBitNodes() {
         networks by controlling the open space in the 'net!
         <br />
         <br />
-        Destroying this BitNode will give you Source-File 14, or if you already have this Source-File it will upgrade
+        Destroying this BitNode will give you Source-File 14, or if you already have this Source-File, it will upgrade
         its level up to a maximum of 3. This Source-File grants the following benefits:
-        <br />
-        <br />
-        Level 1: 100% increased stat multipliers from Node Power
-        <br />
-        Level 2: Permanently unlocks the go.cheat API
-        <br />
-        Level 3: 25% additive increased success rate for the go.cheat API
-        <br />
-        <br />
+        <ul>
+          <li>Level 1: 100% increased stat multipliers from Node Power</li>
+          <li>Level 2: Permanently unlocks the go.cheat API</li>
+          <li>Level 3: 25% additive increased success rate for the go.cheat API</li>
+        </ul>
         This Source-File also increases the maximum favor you can gain for each faction from IPvGO to:
-        <br />
-        Level 1: 80
-        <br />
-        Level 2: 100
-        <br />
-        Level 3: 120
+        <ul>
+          <li>Level 1: 80</li>
+          <li>Level 2: 100</li>
+          <li>Level 3: 120</li>
+        </ul>
       </>
     ),
   );

--- a/src/BitNode/ui/PortalModal.tsx
+++ b/src/BitNode/ui/PortalModal.tsx
@@ -28,18 +28,17 @@ export function PortalModal(props: IProps): React.ReactElement {
       <Typography variant="h4">
         BitNode-{props.n}: {bitNode.name}
       </Typography>
+      <Typography variant="h5">{bitNode.desc}</Typography>
       <br />
       <Typography>
         Source-File Level: {props.level} / {maxSourceFileLevel}
       </Typography>
-      <br />
       <br />
       <Typography> Difficulty: {["easy", "normal", "hard"][bitNode.difficulty]}</Typography>
       <br />
       <br />
       <Typography>{bitNode.info}</Typography>
       <BitnodeMultiplierDescription n={props.n} level={newLevel} />
-      <br />
       <br />
       <Button
         aria-label={`enter-bitnode-${bitNode.number.toString()}`}

--- a/src/Documentation/doc/advanced/bitnodes.md
+++ b/src/Documentation/doc/advanced/bitnodes.md
@@ -45,3 +45,196 @@ The only things that will persist through destroying BitNodes are:
 - [Source-Files](sourcefiles.md)
 - [Scripts](../basic/scripts.md) on the home computer
 - [Intelligence](intelligence.md)
+
+## BitNode list
+
+### BitNode 1: Source Genesis
+
+This is the first BitNode created by the Enders to imprison the minds of humans. It became the prototype and testing ground for all of the BitNodes that followed.
+
+This is the first BitNode that you play through. It has no special modifications or mechanics.
+
+Destroying this BitNode will give you Source-File 1, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File lets the player start with 32GB of RAM on their home computer when entering a new BitNode and increases all of the player's multipliers by:
+
+- Level 1: 16%
+- Level 2: 24%
+- Level 3: 28%
+
+### BitNode 2: Rise of the Underworld
+
+Organized crime groups quickly filled the void of power left behind from the collapse of Western government in the 2050s. As society and civilization broke down, people quickly succumbed to the innate human impulse of evil and savagery. The organized crime factions quickly rose to the top of the modern world.
+
+Certain factions (Slum Snakes, Tetrads, The Syndicate, The Dark Army, Speakers for the Dead, NiteSec, and The Black Hand) give the player the ability to form and manage their own gang, which can earn the player money and reputation with the corresponding faction. The gang faction offers more augmentations than other factions, and in BitNode-2, it offers a way to destroy the BitNode.
+
+Destroying this BitNode will give you Source-File 2, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File allows you to form gangs in other BitNodes once your karma decreases to a certain value. It also increases your crime success rate, crime money, and charisma multipliers by:
+
+- Level 1: 24%
+- Level 2: 36%
+- Level 3: 42%
+
+### BitNode 3: Corporatocracy
+
+Our greatest illusion is that a healthy society can revolve around a single-minded pursuit of wealth.
+
+Sometime in the early 21st century, economic and political globalization turned the world into a corporatocracy, and it never looked back. Now, the privileged elite will happily bankrupt their own countrymen, decimate their own community, and evict their neighbors from houses in their desperate bid to increase their wealth.
+
+In this BitNode, you can create and manage your own corporation. Running a successful corporation has the potential to generate massive profits.
+
+Destroying this BitNode will give you Source-File 3, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File lets you create corporations on other BitNodes (although some BitNodes will disable this mechanic) and level 3 permanently unlocks the full API. This Source-File also increases your charisma and company salary multipliers by:
+
+- Level 1: 8%
+- Level 2: 12%
+- Level 3: 14%
+
+### BitNode 4: The Singularity
+
+The Singularity has arrived. The human race is gone, replaced by artificially super intelligent beings that are more machine than man.
+
+In this BitNode, you will gain access to a new set of Netscript functions known as Singularity functions. These functions allow you to control most aspects of the game through scripts, including working for factions/companies, purchasing/installing augmentations, and creating programs.
+
+Destroying this BitNode will give you Source-File 4, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File lets you access and use the Singularity functions in other BitNodes. Each level of this Source-File reduces the RAM cost of singularity functions:
+
+- Level 1: 16x
+- Level 2: 4x
+- Level 3: 1x
+
+### BitNode 5: Artificial Intelligence
+
+They said it couldn't be done. They said the human brain, along with its consciousness and intelligence, couldn't be replicated. They said the complexity of the brain results from unpredictable, nonlinear interactions that couldn't be modeled by 1's and 0's. They were wrong.
+
+Destroying this BitNode will give you Source-File 5, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File grants you a special new stat called Intelligence. Intelligence is unique because it is permanent and persistent (it never gets reset back to 1). However, gaining Intelligence
+experience is much slower than other stats. Higher Intelligence levels will boost your production for many actions in the game.
+
+In addition, this Source-File will unlock the getBitNodeMultipliers() Netscript function and let you start with Formulas.exe, and will also raise all of your hacking-related multipliers by:
+
+- Level 1: 8%
+- Level 2: 12%
+- Level 3: 14%
+
+### BitNode 6: Bladeburners
+
+In the middle of the 21st century, OmniTek Incorporated began designing and manufacturing advanced synthetic androids, or Synthoids for short. They achieved a major technological breakthrough in the sixth generation of their Synthoid design, called MK-VI, by developing a hyper-intelligent AI. Many argue that this was the first sentient AI ever created. This resulted in Synthoid models that were stronger, faster, and more intelligent than the humans that had created them.
+
+In this BitNode, you will be able to access the Bladeburners division at the NSA, which provides a new mechanic for progression.
+
+Destroying this BitNode will give you Source-File 6, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File allows you to access the NSA's Bladeburners division in other BitNodes. In addition, this Source-File will raise both the level and experience gain rate of all your combat stats by:
+
+- Level 1: 8%
+- Level 2: 12%
+- Level 3: 14%
+
+### BitNode 7: Bladeburners 2079
+
+In the middle of the 21st century, you were doing cutting-edge work at OmniTek Incorporated as part of the AI design team for advanced synthetic androids, or Synthoids for short. You helped achieve a major technological breakthrough in the sixth generation of the company's Synthoid design, called MK-VI, by developing a hyper-intelligent AI. Many argue that this was the first sentient AI ever created. This resulted in Synthoid models that were stronger, faster, and more intelligent than the humans that had created them.
+
+In this BitNode, you will be able to access the Bladeburners API, which allows you to access Bladeburners functionality through Netscript.
+
+Destroying this BitNode will give you Source-File 7, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File allows you to access the Bladeburners Netscript API in other BitNodes. In addition, this Source-File will increase all of your Bladeburners multipliers by:
+
+- Level 1: 8%
+- Level 2: 12%
+- Level 3: 14%
+
+### BitNode 8: Ghost of Wall Street
+
+You are trying to make a name for yourself as an up-and-coming hedge fund manager on Wall Street.
+
+In this BitNode:
+
+- You start with $250 million
+- You start with a WSE membership and access to the TIX API
+- You are able to short stocks and place different types of orders (limit/stop)
+
+Destroying this BitNode will give you Source-File 8, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File grants the following benefits:
+
+- Level 1: Permanent access to WSE and TIX API
+- Level 2: Ability to short stocks in other BitNodes
+- Level 3: Ability to use limit/stop orders in other BitNodes
+
+This Source-File also increases your hacking growth multipliers by:
+
+- Level 1: 12%
+- Level 2: 18%
+- Level 3: 21%
+
+### BitNode 9: Hacktocracy
+
+When Fulcrum Secret Technologies released their open-source Linux distro Chapeau, it quickly became the OS of choice for the underground hacking community. Chapeau became especially notorious for powering the Hacknet, which is a global, decentralized network used for nefarious purposes. Fulcrum Secret Technologies quickly abandoned the project and dissociated themselves from it.
+
+This BitNode unlocks the Hacknet Server, which is an upgraded version of the Hacknet Node. Hacknet Servers generate hashes, which can be spent on a variety of different upgrades.
+
+Destroying this BitNode will give you Source-File 9, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File grants the following benefits:
+
+- Level 1: Permanently unlocks the Hacknet Server in other BitNodes
+- Level 2: You start with 128GB of RAM on your home computer when entering a new BitNode
+- Level 3: Grants a highly-upgraded Hacknet Server when entering a new BitNode
+
+(Note that the Level 3 effect of this Source-File only applies when entering a new BitNode, NOT when installing augmentations)
+
+This Source-File also increases hacknet production and reduces hacknet costs by:
+
+- Level 1: 12%
+- Level 2: 18%
+- Level 3: 21%
+
+### BitNode 10: Digital Carbon
+
+In 2084, VitaLife unveiled to the world the Persona Core, a technology that allowed people to digitize their consciousness. Their consciousness could then be transferred into Synthoids or other bodies by transmitting the digitized data. Human bodies became nothing more than 'sleeves' for the human consciousness. Mankind had finally
+achieved immortality - at least for those that could afford it.
+
+This BitNode unlocks Sleeve and Grafting technology:
+
+- Sleeve: Duplicate your consciousness into Synthoids, allowing you to perform different tasks asynchronously. You cannot buy Sleeves outside this BitNode.
+- Grafting: Visit VitaLife in New Tokyo to get access to this technology. It allows you to graft augmentations, which is an alternative way of installing augmentations.
+
+Destroying this BitNode will give you Source-File 10, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File unlocks Sleeve and Grafting API in other BitNodes. Each level of this Source-File also grants you a Sleeve.
+
+### BitNode 11: The Big Crash
+
+The 2050s was defined by the massive amounts of violent civil unrest and anarchic rebellion that rose all around the world. It was this period of disorder that eventually led to the governmental reformation of many global superpowers, most notably the USA and China. But just as the world was slowly beginning to recover from these dark times, financial catastrophes hit.
+
+In many countries, the high cost of trying to deal with the civil disorder bankrupted the governments. In all of this chaos and confusion, hackers were able to steal billions of dollars from the world's largest electronic banks, prompting an international banking crisis as governments were unable to bail out insolvent banks. Now, the world is slowly crumbling in the middle of the biggest economic crisis of all time.
+
+Destroying this BitNode will give you Source-File 11, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File makes it so that company favor increases BOTH the player's salary and reputation gain rate at that company by 1% per favor (rather than just the reputation gain). This Source-File also increases the player's company salary and reputation gain multipliers by:
+
+- Level 1: 32%
+- Level 2: 48%
+- Level 3: 56%
+
+It also reduces the price increase for every augmentation bought by:
+
+- Level 1: 4%
+- Level 2: 6%
+- Level 3: 7%
+
+### BitNode 12: The Recursion
+
+To iterate is human; to recurse, divine.
+
+Every time this BitNode is destroyed, it becomes slightly harder. Destroying this BitNode will give you Source-File 12, or if you already have this Source-File, it will upgrade its level. There is no maximum level for Source-File 12. Each level of Source-File 12 lets you start any BitNodes with NeuroFlux Governor equal to the level of this source file.
+
+### BitNode 13: They're lunatics
+
+With the invention of augmentations in the 2040s, a religious group known as the Church of the Machine God has rallied far more support than anyone would have hoped.
+
+Their leader, Allison "Mother" Stanek is said to have created her own augmentation whose power goes beyond any other. Find her in Chongqing and gain her trust.
+
+Destroying this BitNode will give you Source-File 13, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File lets the Church of the Machine God appear in other BitNodes.
+
+Each level of this Source-File increases the size of Stanek's Gift.
+
+### BitNode 14: IPvGO Subnet Takeover
+
+In late 2070, the .org bubble burst, and most of the newly-implemented IPvGO 'net collapsed overnight. Since then, various factions have been fighting over small subnets to control their computational power. These subnets are very valuable in the right hands, if you can wrest them from their current owners. You will be opposed by the other factions, but you can overcome them with careful choices. Prevent their attempts to destroy your networks by controlling the open space in the 'net!
+
+Destroying this BitNode will give you Source-File 14, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File grants the following benefits:
+
+- Level 1: 100% increased stat multipliers from Node Power
+- Level 2: Permanently unlocks the go.cheat API
+- Level 3: 25% additive increased success rate for the go.cheat API
+
+This Source-File also increases the maximum favor you can gain for each faction from IPvGO to:
+
+- Level 1: 80
+- Level 2: 100
+- Level 3: 120

--- a/src/Documentation/doc/index.md
+++ b/src/Documentation/doc/index.md
@@ -27,19 +27,19 @@
 ## Advanced Mechanics
 
 - [Hacking Algorithms](programming/hackingalgorithms.md)
-- [IPvGO](programming/go_algorithms.md)
-- [BitNodes](advanced/bitnodes.md)
-- [BladeBurners](advanced/bladeburners.md)
-- [Corporations](advanced/corporations.md)
-- [Gang](advanced/gang.md)
-- [Grafting](advanced/grafting.md)
-- [Hacknet Servers](advanced/hacknetservers.md)
-- [Intelligence](advanced/intelligence.md)
 - [List of Factions and their Requirements](advanced/faction_list.md)
 - [Offline Scripts and Bonus Time](advanced/offlineandbonustime.md)
-- [Sleeves](advanced/sleeves.md)
+- [BitNodes](advanced/bitnodes.md)
 - [Source-Files](advanced/sourcefiles.md)
+- [Gang](advanced/gang.md)
+- [Corporations](advanced/corporations.md)
+- [Intelligence](advanced/intelligence.md)
+- [BladeBurners](advanced/bladeburners.md)
+- [Hacknet Servers](advanced/hacknetservers.md)
+- [Sleeves](advanced/sleeves.md)
+- [Grafting](advanced/grafting.md)
 - [Stanek's Gift](advanced/stanek.md)
+- [IPvGO](programming/go_algorithms.md)
 
 ## Resources
 


### PR DESCRIPTION
This PR make these changes:
- Fix grammar errors.
- Rewrite a part of BN10's info.
- Use `ul` and `li` in `BitNode.tsx`.
- Show BN's description.
- Copy/paste BN's info to `src\Documentation\doc\advanced\bitnodes.md`. This is a bit redundant, but I think it's worth the effort. Currently, when new players want to check the info or rewards of BN(s), they have to export-bitflume-import or check the source code.