### PR TITLE
MISC: Update caniuse-lite to latest version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6190,9 +6190,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001546",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz",
-      "integrity": "sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==",
+      "version": "1.0.30001640",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+      "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
browserslist complains if caniuse-lite is more than 6 months old. This updates to the latest version.

Note that there were no changes in supported versions based on this update.