### PR TITLE
UI: Notify players about documentation tab after getting SF1.1

### DIFF
--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -329,4 +329,10 @@ export function prestigeSourceFile(isFlume: boolean): void {
   resetPidCounter();
 
   setInitialExpForPlayer();
+
+  if (!isFlume && Player.sourceFiles.size === 1 && Player.sourceFileLvl(1) === 1) {
+    delayedDialog(
+      "Congratulations on destroying your first BitNode! Make sure to check the Documentation tab. Many pages are unlocked now.",
+    );
+  }
 }


### PR DESCRIPTION
Most pages in the "Advanced Mechanics" section are inaccessible until the player has at least SF 1.1. It's not obvious that those pages are unlocked when they get SF 1.1. I have seen many new players do not know that we have extensive documentation for BN mechanics.

This PR shows new players a message to notify them about new unlocked documentation pages when they get SF 1.1.