### PR TITLE
EDITOR: Follow-up of #1470

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -41,11 +41,6 @@ export function Editor({ onMount, onChange, onUnmount }: EditorProps) {
       onChange(editorRef.current?.getValue());
     });
 
-    // This is the workaround for a bug in monaco-editor: https://github.com/microsoft/monaco-editor/issues/4455
-    if (containerDiv.current.firstElementChild) {
-      (containerDiv.current.firstElementChild as HTMLElement).style.outline = "none";
-    }
-
     // Unmounting
     return () => {
       onUnmount();

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -47,6 +47,20 @@ function Root(props: IProps): React.ReactElement {
   const rerender = useRerender();
   const editorRef = useRef<IStandaloneCodeEditor | null>(null);
 
+  // This is the workaround for a bug in monaco-editor: https://github.com/microsoft/monaco-editor/issues/4455
+  const removeOutlineOfEditor = useCallback(() => {
+    if (!editorRef.current) {
+      return;
+    }
+    const containerDomNode = editorRef.current.getContainerDomNode();
+    const elements = containerDomNode.getElementsByClassName("monaco-editor");
+    if (elements.length === 0) {
+      return;
+    }
+    const editorElement = elements[0];
+    (editorElement as HTMLElement).style.outline = "none";
+  }, [editorRef]);
+
   const { showRAMError, updateRAM, startUpdatingRAM, finishUpdatingRAM } = useScriptEditorContext();
 
   let decorations: monaco.editor.IEditorDecorationsCollection | undefined;
@@ -278,6 +292,7 @@ function Root(props: IProps): React.ReactElement {
       parseCode(currentScript.code);
       editorRef.current.focus();
     }
+    removeOutlineOfEditor();
   }
 
   function onTabClose(index: number): void {
@@ -324,6 +339,7 @@ function Root(props: IProps): React.ReactElement {
       }
     }
     rerender();
+    removeOutlineOfEditor();
   }
 
   function onTabUpdate(index: number): void {


### PR DESCRIPTION
When we open many files and switch between them, the DOM node of the editor is not the first child of the container. It's also recreated when we switch between files. The fix in #1470 does not handle this case.

Edit: How to test:
- `nano a.js b.js c.js`.
- Switch between them. Check the outline.
- Close `a.js`. Check the outline.