### PR TITLE
BUGFIX: Fix wrong money source when traveling

### DIFF
--- a/src/PersonObjects/PersonMethods.ts
+++ b/src/PersonObjects/PersonMethods.ts
@@ -5,6 +5,7 @@ import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { Player } from "@player";
 import { WorkStats } from "@nsdefs";
 import { CONSTANTS } from "../Constants";
+import { PlayerObject } from "./Player/PlayerObject";
 
 export function gainHackingExp(this: Person, exp: number): void {
   if (isNaN(exp)) {
@@ -176,7 +177,7 @@ export function travel(this: Person, cityName: CityName): boolean {
     return false;
   }
 
-  Player.loseMoney(CONSTANTS.TravelCost, "sleeves");
+  Player.loseMoney(CONSTANTS.TravelCost, this instanceof PlayerObject ? "other" : "sleeves");
   this.city = cityName;
 
   return true;


### PR DESCRIPTION
In #1439, we unify the implementation of `Player.travel` and `Sleeve.travel`, but when we call `Player.loseMoney`, we always use "sleeves" as the money source, even when it's the `Player`, not a `Sleeve`. This PR fixes it.

Fixes #1455.