### PR TITLE
BUGFIX: Correctly show remaining grafting/programming time left when cycles are skipped.

### DIFF
--- a/src/Work/CreateProgramWork.ts
+++ b/src/Work/CreateProgramWork.ts
@@ -64,8 +64,8 @@ export class CreateProgramWork extends Work {
     skillMult *= focusBonus;
     //Skill multiplier directly applied to "time worked"
     this.cyclesWorked += cycles;
-    this.unitRate = CONSTANTS.MilliPerCycle * cycles * skillMult;
-    this.unitCompleted += this.unitRate;
+    this.unitRate = CONSTANTS.MilliPerCycle * skillMult;
+    this.unitCompleted += this.unitRate * cycles;
 
     if (this.unitCompleted >= this.unitNeeded()) {
       return true;

--- a/src/Work/GraftingWork.tsx
+++ b/src/Work/GraftingWork.tsx
@@ -49,8 +49,8 @@ export class GraftingWork extends Work {
   process(cycles: number): boolean {
     const focusBonus = Player.focusPenalty();
     this.cyclesWorked += cycles;
-    this.unitRate = CONSTANTS.MilliPerCycle * cycles * graftingIntBonus() * focusBonus;
-    this.unitCompleted += this.unitRate;
+    this.unitRate = CONSTANTS.MilliPerCycle * graftingIntBonus() * focusBonus;
+    this.unitCompleted += this.unitRate * cycles;
     return this.unitCompleted >= this.unitNeeded();
   }
 


### PR DESCRIPTION
I tried to test this with grafting, but not creating programs.

It seemed to work, but getting the bug to trigger consistently was tricky in my dev environment.

The issue this is fixing is the time display being wildly low if some cycles are skipped.