### PR TITLE
DOC: Fix paths to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The game's official documentation can be found in-game.
 The [in-game documentation](./markdown/bitburner.md) is generated from the [TypeScript definitions](./src/ScriptEditor/NetscriptDefinitions.d.ts).
 
 Anyone is welcome to contribute to the documentation by editing the [source
-files](/doc/source) and then making a pull request with your contributions.
+files](/src/Documentation/doc) and then making a pull request with your contributions.
 For further guidance, please refer to the "As A Documenter" section of
-[CONTRIBUTING](./doc/CONTRIBUTING.md).
+[CONTRIBUTING](./doc/CONTRIBUTING.md#as-a-documenter).
 
 # Contribution
 


### PR DESCRIPTION
- Fixed broken path to documentation source code
- Updated CONTRIBUTION path to link directly to "As a Documenter" heading

Just starting to learn how to make PRs and noticed the path was broken in the README. Since I'm not editing any in-game documentation, I assumed I didn't need to edit a typescript file.
Thank you!