### PR TITLE
CORPORATION: Fix NaN Total Assets caused by bug in bulkPurchase API

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -333,7 +333,9 @@ export function buyMaterial(division: Division, material: Material, amt: number)
     throw new Error(`${material.name} is not a relevant material for industry ${division.type}`);
   }
   if (!Number.isFinite(amt) || amt < 0) {
-    throw new Error("Invalid value for amount field! Must be numeric and greater than or equal to 0");
+    throw new Error(
+      `Invalid amount '${amt}' to buy material '${material.name}'. Must be numeric and greater than or equal to 0`,
+    );
   }
   material.buyAmount = amt;
 }
@@ -351,7 +353,9 @@ export function bulkPurchase(
   const matSize = MaterialInfo[material.name].size;
   const maxAmount = (warehouse.size - warehouse.sizeUsed) / matSize;
   if (!Number.isFinite(amt) || amt < 0) {
-    throw new Error("Invalid value for amount field! Must be numeric and greater than or equal to 0");
+    throw new Error(
+      `Invalid amount '${amt}' to buy material '${material.name}'. Must be numeric and greater than or equal to 0`,
+    );
   }
   if (amt > maxAmount) {
     throw new Error(`You do not have enough warehouse size to fit this purchase`);

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -332,8 +332,8 @@ export function buyMaterial(division: Division, material: Material, amt: number)
   if (!isRelevantMaterial(material.name, division)) {
     throw new Error(`${material.name} is not a relevant material for industry ${division.type}`);
   }
-  if (isNaN(amt) || amt < 0) {
-    throw new Error(`Invalid amount '${amt}' to buy material '${material.name}'`);
+  if (!Number.isFinite(amt) || amt < 0) {
+    throw new Error("Invalid value for amount field! Must be numeric and greater than or equal to 0");
   }
   material.buyAmount = amt;
 }
@@ -350,22 +350,25 @@ export function bulkPurchase(
   }
   const matSize = MaterialInfo[material.name].size;
   const maxAmount = (warehouse.size - warehouse.sizeUsed) / matSize;
-  if (isNaN(amt) || amt < 0) {
-    throw new Error(`Invalid input amount`);
+  if (!Number.isFinite(amt) || amt < 0) {
+    throw new Error("Invalid value for amount field! Must be numeric and greater than or equal to 0");
   }
   if (amt > maxAmount) {
     throw new Error(`You do not have enough warehouse size to fit this purchase`);
   }
+  // Special case: if "amount" is 0, this is a no-op.
+  if (amt === 0) {
+    return;
+  }
   const cost = amt * material.marketPrice;
-  if (corp.funds >= cost) {
-    corp.loseFunds(cost, "materials");
-    material.averagePrice =
-      (material.averagePrice * material.stored + material.marketPrice * amt) / (material.stored + amt);
-    material.stored += amt;
-    warehouse.sizeUsed = warehouse.sizeUsed + amt * matSize;
-  } else {
+  if (corp.funds < cost) {
     throw new Error(`You cannot afford this purchase.`);
   }
+  corp.loseFunds(cost, "materials");
+  material.averagePrice =
+    (material.averagePrice * material.stored + material.marketPrice * amt) / (material.stored + amt);
+  material.stored += amt;
+  warehouse.sizeUsed = warehouse.sizeUsed + amt * matSize;
 }
 
 export function sellShares(corporation: Corporation, numShares: number): number {

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -375,7 +375,7 @@ export class Division {
           // buy them
           for (const [matName, [buyAmt]] of getRecordEntries(smartBuy)) {
             const mat = warehouse.materials[matName];
-            if (mat.stored + buyAmt != 0) {
+            if (mat.stored + buyAmt !== 0) {
               mat.quality = (mat.quality * mat.stored + 1 * buyAmt) / (mat.stored + buyAmt);
               mat.averagePrice = (mat.averagePrice * mat.stored + mat.marketPrice * buyAmt) / (mat.stored + buyAmt);
             } else {

--- a/src/Corporation/Material.ts
+++ b/src/Corporation/Material.ts
@@ -139,8 +139,11 @@ export class Material {
     if (isNaN(material.quality)) {
       material.quality = 1;
     }
-    // averagePrice has not been initialized properly, so if it is 0 (wrong initial value), we set it to marketPrice.
-    if (material.averagePrice === 0) {
+    /**
+     * averagePrice has not been calculated properly, so if it is an invalid value (Number.isFinite returns false) or 0
+     * (wrong initial value), we set it to marketPrice.
+     */
+    if (!Number.isFinite(material.averagePrice) || material.averagePrice === 0) {
       material.averagePrice = material.marketPrice;
     }
     return material;

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -336,8 +336,6 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
       const materialName = getEnumHelper("CorpMaterialName").nsGetMember(ctx, _materialName, "materialName");
       const amt = helpers.number(ctx, "amt", _amt);
-      if (amt < 0 || !Number.isFinite(amt))
-        throw new Error("Invalid value for amount field! Must be numeric and greater than or equal to 0");
       const material = getMaterial(divisionName, cityName, materialName);
       buyMaterial(division, material, amt);
     },


### PR DESCRIPTION
This code is in `bulkPurchase`:
```js
material.averagePrice =
    (material.averagePrice * material.stored + material.marketPrice * amt) / (material.stored + amt);
```
When both `material.stored` and `amt` are 0, `material.averagePrice` will be NaN. This NaN value will be used in `updateTotalAssets`.

How to reproduce it:
- Create a corporation. Create a division.
- Use `bulkPurchase` (API or UI) with amount = 0.
- Check "Total Assets".

I think we should enforce the "positive number" constraint on the "amt" parameter of `bulkPurchase` in the next major version.