### PR TITLE
MISC: Improve rep calculation accuracy

### DIFF
--- a/src/Faction/formulas/favor.ts
+++ b/src/Faction/formulas/favor.ts
@@ -7,16 +7,16 @@ import { clampNumber } from "../../utils/helpers/clampNumber";
 export const MaxFavor = 35331;
 // This is the nearest representable value of log(1.02), which is the base of our power.
 // It is *not* the same as Math.log(1.02), since "1.02" lacks sufficient precision.
-const log1point2 = 0.019802627296179712;
+const log1point02 = 0.019802627296179712;
 
 export function favorToRep(f: number): number {
   // expm1 is e^x - 1, which is more accurate for small x than doing it the obvious way.
-  return clampNumber(25000 * Math.expm1(log1point2 * f), 0);
+  return clampNumber(25000 * Math.expm1(log1point02 * f), 0);
 }
 
 export function repToFavor(r: number): number {
   // log1p is log(x + 1), which is more accurate for small x than doing it the obvious way.
-  return clampNumber(Math.log1p(r / 25000) / log1point2, 0, MaxFavor);
+  return clampNumber(Math.log1p(r / 25000) / log1point02, 0, MaxFavor);
 }
 
 export function calculateFavorAfterResetting(favor: number, playerReputation: number) {

--- a/src/Faction/formulas/favor.ts
+++ b/src/Faction/formulas/favor.ts
@@ -5,13 +5,18 @@
 import { clampNumber } from "../../utils/helpers/clampNumber";
 
 export const MaxFavor = 35331;
+// This is the nearest representable value of log(1.02), which is the base of our power.
+// It is *not* the same as Math.log(1.02), since "1.02" lacks sufficient precision.
+const log1point2 = 0.019802627296179712;
 
 export function favorToRep(f: number): number {
-  return clampNumber(25000 * (Math.pow(1.02, f) - 1), 0);
+  // expm1 is e^x - 1, which is more accurate for small x than doing it the obvious way.
+  return clampNumber(25000 * Math.expm1(log1point2 * f), 0);
 }
 
 export function repToFavor(r: number): number {
-  return clampNumber(Math.log(r / 25000 + 1) / Math.log(1.02), 0, MaxFavor);
+  // log1p is log(x + 1), which is more accurate for small x than doing it the obvious way.
+  return clampNumber(Math.log1p(r / 25000) / log1point2, 0, MaxFavor);
 }
 
 export function calculateFavorAfterResetting(favor: number, playerReputation: number) {


### PR DESCRIPTION
The way the rep calculations were written creates a significant (in the floating-point sense) amount of inaccuracy, especially at small favor/rep values. Here's a test script:

`factionError.js`
```js
/** @param {NS} ns */
export async function main(ns) {
  let sum = 0;
  let worst = 0;
  for (let i = 1; i <= 2000; ++i) {
    const favor = ns.formulas.reputation.calculateRepToFavor(i);
    const rep = ns.formulas.reputation.calculateFavorToRep(favor);
    const error = Math.abs((i - rep) / i);
    if (error > worst) worst = error;
    sum += error;
  }
  ns.tprint(`Average relative error: ${sum / 2000}`)
  ns.tprint(`Worst relative error: ${worst}`)
}
```

Running in 2.6.2
```
factionError.js: Average relative error: 5.748654525442948e-15
factionError.js: Worst relative error: 1.000088900582341e-12
```

With this PR
```
factionError.js: Average relative error: 4.2920498646771374e-17
factionError.js: Worst relative error: 4.020754649747693e-16
```
(Note that a 1-bit relative error is, on average, 1.539095918623324e-16, so this means the majority of errors are now zero.)