### PR TITLE
BUGFIX: Duplicated program in edge case

### DIFF
--- a/src/DevMenu/ui/ProgramsDev.tsx
+++ b/src/DevMenu/ui/ProgramsDev.tsx
@@ -18,12 +18,13 @@ export function ProgramsDev(): React.ReactElement {
     setProgram(event.target.value as CompletedProgramName);
   }
   function addProgram(): void {
-    if (!Player.hasProgram(program)) Player.getHomeComputer().programs.push(program);
+    Player.getHomeComputer().pushProgram(program);
   }
 
   function addAllPrograms(): void {
+    const home = Player.getHomeComputer();
     for (const name of Object.values(CompletedProgramName)) {
-      if (!Player.hasProgram(name)) Player.getHomeComputer().programs.push(name);
+      home.pushProgram(name);
     }
   }
 

--- a/src/Message/MessageHelpers.tsx
+++ b/src/Message/MessageHelpers.tsx
@@ -74,10 +74,7 @@ function checkForMessagesToSend(): void {
     }
   } else if (!recvd(MessageFilename.Jumper0) && Player.skills.hacking >= 25) {
     sendMessage(MessageFilename.Jumper0);
-    const homeComp = Player.getHomeComputer();
-    if (!homeComp.programs.includes(CompletedProgramName.flight)) {
-      homeComp.programs.push(CompletedProgramName.flight);
-    }
+    Player.getHomeComputer().pushProgram(CompletedProgramName.flight);
   } else if (!recvd(MessageFilename.Jumper1) && Player.skills.hacking >= 40) {
     sendMessage(MessageFilename.Jumper1);
   } else if (!recvd(MessageFilename.CyberSecTest) && Player.skills.hacking >= 50) {

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -67,7 +67,7 @@ export function init(this: PlayerObject): void {
   this.currentServer = SpecialServers.Home;
   AddToAllServers(t_homeComp);
 
-  this.getHomeComputer().programs.push(CompletedProgramName.nuke);
+  this.getHomeComputer().pushProgram(CompletedProgramName.nuke);
 }
 
 export function prestigeAugmentation(this: PlayerObject): void {

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -80,11 +80,11 @@ export function prestigeAugmentation(): void {
     const aug = Augmentations[ownedAug.name];
     Player.gainMoney(aug.startingMoney, "other");
     for (const program of aug.programs) {
-      homeComp.programs.push(program);
+      homeComp.pushProgram(program);
     }
   }
   if (canAccessBitNodeFeature(5)) {
-    homeComp.programs.push(CompletedProgramName.formulas);
+    homeComp.pushProgram(CompletedProgramName.formulas);
   }
 
   // Re-create foreign servers
@@ -248,7 +248,7 @@ export function prestigeSourceFile(isFlume: boolean): void {
   Player.reapplyAllSourceFiles();
 
   if (canAccessBitNodeFeature(5)) {
-    homeComp.programs.push(CompletedProgramName.formulas);
+    homeComp.pushProgram(CompletedProgramName.formulas);
   }
 
   // BitNode 3: Corporatocracy

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -197,9 +197,9 @@ export function prestigeHomeComputer(homeComp: Server): void {
   homeComp.serversOnNetwork = [];
   homeComp.isConnectedTo = true;
   homeComp.ramUsed = 0;
-  homeComp.programs.push(CompletedProgramName.nuke);
+  homeComp.pushProgram(CompletedProgramName.nuke);
   if (hasBitflume) {
-    homeComp.programs.push(CompletedProgramName.bitFlume);
+    homeComp.pushProgram(CompletedProgramName.bitFlume);
   }
 
   homeComp.messages.length = 0; //Remove .lit and .msg files

--- a/src/Work/CreateProgramWork.ts
+++ b/src/Work/CreateProgramWork.ts
@@ -87,14 +87,12 @@ export class CreateProgramWork extends Work {
         dialogBoxCreate(lines.join("\n"));
       }
 
-      if (!Player.getHomeComputer().programs.includes(programName)) {
-        Player.getHomeComputer().programs.push(programName);
-      }
+      Player.getHomeComputer().pushProgram(programName);
     } else if (!Player.getHomeComputer().programs.includes(programName)) {
       //Incomplete case
       const perc = ((100 * this.unitCompleted) / this.unitNeeded()).toFixed(2);
       const incompleteName = asProgramFilePath(programName + "-" + perc + "%-INC");
-      Player.getHomeComputer().programs.push(incompleteName);
+      Player.getHomeComputer().pushProgram(incompleteName);
     }
   }
 


### PR DESCRIPTION
In `prestigeAugmentation` (`src\Prestige.ts`), we add programs (from augmentations) without checking if those programs have already been on the home PC. If many augmentations give same programs, those programs will be duplicated. This is not a problem right now, because there are no **normal** augmentations that give same programs. The only exception is the special "BigDsBigBrain".

How to reproduce it:
- Load a clean save.
- Use dev menu to install all augmentations.
- Check the program list on home.

This PR replaces all `server.programs.push` with `server.pushProgram` (this function has a built-in check for this problem). We will never see this problem again, even when we add new augmentations that give same programs.