### PR TITLE
DOCUMENTATION: Clarify security increase of ns.hack and ns.grow

### DIFF
--- a/markdown/bitburner.ns.grow.md
+++ b/markdown/bitburner.ns.grow.md
@@ -47,7 +47,9 @@ To determine how many threads are needed to return a server to max money, obtain
 
 Like [hack](./bitburner.ns.hack.md)<!-- -->, `grow` can be called on any hackable server, regardless of where the script is running. Hackable servers are any servers not owned by the player.
 
-The grow() command requires root access to the target server, but there is no required hacking level to run the command. It also raises the security level of the target server based on the number of threads. The security increase can be determined using [growthAnalyzeSecurity](./bitburner.ns.growthanalyzesecurity.md)<!-- -->.
+The grow() command requires root access to the target server, but there is no required hacking level to run the command. It also raises the security level of the target server based on the number of threads.
+
+The security level is increased by 0.004 per "used thread". "used thread" may not be the same as opts.threads. Let's say you call this function with opts.threads = 1000, but it only takes 500 threads to grow the targeted server to the max money. In this case, "used thread" is 500. You should use [growthAnalyzeSecurity](./bitburner.ns.growthanalyzesecurity.md) to calculate the security increase.
 
 ## Example
 

--- a/markdown/bitburner.ns.hack.md
+++ b/markdown/bitburner.ns.hack.md
@@ -33,7 +33,7 @@ Function that is used to try and hack servers to steal money and gain hacking ex
 
 A script can hack a server from anywhere. It does not need to be running on the same server to hack that server. For example, you can create a script that hacks the `foodnstuff` server and run that script on any server in the game.
 
-A successful `hack()` on a server will raise that server’s security level by 0.002 per thread. You can use [hackAnalyzeSecurity](./bitburner.ns.hackanalyzesecurity.md) to calculate the security increase for a number of threads.
+A successful `hack()` on a server will raise that server’s security level by 0.002 per "used thread". "used thread" may not be the same as opts.threads. Let's say you call this function with opts.threads = 1000, but it only takes 500 threads to hack all money in the targeted server. In this case, "used thread" is 500. You should use [hackAnalyzeSecurity](./bitburner.ns.hackanalyzesecurity.md) to calculate the security increase.
 
 ## Example
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5547,8 +5547,10 @@ export interface NS {
    * server to hack that server. For example, you can create a script that hacks the `foodnstuff`
    * server and run that script on any server in the game.
    *
-   * A successful `hack()` on a server will raise that server’s security level by 0.002 per thread. You can use
-   * {@link NS.hackAnalyzeSecurity | hackAnalyzeSecurity} to calculate the security increase for a number of threads.
+   * A successful `hack()` on a server will raise that server’s security level by 0.002 per "used thread". "used thread"
+   * may not be the same as opts.threads. Let's say you call this function with opts.threads = 1000, but it only takes
+   * 500 threads to hack all money in the targeted server. In this case, "used thread" is 500. You should use
+   * {@link NS.hackAnalyzeSecurity | hackAnalyzeSecurity} to calculate the security increase.
    *
    * @example
    * ```js
@@ -5593,7 +5595,11 @@ export interface NS {
    *
    * The grow() command requires root access to the target server, but there is no required hacking
    * level to run the command. It also raises the security level of the target server based on the number of threads.
-   * The security increase can be determined using {@link NS.growthAnalyzeSecurity | growthAnalyzeSecurity}.
+   *
+   * The security level is increased by 0.004 per "used thread". "used thread" may not be the same as opts.threads. Let's
+   * say you call this function with opts.threads = 1000, but it only takes 500 threads to grow the targeted server to
+   * the max money. In this case, "used thread" is 500. You should use {@link NS.growthAnalyzeSecurity | growthAnalyzeSecurity}
+   * to calculate the security increase.
    *
    * @example
    * ```js


### PR DESCRIPTION
This PR makes 2 changes:
- `ns.grow`: add new information: the security increase is 0.004 per thread.
- `ns.grow` and `ns.hack`: "per thread" is not exactly true. I change it to "per used thread" and explain what "used thread" means. It answers these questions:
  - "If it's as simple as 'X per thread', why do I need to use other functions (`hackAnalyzeSecurity` and `growthAnalyzeSecurity`)?"
  - "I call `ns.grow` to grow server X, but the security increase is not 0.004 per thread".
  - "I call `ns.hack` to hack server X, but the security increase is not 0.002 per thread".