### PR TITLE
BLADE: Adjust IV action to current-city affect rather than global

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1203,7 +1203,7 @@ export class Bladeburner {
             }
             const city = this.getCurrentCity();
             city.chaos += 10;
-            city.chaos += city.chaos / Math.log(city.chaos / 10);
+            city.chaos += city.chaos / (Math.log(city.chaos) / Math.log(10));
             break;
           }
           default: {

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -646,7 +646,7 @@ export class Bladeburner {
     } else if (chance <= 0.7) {
       // Synthoid Riots (+chaos), 20%
       sourceCity.changeChaosByCount(1);
-      sourceCity.changeChaosByPercentage(getRandomIntInclusive(5, 20) / 100);
+      sourceCity.changeChaosByPercentage(getRandomIntInclusive(5, 20));
       if (this.logging.events) {
         this.log("Tensions between Synthoids and humans lead to riots in " + sourceCityName + "! Chaos increased");
       }

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1201,11 +1201,9 @@ export class Bladeburner {
             if (this.logging.general) {
               this.log(`${person.whoAmI()}: Incited violence in the synthoid communities.`);
             }
-            for (const cityName of Object.values(CityName)) {
-              const city = this.cities[cityName];
-              city.chaos += 10;
-              city.chaos += city.chaos / (Math.log(city.chaos) / Math.log(10));
-            }
+            const city = this.getCurrentCity();
+            city.chaos += 10;
+            city.chaos += city.chaos / Math.log(city.chaos / 10);
             break;
           }
           default: {

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1203,7 +1203,7 @@ export class Bladeburner {
             }
             const city = this.getCurrentCity();
             city.changeChaosByCount(10);
-            city.changeChaosByPercentage(getRandomIntInclusive(2, 10));
+            city.changeChaosByCount(city.chaos / Math.log(city.chaos) / Math.log(10));
             break;
           }
           default: {

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -645,8 +645,8 @@ export class Bladeburner {
       }
     } else if (chance <= 0.7) {
       // Synthoid Riots (+chaos), 20%
-      sourceCity.chaos += 1;
-      sourceCity.chaos *= 1 + getRandomIntInclusive(5, 20) / 100;
+      sourceCity.changeChaosByCount(1);
+      sourceCity.changeChaosByPercentage(getRandomIntInclusive(5, 20) / 100);
       if (this.logging.events) {
         this.log("Tensions between Synthoids and humans lead to riots in " + sourceCityName + "! Chaos increased");
       }
@@ -1202,8 +1202,8 @@ export class Bladeburner {
               this.log(`${person.whoAmI()}: Incited violence in the synthoid communities.`);
             }
             const city = this.getCurrentCity();
-            city.chaos += 10;
-            city.chaos += city.chaos / (Math.log(city.chaos) / Math.log(10));
+            city.changeChaosByCount(10);
+            city.changeChaosByPercentage(getRandomIntInclusive(2, 10));
             break;
           }
           default: {

--- a/src/Bladeburner/data/GeneralActions.ts
+++ b/src/Bladeburner/data/GeneralActions.ts
@@ -53,6 +53,6 @@ export const GeneralActions: Record<BladeGeneralActionName, GeneralAction> = {
     getActionTime: () => 60,
     desc:
       "Purposefully stir trouble in the synthoid community in order to gain a political edge. This will generate " +
-      "additional contracts and operations, at the cost of increased Chaos.",
+      "additional contracts and operations, at the cost of increased Chaos in your current city.",
   }),
 };

--- a/src/Bladeburner/data/GeneralActions.ts
+++ b/src/Bladeburner/data/GeneralActions.ts
@@ -53,6 +53,6 @@ export const GeneralActions: Record<BladeGeneralActionName, GeneralAction> = {
     getActionTime: () => 60,
     desc:
       "Purposefully stir trouble in the synthoid community in order to gain a political edge. This will generate " +
-      "additional contracts and operations, at the cost of increased Chaos in your current city.",
+      "additional contracts and operations. Completing this action will increase the Chaos level in your current city.",
   }),
 };

--- a/src/DevMenu/ui/BladeburnerDev.tsx
+++ b/src/DevMenu/ui/BladeburnerDev.tsx
@@ -50,10 +50,10 @@ export function BladeburnerDev({ bladeburner }: { bladeburner: Bladeburner }): R
   const wipeAllChaos = () => Object.values(CityName).forEach((city) => (bladeburner.cities[city].chaos = 0));
   const wipeActiveCityChaos = () => (bladeburner.cities[bladeburner.city].chaos = 0);
   const addAllChaos = (modify: number) => (chaos: number) => {
-    Object.values(CityName).forEach((city) => (bladeburner.cities[city].changeChaosByCount(chaos * modify)));
+    Object.values(CityName).forEach((city) => bladeburner.cities[city].changeChaosByCount(chaos * modify));
   };
   const addTonsAllChaos = () => {
-    Object.values(CityName).forEach((city) => (bladeburner.cities[city].changeChaosByCount(bigNumber)));
+    Object.values(CityName).forEach((city) => bladeburner.cities[city].changeChaosByCount(bigNumber));
   };
 
   // Skill functions

--- a/src/DevMenu/ui/BladeburnerDev.tsx
+++ b/src/DevMenu/ui/BladeburnerDev.tsx
@@ -50,10 +50,10 @@ export function BladeburnerDev({ bladeburner }: { bladeburner: Bladeburner }): R
   const wipeAllChaos = () => Object.values(CityName).forEach((city) => (bladeburner.cities[city].chaos = 0));
   const wipeActiveCityChaos = () => (bladeburner.cities[bladeburner.city].chaos = 0);
   const addAllChaos = (modify: number) => (chaos: number) => {
-    Object.values(CityName).forEach((city) => (bladeburner.cities[city].chaos += chaos * modify));
+    Object.values(CityName).forEach((city) => (bladeburner.cities[city].changeChaosByCount(chaos * modify)));
   };
   const addTonsAllChaos = () => {
-    Object.values(CityName).forEach((city) => (bladeburner.cities[city].chaos += bigNumber));
+    Object.values(CityName).forEach((city) => (bladeburner.cities[city].changeChaosByCount(bigNumber)));
   };
 
   // Skill functions


### PR DESCRIPTION
# Adjust Bladeburner IV action to affect a single city

This PR makes the Bladeburner general action "Incite Violence" affect only the current city, rather than all cities on the map. This change opens up potential room for strategic behavior from the player, while removing a trap that can very easily lead to ruining an entire bitnode mid-play with very little effort or guidance.

![image](https://github.com/user-attachments/assets/316f2106-d26e-4489-bb0e-07096a9352ae)

# Context

Choice of player city is a core aspect of Bladeburner, where anything that affects any city, affects the player's Bladeburner HQ city. Typically, for most actions, you want to choose a city with higher populations, because they make your tasks easier; and due to Chaos penalties, you typically need to perform Diplomacy actions any time Chaos approaches 50, otherwise it becomes increasingly difficult to progress.

The Incite Violence general action has the stated goal of providing new contracts for the player, at the expense of increased Chaos. However, _unlike all other Bladeburner actions,_ right now this affects **all** cities. This is counter-intuitive and non-obvious to the user, as well as being non-visible to the player unless they have scripted a dashboard for themself using the Bladeburner API (which is not immediately available).

Current implementation:
- All Bladeburner mechanics except for Incite Violence are targeted to specific regions
- Incite Violence causes all cities grow chaos at both a static and inverse-logarithmic rate
- There is no player skill scaling in either contract gain or violence increase
- The static increase `chaos += 10` is more drastic already than any other player action

This leads to the following results:
- The player's choice of city is irrelevant for this mechanic, which goes against all other Bladeburner mechanics
- The player can lock themselves out of hours of gameplay with only a few cycles
- A character with end-node-levels of high charisma can essentially ignore this penalty, but early-mid-node, the chaos penalty locks you out of **all** Bladeburner activities quite quickly, because the Chaos penalty to Contracts and Operations can quickly bring you into < 10% success rate on even Tracking contracts

For comparison with other related mechanics:
- Choice-of-city is directly relevant to the Bladeburner mechanic design. Every other action that affects the world, affects the _current_ city, with difficulties and impacts relating to actions there
- The highest chaos changes from other mechanics are:
 - `+ 1.00 + getRandomIntInclusive(5, 20) / 100` from synthoid riots random event, at 20% chance
 - `+ 0.01` flat gain from Sting operations
 - `+ 1-5%` percentage gain from Raid operations
 - `+/- up to 5%` from Assassination operations
 - `+ 0.02` from Bounty Hunter contracts
 - `+ 0.04` from Retirement contracts 
 - All of the above are _single-city_ adjustments

Incite Violence has **both** a flat gain that is **250x** as powerful as the next most disruptive player event, and a **minimum +10% scaling** that is more than double the Raid operations, with no ceiling. Meanwhile, the benefit is a **constant, non-scaling** amount of change. 

# Solution

The changes made at time of writing remove the global factors to the city population gains.

# Linked issues

Per Discord conversation:
- [Venusaur's comment on August 14 asking if this is a bug](https://discord.com/channels/415207508303544321/923445914461413376/1273465421433143408)
- More people thinking this is a bug ([list created by FicocelliGuy](https://discord.com/channels/415207508303544321/923445914461413376/1273681258865492048)): [1](https://discord.com/channels/415207508303544321/415207923506216971/1157269063198855229) [2](https://discord.com/channels/415207508303544321/923445914461413376/1235822552740270131) [3](https://discord.com/channels/415207508303544321/415207923506216971/1231866450084364379) [4](https://discord.com/channels/415207508303544321/923445914461413376/1226607705561763873) [5](https://discord.com/channels/415207508303544321/923445914461413376/1199803564642549780) [6](https://discord.com/channels/415207508303544321/923445914461413376/1183834409330286602) [7](https://discord.com/channels/415207508303544321/415207923506216971/1147959675929772063)
- [CatLover's response that "it's intentional, but it does not mean that it's a good idea](https://discord.com/channels/415207508303544321/923445914461413376/1273581155907538987)

Conversation ensues from that point.

# Documentation

Clarity is added to the general action in-game description.

# Testing

- [x] Include how it was tested
- [x] Include screenshot / gif (if possible)
- [x] Make sure you run `npm run format` and `npm run lint` before pushing.

After changes, before inciting violence:
![Screenshot 2024-08-15 at 11 30 36 AM](https://github.com/user-attachments/assets/13847eae-4eea-4368-932c-d654bcc091be)

After changes, after 1 incite violence:
![image](https://github.com/user-attachments/assets/abdce4df-8b8b-47fa-9d69-138f5ce0d3ed)

After changes, after getting up and going to the restroom and coming straight back:
![image](https://github.com/user-attachments/assets/3244f0d6-f8a9-4c2f-9cf9-2759fd8f878b)

Before the changes, this affected all cities in the game equally.