### PR TITLE
UI: Fix misleading favor numbers

### DIFF
--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -207,7 +207,7 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
             <Typography>
               <b>Reputation:</b> <Reputation reputation={faction.playerReputation} />
               <br />
-              <b>Favor:</b> <Favor favor={Math.floor(faction.favor)} />
+              <b>Favor:</b> <Favor favor={faction.favor} />
             </Typography>
           </Box>
           <Box sx={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)" }}>

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -193,9 +193,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
 
       {props.faction.isMember && (
         <Box display="grid" sx={{ alignItems: "center", justifyItems: "left", gridAutoFlow: "row" }}>
-          <Typography sx={{ color: Settings.theme.rep }}>
-            {formatFavor(Math.floor(props.faction.favor))} favor
-          </Typography>
+          <Typography sx={{ color: Settings.theme.rep }}>{formatFavor(props.faction.favor)} favor</Typography>
           <Typography sx={{ color: Settings.theme.rep }}>
             {formatReputation(props.faction.playerReputation)} rep
           </Typography>

--- a/src/Faction/ui/Info.tsx
+++ b/src/Faction/ui/Info.tsx
@@ -91,7 +91,7 @@ export function Info(props: IProps): React.ReactElement {
           }
         >
           <Typography>
-            Faction Favor: <Favor favor={Math.floor(props.faction.favor)} />
+            Faction Favor: <Favor favor={props.faction.favor} />
           </Typography>
         </Tooltip>
       </Box>

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -143,7 +143,7 @@ export function formatNumber(n: number, fractionalDigits = 3, suffixStart = 1000
 export const formatNumberNoSuffix = (n: number, fractionalDigits = 0) => {
   return formatNumber(n, fractionalDigits, 1e33);
 };
-export const formatFavor = formatNumberNoSuffix;
+export const formatFavor = (n: number) => formatNumberNoSuffix(n, 3);
 
 /** Standard noninteger formatting with no options set. Collapses to suffix at 1000 and shows 3 fractional digits. */
 export const formatBigNumber = (n: number) => formatNumber(n);


### PR DESCRIPTION
Favor is not an integer, but we "pretend" that it is by using `Math.floor` in many places in UI. The problem is that the usage of `Math.floor` is inconsistent, and UI shows "misleading" numbers in some cases.

How to reproduce it:
- Join a faction.
- Set favor to 149 and current reputation to 5000.
- Hover the mouse over `Reputation:`. It shows "You will have 150 faction favor ...".
- Soft reset. Check `Faction Favor:`. It shows "149".

Fix: remove the usage of `Math.floor` and change `formatFavor`.
Alternative fix in case we want to show Favor as an integer (I don't like this approach): use `Math.floor` consistently.