### PR TITLE
BUGFIX: Wrong success chance in ns.bladeburner.getActionEstimatedSuccessChance

### DIFF
--- a/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
+++ b/markdown/bitburner.bladeburner.getactionestimatedsuccesschance.md
@@ -9,7 +9,7 @@ Get estimate success chance of an action.
 **Signature:**
 
 ```typescript
-getActionEstimatedSuccessChance(type: string, name: string, sleeve?: number): [number, number];
+getActionEstimatedSuccessChance(type: string, name: string, sleeveNumber?: number): [number, number];
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ getActionEstimatedSuccessChance(type: string, name: string, sleeve?: number): [n
 |  --- | --- | --- |
 |  type | string | Type of action. |
 |  name | string | Name of action. Must be an exact match. |
-|  sleeve | number | _(Optional)_ Optional. Sleeve number to check for success. |
+|  sleeveNumber | number | _(Optional)_ Optional. Index of the sleeve to retrieve information. |
 
 **Returns:**
 

--- a/markdown/bitburner.bladeburner.md
+++ b/markdown/bitburner.bladeburner.md
@@ -24,7 +24,7 @@ You have to be employed in the Bladeburner division and be in BitNode-7 or have 
 |  [getActionCountRemaining(type, name)](./bitburner.bladeburner.getactioncountremaining.md) | Get action count remaining. |
 |  [getActionCurrentLevel(type, name)](./bitburner.bladeburner.getactioncurrentlevel.md) | Get the current level of an action. |
 |  [getActionCurrentTime()](./bitburner.bladeburner.getactioncurrenttime.md) | Get the time elapsed on current action. |
-|  [getActionEstimatedSuccessChance(type, name, sleeve)](./bitburner.bladeburner.getactionestimatedsuccesschance.md) | Get estimate success chance of an action. |
+|  [getActionEstimatedSuccessChance(type, name, sleeveNumber)](./bitburner.bladeburner.getactionestimatedsuccesschance.md) | Get estimate success chance of an action. |
 |  [getActionMaxLevel(type, name)](./bitburner.bladeburner.getactionmaxlevel.md) | Get the maximum level of an action. |
 |  [getActionRepGain(type, name, level)](./bitburner.bladeburner.getactionrepgain.md) | Get the reputation gain of an action. |
 |  [getActionSuccesses(type, name)](./bitburner.bladeburner.getactionsuccesses.md) | Get action successes. |

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -120,22 +120,22 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     getActionEstimatedSuccessChance: (ctx) => (type, name, _sleeve) => {
       const bladeburner = getBladeburner(ctx);
       const action = getAction(ctx, type, name);
-      if (_sleeve != null) {
-        checkSleeveAPIAccess(ctx);
-        const sleeveNumber = helpers.number(ctx, "sleeve", _sleeve);
-        checkSleeveNumber(ctx, sleeveNumber);
-        switch (action.type) {
-          case BladeActionType.general:
-            return [1, 1];
-          case BladeActionType.contract: {
-            const sleevePerson = Player.sleeves[sleeveNumber];
-            return action.getSuccessRange(bladeburner, sleevePerson);
-          }
-          default:
-            return [0, 0];
-        }
+      if (_sleeve == null) {
+        return action.getSuccessRange(bladeburner, Player);
       }
-      return action.getSuccessRange(bladeburner, Player);
+      checkSleeveAPIAccess(ctx);
+      const sleeveNumber = helpers.number(ctx, "sleeve", _sleeve);
+      checkSleeveNumber(ctx, sleeveNumber);
+      switch (action.type) {
+        case BladeActionType.general:
+          return [1, 1];
+        case BladeActionType.contract: {
+          const sleevePerson = Player.sleeves[sleeveNumber];
+          return action.getSuccessRange(bladeburner, sleevePerson);
+        }
+        default:
+          return [0, 0];
+      }
     },
     getActionRepGain: (ctx) => (type, name, _level) => {
       checkBladeburnerAccess(ctx);

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -124,13 +124,17 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
         checkSleeveAPIAccess(ctx);
         const sleeveNumber = helpers.number(ctx, "sleeve", _sleeve);
         checkSleeveNumber(ctx, sleeveNumber);
-        if (action.type === BladeActionType.contract) {
-          const sleevePerson = Player.sleeves[sleeveNumber];
-          return action.getSuccessRange(bladeburner, sleevePerson);
-        } else return [0, 0];
-      } else {
-        return action.getSuccessRange(bladeburner, Player);
+        switch (action.type) {
+          case BladeActionType.general:
+            return [1, 1];
+          case BladeActionType.contract:
+            const sleevePerson = Player.sleeves[sleeveNumber];
+            return action.getSuccessRange(bladeburner, sleevePerson);
+          default:
+            return [0, 0];
+        }
       }
+      return action.getSuccessRange(bladeburner, Player);
     },
     getActionRepGain: (ctx) => (type, name, _level) => {
       checkBladeburnerAccess(ctx);

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -127,9 +127,10 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
         switch (action.type) {
           case BladeActionType.general:
             return [1, 1];
-          case BladeActionType.contract:
+          case BladeActionType.contract: {
             const sleevePerson = Player.sleeves[sleeveNumber];
             return action.getSuccessRange(bladeburner, sleevePerson);
+          }
           default:
             return [0, 0];
         }

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -28,7 +28,6 @@ export const checkSleeveAPIAccess = function (ctx: NetscriptContext) {
 export const checkSleeveNumber = function (ctx: NetscriptContext, sleeveNumber: number) {
   if (sleeveNumber >= Player.sleeves.length || sleeveNumber < 0) {
     const msg = `Invalid sleeve number: ${sleeveNumber}`;
-    helpers.log(ctx, () => msg);
     throw helpers.errorMessage(ctx, msg);
   }
 };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3145,10 +3145,10 @@ export interface Bladeburner {
    *
    * @param type - Type of action.
    * @param name - Name of action. Must be an exact match.
-   * @param sleeve - Optional.  Sleeve number to check for success.
+   * @param sleeveNumber - Optional. Index of the sleeve to retrieve information.
    * @returns Estimated success chance for the specified action.
    */
-  getActionEstimatedSuccessChance(type: string, name: string, sleeve?: number): [number, number];
+  getActionEstimatedSuccessChance(type: string, name: string, sleeveNumber?: number): [number, number];
 
   /**
    * Get the reputation gain of an action.


### PR DESCRIPTION
If the action type is `BladeActionType.general`, the success chance must be [1, 1].

This PR also fixes the duplicate error message in `checkSleeveNumber`.