### PR TITLE
UI: Allow filtering graftable augmentations

### DIFF
--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -70,13 +70,19 @@ export const GraftingRoot = (): React.ReactElement => {
   const selectedAugmentation = Augmentations[selectedAug];
   const rerender = useCycleRerender();
 
+  const matches = (s1: string, s2: string) => s1.toLowerCase().includes(s2.toLowerCase());
   const getAugsSorted = (): AugmentationName[] => {
     const augs = getGraftingAvailableAugs();
     if (Settings.PurchaseAugmentationsOrder === PurchaseAugmentationsOrderSetting.Cost) {
       augs.sort((a, b) => graftableAugmentations[a].cost - graftableAugmentations[b].cost);
     }
     if (filterText !== "") {
-      return augs.filter((augmentationName) => augmentationName.toLowerCase().includes(filterText));
+      return augs.filter(
+        (aug: AugmentationName) =>
+          matches(Augmentations[aug].name, filterText) ||
+          matches(Augmentations[aug].info, filterText) ||
+          matches(Augmentations[aug].stats, filterText),
+      );
     }
     return augs;
   };

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -4,8 +4,8 @@ import { Player } from "@player";
 import { AugmentationName } from "@enums";
 
 import React, { useState } from "react";
-import { CheckBox, CheckBoxOutlineBlank, Construction } from "@mui/icons-material";
-import { Box, Button, Container, List, ListItemButton, Paper, Typography } from "@mui/material";
+import { CheckBox, CheckBoxOutlineBlank, Construction, Search } from "@mui/icons-material";
+import { Box, Button, Container, List, ListItemButton, Paper, TextField, Typography } from "@mui/material";
 
 import { GraftingWork } from "../../../Work/GraftingWork";
 import { Augmentations } from "../../../Augmentation/Augmentations";
@@ -66,17 +66,19 @@ export const GraftingRoot = (): React.ReactElement => {
 
   const [selectedAug, setSelectedAug] = useState(getGraftingAvailableAugs()[0]);
   const [graftOpen, setGraftOpen] = useState(false);
+  const [filterText, setFilterText] = useState("");
   const selectedAugmentation = Augmentations[selectedAug];
   const rerender = useCycleRerender();
 
   const getAugsSorted = (): AugmentationName[] => {
     const augs = getGraftingAvailableAugs();
-    switch (Settings.PurchaseAugmentationsOrder) {
-      case PurchaseAugmentationsOrderSetting.Cost:
-        return augs.sort((a, b) => graftableAugmentations[a].cost - graftableAugmentations[b].cost);
-      default:
-        return augs;
+    if (Settings.PurchaseAugmentationsOrder === PurchaseAugmentationsOrderSetting.Cost) {
+      augs.sort((a, b) => graftableAugmentations[a].cost - graftableAugmentations[b].cost);
     }
+    if (filterText !== "") {
+      return augs.filter((augmentationName) => augmentationName.toLowerCase().includes(filterText));
+    }
+    return augs;
   };
 
   const switchSortOrder = (newOrder: PurchaseAugmentationsOrderSetting): void => {
@@ -114,19 +116,29 @@ export const GraftingRoot = (): React.ReactElement => {
         </Paper>
         {getGraftingAvailableAugs().length > 0 ? (
           <Paper sx={{ mb: 1, width: "fit-content", display: "grid", gridTemplateColumns: "1fr 3fr" }}>
-            <List sx={{ height: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
-              {getAugsSorted().map((k, i) => (
-                <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
-                  <Typography
-                    sx={{
-                      color: canGraft(graftableAugmentations[k]) ? Settings.theme.primary : Settings.theme.disabled,
-                    }}
-                  >
-                    {k}
-                  </Typography>
-                </ListItemButton>
-              ))}
-            </List>
+            <Box>
+              <TextField
+                style={{ width: "100%" }}
+                value={filterText}
+                onChange={(e) => {
+                  setFilterText(e.target.value);
+                }}
+                InputProps={{ startAdornment: <Search /> }}
+              />
+              <List sx={{ height: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
+                {getAugsSorted().map((k, i) => (
+                  <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
+                    <Typography
+                      sx={{
+                        color: canGraft(graftableAugmentations[k]) ? Settings.theme.primary : Settings.theme.disabled,
+                      }}
+                    >
+                      {k}
+                    </Typography>
+                  </ListItemButton>
+                ))}
+              </List>
+            </Box>
             <Box sx={{ m: 1 }}>
               <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
                 <Construction sx={{ mr: 1 }} /> {selectedAug}


### PR DESCRIPTION
The filter implementation is different from the one in `AugmentationsPage.tsx`. In `AugmentationsPage.tsx`, we filter by name, info, and stats of augmentations. I don't agree with that implementation. In this one, I only filter by name.

Screenshots:
![Capture 1](https://github.com/user-attachments/assets/a076bdce-ca8b-4b47-9d03-21e5f65b5662)
![Capture 2](https://github.com/user-attachments/assets/fffe4d32-51fc-42e1-938a-b03d89a8b1f3)
