### PR TITLE
MISC: Add some more types for developement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "format": "prettier -c --write .",
     "format:report": "prettier -c .",
     "start": "electron .app/index.html",
-    "start:dev": "webpack serve --progress --env devServer --mode development",
+    "start:dev": "webpack serve --progress --mode development",
     "build": "bash ./tools/build.sh production",
     "build:dev": "bash ./tools/build.sh development",
     "lint": "eslint --fix --ext js,jsx,ts,tsx --max-warnings 0 src",


### PR DESCRIPTION
- Show values of constants in type hint by making the types literal types.
- Add some more types to `webpack.config.js`.
  -  Also fix some errors detected when turning on checking for it.