### PR TITLE
BLADEBURNER: Fix wrong behavior of ns.bladeburner.getSkillUpgradeCost

### DIFF
--- a/markdown/bitburner.bladeburner.getskillupgradecost.md
+++ b/markdown/bitburner.bladeburner.getskillupgradecost.md
@@ -31,5 +31,5 @@ RAM cost: 4 GB
 
 This function returns the number of skill points needed to upgrade the specified skill the specified number of times.
 
-The function returns -1 if an invalid skill name is passed in, and Infinity if the count overflows the maximum level.
+The function returns Infinity if the sum of the current level and count exceeds the maximum level.
 

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -214,7 +214,11 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
       const skillName = getEnumHelper("BladeSkillName").nsGetMember(ctx, _skillName, "skillName");
       const count = helpers.positiveInteger(ctx, "count", _count ?? 1);
       const currentLevel = bladeburner.getSkillLevel(skillName);
-      return Skills[skillName].calculateCost(currentLevel, count);
+      const skill = Skills[skillName];
+      if (currentLevel + count > skill.maxLvl) {
+        return Infinity;
+      }
+      return skill.calculateCost(currentLevel, count);
     },
     upgradeSkill: (ctx) => (_skillName, _count) => {
       const bladeburner = getBladeburner(ctx);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3325,7 +3325,7 @@ export interface Bladeburner {
    *
    * This function returns the number of skill points needed to upgrade the specified skill the specified number of times.
    *
-   * The function returns -1 if an invalid skill name is passed in, and Infinity if the count overflows the maximum level.
+   * The function returns Infinity if the sum of the current level and count exceeds the maximum level.
    *
    * @param skillName - Name of skill. Case-sensitive and must be an exact match.
    * @param count - Number of times to upgrade the skill. Defaults to 1 if not specified.


### PR DESCRIPTION
> The function returns -1 if an invalid skill name is passed in, and Infinity if the count overflows the maximum level.

The description is wrong:
- Invalid skill name: We throw an error instead of returning -1. This is the expected behavior, so I changed the description.
- The sum of the current level and count exceeds the maximum level: We do not return Infinity. I changed the behavior to match the description.