### PR TITLE
BUGFIX: Tab completion uses wrong command list

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -76,6 +76,7 @@ import { wget } from "./commands/wget";
 import { hash } from "../hash/hash";
 import { apr1 } from "./commands/apr1";
 import { changelog } from "./commands/changelog";
+import { clear } from "./commands/clear";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { Engine } from "../engine";
 import { Directory, resolveDirectory, root } from "../Paths/Directory";
@@ -83,6 +84,52 @@ import { FilePath, isFilePath, resolveFilePath } from "../Paths/FilePath";
 import { hasTextExtension } from "../Paths/TextFilePath";
 import { ContractFilePath } from "../Paths/ContractFilePath";
 import { ServerConstants } from "../Server/data/Constants";
+
+export const TerminalCommands: Record<string, (args: (string | number | boolean)[], server: BaseServer) => void> = {
+  "scan-analyze": scananalyze,
+  alias: alias,
+  analyze: analyze,
+  backdoor: backdoor,
+  buy: buy,
+  cat: cat,
+  cd: cd,
+  changelog: changelog,
+  check: check,
+  clear: clear,
+  cls: clear,
+  connect: connect,
+  cp: cp,
+  download: download,
+  expr: expr,
+  free: free,
+  grep: grep,
+  grow: grow,
+  hack: hack,
+  help: help,
+  history: history,
+  home: home,
+  hostname: hostname,
+  kill: kill,
+  killall: killall,
+  ls: ls,
+  lscpu: lscpu,
+  mem: mem,
+  mv: mv,
+  nano: nano,
+  ps: ps,
+  rm: rm,
+  run: run,
+  scan: scan,
+  scp: scp,
+  sudov: sudov,
+  tail: tail,
+  apr1: apr1,
+  top: top,
+  unalias: unalias,
+  vim: vim,
+  weaken: weaken,
+  wget: wget,
+};
 
 export class Terminal {
   // Flags to determine whether the player is currently running a hack or an analyze
@@ -744,53 +791,7 @@ export class Terminal {
     // Aside from the run-by-path command, we don't need the first entry once we've stored it in commandName.
     commandArray.shift();
 
-    const commands: Record<string, (args: (string | number | boolean)[], server: BaseServer) => void> = {
-      "scan-analyze": scananalyze,
-      alias: alias,
-      analyze: analyze,
-      backdoor: backdoor,
-      buy: buy,
-      cat: cat,
-      cd: cd,
-      changelog: changelog,
-      check: check,
-      clear: () => this.clear(),
-      cls: () => this.clear(),
-      connect: connect,
-      cp: cp,
-      download: download,
-      expr: expr,
-      free: free,
-      grep: grep,
-      grow: grow,
-      hack: hack,
-      help: help,
-      history: history,
-      home: home,
-      hostname: hostname,
-      kill: kill,
-      killall: killall,
-      ls: ls,
-      lscpu: lscpu,
-      mem: mem,
-      mv: mv,
-      nano: nano,
-      ps: ps,
-      rm: rm,
-      run: run,
-      scan: scan,
-      scp: scp,
-      sudov: sudov,
-      tail: tail,
-      apr1: apr1,
-      top: top,
-      unalias: unalias,
-      vim: vim,
-      weaken: weaken,
-      wget: wget,
-    };
-
-    const f = commands[commandName.toLowerCase()];
+    const f = TerminalCommands[commandName.toLowerCase()];
     if (!f) return this.error(`Command ${commandName} not found`);
 
     f(commandArray, currentServer);

--- a/src/Terminal/commands/clear.ts
+++ b/src/Terminal/commands/clear.ts
@@ -1,0 +1,5 @@
+import { Terminal } from "../../Terminal";
+
+export function clear(): void {
+  Terminal.clear();
+}

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -11,50 +11,7 @@ import libarg from "arg";
 import { getAllDirectories, resolveDirectory, root } from "../Paths/Directory";
 import { isLegacyScript, resolveScriptFilePath } from "../Paths/ScriptFilePath";
 import { enums } from "../NetscriptFunctions";
-
-// TODO: this shouldn't be hardcoded in two places with no typechecks to verify equivalence
-// An array of all Terminal commands
-const gameCommands = [
-  "alias",
-  "analyze",
-  "backdoor",
-  "cat",
-  "cd",
-  "changelog",
-  "check",
-  "clear",
-  "cls",
-  "connect",
-  "cp",
-  "download",
-  "expr",
-  "free",
-  "grow",
-  "hack",
-  "help",
-  "home",
-  "hostname",
-  "ifconfig",
-  "kill",
-  "killall",
-  "ls",
-  "lscpu",
-  "mem",
-  "mv",
-  "nano",
-  "ps",
-  "rm",
-  "run",
-  "scan-analyze",
-  "scan",
-  "scp",
-  "sudov",
-  "tail",
-  "theme",
-  "top",
-  "vim",
-  "weaken",
-];
+import { TerminalCommands } from "./Terminal";
 
 /** Suggest all completion possibilities for the last argument in the last command being typed
  * @param terminalText The current full text entered in the terminal
@@ -123,7 +80,7 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
 
   const addAliases = () => addGeneric({ iterable: Aliases.keys() });
   const addGlobalAliases = () => addGeneric({ iterable: GlobalAliases.keys() });
-  const addCommands = () => addGeneric({ iterable: gameCommands });
+  const addCommands = () => addGeneric({ iterable: Object.keys(TerminalCommands) });
   const addDarkwebItems = () => addGeneric({ iterable: Object.values(DarkWebItems).map((item) => item.program) });
   const addServerNames = () => addGeneric({ iterable: GetAllServers().map((server) => server.hostname) });
   const addScripts = () => addGeneric({ iterable: currServ.scripts.keys(), usePathing: true });


### PR DESCRIPTION
When I checked `getTabCompletionPossibilities.ts`, I saw this comment: `TODO: this shouldn't be hardcoded in two places with no typechecks to verify equivalence`. `gameCommands` is not the same as `commands` in `executeCommand` (`Terminal.ts`). The discrepancy:
- Missing commands: buy, grep, history, unalias, wget
- Nonexistent commands: ifconfig, theme

This PR refactors the command list.