### PR TITLE
BUGFIX: Wrong countdown of remaining time for Bladeburner action

### DIFF
--- a/src/Bladeburner/ui/ActionHeader.tsx
+++ b/src/Bladeburner/ui/ActionHeader.tsx
@@ -27,10 +27,11 @@ export function ActionHeader({ bladeburner, action, rerender }: ActionHeaderProp
     bladeburner.actionTimeToComplete,
   );
   const remainingSeconds = Math.max(
-    bladeburner.actionTimeToComplete - bladeburner.actionTimeCurrent + bladeburner.actionTimeOverflow,
+    bladeburner.actionTimeToComplete - bladeburner.actionTimeCurrent - bladeburner.actionTimeOverflow,
     0,
   );
-  const remainingBonusSeconds = Math.floor(bladeburner.storedCycles / BladeburnerConstants.CyclesPerSecond);
+  const remainingBonusSeconds = bladeburner.storedCycles / BladeburnerConstants.CyclesPerSecond;
+  const showMilliseconds = remainingBonusSeconds > 4;
   /**
    * Bladeburner is processed every second. Each time it's processed, we use (up to) 4 bonus seconds and process it as
    * if (up to) 5 seconds passed.
@@ -41,7 +42,7 @@ export function ActionHeader({ bladeburner, action, rerender }: ActionHeaderProp
   let eta;
   if (remainingSeconds <= effectiveBonusSeconds) {
     // If we have enough effectiveBonusSeconds, ETA is (remainingSeconds / 5).
-    eta = Math.floor(remainingSeconds / 5);
+    eta = remainingSeconds / 5;
   } else {
     /**
      * For example, let's say we start the "Training" action with 20 bonus seconds: remainingSeconds=30;remainingBonusSeconds=20.
@@ -75,7 +76,9 @@ export function ActionHeader({ bladeburner, action, rerender }: ActionHeaderProp
               progress: computedActionTimeCurrent / bladeburner.actionTimeToComplete,
             })}
           </Typography>
-          <Typography marginLeft="1rem">Remaining time: {convertTimeMsToTimeElapsedString(eta * 1000)}</Typography>
+          <Typography marginLeft="1rem">
+            Remaining time: {convertTimeMsToTimeElapsedString(eta * 1000, showMilliseconds)}
+          </Typography>
         </Box>
       </>
     );


### PR DESCRIPTION
The logic of `remainingSeconds` is wrong. I also changed how we show the milliseconds:
- Before: always show seconds.
- After: show milliseconds when the player has enough bonus time.

Logs:

Before:
```
 0/16 3.200 seconds remainingSeconds: 16, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 0
 5/16 2.200 seconds remainingSeconds: 11, actionTimeToComplete: 16, actionTimeCurrent: 5, actionTimeOverflow: 0
10/16 1.200 seconds remainingSeconds: 6, actionTimeToComplete: 16, actionTimeCurrent: 10, actionTimeOverflow: 0
15/16 0.200 seconds remainingSeconds: 1, actionTimeToComplete: 16, actionTimeCurrent: 15, actionTimeOverflow: 0
 4/16 4.000 seconds remainingSeconds: 20, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 4
 9/16 1.400 seconds remainingSeconds: 7, actionTimeToComplete: 16, actionTimeCurrent: 9, actionTimeOverflow: 0
14/16 0.400 seconds remainingSeconds: 2, actionTimeToComplete: 16, actionTimeCurrent: 14, actionTimeOverflow: 0
 3/16 3.800 seconds remainingSeconds: 19, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 3
 8/16 1.600 seconds remainingSeconds: 8, actionTimeToComplete: 16, actionTimeCurrent: 8, actionTimeOverflow: 0
13/16 0.600 seconds remainingSeconds: 3, actionTimeToComplete: 16, actionTimeCurrent: 13, actionTimeOverflow: 0
 2/16 3.600 seconds remainingSeconds: 18, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 2
 7/16 1.800 seconds remainingSeconds: 9, actionTimeToComplete: 16, actionTimeCurrent: 7, actionTimeOverflow: 0
12/16 0.800 seconds remainingSeconds: 4, actionTimeToComplete: 16, actionTimeCurrent: 12, actionTimeOverflow: 0
 1/16 3.400 seconds remainingSeconds: 17, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 1
 6/16 2.000 seconds remainingSeconds: 10, actionTimeToComplete: 16, actionTimeCurrent: 6, actionTimeOverflow: 0
11/16 1.000 seconds remainingSeconds: 5, actionTimeToComplete: 16, actionTimeCurrent: 11, actionTimeOverflow: 0
 0/16 3.200 seconds remainingSeconds: 16, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 0
```

After:
```
 0/16 3.200 seconds remainingSeconds: 16, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 0
 5/16 2.200 seconds remainingSeconds: 11, actionTimeToComplete: 16, actionTimeCurrent: 5, actionTimeOverflow: 0
10/16 1.200 seconds remainingSeconds: 6, actionTimeToComplete: 16, actionTimeCurrent: 10, actionTimeOverflow: 0
15/16 0.200 seconds remainingSeconds: 1, actionTimeToComplete: 16, actionTimeCurrent: 15, actionTimeOverflow: 0
 4/16 2.400 seconds remainingSeconds: 12, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 4
 9/16 1.400 seconds remainingSeconds: 7, actionTimeToComplete: 16, actionTimeCurrent: 9, actionTimeOverflow: 0
14/16 0.400 seconds remainingSeconds: 2, actionTimeToComplete: 16, actionTimeCurrent: 14, actionTimeOverflow: 0
 3/16 2.600 seconds remainingSeconds: 13, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 3
 8/16 1.600 seconds remainingSeconds: 8, actionTimeToComplete: 16, actionTimeCurrent: 8, actionTimeOverflow: 0
13/16 0.600 seconds remainingSeconds: 3, actionTimeToComplete: 16, actionTimeCurrent: 13, actionTimeOverflow: 0
 2/16 2.800 seconds remainingSeconds: 14, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 2
 7/16 1.800 seconds remainingSeconds: 9, actionTimeToComplete: 16, actionTimeCurrent: 7, actionTimeOverflow: 0
12/16 0.800 seconds remainingSeconds: 4, actionTimeToComplete: 16, actionTimeCurrent: 12, actionTimeOverflow: 0
 1/16 3.000 seconds remainingSeconds: 15, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 1
 6/16 2.000 seconds remainingSeconds: 10, actionTimeToComplete: 16, actionTimeCurrent: 6, actionTimeOverflow: 0
11/16 1.000 seconds remainingSeconds: 5, actionTimeToComplete: 16, actionTimeCurrent: 11, actionTimeOverflow: 0
 0/16 3.200 seconds remainingSeconds: 16, actionTimeToComplete: 16, actionTimeCurrent: 0, actionTimeOverflow: 0
```

Videos:

https://github.com/user-attachments/assets/2b34707f-7b17-4ac3-a80f-3797135d6c61

https://github.com/user-attachments/assets/6fc4c5da-346a-46a0-96ba-12838a16b475

Fixes #1479.