### PR TITLE
BUGFIX: Fix link to non-existing page

### DIFF
--- a/src/Documentation/doc/basic/reputation.md
+++ b/src/Documentation/doc/basic/reputation.md
@@ -2,7 +2,7 @@
 
 In order to acquire [Augmentations](augmentations.md) from [Factions](factions.md), you need to earn their trust.
 
-This can be done in a variety of ways, but the most common is offering your services to a [Faction](faction.md).
+This can be done in a variety of ways, but the most common is offering your services to a [Faction](factions.md).
 Another option is to give them intel from [Infiltrations](infiltration.md).
 
 When installing [Augmentations](augmentations.md), all your reputation gets converted to favor.


### PR DESCRIPTION
There was a link in the `Reputation` docs page which lead to `faction.md` instead of `factions.md`. This results in the following page being shown:

![image](https://github.com/user-attachments/assets/63e30d24-eeb4-462f-a9c7-8070247cb23d)

This pull request fixes this by correcting the link to lead to `factions.md`.