### PR TITLE
BUGFIX: Fix Bladeburner city chaos reaching Infinity/NaN

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -700,14 +700,14 @@ export class Bladeburner {
     };
   }
 
-  getDiplomacyEffectiveness(person: Person): number {
-    // Returns a decimal by which the city's chaos level should be multiplied (e.g. 0.98)
+  getDiplomacyPercentage(person: Person): number {
+    // Returns a percentage by which the city's chaos level should be modified (e.g. 2 for 2%)
     const CharismaLinearFactor = 1e3;
     const CharismaExponentialFactor = 0.045;
 
     const charismaEff =
       Math.pow(person.skills.charisma, CharismaExponentialFactor) + person.skills.charisma / CharismaLinearFactor;
-    return (100 - charismaEff) / 100;
+    return charismaEff;
   }
 
   getRecruitmentSuccessChance(person: Person): number {
@@ -1155,12 +1155,12 @@ export class Bladeburner {
             break;
           }
           case BladeGeneralActionName.diplomacy: {
-            const eff = this.getDiplomacyEffectiveness(person);
-            this.getCurrentCity().changeChaosByPercentage((1 - eff) * 100);
+            const diplomacyPct = this.getDiplomacyPercentage(person);
+            this.getCurrentCity().changeChaosByPercentage(-diplomacyPct);
             if (this.logging.general) {
               this.log(
                 `${person.whoAmI()}: Diplomacy completed. Chaos levels in the current city fell by ${formatPercent(
-                  1 - eff,
+                  diplomacyPct / 100,
                 )}.`,
               );
             }

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1156,7 +1156,7 @@ export class Bladeburner {
           }
           case BladeGeneralActionName.diplomacy: {
             const eff = this.getDiplomacyEffectiveness(person);
-            this.getCurrentCity().changeChaosByPercentage(1 - eff);
+            this.getCurrentCity().changeChaosByPercentage((1 - eff) * 100);
             if (this.logging.general) {
               this.log(
                 `${person.whoAmI()}: Diplomacy completed. Chaos levels in the current city fell by ${formatPercent(

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -645,8 +645,8 @@ export class Bladeburner {
       }
     } else if (chance <= 0.7) {
       // Synthoid Riots (+chaos), 20%
-      sourceCity.chaos += 1;
-      sourceCity.chaos *= 1 + getRandomIntInclusive(5, 20) / 100;
+      sourceCity.changeChaosByCount(1);
+      sourceCity.changeChaosByPercentage(getRandomIntInclusive(5, 20));
       if (this.logging.events) {
         this.log("Tensions between Synthoids and humans lead to riots in " + sourceCityName + "! Chaos increased");
       }
@@ -1156,10 +1156,7 @@ export class Bladeburner {
           }
           case BladeGeneralActionName.diplomacy: {
             const eff = this.getDiplomacyEffectiveness(person);
-            this.getCurrentCity().chaos *= eff;
-            if (this.getCurrentCity().chaos < 0) {
-              this.getCurrentCity().chaos = 0;
-            }
+            this.getCurrentCity().changeChaosByPercentage(1 - eff);
             if (this.logging.general) {
               this.log(
                 `${person.whoAmI()}: Diplomacy completed. Chaos levels in the current city fell by ${formatPercent(
@@ -1203,8 +1200,8 @@ export class Bladeburner {
             }
             for (const cityName of Object.values(CityName)) {
               const city = this.cities[cityName];
-              city.chaos += 10;
-              city.chaos += city.chaos / (Math.log(city.chaos) / Math.log(10));
+              city.changeChaosByCount(10);
+              city.changeChaosByCount(city.chaos / (Math.log(city.chaos) / Math.log(10)));
             }
             break;
           }

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1201,7 +1201,7 @@ export class Bladeburner {
             for (const cityName of Object.values(CityName)) {
               const city = this.cities[cityName];
               city.changeChaosByCount(10);
-              city.changeChaosByCount(city.chaos / (Math.log(city.chaos) / Math.log(10)));
+              city.changeChaosByCount(city.chaos / Math.log10(city.chaos));
             }
             break;
           }

--- a/src/DevMenu/ui/BladeburnerDev.tsx
+++ b/src/DevMenu/ui/BladeburnerDev.tsx
@@ -50,10 +50,10 @@ export function BladeburnerDev({ bladeburner }: { bladeburner: Bladeburner }): R
   const wipeAllChaos = () => Object.values(CityName).forEach((city) => (bladeburner.cities[city].chaos = 0));
   const wipeActiveCityChaos = () => (bladeburner.cities[bladeburner.city].chaos = 0);
   const addAllChaos = (modify: number) => (chaos: number) => {
-    Object.values(CityName).forEach((city) => (bladeburner.cities[city].chaos += chaos * modify));
+    Object.values(CityName).forEach((city) => bladeburner.cities[city].changeChaosByCount(chaos * modify));
   };
   const addTonsAllChaos = () => {
-    Object.values(CityName).forEach((city) => (bladeburner.cities[city].chaos += bigNumber));
+    Object.values(CityName).forEach((city) => bladeburner.cities[city].changeChaosByCount(bigNumber));
   };
 
   // Skill functions


### PR DESCRIPTION
# Fix Bladeburner cities from reaching Infinity/NaN Chaos

It's currently possible to accidentally brick the Bladeburner mechanic by hitting Infinity chaos, which is irrecoverable from. This is possible because of places that manually `+=` or `*=` on the Chaos value without clamping the number between 0 and `Number.MAX_VALUE` (1.798e+308). This clamping feature is performed automatically by the provided functions `changeChaosByCount` and `changeChaosByPercentage` which are already built-in to the City class, but some locations are improperly modifying the chaos attribute directly. This PR fixes that.

# Bug fix

- [x] Include how it was tested
- [x] Include screenshot / gif (if possible)
- [x] Make sure you run `npm run format` and `npm run lint` before pushing.

Tested using the dev console to add Infinity levels of chaos, then performing Incite Violence and other actions.

This is the result:

![image](https://github.com/user-attachments/assets/7f578365-33f2-40a3-8576-43a1f2668476)

## Diplomacy efficiency -> percentage

D0sboots suggested renaming the `getDiplomacyEfficiency` to `getDiplomacyPercentage` to clean some of the code up. I have attached a test showing that 

Testing with the following servers:
![image](https://github.com/user-attachments/assets/7acfc41c-8b6d-47c1-b151-ade81d1ccef3)

Per the charisma efficiency, I would expect a ~1.82% change (calculated at 500 charisma):
![image](https://github.com/user-attachments/assets/1411a14f-31ed-46b7-9f3b-904390d48a70)

In-game testing results demonstrate the correct percentage:
![image](https://github.com/user-attachments/assets/5c5b56ab-9ecb-4b69-b016-58bd07acb601)

