### PR TITLE
BUGFIX: Duplicated augmentation when buying after grafting

### DIFF
--- a/src/DevMenu/ui/AugmentationsDev.tsx
+++ b/src/DevMenu/ui/AugmentationsDev.tsx
@@ -20,12 +20,19 @@ export function AugmentationsDev(): React.ReactElement {
   function setAugmentationDropdown(event: SelectChangeEvent): void {
     setAugmentation(event.target.value as AugmentationName);
   }
+
   function queueAug(): void {
+    if (Player.hasAugmentation(augmentation)) {
+      return;
+    }
     Player.queueAugmentation(augmentation);
   }
 
   function queueAllAugs(): void {
     for (const augName of Object.values(AugmentationName)) {
+      if (Player.hasAugmentation(augName)) {
+        continue;
+      }
       Player.queueAugmentation(augName);
     }
   }

--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -2,7 +2,6 @@ import type { Augmentation } from "../Augmentation/Augmentation";
 import type { Faction } from "./Faction";
 
 import { Augmentations } from "../Augmentation/Augmentations";
-import { PlayerOwnedAugmentation } from "../Augmentation/PlayerOwnedAugmentation";
 import { AugmentationName, FactionDiscovery } from "@enums";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 

--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -83,7 +83,7 @@ export function purchaseAugmentation(aug: Augmentation, fac: Faction, sing = fal
     }
     dialogBoxCreate(txt);
   } else if (augCosts.moneyCost === 0 || Player.money >= augCosts.moneyCost) {
-    Player.queueAugmentation(aug.name, sing);
+    Player.queueAugmentation(aug.name);
 
     Player.loseMoney(augCosts.moneyCost, "augmentations");
 

--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -84,11 +84,7 @@ export function purchaseAugmentation(aug: Augmentation, fac: Faction, sing = fal
     }
     dialogBoxCreate(txt);
   } else if (augCosts.moneyCost === 0 || Player.money >= augCosts.moneyCost) {
-    const queuedAugmentation = new PlayerOwnedAugmentation(aug.name);
-    if (aug.name == AugmentationName.NeuroFluxGovernor) {
-      queuedAugmentation.level = aug.getNextLevel();
-    }
-    Player.queuedAugmentations.push(queuedAugmentation);
+    Player.queueAugmentation(aug.name, sing);
 
     Player.loseMoney(augCosts.moneyCost, "augmentations");
 

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -156,19 +156,17 @@ export const GraftingRoot = (): React.ReactElement => {
                   Router.toPage(Page.Work);
                 }}
                 confirmationText={
-                  <>
+                  <Typography component="div" paddingBottom="1rem">
                     Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b>{" "}
                     be returned.
-                    <br />
-                    <br />
                     {!Player.hasAugmentation(AugmentationName.CongruityImplant) && (
                       <>
+                        <br />
+                        <br />
                         Additionally, grafting an Augmentation will increase the potency of the Entropy virus.
-                        <br />
-                        <br />
                       </>
                     )}
-                  </>
+                  </Typography>
                 }
               />
               <Box sx={{ maxHeight: 330, overflowY: "scroll" }}>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -159,11 +159,16 @@ export const GraftingRoot = (): React.ReactElement => {
                   <>
                     Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b>{" "}
                     be returned.
+                    <br />
+                    <br />
+                    If you purchase this augmentation, the current grafting work will be canceled.
+                    <br />
+                    <br />
                     {!Player.hasAugmentation(AugmentationName.CongruityImplant) && (
                       <>
-                        <br />
-                        <br />
                         Additionally, grafting an Augmentation will increase the potency of the Entropy virus.
+                        <br />
+                        <br />
                       </>
                     )}
                   </>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -161,9 +161,6 @@ export const GraftingRoot = (): React.ReactElement => {
                     be returned.
                     <br />
                     <br />
-                    If you purchase this augmentation, the current grafting work will be canceled.
-                    <br />
-                    <br />
                     {!Player.hasAugmentation(AugmentationName.CongruityImplant) && (
                       <>
                         Additionally, grafting an Augmentation will increase the potency of the Entropy virus.

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -50,6 +50,9 @@ import { achievements } from "../../Achievements/Achievements";
 import { isCompanyWork } from "../../Work/CompanyWork";
 import { isMember } from "../../utils/EnumHelper";
 import { canAccessBitNodeFeature } from "../../BitNode/BitNodeUtils";
+import { isGraftingWork } from "../../Work/GraftingWork";
+import { AlertEvents } from "../../ui/React/AlertManager";
+import { Augmentations } from "../../Augmentation/Augmentations";
 
 export function init(this: PlayerObject): void {
   /* Initialize Player's home computer */
@@ -454,22 +457,36 @@ export function setBitNodeNumber(this: PlayerObject, n: number): void {
   this.bitNodeN = n;
 }
 
-export function queueAugmentation(this: PlayerObject, name: AugmentationName): void {
-  for (const aug of this.queuedAugmentations) {
-    if (aug.name == name) {
-      console.warn(`tried to queue ${name} twice, this may be a bug`);
-      return;
+export function queueAugmentation(this: PlayerObject, name: AugmentationName, callFromSingularityAPI = false): void {
+  // Cancel the current work if the player is grafting this augmentation.
+  if (isGraftingWork(this.currentWork) && this.currentWork.augmentation === name) {
+    this.finishWork(true, callFromSingularityAPI);
+  }
+
+  if (name !== AugmentationName.NeuroFluxGovernor) {
+    for (const aug of this.queuedAugmentations) {
+      if (name === aug.name) {
+        AlertEvents.emit(`Tried to queue ${name} twice. This is a bug. Please contact developers.`);
+        return;
+      }
+    }
+
+    for (const aug of this.augmentations) {
+      if (aug.name === name) {
+        AlertEvents.emit(
+          `Tried to queue ${name}, but this augmentation was installed. This is a bug. Please contact developers.`,
+        );
+        return;
+      }
     }
   }
 
-  for (const aug of this.augmentations) {
-    if (aug.name == name) {
-      console.warn(`tried to queue ${name} twice, this may be a bug`);
-      return;
-    }
+  const queuedAugmentation = new PlayerOwnedAugmentation(name);
+  if (name === AugmentationName.NeuroFluxGovernor) {
+    const augmentation = Augmentations[name];
+    queuedAugmentation.level = augmentation.getNextLevel();
   }
-
-  this.queuedAugmentations.push(new PlayerOwnedAugmentation(name));
+  this.queuedAugmentations.push(queuedAugmentation);
 }
 
 /************* Coding Contracts **************/

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -50,7 +50,6 @@ import { achievements } from "../../Achievements/Achievements";
 import { isCompanyWork } from "../../Work/CompanyWork";
 import { isMember } from "../../utils/EnumHelper";
 import { canAccessBitNodeFeature } from "../../BitNode/BitNodeUtils";
-import { isGraftingWork } from "../../Work/GraftingWork";
 import { AlertEvents } from "../../ui/React/AlertManager";
 import { Augmentations } from "../../Augmentation/Augmentations";
 
@@ -457,12 +456,7 @@ export function setBitNodeNumber(this: PlayerObject, n: number): void {
   this.bitNodeN = n;
 }
 
-export function queueAugmentation(this: PlayerObject, name: AugmentationName, callFromSingularityAPI = false): void {
-  // Cancel the current work if the player is grafting this augmentation.
-  if (isGraftingWork(this.currentWork) && this.currentWork.augmentation === name) {
-    this.finishWork(true, callFromSingularityAPI);
-  }
-
+export function queueAugmentation(this: PlayerObject, name: AugmentationName): void {
   if (name !== AugmentationName.NeuroFluxGovernor) {
     for (const aug of this.queuedAugmentations) {
       if (name === aug.name) {

--- a/src/Work/GraftingWork.tsx
+++ b/src/Work/GraftingWork.tsx
@@ -59,6 +59,14 @@ export class GraftingWork extends Work {
     if (!cancelled) {
       applyAugmentation({ name: augName, level: 1 });
 
+      // Remove this augmentation from the list of queued augmentations.
+      for (let i = 0; i < Player.queuedAugmentations.length; ++i) {
+        if (Player.queuedAugmentations[i].name === augName) {
+          Player.queuedAugmentations.splice(i, 1);
+          break;
+        }
+      }
+
       if (!Player.hasAugmentation(AugmentationName.CongruityImplant, true)) {
         Player.entropy += 1;
         Player.applyEntropy(Player.entropy);


### PR DESCRIPTION
This bug can be exploited to duplicate all graftable augmentations. How to reproduce it:
- Load a clean save with SF10.
- Graft QLink.
- Join Illuminati. Buy QLink.
- Wait until the grafting QLink finishes, or use the Dev tool to "time skip".
- Check the augmentation list.

![Capture-1](https://github.com/user-attachments/assets/4082548f-1ac0-4038-9f8e-f7c5703d0243)
![Capture-2](https://github.com/user-attachments/assets/fab1479d-59a4-4d29-b98c-c90ec56ac007)
