### PR TITLE
INFILTRATION: Follow-up of #1414

### DIFF
--- a/src/utils/Protections.ts
+++ b/src/utils/Protections.ts
@@ -7,3 +7,17 @@ Object.defineProperties(window, {
   Object: { writable: false },
   String: { writable: false },
 });
+
+/**
+ * Automated infiltration scripts usually intercept document.addEventListener and document.removeEventListener.
+ */
+Object.defineProperty(document, "addEventListener", {
+  writable: false,
+  configurable: false,
+  value: document.addEventListener,
+});
+Object.defineProperty(document, "removeEventListener", {
+  writable: false,
+  configurable: false,
+  value: document.removeEventListener,
+});


### PR DESCRIPTION
Snarling merged #1414 before I could commit this change, so I submitted it as a separate PR.

I agree with some of Snarling's points in #1414. Generally, we should not play the whack-a-mole game with our players when it comes to UI-based exploits like automated infiltration. Just as Snarling said, the protections in that PR can be bypassed, and it's hard to make it bulletproof. However, IMO, it's too easy to bypass the new check. The popular automated infiltration script only needs to add 1 line to bypass the check. This PR adds 1 more protection layer.

I understand that this change makes it look like we are starting an unnecessary "fight" with our players. I agree that we should not add more and more protection layers because they will eventually find a way to bypass our checks. I'm fine if this PR is closed.