### PR TITLE
CORPORATION: Fix wrong product price calculation

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -574,8 +574,7 @@ export class Division {
               sCost = optimalPrice;
             } else if (mat.marketTa1) {
               sCost = mat.marketPrice + markupLimit;
-              // check truthyness to avoid unnecessary eval
-            } else if (typeof mat.desiredSellPrice === "string" && mat.desiredSellPrice) {
+            } else if (typeof mat.desiredSellPrice === "string") {
               sCost = mat.desiredSellPrice.replace(/MP/g, mat.marketPrice.toString());
               sCost = eval(sCost);
             } else {
@@ -903,7 +902,7 @@ export class Division {
               product.markup = 1;
             }
             sCostString = sCostString.replace(/MP/g, product.cityData[city].productionCost.toString());
-            sCost = Math.max(product.cityData[city].productionCost, eval(sCostString));
+            sCost = eval(sCostString);
           } else {
             sCost = sellPrice;
           }


### PR DESCRIPTION
This PR makes 2 changes:
- Remove the check `&& mat.desiredSellPrice` in the material price calculation. I don't get why it's needed. The product price calculation does not have this check.
- Allow the price of products to go lower than MP when the player sets it with a string. Without this change, `MP/2` is the same as `MP`.