### PR TITLE
BUGFIX: Cap Gang recruit member calculation

### DIFF
--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -320,19 +320,10 @@ export class Gang {
     if (this.members.length >= GangConstants.MaximumGangMembers) {
       return 0;
     }
-    const numFreeMembers = 3;
-    const recruitCostBase = 5;
-    if (this.members.length < numFreeMembers && this.respect < Math.pow(recruitCostBase, numFreeMembers)) {
-      return numFreeMembers - this.members.length; // if the max possible is less than freeMembers
-    }
-    return (
-      Math.min(
-        Math.floor(Math.log(this.respect) / Math.log(recruitCostBase)),
-        GangConstants.MaximumGangMembers - numFreeMembers,
-      ) +
-      numFreeMembers -
-      this.members.length
-    ); //else
+    const numFreeMembers = GangConstants.numFreeMembers;
+    const recruitCostBase = GangConstants.recruitThresholdBase;
+    const membersRecruitabile = Math.floor(Math.log(this.respect) / Math.log(recruitCostBase)) + numFreeMembers;
+    return Math.min(membersRecruitabile, GangConstants.MaximumGangMembers) - this.members.length;
   }
 
   recruitMember(name: string): boolean {

--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -325,7 +325,14 @@ export class Gang {
     if (this.members.length < numFreeMembers && this.respect < Math.pow(recruitCostBase, numFreeMembers)) {
       return numFreeMembers - this.members.length; // if the max possible is less than freeMembers
     }
-    return Math.floor(Math.log(this.respect) / Math.log(recruitCostBase)) + numFreeMembers - this.members.length; //else
+    return (
+      Math.min(
+        Math.floor(Math.log(this.respect) / Math.log(recruitCostBase)),
+        GangConstants.MaximumGangMembers - numFreeMembers,
+      ) +
+      numFreeMembers -
+      this.members.length
+    ); //else
   }
 
   recruitMember(name: string): boolean {

--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -322,7 +322,8 @@ export class Gang {
     }
     const numFreeMembers = GangConstants.numFreeMembers;
     const recruitCostBase = GangConstants.recruitThresholdBase;
-    const membersRecruitabile = Math.floor(Math.log(this.respect) / Math.log(recruitCostBase)) + numFreeMembers;
+    const membersRecruitabile =
+      Math.floor(Math.max(Math.log(this.respect), 0) / Math.log(recruitCostBase)) + numFreeMembers;
     return Math.min(membersRecruitabile, GangConstants.MaximumGangMembers) - this.members.length;
   }
 


### PR DESCRIPTION
The current calculation for recruit-able gang members is
`Math.floor(Math.log(this.respect) / Math.log(recruitCostBase)) + numFreeMembers - this.members.length; `
The issue with this is that `Math.log(this.respect) / Math.log(recruitCostBase)` has no ceiling.  It's possible for this number to actually be greater than the current possible 12 gang members after the complete calculation.  This causes an issue where the UI claims there are more gang members available than there are possible to recruit

![image](https://github.com/user-attachments/assets/0b1bbc42-52f8-4832-98a5-89d628fd3a63)

I just added a check to see which one was smaller, the already existing calculation, or the actual limit of gang members.