### PR TITLE
EDITOR: Work around bug in monaco-editor

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -41,6 +41,11 @@ export function Editor({ onMount, onChange, onUnmount }: EditorProps) {
       onChange(editorRef.current?.getValue());
     });
 
+    // This is the workaround for a bug in monaco-editor: https://github.com/microsoft/monaco-editor/issues/4455
+    if (containerDiv.current.firstElementChild) {
+      (containerDiv.current.firstElementChild as HTMLElement).style.outline = "none";
+    }
+
     // Unmounting
     return () => {
       onUnmount();


### PR DESCRIPTION
The new version of monaco-editor has a bug: https://github.com/microsoft/monaco-editor/issues/4455.

Dev:
![dev](https://github.com/bitburner-official/bitburner-src/assets/152669316/d60c4f81-bd06-44f0-a94e-b05c7c256c89)
![dev-css](https://github.com/bitburner-official/bitburner-src/assets/152669316/4a6a87df-8893-469d-a9e9-601742af35e3)

Stable:
![stable](https://github.com/bitburner-official/bitburner-src/assets/152669316/04c444d8-d581-4a21-9bd1-425046688332)
![stable-css](https://github.com/bitburner-official/bitburner-src/assets/152669316/5c7be45c-e1c8-4958-ad52-87aab131a33d)

The root cause is the unnecessary outline. That outline might be added mistakenly: https://github.com/microsoft/vscode/pull/209368.
