### PR TITLE
MISC: Always include stack trace in Recovery Mode

### DIFF
--- a/src/ui/React/RecoveryRoot.tsx
+++ b/src/ui/React/RecoveryRoot.tsx
@@ -5,7 +5,7 @@ import { Settings } from "../../Settings/Settings";
 import { load } from "../../db";
 import { Router } from "../GameRoot";
 import { Page } from "../Router";
-import { IErrorData, newIssueUrl } from "../../utils/ErrorHelper";
+import { IErrorData, newIssueUrl, getErrorForDisplay } from "../../utils/ErrorHelper";
 import { DeleteGameButton } from "./DeleteGameButton";
 import { SoftResetButton } from "./SoftResetButton";
 
@@ -37,6 +37,13 @@ export function RecoveryRoot({ softReset, errorData, resetError }: IProps): Reac
     Router.toPage(Page.Terminal);
   }
   Settings.AutosaveInterval = 0;
+
+  // The architecture around RecoveryRoot is awkward, and it can be invoked in
+  // a number of ways. If we are invoked via a save error, sourceError will be set
+  // and we won't have decoded the information into errorData.
+  if (errorData == null && sourceError) {
+    errorData = getErrorForDisplay(sourceError, undefined, Page.LoadingScreen);
+  }
 
   useEffect(() => {
     load()


### PR DESCRIPTION
We are getting some more error reports coming in that don't have enough info in them. It turns out that populating the stack trace was gated behind the dev flag; in reality, production builds are where we need it most. Even if it ends up being obfuscated (source maps should prevent this), we can figure out the actual source lines with enough effort if need be.

This also changes to using the actual stack trace, rather than the "component" trace (the tree of JSX objects), since knowing where the code failed is far more valuable. Also, it ensures we get the full error details when things go wrong in savefile loading.

![image](https://github.com/user-attachments/assets/5ee2cce3-a058-4eae-8f65-a34016cd1ad3)

Tested by trying recovery mode in various scenarios. The "file a bug" link also works as expected (still).