### PR TITLE
MISC: Remove unsed attribues of internal `ScriptDeath`.

### DIFF
--- a/src/Netscript/ErrorMessages.ts
+++ b/src/Netscript/ErrorMessages.ts
@@ -76,14 +76,10 @@ export function errorMessage(ctx: NetscriptContext, msg: string, type = "RUNTIME
 }
 
 /** Generate an error dialog when workerscript is known */
-export function handleUnknownError(e: unknown, ws: WorkerScript | ScriptDeath | null = null, initialText = "") {
+export function handleUnknownError(e: unknown, ws: WorkerScript | null = null, initialText = "") {
   if (e instanceof ScriptDeath) {
-    //No dialog for an empty ScriptDeath
-    if (e.errorMessage === "") return;
-    if (!ws) {
-      ws = e;
-      e = ws.errorMessage;
-    }
+    // No dialog for ScriptDeath
+    return;
   }
   if (ws && typeof e === "string") {
     const headerText = basicErrorMessage(ws, "", "");

--- a/src/Netscript/ScriptDeath.ts
+++ b/src/Netscript/ScriptDeath.ts
@@ -20,14 +20,10 @@ export class ScriptDeath {
   /** IP Address on which the script was running */
   hostname: string;
 
-  /** Status message in case of script error. */
-  errorMessage = "";
-
   constructor(ws: WorkerScript) {
     this.pid = ws.pid;
     this.name = ws.name;
     this.hostname = ws.hostname;
-    this.errorMessage = ws.errorMessage;
 
     Object.freeze(this);
   }

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -51,9 +51,6 @@ export class WorkerScript {
   /** Netscript Environment for this script */
   env: Environment;
 
-  /** Status message in case of script error. */
-  errorMessage = "";
-
   /**
    * Used for static RAM calculation. Stores names of all functions that have
    * already been checked by this script


### PR DESCRIPTION
As far as I can tell, these attributes are entirely unused, and `ScriptDeath` is not part of the public interface.