### PR TITLE
MISC: Add threshold for warning about system clock

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -49,8 +49,10 @@ import { Go } from "./Go/Go";
 // Only show warning if the time diff is greater than this value.
 const thresholdOfTimeDiffForShowingWarningAboutSystemClock = CONSTANTS.MillisecondsPerFiveMinutes;
 
-function showWarningAboutSystemClock() {
-  AlertEvents.emit("Warning: The system clock moved backward.");
+function showWarningAboutSystemClock(timeDiff: number) {
+  AlertEvents.emit(
+    `Warning: The system clock moved backward: ${convertTimeMsToTimeElapsedString(Math.abs(timeDiff))}.`,
+  );
 }
 
 /** Game engine. Handles the main game loop. */
@@ -257,8 +259,9 @@ const Engine: {
       let timeOffline = Engine._lastUpdate - lastUpdate;
       if (timeOffline < 0) {
         if (Math.abs(timeOffline) > thresholdOfTimeDiffForShowingWarningAboutSystemClock) {
+          const timeDiff = timeOffline;
           setTimeout(() => {
-            showWarningAboutSystemClock();
+            showWarningAboutSystemClock(timeDiff);
           }, 250);
         }
         timeOffline = 0;
@@ -410,7 +413,7 @@ const Engine: {
     let diff = _thisUpdate - Engine._lastUpdate;
     if (diff < 0) {
       if (Math.abs(diff) > thresholdOfTimeDiffForShowingWarningAboutSystemClock) {
-        showWarningAboutSystemClock();
+        showWarningAboutSystemClock(diff);
       }
       diff = 0;
       Engine._lastUpdate = _thisUpdate;

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -46,6 +46,9 @@ import { SnackbarEvents } from "./ui/React/Snackbar";
 import { SaveData } from "./types";
 import { Go } from "./Go/Go";
 
+// Only show warning if the time diff is greater than this value.
+const thresholdOfTimeDiffForShowingWarningAboutSystemClock = CONSTANTS.MillisecondsPerFiveMinutes;
+
 function showWarningAboutSystemClock() {
   AlertEvents.emit("Warning: The system clock moved backward.");
 }
@@ -253,10 +256,12 @@ const Engine: {
       const lastUpdate = Player.lastUpdate;
       let timeOffline = Engine._lastUpdate - lastUpdate;
       if (timeOffline < 0) {
+        if (Math.abs(timeOffline) > thresholdOfTimeDiffForShowingWarningAboutSystemClock) {
+          setTimeout(() => {
+            showWarningAboutSystemClock();
+          }, 250);
+        }
         timeOffline = 0;
-        setTimeout(() => {
-          showWarningAboutSystemClock();
-        }, 250);
       }
       const numCyclesOffline = Math.floor(timeOffline / CONSTANTS.MilliPerCycle);
 
@@ -404,10 +409,12 @@ const Engine: {
     const _thisUpdate = new Date().getTime();
     let diff = _thisUpdate - Engine._lastUpdate;
     if (diff < 0) {
+      if (Math.abs(diff) > thresholdOfTimeDiffForShowingWarningAboutSystemClock) {
+        showWarningAboutSystemClock();
+      }
       diff = 0;
       Engine._lastUpdate = _thisUpdate;
       Player.lastUpdate = _thisUpdate;
-      showWarningAboutSystemClock();
     }
     const offset = diff % CONSTANTS.MilliPerCycle;
 


### PR DESCRIPTION
The system clock can be altered by many things, including NTP services. The check in #1354 may be a bit too sensitive in some cases; for example, the NTP service may adject the system clock and make it go backward a few seconds.

This PR adds a threshold. We will only show the warning about the system clock if the time difference exceeds that threshold.