### PR TITLE
BUGFIX: Wrong success range of Bladeburner general action

### DIFF
--- a/src/Bladeburner/Actions/GeneralAction.ts
+++ b/src/Bladeburner/Actions/GeneralAction.ts
@@ -4,6 +4,7 @@ import type { ActionIdentifier } from "../Types";
 
 import { BladeActionType, BladeGeneralActionName } from "@enums";
 import { ActionClass, ActionParams } from "./Action";
+import { clampNumber } from "../../utils/helpers/clampNumber";
 
 type GeneralActionParams = ActionParams & {
   name: BladeGeneralActionName;
@@ -28,8 +29,9 @@ export class GeneralAction extends ActionClass {
   getSuccessChance(__bladeburner: Bladeburner, __person: Person): number {
     return 1;
   }
+
   getSuccessRange(bladeburner: Bladeburner, person: Person): [minChance: number, maxChance: number] {
-    const chance = this.getSuccessChance(bladeburner, person);
+    const chance = clampNumber(this.getSuccessChance(bladeburner, person), 0, 1);
     return [chance, chance];
   }
 }

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -129,7 +129,6 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
       checkSleeveNumber(ctx, sleeveNumber);
       switch (action.type) {
         case BladeActionType.general:
-          return [1, 1];
         case BladeActionType.contract: {
           const sleevePerson = Player.sleeves[sleeveNumber];
           return action.getSuccessRange(bladeburner, sleevePerson);


### PR DESCRIPTION
This PR fixes 2 bugs:

Bug 1:
In #1428, we added support for Sleeves in `ns.bladeburner.getActionEstimatedSuccessChance`. It has a bug: It only calculates the success range for Contract actions, so the success range of General actions is always [0, 0]. I fixed that bug in #1450. However, the fix is incomplete. `getSuccessChance` of `GeneralAction` returns 1, but it can be overridden. "Recruitment" action overrides it in `src\Bladeburner\data\GeneralActions.ts`.

Bug 2:
`getSuccessRange` in `GeneralAction` does not "clamp" the chance. The success chance can be greater than 1.