### PR TITLE
BUGFIX: Fix mathjax path on dev server.

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,5 +1,6 @@
 // Defined by webpack on startup or compilation
 declare const __COMMIT_HASH__: string;
+declare const __webpack_public_path__: string;
 
 // When using file-loader, we'll get a path to the resource
 declare module "*.png" {

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -385,7 +385,7 @@ export function GameRoot(): React.ReactElement {
   }
 
   return (
-    <MathJaxContext version={3} src={"dist/mathjax/tex-chtml.js"}>
+    <MathJaxContext version={3} src={__webpack_public_path__ + "mathjax/tex-chtml.js"}>
       <ErrorBoundary key={errorBoundaryKey} softReset={softReset}>
         <BypassWrapper content={bypassGame ? mainPage : null}>
           <HistoryProvider>


### PR DESCRIPTION
Apparently #1491 broke the devserver. I suspect this didn't get caught, because running `npm run build` will cause the devserver to start working, so if you are testing both electron and the devserver, you may not notice the failure.