### PR TITLE
EDITOR: Add support for "Go to Definition" for definitions from other open files.

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -81,7 +81,6 @@ export function Editor({ onMount, onChange, onUnmount, openFile }: EditorProps) 
     return () => {
       onUnmount();
       disposables.forEach((d) => d.dispose());
-      monaco.editor.getModels().forEach((model) => model.dispose());
       editorRef.current?.dispose();
     };
     // this eslint ignore instruction can potentially cause unobvious bugs

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -328,7 +328,7 @@ function Root(props: IProps): React.ReactElement {
         },
       });
     }
-    //unmounting the editor will dispose all, doesnt hurt to dispose on close aswell
+
     closingScript.model.dispose();
     openScripts.splice(index, 1);
     if (openScripts.length === 0) {

--- a/src/ScriptEditor/ui/utils.ts
+++ b/src/ScriptEditor/ui/utils.ts
@@ -25,7 +25,8 @@ function reorder(list: unknown[], startIndex: number, endIndex: number): void {
 function makeModel(hostname: string, filename: string, code: string) {
   const uri = Uri.from({
     scheme: "file",
-    path: `${hostname}/${filename}`,
+    authority: hostname,
+    path: filename,
   });
   let language;
   const fileType = getFileType(filename);


### PR DESCRIPTION
This uses `registerEditorOpener` API introduced in introduced in moncao-editor [v0.38](https://github.com/microsoft/monaco-editor/blob/main/CHANGELOG.md#0380) to allow going to definitions in other opened files.

This also stops disposing of editor models when navigating. This means the language server doesn't forget about all the code in open but not focused tabs.

---

This subsumes part of #1138. I've looked at supporting non-open files, but doing that changes the lifecycle of models, so probably requires a larger refactor.
