### PR TITLE
BUGFIX: Prevent runtime error on Safari window resize

### DIFF
--- a/src/ui/React/Overview.tsx
+++ b/src/ui/React/Overview.tsx
@@ -94,7 +94,11 @@ export function Overview({ children, mode }: IProps): React.ReactElement {
         triggerMouseEvent(node, "mousedown");
         triggerMouseEvent(document, "mousemove");
         triggerMouseEvent(node, "mouseup");
-        triggerMouseEvent(node, "click");
+        // According to a comment in the above GitHub issue, apparently mousemove is important,
+        // but click probably isn't. This click causes a runtime error in Safari (NotAllowedError),
+        // but not Chromium. If further errors occur, a more thorough fix, possibly using
+        // navigator.userActivation.isActive, might be necessary.
+        // triggerMouseEvent(node, "click");
       }, 100),
     [],
   );
@@ -111,8 +115,7 @@ export function Overview({ children, mode }: IProps): React.ReactElement {
   }, [fakeDrag]);
 
   const triggerMouseEvent = (node: HTMLDivElement | Document, eventType: string): void => {
-    const clickEvent = document.createEvent("MouseEvents");
-    clickEvent.initEvent(eventType, true, true);
+    const clickEvent = new MouseEvent(eventType, { bubbles: true, cancelable: true });
     node.dispatchEvent(clickEvent);
   };
 


### PR DESCRIPTION
When the browser window was resized after opening (and possibly exiting) the Script Editor, a runtime NotAllowedError would be thrown in Safari (but not Chromium, including Electron). Looking at the call stack when an error was logged, a simulated click event in Overview.tsx caused the issue. The problematic function simulates a drag event to send an update to the Overview element, to ensure that the character overview can reposition itself and not end up offscreen after the window is resized. I tested that behavior before and after making this change, and the function's other mouse events still make it work. I still don't know exactly how opening the Script Editor contributes to the problem (it might have to do with user activations), but at least I haven't managed to trigger this bug on my device with the patch.
<img width="532" alt="Screenshot of errors" src="https://github.com/user-attachments/assets/87cb2742-563e-4191-be70-61cb24f4b510">
<img width="308" alt="Screenshot of call stack" src="https://github.com/user-attachments/assets/2947e529-bd59-4ace-af4e-ba9fffdc42f5">
