### PR TITLE
TERMINAL: Stop terminal scp from revealing and copying to unreachable servers

### DIFF
--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -22,24 +22,10 @@ import "../Script/RunningScript"; // For reviver side-effect
 let AllServers: Record<string, Server | HacknetServer> = {};
 
 function GetServerByIP(ip: string): BaseServer | undefined {
-  for (const key of Object.keys(AllServers)) {
-    const server = AllServers[key];
+  for (const server of Object.values(AllServers)) {
     if (server.ip !== ip) continue;
     return server;
   }
-}
-
-//Returns server object with corresponding hostname
-//    Relatively slow, would rather not use this a lot
-function GetServerByHostname(hostname: string): BaseServer | null {
-  for (const key of Object.keys(AllServers)) {
-    const server = AllServers[key];
-    if (server.hostname == hostname) {
-      return server;
-    }
-  }
-
-  return null;
 }
 
 //Get server by IP or hostname. Returns null if invalid
@@ -48,15 +34,21 @@ export function GetServer(s: string): BaseServer | null {
     const server = AllServers[s];
     if (server) return server;
   }
-
-  if (!isIPAddress(s)) return GetServerByHostname(s);
-
+  if (!isIPAddress(s)) return null;
   const ipserver = GetServerByIP(s);
   if (ipserver !== undefined) {
     return ipserver;
   }
 
   return null;
+}
+
+//Get server by IP or hostname. Returns null if invalid or unreachable.
+export function GetReachableServer(s: string): BaseServer | null {
+  const server = GetServer(s);
+  if (server === null) return server;
+  if (server.serversOnNetwork.length === 0) return null;
+  return server;
 }
 
 export function GetAllServers(): BaseServer[] {

--- a/src/Terminal/commands/scp.ts
+++ b/src/Terminal/commands/scp.ts
@@ -1,6 +1,6 @@
 import { Terminal } from "../../Terminal";
 import { BaseServer } from "../../Server/BaseServer";
-import { GetServer } from "../../Server/AllServers";
+import { GetReachableServer } from "../../Server/AllServers";
 import { hasScriptExtension } from "../../Paths/ScriptFilePath";
 import { hasTextExtension } from "../../Paths/TextFilePath";
 import { isMember } from "../../utils/EnumHelper";
@@ -14,7 +14,7 @@ export function scp(args: (string | number | boolean)[], server: BaseServer): vo
 
   // Validate destination server
   const destHostname = String(args.pop());
-  const destServer = GetServer(destHostname);
+  const destServer = GetReachableServer(destHostname);
   if (!destServer) return Terminal.error(`Invalid destination server: ${destHostname}`);
 
   // Validate filepaths

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -125,7 +125,12 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
   const addGlobalAliases = () => addGeneric({ iterable: GlobalAliases.keys() });
   const addCommands = () => addGeneric({ iterable: gameCommands });
   const addDarkwebItems = () => addGeneric({ iterable: Object.values(DarkWebItems).map((item) => item.program) });
-  const addServerNames = () => addGeneric({ iterable: GetAllServers().map((server) => server.hostname) });
+  const addServerNames = () =>
+    addGeneric({
+      iterable: GetAllServers()
+        .filter((server) => server.serversOnNetwork.length !== 0)
+        .map((server) => server.hostname),
+    });
   const addScripts = () => addGeneric({ iterable: currServ.scripts.keys(), usePathing: true });
   const addTextFiles = () => addGeneric({ iterable: currServ.textFiles.keys(), usePathing: true });
   const addCodingContracts = () => {


### PR DESCRIPTION
Currently tab autocomplete on terminal `scp` spoils the existence of WD before installing TRP. This PR also makes terminal `scp` unable to copy to unreachable servers for consistency with `ns.scp`.