### PR TITLE
MISC: Remove debug code

### DIFF
--- a/src/ScriptEditor/ui/StatusBar.tsx
+++ b/src/ScriptEditor/ui/StatusBar.tsx
@@ -144,7 +144,6 @@ export class StatusBar {
       const value = registerValue.slice(2).trim();
       this.registers[name] = value;
     }
-    console.log(this.registers);
   };
   // this is used to show notifications.
   // The package passes a new HTMLElement, but we only want to show the text.

--- a/src/Terminal/commands/grep.ts
+++ b/src/Terminal/commands/grep.ts
@@ -148,7 +148,6 @@ class Args {
   };
 
   private spliceParam(validArgs: ArgStrings): string {
-    console.log(validArgs);
     const argIndex = [...validArgs.long, ...validArgs.short].reduce((ret: number, arg: string) => {
       const argIndex = this.args.indexOf(arg);
       return argIndex > -1 ? argIndex : ret;


### PR DESCRIPTION
These codes were only useful for debugging when the PRs were being developed. They should not be in our codebase after that. I do not remove `logBoard` in `src\Go\boardAnalysis\scoring.ts` because it may still be useful.