### PR TITLE
BUGFIX: Stop current work when starting a program with Singulatiry

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1026,6 +1026,9 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           helpers.log(ctx, () => `Hacking level is too low to create '${p.name}' (level ${create.level} req)`);
           return false;
         }
+        if (Player.currentWork) {
+          Player.finishWork(true);
+        }
 
         Player.startWork(
           new CreateProgramWork({


### PR DESCRIPTION
Current implementation of the CreateProgram singularity API doesn't stop the current work before calling the CreateProgramWork function.  The issue with this is that that function checks to see if you're resuming an incomplete program.  Since the work done on an incomplete program isn't written to the users home directory until the work is stopped, this check fails, ending up with 2 incomplete programs

![image](https://github.com/user-attachments/assets/4dd381b4-bf11-4ad5-bb71-2d9207973a7f)

My fix is, once singularity verifies you can actually create a program, it checks to see if you're busy and if so, stops it, then creates the program.  

I could reproduce this before by just calling the same singulatiry API twice, but can't after my fix.