### PR TITLE
MISC: Clarify deprecation warning of ns.getTimeSinceLastAug()

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1633,7 +1633,11 @@ export const ns: InternalAPI<NSFull> = {
     return convertTimeMsToTimeElapsedString(milliseconds, milliPrecision);
   },
   getTimeSinceLastAug: () => () => {
-    deprecationWarning("ns.getTimeSinceLastAug()", "Use ns.getResetInfo().lastAugReset instead.");
+    deprecationWarning(
+      "ns.getTimeSinceLastAug()",
+      "Use ns.getResetInfo().lastAugReset instead. Please note that ns.getResetInfo().lastAugReset does NOT return the " +
+        "same value as ns.getTimeSinceLastAug(). Check the NS API documentation for details.",
+    );
     return Player.playtimeSinceLastAug;
   },
   alert: (ctx) => (_message) => {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1635,7 +1635,7 @@ export const ns: InternalAPI<NSFull> = {
   getTimeSinceLastAug: () => () => {
     deprecationWarning(
       "ns.getTimeSinceLastAug()",
-      "Use ns.getResetInfo().lastAugReset instead. Please note that ns.getResetInfo().lastAugReset does NOT return the " +
+      "Use `Date.now() - ns.getResetInfo().lastAugReset` instead. Please note that ns.getResetInfo().lastAugReset does NOT return the " +
         "same value as ns.getTimeSinceLastAug(). Check the NS API documentation for details.",
     );
     return Player.playtimeSinceLastAug;


### PR DESCRIPTION
Closes #1533.