### PR TITLE
GANG: Fix ns.gang.getRecruitsAvailable

### DIFF
--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -317,10 +317,14 @@ export class Gang {
   }
 
   getRecruitsAvailable(): number {
+    if (this.members.length >= GangConstants.MaximumGangMembers) {
+      return 0;
+    }
     const numFreeMembers = 3;
     const recruitCostBase = 5;
-    if (this.members.length < numFreeMembers && this.respect < Math.pow(recruitCostBase, numFreeMembers))
+    if (this.members.length < numFreeMembers && this.respect < Math.pow(recruitCostBase, numFreeMembers)) {
       return numFreeMembers - this.members.length; // if the max possible is less than freeMembers
+    }
     return Math.floor(Math.log(this.respect) / Math.log(recruitCostBase)) + numFreeMembers - this.members.length; //else
   }
 


### PR DESCRIPTION
This API does not check the maximum number of gang members.