### PR TITLE
BUGFIX: Add missing BN multipliers in UI

### DIFF
--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -141,6 +141,10 @@ function CompanyMults({ mults }: IMultsProps): React.ReactElement {
       name: "Work Money",
       color: Settings.theme.money,
     },
+    CompanyWorkRepGain: {
+      name: "Work Reputation",
+      color: Settings.theme.rep,
+    },
     CompanyWorkExpGain: { name: "Work Exp" },
   };
 
@@ -177,11 +181,13 @@ function CrimeMults({ mults }: IMultsProps): React.ReactElement {
   const rows: IBNMultRows = {
     CrimeExpGain: {
       name: "Crime Exp",
-      color: Settings.theme.combat,
     },
     CrimeMoney: {
       name: "Crime Money",
-      color: Settings.theme.combat,
+      color: Settings.theme.money,
+    },
+    CrimeSuccessRate: {
+      name: "Crime Success Rate",
     },
   };
 
@@ -225,9 +231,13 @@ function HackingMults({ mults }: IMultsProps): React.ReactElement {
       name: "Hacking Exp",
       color: Settings.theme.hack,
     },
+    HackingSpeedMultiplier: {
+      name: "Hacking Speed",
+      color: Settings.theme.hack,
+    },
     ServerGrowthRate: { name: "Server Growth Rate" },
-    ServerMaxMoney: { name: "Server Max Money" },
-    ServerStartingMoney: { name: "Server Starting Money" },
+    ServerMaxMoney: { name: "Server Max Money", color: Settings.theme.money },
+    ServerStartingMoney: { name: "Server Starting Money", color: Settings.theme.money },
     ServerStartingSecurity: { name: "Server Starting Security" },
     ServerWeakenRate: { name: "Server Weaken Rate" },
     ManualHackMoney: {


### PR DESCRIPTION
`BitnodeMultipliersDescription.tsx` does not handle these multipliers:
- CompanyWorkRepGain
- CrimeSuccessRate
- HackingSpeedMultiplier

I also change the colors of some multipliers to make them consistent:
- CrimeExpGain: remove theme color "combat". Except "Hacking Exp", all "XXX EXP" do not have a theme color.
- CrimeMoney: "combat" -> "money".
- ServerMaxMoney, ServerStartingMoney: use "money".

Before:
![before](https://github.com/user-attachments/assets/5648fe20-cc64-49b7-90fd-39c90a89e1c2)

After:
![after](https://github.com/user-attachments/assets/8e565975-d77c-4035-9874-9db2681a4e65)

Fixes #1544.