### PR TITLE
BUGFIX: Prompt does not reset text value

### DIFF
--- a/src/ui/React/PromptManager.tsx
+++ b/src/ui/React/PromptManager.tsx
@@ -52,8 +52,9 @@ export function PromptManager({ hidden }: { hidden: boolean }): React.ReactEleme
   };
 
   let PromptContent = PromptMenuBoolean;
-  if (prompt?.options?.type && ["text", "select"].includes(prompt.options.type))
+  if (prompt?.options?.type && ["text", "select"].includes(prompt.options.type)) {
     PromptContent = types[prompt.options.type];
+  }
   const resolve = (value: boolean | string): void => {
     prompt?.resolve(value);
     setPrompt(null);
@@ -94,10 +95,17 @@ function PromptMenuBoolean({ resolve }: IContentProps): React.ReactElement {
   );
 }
 
-function PromptMenuText({ resolve }: IContentProps): React.ReactElement {
+function PromptMenuText({ prompt, resolve }: IContentProps): React.ReactElement {
   const [value, setValue] = useState("");
 
-  const submit = (): void => resolve(value);
+  const submit = (): void => {
+    resolve(value);
+    setValue("");
+  };
+
+  useEffect(() => {
+    setValue("");
+  }, [prompt]);
 
   const onInput = (event: React.ChangeEvent<HTMLInputElement>): void => {
     setValue(event.target.value);
@@ -133,7 +141,14 @@ function PromptMenuText({ resolve }: IContentProps): React.ReactElement {
 function PromptMenuSelect({ prompt, resolve }: IContentProps): React.ReactElement {
   const [value, setValue] = useState("");
 
-  const submit = (): void => resolve(value);
+  const submit = (): void => {
+    resolve(value);
+    setValue("");
+  };
+
+  useEffect(() => {
+    setValue("");
+  }, [prompt]);
 
   const onChange = (event: SelectChangeEvent): void => {
     setValue(event.target.value);
@@ -158,7 +173,11 @@ function PromptMenuSelect({ prompt, resolve }: IContentProps): React.ReactElemen
   return (
     <>
       <div style={{ display: "flex", alignItems: "center", paddingTop: "10px" }}>
-        <Select onChange={onChange} value={value} style={{ flex: "1 0 auto" }}>
+        <Select
+          onChange={onChange}
+          value={prompt.options?.choices.includes(value) ? value : ""}
+          style={{ flex: "1 0 auto" }}
+        >
           {getItems(prompt.options?.choices || [])}
         </Select>
         <Button onClick={submit} disabled={value === ""}>


### PR DESCRIPTION
The prompt modal does not reset its value when a new prompt is spawned.

MRE:
```js
/** @param {NS} ns */
export async function main(ns) {
  const a = await ns.prompt("prompt 1", { type: "text" });
  const b = await ns.prompt("prompt 2", { type: "text" });
}
```
- Run the code above.
- Enter any string.
- Click "Confirm" or click ouside the modal to cancel it.
- The old string is still in the second prompt.

Full test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.clearLog();
  const a = await ns.prompt("prompt 1", { type: "text" });
  ns.print("a:", a);
  const b = await ns.prompt("prompt 2", { type: "text" });
  ns.print("b:", b);
  const c = await ns.prompt("prompt 3", { type: "select", choices: ["option 1", "option 2"] });
  ns.print("c:", c);
  const d = await ns.prompt("prompt 4", { type: "select", choices: ["option 3", "option 4"] });
  ns.print("d:", d);
  const e = await ns.prompt("prompt 5", { type: "boolean" });
  ns.print("e:", e);
  const f = await ns.prompt("prompt 6", { type: "boolean" });
  ns.print("f:", f);
}
```