### PR TITLE
NETSCRIPT: placeOrder parameter info changed to reflect BitBurner Docs

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1423,7 +1423,7 @@ export interface TIX {
    */
   sellShort(sym: string, shares: number): number;
 
-/**
+  /**
    * Place order for stocks.
    * @remarks
    * RAM cost: 2.5 GB

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1423,11 +1423,11 @@ export interface TIX {
    */
   sellShort(sym: string, shares: number): number;
 
-  /**
+/**
    * Place order for stocks.
    * @remarks
    * RAM cost: 2.5 GB
-   * Places an order on the stock market. This function only works for Limit and Stop Orders.
+   * Places a limit or stop order on the stock market. This function only works for Limit and Stop Orders.
    *
    * The ability to place limit and stop orders is **not** immediately available to the player and
    * must be unlocked later on in the game.
@@ -1435,10 +1435,16 @@ export interface TIX {
    * Returns true if the order is successfully placed, and false otherwise.
    *
    * @param sym - Stock symbol.
-   * @param shares - Number of shares for order. Must be positive. Will be rounded to the nearest integer.
+   * @param shares - Number of shares for the order. Must be positive. Will be rounded to the nearest integer.
    * @param price - Execution price for the order.
-   * @param type - Type of order.
-   * @param pos - Specifies whether the order is a “Long” or “Short” position.
+   * @param type - Type of order. Valid values are:
+   *               - "Limit Buy"
+   *               - "Limit Sell"
+   *               - "Stop Buy"
+   *               - "Stop Sell"
+   * @param pos - Specifies whether the order is a “Long” or “Short” position. Valid values are:
+   *             - "Long"
+   *             - "Short"
    * @returns True if the order is successfully placed, and false otherwise.
    */
   placeOrder(sym: string, shares: number, price: number, type: string, pos: string): boolean;


### PR DESCRIPTION
# Linked issues

fixes #74 - TIX: Some documentation doesn't provide guidance on what the input should be

Updated placeOrder parameter docs to show valid inputs as shown on the BitBurner Docs website.

# Documentation

Got a few error messages with Netscript but I've only made changes at placeOrder function.

![Screenshot (491)](https://github.com/user-attachments/assets/2d575531-2d67-48d3-910c-358c362162ae)

Any suggestions here would be great.


Fixed formatting and linting issues with `npm run format` and `npm run lint`.
