### PR TITLE
MISC: Simplify graftingIntBonus calculation.

### DIFF
--- a/src/PersonObjects/Grafting/GraftingHelpers.ts
+++ b/src/PersonObjects/Grafting/GraftingHelpers.ts
@@ -21,7 +21,7 @@ export const getGraftingAvailableAugs = (): AugmentationName[] => {
 };
 
 export const graftingIntBonus = (): number => {
-  return 1 + (calculateIntelligenceBonus(Player.skills.intelligence, 3) - 1) / 3;
+  return calculateIntelligenceBonus(Player.skills.intelligence, 1);
 };
 
 export const calculateGraftingTimeWithBonus = (aug: GraftableAugmentation): number => {


### PR DESCRIPTION
The weight of the intelligence bonus is a multiplier to the percentage increase. So, rather than calculate it with a weight of 3 and then divide by 3, we can just calculate it with a weight of 1.