### PR TITLE
BUGFIX: Block hacking-related actions on player-owned servers

### DIFF
--- a/src/Hacking/netscriptCanHack.ts
+++ b/src/Hacking/netscriptCanHack.ts
@@ -9,28 +9,28 @@ import { IReturnStatus } from "../types";
 import { Player } from "@player";
 import { Server } from "../Server/Server";
 
-function baseCheck(server: Server, fnName: string): IReturnStatus {
+function baseCheck(server: Server, actionName: string): IReturnStatus {
   const hostname = server.hostname;
 
-  if (!("requiredHackingSkill" in server)) {
+  if (server.purchasedByPlayer) {
     return {
       res: false,
-      msg: `Cannot ${fnName} ${hostname} server because it is a Hacknet Node`,
+      msg: `Cannot ${actionName} ${hostname} server because it is your server`,
     };
   }
 
   if (!server.hasAdminRights) {
     return {
       res: false,
-      msg: `Cannot ${fnName} ${hostname} server because you do not have root access`,
+      msg: `Cannot ${actionName} ${hostname} server because you do not have root access`,
     };
   }
 
   return { res: true };
 }
 
-export function netscriptCanHack(server: Server): IReturnStatus {
-  const initialCheck = baseCheck(server, "hack");
+export function netscriptCanHack(server: Server, customActionName?: string): IReturnStatus {
+  const initialCheck = baseCheck(server, customActionName ?? "hack");
   if (!initialCheck.res) {
     return initialCheck;
   }

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -559,14 +559,14 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       helpers.checkSingularityAccess(ctx);
       const baseserver = Player.getCurrentServer();
       if (!(baseserver instanceof Server)) {
-        helpers.log(ctx, () => "cannot backdoor this kind of server");
+        helpers.log(ctx, () => "Cannot backdoor this kind of server");
         return Promise.resolve();
       }
       const server = baseserver;
       const installTime = (calculateHackingTime(server, Player) / 4) * 1000;
 
       // No root access or skill level too low
-      const canHack = netscriptCanHack(server);
+      const canHack = netscriptCanHack(server, "backdoor");
       if (!canHack.res) {
         throw helpers.errorMessage(ctx, canHack.msg || "");
       }


### PR DESCRIPTION
Implementations of hack, grow, weaken, and backdoor are inconsistent between CLI and API. In CLI, we check `server.purchasedByPlayer`, but we do not check it in API. This PR fixes it. As we discussed on Discord, this change is pretty harmless.

On Discord, I talked about this case: `await ns.singularity.installBackdoor("hacknet-node-0")` shows `singularity.installBackdoor: Successfully installed backdoor on 'home'.` Just ignore it. I forgot that `installBackdoor` is a no-parameter API, and we need to connect to the targeted server before using it. We cannot connect to a Hacknet Node (not Hacknet Server), so it won't be a problem.

Although the PR's title says "hacking-related actions", I don't touch nuke and port-opener APIs in this PR. It seems unnecessary to change them. If you think we should change them too, I'll do it.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.clearLog();
  await ns.hack("home");
  await ns.grow("home");
  await ns.weaken("home");
  ns.singularity.connect("home"); await ns.singularity.installBackdoor();

  await ns.hack("hacknet-node-0");

  await ns.hack("hacknet-server-0");
  await ns.grow("hacknet-server-0");
  await ns.weaken("hacknet-server-0");
  ns.singularity.connect("hacknet-server-0"); await ns.singularity.installBackdoor();
}
```