### PR TITLE
TRAVEL: Unify implementation for Player and Sleeves (and some followup for #1365)

### DIFF
--- a/src/PersonObjects/Person.ts
+++ b/src/PersonObjects/Person.ts
@@ -51,6 +51,7 @@ export abstract class Person implements IPerson {
   regenerateHp = personMethods.regenerateHp;
   updateSkillLevels = personMethods.updateSkillLevels;
   hasAugmentation = personMethods.hasAugmentation;
+  travel = personMethods.travel;
   calculateSkill = calculateSkill; //Class version is equal to imported version
 
   /** Reset all multipliers to 1 */

--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -1,8 +1,10 @@
+import type { CityName } from "@enums";
 import { Person } from "./Person";
 import { calculateSkill } from "./formulas/skill";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { Player } from "@player";
 import { WorkStats } from "@nsdefs";
+import { CONSTANTS } from "../Constants";
 
 export function gainHackingExp(this: Person, exp: number): void {
   if (isNaN(exp)) {
@@ -166,4 +168,16 @@ export function hasAugmentation(this: Person, augName: string, ignoreQueued = fa
     return true;
   }
   return false;
+}
+
+/** Travel to another City. Costs money from player regardless of which person is traveling */
+export function travel(this: Person, cityName: CityName): boolean {
+  if (!Player.canAfford(CONSTANTS.TravelCost)) {
+    return false;
+  }
+
+  Player.loseMoney(CONSTANTS.TravelCost, "sleeves");
+  this.city = cityName;
+
+  return true;
 }

--- a/src/PersonObjects/Player/PlayerObject.ts
+++ b/src/PersonObjects/Player/PlayerObject.ts
@@ -110,7 +110,6 @@ export class PlayerObject extends Person implements IPlayer {
   startFocusing = generalMethods.startFocusing;
   startGang = gangMethods.startGang;
   takeDamage = generalMethods.takeDamage;
-  travel = generalMethods.travel;
   giveExploit = generalMethods.giveExploit;
   giveAchievement = generalMethods.giveAchievement;
   getCasinoWinnings = generalMethods.getCasinoWinnings;

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -28,8 +28,6 @@ import { Faction } from "../../Faction/Faction";
 import { Factions } from "../../Faction/Factions";
 import { FactionInvitationEvents } from "../../Faction/ui/FactionInvitationManager";
 import { resetGangs } from "../../Gang/AllGangs";
-import { Cities } from "../../Locations/Cities";
-import { Locations } from "../../Locations/Locations";
 import { Sleeve } from "../Sleeve/Sleeve";
 import { SleeveWorkType } from "../Sleeve/Work/Work";
 import { calculateSkillProgress as calculateSkillProgressF, ISkillProgress } from "../formulas/skill";
@@ -532,26 +530,8 @@ export function gainCodingContractReward(
   }
 }
 
-export function travel(this: PlayerObject, cityName: CityName): boolean {
-  if (Cities[cityName] == null) {
-    throw new Error(`Player.travel() was called with an invalid city: ${cityName}`);
-  }
-  if (!this.canAfford(CONSTANTS.TravelCost)) {
-    return false;
-  }
-
-  this.loseMoney(CONSTANTS.TravelCost, "other");
-  this.city = cityName;
-
-  return true;
-}
-
 export function gotoLocation(this: PlayerObject, to: LocationName): boolean {
-  if (Locations[to] == null) {
-    throw new Error(`Player.gotoLocation() was called with an invalid location: ${to}`);
-  }
   this.location = to;
-
   return true;
 }
 

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -44,7 +44,6 @@ import { SleeveCrimeWork } from "./Work/SleeveCrimeWork";
 import * as sleeveMethods from "./SleeveMethods";
 import { calculateIntelligenceBonus } from "../formulas/intelligence";
 import { getEnumHelper } from "../../utils/EnumHelper";
-import { Cities } from "../../Locations/Cities";
 
 export class Sleeve extends Person implements SleevePerson {
   currentWork: SleeveWork | null = null;
@@ -252,21 +251,6 @@ export class Sleeve extends Person implements SleevePerson {
         location: loc,
       }),
     );
-    return true;
-  }
-
-  /** Travel to another City. Costs money from player */
-  travel(cityName: CityName): boolean {
-    if (Cities[cityName] == null) {
-      throw new Error(`Sleeve.travel() was called with an invalid city: ${cityName}`);
-    }
-    if (!Player.canAfford(CONSTANTS.TravelCost)) {
-      return false;
-    }
-
-    Player.loseMoney(CONSTANTS.TravelCost, "sleeves");
-    this.city = cityName;
-
     return true;
   }
 

--- a/src/PersonObjects/Sleeve/ui/TravelModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/TravelModal.tsx
@@ -9,16 +9,16 @@ import { Settings } from "../../../Settings/Settings";
 import { dialogBoxCreate } from "../../../ui/React/DialogBox";
 import { Modal } from "../../../ui/React/Modal";
 
-interface IProps {
+interface TravelModalProps {
   open: boolean;
   onClose: () => void;
   sleeve: Sleeve;
   rerender: () => void;
 }
 
-export function TravelModal(props: IProps): React.ReactElement {
-  function travel(city: string): void {
-    if (!props.sleeve.travel(city as CityName)) {
+export function TravelModal(props: TravelModalProps): React.ReactElement {
+  function travel(city: CityName): void {
+    if (!props.sleeve.travel(city)) {
       dialogBoxCreate("You cannot afford to have this sleeve travel to another city");
       return;
     }
@@ -36,13 +36,13 @@ export function TravelModal(props: IProps): React.ReactElement {
           also set your current sleeve task to idle.
         </Typography>
         {Settings.DisableASCIIArt ? (
-          Object.values(CityName).map((city: CityName) => (
+          Object.values(CityName).map((city) => (
             <Button key={city} onClick={() => travel(city)}>
               {city}
             </Button>
           ))
         ) : (
-          <WorldMap currentCity={props.sleeve.city} onTravel={(city: CityName) => travel(city)} />
+          <WorldMap currentCity={props.sleeve.city} onTravel={travel} />
         )}
       </>
     </Modal>


### PR DESCRIPTION
Just some minor followup while reviewing PRs that got merged recently. @catloversg FYI

I think the only thing added in #1365 that was an issue was some unnecessary typechecking code in the travel functions, but the other changes are all in the same modified code.

* Player.travel and Sleeve.travel moved to Person.travel (they were identical implementations)
* Removed some unnecessary typechecking code in travel and goToLocation (parameters already strongly typed, requiring typechecking before calling the function)
* In TravelModal, removed an `as CityName` assertion and some other unnecessary typecode.