### PR TITLE
BLADEBURNER: Change formula of skill cost

### DIFF
--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -39,6 +39,9 @@ export class Skill {
      * The cost of the next level: (baseCost + currentLevel * costInc) * mult. The cost needs to be an integer, so we
      * need to use Math.floor or Math.round.
      *
+     * Note: there is no notation for Math.round, so I use \lceil and \rceil as alternatives for non-existent \lround
+     * and \rround. When you see \lceil and \rceil, it means Math.round, not Math.ceil.
+     *
      * In order to calculate the cost of "count" levels, we need to run a loop. "count" can be a big number, so it's
      * infeasible to calculate the cost in that way. We need to find the closed forms of:
      *

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -3,7 +3,7 @@ import type { BladeMultName, BladeSkillName } from "@enums";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { Bladeburner } from "./Bladeburner";
 import { Availability } from "./Types";
-import { PositiveInteger, PositiveSafeInteger, isPositiveInteger } from "../types";
+import { PositiveInteger, isPositiveInteger } from "../types";
 import { PartialRecord, getRecordEntries } from "../Types/Record";
 
 interface SkillParams {
@@ -35,30 +35,10 @@ export class Skill {
   }
 
   calculateCost(currentLevel: number, count = 1 as PositiveInteger): number {
-    if (currentLevel + count > this.maxLvl) return Infinity;
-
-    const recursiveMode = (currentLevel: number, count: PositiveSafeInteger): number => {
-      if (count <= 1) {
-        return Math.floor((this.baseCost + currentLevel * this.costInc) * currentNodeMults.BladeburnerSkillCost);
-      } else {
-        const thisUpgrade = Math.floor(
-          (this.baseCost + currentLevel * this.costInc) * currentNodeMults.BladeburnerSkillCost,
-        );
-        return this.calculateCost(currentLevel + 1, (count - 1) as PositiveSafeInteger) + thisUpgrade;
-      }
-    };
-
-    // Use recursive mode if count is small
-    if (count <= 100) return recursiveMode(currentLevel, count as PositiveSafeInteger);
-    // Use optimized mode if count is large
-    else {
-      //unFloored is roughly equivalent to
-      //(this.baseCost + currentLevel * this.costInc) * BitNodeMultipliers.BladeburnerSkillCost
-      //being repeated for increasing currentLevel
-      const preMult = (count * (2 * this.baseCost + this.costInc * (2 * currentLevel + count + 1))) / 2;
-      const unFloored = preMult * currentNodeMults.BladeburnerSkillCost - count / 2;
-      return Math.floor(unFloored);
-    }
+    return Math.floor(
+      count * this.baseCost * currentNodeMults.BladeburnerSkillCost +
+        this.costInc * currentNodeMults.BladeburnerSkillCost * (count * currentLevel + (count * (count - 1)) / 2),
+    );
   }
 
   canUpgrade(bladeburner: Bladeburner, count = 1): Availability<{ cost: number }> {

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -35,9 +35,45 @@ export class Skill {
   }
 
   calculateCost(currentLevel: number, count = 1 as PositiveInteger): number {
-    return Math.floor(
-      count * this.baseCost * currentNodeMults.BladeburnerSkillCost +
-        this.costInc * currentNodeMults.BladeburnerSkillCost * (count * currentLevel + (count * (count - 1)) / 2),
+    /**
+     * The cost of the next level: (baseCost + currentLevel * costInc) * mult. The cost needs to be an integer, so we
+     * need to use Math.floor or Math.round.
+     *
+     * In order to calculate the cost of "count" levels, we need to run a loop. "count" can be a big number, so it's
+     * infeasible to calculate the cost in that way. We need to find the closed forms of:
+     *
+     * [1]:
+     * $$Cost = \sum_{i = CurrentLevel}^{CurrentLevel+Count-1}\lfloor ((BaseCost + i \ast CostInc) \ast Mult) \rfloor$$
+     *
+     * Or:
+     *
+     * [2]:
+     * $$Cost = \sum_{i = CurrentLevel}^{CurrentLevel+Count-1}\lceil ((BaseCost + i \ast CostInc) \ast Mult) \rceil$$
+     *
+     * It's really hard to find the closed forms of those two equations, so we switch to these equations:
+     *
+     * [3]:
+     * $$Cost = \lfloor\sum_{i = CurrentLevel}^{CurrentLevel+Count-1} ((BaseCost + i \ast CostInc) \ast Mult) \rfloor$$
+     *
+     * Or
+     *
+     * [4]:
+     * $$Cost = \lceil\sum_{i = CurrentLevel}^{CurrentLevel+Count-1} ((BaseCost + i \ast CostInc) \ast Mult) \rceil$$
+     *
+     * This means that we do the flooring/rounding at the end instead of each iterative step.
+     *
+     * [3] and [4] are not equivalent to [1] and [2] respectively, but it's much easier to find the close forms of [3]
+     * and [4] than [1] and [2]. After testing, we conclude that the cost calculated by [4] is a good approximation of
+     * [2], so we choose [4] to calculate the cost. In order to calculate the cost with a big "count", we accept the
+     * slight inaccuracy.
+     *
+     * The closed form of [4]:
+     *
+     * $$Cost = \lceil Count \ast Mult \ast (BaseCost + (CostInc \ast (CurrentLevel + \frac{Count - 1}{2}))) \rceil$$
+     *
+     */
+    return Math.round(
+      count * currentNodeMults.BladeburnerSkillCost * (this.baseCost + this.costInc * (currentLevel + (count - 1) / 2)),
     );
   }
 


### PR DESCRIPTION
## Problem
For a long time, `calculateCost` only calculated the cost of the next level. Starting from 908d5e95707bde21faa170b8c8945d8e27a58223, it supported an arbitrary number of levels. However, it still has 2 problems:
- The weird recursive mode for a small `count`. It can be rewritten with only 1 simple loop.
- When `count` is greater than 100, it uses a questionable formula. That formula only calculates an approximation instead of an exact value, and that approximation is not even a good one.

Formulas:

[1]:
$$CostOfNextLevel = \lfloor ((BaseCost + CurrentLevel \ast CostInc) \ast Mult) \rfloor$$

[2]:
$$Cost = \sum_{i = 0}^{Count-1}\lfloor ((BaseCost + (CurrentLevel + i) \ast CostInc) \ast Mult) \rfloor$$

≡

$$Cost = \sum_{i = CurrentLevel}^{CurrentLevel+Count-1}\lfloor ((BaseCost + i \ast CostInc) \ast Mult) \rfloor$$

[1] contains a floor function, so it's really hard to find the closed form of [2].

## Proposed solutions

### Solution 1

Instead of using a recursive function and fall back to the "approximation" formula when `count` is too big, we use a simple loop. This is the simplest solution. It has 2 drawbacks:
- It cannot support a big `count`. This is not a problem, unless the player is in deep BN12 or a long intelligent-grinding session.
- It's really hard to answer the question: "How many skill levels can I buy with X skill points?".

### Solution 2

When we calculate the sum, we can use the floor function at the last step instead of all iteration steps.

[3]:
$$Cost = \lfloor\sum_{i = CurrentLevel}^{CurrentLevel+Count-1} ((BaseCost + i \ast CostInc) \ast Mult) \rfloor$$

**[3] is not equivalent to [2].**

It's easy to find [3]'s closed form, so this solution has 2 upsides:
- It can support a big `count`.
- It's easy to answer the question: "How many skill levels can I buy with X skill points?".

The drawback of this solution is that making many small purchases may be cheaper than making a big purchase. For example, (0->3) + (3->6) is cheaper than (0->6).

[3]'s closed form:

$$Cost = \lfloor\sum_{i = CurrentLevel}^{CurrentLevel+Count-1} ((BaseCost + i \ast CostInc) \ast Mult) \rfloor$$

≡

$$Cost = \lfloor\sum_{i = CurrentLevel}^{CurrentLevel+Count-1} (BaseCost \ast Mult + i \ast CostInc \ast Mult) \rfloor$$

≡

$$Cost = \lfloor (Count \ast BaseCost \ast Mult) + (CostInc \ast Mult \ast \sum_{i = CurrentLevel}^{CurrentLevel+Count-1} (i)) \rfloor$$

≡

$$Cost = \lfloor (Count \ast BaseCost \ast Mult) + (CostInc \ast Mult \ast \frac{Count \ast (2 \ast CurrentLevel + Count - 1)}{2}) \rfloor$$

≡

$$Cost = \lfloor (Count \ast BaseCost \ast Mult) + (CostInc \ast Mult \ast (Count \ast CurrentLevel + \frac{Count \ast (Count - 1)}{2})) \rfloor$$

This PR uses solution 2.

**Edit**: we decide to use `Math.round` instead of `Math.floor`. The final formula:

$$Cost = \lceil (Count \ast BaseCost \ast Mult) + (CostInc \ast Mult \ast (Count \ast CurrentLevel + \frac{Count \ast (Count - 1)}{2})) \rceil$$

≡

$$Cost = \lceil Count \ast Mult \ast (BaseCost + (CostInc \ast (CurrentLevel + \frac{Count - 1}{2}))) \rceil$$