### PR TITLE
EDITOR: Use ramOverride() to set compiled script RAM

### DIFF
--- a/src/ScriptEditor/ui/Toolbar.tsx
+++ b/src/ScriptEditor/ui/Toolbar.tsx
@@ -8,6 +8,7 @@ import Table from "@mui/material/Table";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import TableBody from "@mui/material/TableBody";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
 import SettingsIcon from "@mui/icons-material/Settings";
@@ -87,20 +88,28 @@ export function Toolbar({ editor, onSave }: IProps) {
         onThemeChange={onThemeChange}
       />
       <Modal open={ramInfoOpen} onClose={closeRAMInfo}>
-        <Table>
-          <TableBody>
-            {ramEntries.map(([n, r]) => (
-              <React.Fragment key={n + r}>
-                <TableRow>
-                  <TableCell sx={{ color: Settings.theme.primary }}>{n}</TableCell>
-                  <TableCell align="right" sx={{ color: Settings.theme.primary }}>
-                    {r}
-                  </TableCell>
-                </TableRow>
-              </React.Fragment>
-            ))}
-          </TableBody>
-        </Table>
+        <Tooltip
+          title={
+            "Static RAM costs of individual functions used by this script. " +
+            "Calling `ns.ramOverride()` with a constant number as the first statement in " +
+            "your script will override the value here, as well."
+          }
+        >
+          <Table>
+            <TableBody>
+              {ramEntries.map(([n, r]) => (
+                <React.Fragment key={n + r}>
+                  <TableRow>
+                    <TableCell sx={{ color: Settings.theme.primary }}>{n}</TableCell>
+                    <TableCell align="right" sx={{ color: Settings.theme.primary }}>
+                      {r}
+                    </TableCell>
+                  </TableRow>
+                </React.Fragment>
+              ))}
+            </TableBody>
+          </Table>
+        </Tooltip>
       </Modal>
     </>
   );

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -169,4 +169,18 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
       });
     }
   });
+
+  describe("ramOverride checks", () => {
+    test.each([
+      ["ns.ramOverride(5)", 5],
+      ["ramOverride(5)", 5],
+      ["ns.ramOverride(5 * 1024)", baseCost], // Constant expressions are not handled yet
+    ])("%s", (code, expected) => {
+      const fullCode = `export function main(ns) { ${code} }`;
+
+      const result = calculateRamUsage(fullCode, "testfile.js", new Map(), "testserver");
+      expect(result.errorMessage).toBe(undefined);
+      expect(result.cost).toBe(expected);
+    });
+  });
 });


### PR DESCRIPTION
To use this, add a line like "ns.ramOverride(2);" as the first statement in main(). Not only will it take effect at runtime, but it will now *also* be parsed at compile time, changing the script's static RAM limit. Since ns.ramOverride is a 0-cost function, the call to it on startup then becomes a no-op.

This is an often-requested feature, and allows for scripts to set their usage without it needing to be explicitly mentioned via args or options when being launched. This also reduces pressure on the static RAM analysis to be perfect all the time. (But certain limits, such as "functions names must be unique across namespaces," remain.)

This also adds a tooltip to the RAM calculation, to make this slightly discoverable.

![image](https://github.com/bitburner-official/bitburner-src/assets/459704/7801d778-001f-431f-b3fe-636d3808118b)

Tested by playing with the tag values a lot, trying nonsense values, etc. Also added some automated test cases. You can set impossibly large values, which I view as OK. (The same is true of the `ramOverride` param.)