### PR TITLE
INFILTRATION: Minesweepergame minor bugfix, made rounding behavior for height, width and mine count consistent

### DIFF
--- a/src/Infiltration/ui/MinesweeperGame.tsx
+++ b/src/Infiltration/ui/MinesweeperGame.tsx
@@ -166,7 +166,7 @@ function fieldEquals(a: boolean[][], b: boolean[][]): boolean {
 
 function generateEmptyField(difficulty: Difficulty): boolean[][] {
   const field = [];
-  for (let i = 0; i < difficulty.height; i++) {
+  for (let i = 0; i < Math.round(difficulty.height); i++) {
     field.push(new Array(Math.round(difficulty.width)).fill(false));
   }
   return field;
@@ -174,7 +174,7 @@ function generateEmptyField(difficulty: Difficulty): boolean[][] {
 
 function generateMinefield(difficulty: Difficulty): boolean[][] {
   const field = generateEmptyField(difficulty);
-  for (let i = 0; i < difficulty.mines; i++) {
+  for (let i = 0; i < Math.round(difficulty.mines); i++) {
     const x = Math.floor(Math.random() * field.length);
     const y = Math.floor(Math.random() * field[0].length);
     if (field[x][y]) {


### PR DESCRIPTION
A detailed description of the bug that this PR fixes can be found in #1520 .

# Linked issues

fixes #1520 

# Bug fix

Tested it with and without this change:

Without:
![image](https://github.com/user-attachments/assets/a9b06fb1-f8a8-4302-a42a-df23a64d06cb)

With:
![image](https://github.com/user-attachments/assets/8c476a2d-bdc0-4c38-9911-b5a17be253a9)

Screenshot's confirm the fix, all data to reproduce should also be in the screenshots.
