### PR TITLE
DOCUMENTATION: Remove unmaintained VS Code extension

### DIFF
--- a/src/Documentation/doc/help/tools_and_resources.md
+++ b/src/Documentation/doc/help/tools_and_resources.md
@@ -5,16 +5,3 @@
 There are plans to create an official repository of Bitburner scripts.
 As of right now, this is not a priority and has not been started.
 However, if you'd like to contribute scripts now, you can find the repository [here](https://github.com/bitburner-official/bitburner-scripts) and submit pull requests.
-
-## Visual Studio Code Extension
-
-One user created a Bitburner extension for the Visual Studio Code (VSCode) editor.
-
-This extension includes several features such as:
-
-- Dynamic RAM calculation
-- RAM Usage breakdown
-- Typescript definition files with JSDoc comments
-- Syntax highlighting
-
-You can find more information and download links [on this Reddit post](https://www.reddit.com/r/Bitburner/comments/bh48y2/visual_studio_code_ram_calculator_extra/).


### PR DESCRIPTION
`tools_and_resources.md` mentions an unmaintained VS Code extension. It is **not** our deprecated VS Code extension. This PR removes the mention of that extension.