### PR TITLE
BUGFIX: Fix "Router called before initialization" race

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -22,6 +22,7 @@ import { Skills } from "./data/Skills";
 import { City } from "./City";
 import { Player } from "@player";
 import { Router } from "../ui/GameRoot";
+import { Page } from "../ui/Router";
 import { ConsoleHelpText } from "./data/Help";
 import { exceptionAlert } from "../utils/helpers/exceptionAlert";
 import { getRandomIntInclusive } from "../utils/helpers/getRandomIntInclusive";
@@ -1307,7 +1308,7 @@ export class Bladeburner {
 
   process(): void {
     // Edge race condition when the engine checks the processing counters and attempts to route before the router is initialized.
-    if (!Router.isInitialized) return;
+    if (Router.page() === Page.LoadingScreen) return;
 
     // If the Player starts doing some other actions, set action to idle and alert
     if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true) && Player.currentWork) {

--- a/src/Message/MessageHelpers.tsx
+++ b/src/Message/MessageHelpers.tsx
@@ -3,7 +3,6 @@ import { Message } from "./Message";
 import { AugmentationName, CompletedProgramName, FactionName, MessageFilename } from "@enums";
 import { Router } from "../ui/GameRoot";
 import { Player } from "@player";
-import { Page } from "../ui/Router";
 import { GetServer } from "../Server/AllServers";
 import { SpecialServers } from "../Server/data/SpecialServers";
 import { Settings } from "../Settings/Settings";
@@ -53,7 +52,7 @@ function recvd(name: MessageFilename): boolean {
 
 //Checks if any of the 'timed' messages should be sent
 function checkForMessagesToSend(): void {
-  if (Router.page() === Page.BitVerse) return;
+  if (Router.hidingMessages()) return;
 
   if (Player.hasAugmentation(AugmentationName.TheRedPill, true)) {
     //Get the world daemon required hacking level

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -8,7 +8,6 @@ import { Factions } from "./Faction/Factions";
 import { staneksGift } from "./CotMG/Helper";
 import { processPassiveFactionRepGain, inviteToFaction } from "./Faction/FactionHelpers";
 import { Router } from "./ui/GameRoot";
-import { Page } from "./ui/Router";
 import "./utils/Protections"; // Side-effect: Protect against certain unrecoverable errors
 import "./PersonObjects/Player/PlayerObject"; // For side-effect of creating Player
 
@@ -441,8 +440,7 @@ function warnAutosaveDisabled(): void {
 
   // We don't want this warning to show up on certain pages.
   // When in recovery or importing we want to keep autosave disabled.
-  const ignoredPages = [Page.Recovery as Page, Page.ImportSave];
-  if (ignoredPages.includes(Router.page())) return;
+  if (Router.hidingMessages()) return;
 
   const warningToast = (
     <>

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -49,6 +49,7 @@ export enum ComplexPage {
   Location = "Location",
   ImportSave = "Import Save",
   Documentation = "Documentation",
+  LoadingScreen = "Loading Screen", // Has no PageContext, and thus toPage() cannot be used
 }
 
 // Using the same name as both type and object to mimic enum-like behavior.
@@ -86,6 +87,7 @@ export type PageWithContext =
   | ({ page: ComplexPage.Location } & PageContext<ComplexPage.Location>)
   | ({ page: ComplexPage.ImportSave } & PageContext<ComplexPage.ImportSave>)
   | ({ page: ComplexPage.Documentation } & PageContext<ComplexPage.Documentation>)
+  | { page: ComplexPage.LoadingScreen }
   | { page: SimplePage };
 
 export interface ScriptEditorRouteOptions {
@@ -95,9 +97,10 @@ export interface ScriptEditorRouteOptions {
 
 /** The router keeps track of player navigation/routing within the game. */
 export interface IRouter {
-  isInitialized: boolean;
   page(): Page;
   allowRouting(value: boolean): void;
+  /** If messages/toasts are hidden on this page */
+  hidingMessages(): boolean;
   toPage(page: SimplePage): void;
   toPage<T extends ComplexPage>(page: T, context: PageContext<T>): void;
   /** go to a preveious page (if any) */

--- a/test/jest/Messages/MessageHelper.test.ts
+++ b/test/jest/Messages/MessageHelper.test.ts
@@ -12,6 +12,7 @@ jest.mock("../../../src/ui/GameRoot", () => ({
   Router: {
     page: () => ({}),
     toPage: () => ({}),
+    hidingMessages: () => false,
   },
 }));
 


### PR DESCRIPTION
If the game takes long enough to load, certain counters can become eligible to run as soon as Engine.start() runs. When this happens, eventually Router.page() is called, which throws an Error since Router isn't initialized yet. (Dropping a breakpoint before Engine.start() and waiting at least 30 seconds is enough to reliably repro, but I have seen this both live and in tests.)

This fixes it so that Router.page() is valid immediately, returning a value of Page.LoadingScreen. It also removes the isInitialized field, since this is now redundant. Trying to switch pages is still an error, but that doesn't happen without user input, whereas checking the current page is quite common.

This also consolidates a check for "should we show toasts" behind a function in Router, making the logic central and equal for a few usecases. This means (for instance) that the "autosave is disabled" logic won't run during infiltration. (The toast should have already been suppressed.)