### PR TITLE
CONTRACT: Remove "&nbsp;"s from .getDescription() result

### DIFF
--- a/src/CodingContracts.ts
+++ b/src/CodingContracts.ts
@@ -129,7 +129,7 @@ export class CodingContract {
   }
 
   getDescription(): string {
-    return CodingContractTypes[this.type].desc(this.data).replaceAll("&nbsp;"," ");
+    return CodingContractTypes[this.type].desc(this.data).replaceAll("&nbsp;", " ");
   }
 
   getDifficulty(): number {

--- a/src/CodingContracts.ts
+++ b/src/CodingContracts.ts
@@ -129,7 +129,7 @@ export class CodingContract {
   }
 
   getDescription(): string {
-    return CodingContractTypes[this.type].desc(this.data);
+    return CodingContractTypes[this.type].desc(this.data).replaceAll("&nbsp;"," ");
   }
 
   getDifficulty(): number {


### PR DESCRIPTION
closes #1514 

Using `run contract-XXXX.cct` in the terminal displays fine, a small tweak to `ns.codingcontract.getDescription()` removes the `&nbsp;`  from the function return string too and cleans up the script logging issue. There's probably a more elegant way to do this, sorry.

screenshots of the terminal print of `ns.codingcontract.getDescription()` and  `run contract-XXXX.cct` results post-change attached, in that order.

![getDescription](https://github.com/user-attachments/assets/09776d7a-c94d-4b5b-bb0c-30e71f30ddc3)
![run](https://github.com/user-attachments/assets/ace331c7-0a48-4e89-bef2-187256500633)
