### PR TITLE
UI: Tweak Hacknet summary

### DIFF
--- a/src/Hacknet/ui/PlayerInfo.tsx
+++ b/src/Hacknet/ui/PlayerInfo.tsx
@@ -55,7 +55,7 @@ export function PlayerInfo(props: IProps): React.ReactElement {
   return (
     <Paper sx={{ display: "inline-block", padding: "0.5em 1em", margin: "0.5em 0" }}>
       <Typography variant="h6">Hacknet Summary</Typography>
-      <StatsTable rows={rows} />
+      <StatsTable rows={rows} textAlign="left" />
     </Paper>
   );
 }

--- a/src/ui/React/StatsTable.tsx
+++ b/src/ui/React/StatsTable.tsx
@@ -3,23 +3,25 @@ import React, { ReactNode, ReactElement } from "react";
 import { Table, TableCell } from "./Table";
 import { TableBody, TableRow, Table as MuiTable, Typography } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
+import type { Property } from "csstype";
 
 interface StatsTableProps {
   rows: ReactNode[][];
   title?: string;
   wide?: boolean;
+  textAlign?: Property.TextAlign;
   paddingLeft?: string;
 }
 
-const useStyles = (paddingLeft: string) =>
+const useStyles = (textAlign: Property.TextAlign, paddingLeft: string) =>
   makeStyles()({
     firstCell: { textAlign: "left" },
-    nonFirstCell: { textAlign: "right", paddingLeft: paddingLeft },
+    nonFirstCell: { textAlign: textAlign, paddingLeft: paddingLeft },
   })();
 
-export function StatsTable({ rows, title, wide, paddingLeft }: StatsTableProps): ReactElement {
+export function StatsTable({ rows, title, wide, textAlign, paddingLeft }: StatsTableProps): ReactElement {
   const T = wide ? MuiTable : Table;
-  const { classes } = useStyles(paddingLeft ?? "0.5em");
+  const { classes } = useStyles(textAlign ?? "right", paddingLeft ?? "0.5em");
   return (
     <>
       {title && <Typography>{title}</Typography>}


### PR DESCRIPTION
There is a complaint on Discord:
> The hacknet summary box is now with dynamic size when the hashes row width overflow, which makes the right aligned numbers on all other rows move around and hard to read.

![before](https://github.com/bitburner-official/bitburner-src/assets/152669316/7a9ef368-f420-440f-a754-accd39dc422b)

This PR makes the data column left-aligned:
![after](https://github.com/bitburner-official/bitburner-src/assets/152669316/fdad920b-9f4a-4ca4-85ae-e14039c43e7c)
When a value changes, it does not affect the positions of other values.
