### PR TITLE
BUGFIX: Don't spin forever if IDB can't be loaded

### DIFF
--- a/src/ui/LoadingScreen.tsx
+++ b/src/ui/LoadingScreen.tsx
@@ -32,21 +32,18 @@ export function LoadingScreen(): React.ReactElement {
   });
 
   useEffect(() => {
-    load().then(async (saveData) => {
-      try {
-        await initSwc();
-        await Engine.load(saveData);
-      } catch (error) {
+    load()
+      .then((saveData) => Promise.all([initSwc(), Engine.load(saveData)]))
+      .then(() => {
+        pushGameReady();
+        setLoaded(true);
+      })
+      .catch(async (error) => {
         console.error(error);
         ActivateRecoveryMode(error);
         await Engine.load("");
         setLoaded(true);
-        return;
-      }
-
-      pushGameReady();
-      setLoaded(true);
-    });
+      });
   }, []);
 
   return loaded ? (

--- a/src/ui/React/DeleteGameButton.tsx
+++ b/src/ui/React/DeleteGameButton.tsx
@@ -29,7 +29,7 @@ export function DeleteGameButton({ color = "primary" }: IProps): React.ReactElem
               pushDisableRestore();
               setTimeout(() => location.reload(), 1000);
             })
-            .catch((r) => console.error(`Could not delete game: ${r}`));
+            .catch((r) => console.error("Could not delete game: %o", r));
         }}
         open={modalOpened}
         onClose={() => setModalOpened(false)}


### PR DESCRIPTION
I recently encountered a problem where my local electron build can't use IndexDB. I'm not sure why, and it bears further investigation, but in the meantime it revealed issues in our error-handling.

----

Our IndexDB handling did not have very good error handling. It wasn't reporting the actual errors that occured, nor was it using actual Error objects. In some cases it also had overly convoluted Promise use, and it didn't need to be .tsx either.

The biggest issue was that if any problem occured during the main load(), this would end up as an unhandled rejection and so it would only be logged to the console. This extends the previous catch to also cover this, so that the recovery screen is activated.