### PR TITLE
API: Hide spoiler properties in getPlayer

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -111,7 +111,7 @@ import { ServerConstants } from "./Server/data/Constants";
 import { assertFunction } from "./Netscript/TypeAssertion";
 import { Router } from "./ui/GameRoot";
 import { Page } from "./ui/Router";
-import { canAccessBitNodeFeature, validBitNodes } from "./BitNode/BitNodeUtils";
+import { canAccessBitNodeFeature, validBitNodes, knowAboutBitverse } from "./BitNode/BitNodeUtils";
 
 export const enums: NSEnums = {
   CityName,
@@ -1749,18 +1749,47 @@ export const ns: InternalAPI<NSFull> = {
         identifier: "ns.getPlayer().playtimeSinceLastAug",
         message: "Use ns.getResetInfo().lastAugReset instead. This is a static timestamp instead of an elapsed time.",
         value: Player.playtimeSinceLastAug,
+        hide: false,
       },
       playtimeSinceLastBitnode: {
         identifier: "ns.getPlayer().playtimeSinceLastBitnode",
         message: "Use ns.getResetInfo().lastNodeReset instead. This is a static timestamp instead of an elapsed time.",
         value: Player.playtimeSinceLastBitnode,
+        hide: !knowAboutBitverse(),
       },
       bitNodeN: {
         identifier: "ns.getPlayer().bitNodeN",
         message: "Use ns.getResetInfo().currentNode instead",
         value: Player.bitNodeN,
+        hide: !knowAboutBitverse(),
       },
     });
+    // Hide values which should not yet be available
+    if (!canAccessBitNodeFeature(5)) {
+      Object.defineProperty(data.skills, "intelligence", { value: data.skills.intelligence, enumerable: false });
+      Object.defineProperty(data.exp, "intelligence", { value: data.exp.intelligence, enumerable: false });
+    }
+    if (!canAccessBitNodeFeature(6) && !canAccessBitNodeFeature(7)) {
+      Object.defineProperty(data.mults, "bladeburner_max_stamina", {
+        value: data.mults.bladeburner_max_stamina,
+        enumerable: false,
+      });
+      Object.defineProperty(data.mults, "bladeburner_stamina_gain", {
+        value: data.mults.bladeburner_stamina_gain,
+        enumerable: false,
+      });
+      Object.defineProperty(data.mults, "bladeburner_analysis", {
+        value: data.mults.bladeburner_analysis,
+        enumerable: false,
+      });
+      Object.defineProperty(data.mults, "bladeburner_success_chance", {
+        value: data.mults.bladeburner_success_chance,
+        enumerable: false,
+      });
+    }
+    if (!canAccessBitNodeFeature(10)) {
+      Object.defineProperty(data, "entropy", { value: data.entropy, enumerable: false });
+    }
     return data;
   },
   getMoneySources: () => () => ({

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -687,6 +687,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
           identifier: "ns.corporation.getCorporation().state",
           message: "Use ns.corporation.getCorporation().nextState instead.",
           value: corporation.state.nextName,
+          hide: false,
         },
       });
       return data;

--- a/src/utils/DeprecationHelper.ts
+++ b/src/utils/DeprecationHelper.ts
@@ -3,7 +3,7 @@ import { Terminal } from "../Terminal";
 const deprecatedWarningsGiven = new Set();
 export function setDeprecatedProperties(
   obj: object,
-  properties: Record<string, { identifier: string; message: string; value: any }>,
+  properties: Record<string, { identifier: string; message: string; value: any; hide: boolean }>,
 ) {
   for (const [name, info] of Object.entries(properties)) {
     Object.defineProperty(obj, name, {
@@ -12,7 +12,7 @@ export function setDeprecatedProperties(
         return info.value;
       },
       set: (value: any) => (info.value = value),
-      enumerable: true,
+      enumerable: !info.hide,
     });
   }
 }


### PR DESCRIPTION
Per description. The properties are still available to avoid API breaks.

The documentation on getPlayer also needs work - several of the properties are not listed there, and the existence of entropy is spoiled.