### PR TITLE
NETSCRIPT: Rework disableLog for efficiency

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -131,7 +131,7 @@ export class WorkerScript {
   }
 
   shouldLog(fn: string): boolean {
-    return this.disableLogs[fn] == null;
+    return !(this.disableLogs.ALL || this.disableLogs[fn]);
   }
 
   log(func: string, txt: () => string): void {

--- a/test/jest/Netscript/DisableLog.test.ts
+++ b/test/jest/Netscript/DisableLog.test.ts
@@ -1,0 +1,87 @@
+import type { Script } from "../../../src/Script/Script";
+import type { ScriptFilePath } from "../../../src/Paths/ScriptFilePath";
+import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
+import { Server } from "../../../src/Server/Server";
+import { RunningScript } from "../../../src/Script/RunningScript";
+import { CompletedProgramName } from "../../../src/Programs/Enums";
+import { WorkerScript } from "../../../src/Netscript/WorkerScript";
+import { NetscriptFunctions } from "../../../src/NetscriptFunctions";
+import { AddToAllServers, DeleteServer } from "../../../src/Server/AllServers";
+
+test("Edge cases of disableLog", function () {
+  // Ensure that formatting functions work properly
+  FormatsNeedToChange.emit();
+  let server;
+  try {
+    server = new Server({ hostname: "home", adminRights: true, maxRam: 8 });
+    server.programs.push(CompletedProgramName.bruteSsh, CompletedProgramName.ftpCrack);
+    AddToAllServers(server);
+    // We don't need this script to be runnable, it just needs to exist so that
+    // we can create a RunningScript and WorkerScript object.
+    expect(server.writeToScriptFile("test.js" as ScriptFilePath, "")).toEqual({ overwritten: false });
+    const script = server.scripts.get("test.js" as ScriptFilePath) as Script;
+
+    const runningScript = new RunningScript(script, 2);
+    const ws = new WorkerScript(runningScript, 1, NetscriptFunctions);
+
+    const ns = ws.env.vars;
+
+    // Generate logs in a specific pattern that checks edge cases in
+    // disableLog. We want to check various combinations of things that
+    // are/aren't disabled, as well as previously disabled.
+    ns.brutessh("home");
+    ns.ftpcrack("home");
+    ns.print("before disableLog ALL");
+
+    expect(() => ns.disableLog("all")).toThrow("Invalid argument: all.");
+    ns.disableLog("ALL");
+
+    ns.brutessh("home");
+    ns.ftpcrack("home");
+    ns.print("after disableLog ALL");
+
+    ns.enableLog("brutessh");
+    ns.brutessh("home");
+    ns.ftpcrack("home");
+    ns.print("after enableLog brutessh");
+
+    ns.disableLog("brutessh");
+    ns.enableLog("ftpcrack");
+    ns.brutessh("home");
+    ns.ftpcrack("home");
+    ns.print("after enableLog ftpcrack");
+
+    ns.enableLog("ftpcrack");
+    ns.brutessh("home");
+    ns.ftpcrack("home");
+
+    ns.print("after redundant enable");
+    ns.disableLog("ALL");
+    ns.brutessh("home");
+    ns.ftpcrack("home");
+    ns.enableLog("ALL");
+    ns.brutessh("home");
+    ns.ftpcrack("home");
+    ns.print("end");
+
+    expect(runningScript.logs).toEqual([
+      "brutessh: Executed BruteSSH.exe on 'home' to open SSH port (22).",
+      "ftpcrack: Executed FTPCrack.exe on 'home' to open FTP port (21).",
+      "before disableLog ALL",
+      "disableLog: Invalid argument: all.",
+      "after disableLog ALL",
+      "brutessh: SSH Port (22) already opened on 'home'.",
+      "after enableLog brutessh",
+      "ftpcrack: FTP Port (21) already opened on 'home'.",
+      "after enableLog ftpcrack",
+      "ftpcrack: FTP Port (21) already opened on 'home'.",
+      "after redundant enable",
+      "enableLog: Enabled logging for all functions",
+      "brutessh: SSH Port (22) already opened on 'home'.",
+      "ftpcrack: FTP Port (21) already opened on 'home'.",
+      "end",
+    ]);
+  } finally {
+    DeleteServer(server.hostname);
+  }
+});


### PR DESCRIPTION
TL;DR: I'm seeing almost a 3x reduction in script size and a 10x performance increase in script launch + `disableLog("ALL")`. Numbers will be less impressive when actual batching logic is added. Old one could only get to ~1m scripts, new can easily get to 3m.

----

The current implementation was naive; disableLog("ALL") was storing a key for every function, and iterating over a different object to do it (when iterating over objects is quite slow).

The common cases of Bitburner (and especially batching, where efficiency matters most) are either never disabling anything, or disabling "ALL". This optimizes for these two cases, at the expense of slightly more complicated code to deal with the less-common edge cases.

# Tests

Added a new test to verify some of the potential new edge cases

# Performance

`benchmark_disableLog.js`
```js
/** @param {NS} ns */
export async function main(ns) {
    const perf = globalThis.performance;
    const startMem = perf.memory.usedJSHeapSize;
    ns.tprintf("Starting memory: %d", startMem);
    let speedMax = 0;
    const totalScripts = Number(ns.args[0]);
    let start = perf.now();
    for (let i = 0; i < totalScripts;) {
        const k = Math.min(i + 10000, totalScripts);
        for (; i < k; i++) {
            if (ns.run("lib/disableLog.js", {temporary: true}) <= 0) {
              throw new Error("Out of memory: " + i);
            }
        }
        await new Promise(setTimeout);
        const end = perf.now();
        const speed = 1e7 / (end - start);
        start = end;
        speedMax = speed > speedMax ? speed : speedMax;
        ns.tprintf("Iter %6d: %.3f/sec", i, speed);
    }
    ns.tprintf("Best: %.3f/sec", speedMax);
    const endMem = perf.memory.usedJSHeapSize;
    ns.tprintf("Ending memory: %d", endMem);
    ns.tprintf("Used ~%.1f bytes/script", (endMem - startMem) / totalScripts);
}
```
`lib/disableLog.js`
```js
/** @param {NS} ns */
export function main(ns) {
  ns.disableLog("ALL");
  // This will never resolve, and doesn't require defining a closure.
  return new Promise(Boolean);
}
```

I ran these tests in my browser, against dev BB before/after the change. Before:
```
run benchmark_disableLog.js 1000000
...
Iter 970000: 5863.039/sec
Iter 980000: 5844.194/sec
Iter 990000: 2724.350/sec
Iter 1000000: 4868.549/sec
Best: 7647.599/sec
Ending memory: 3383249365
Used ~2892.2 bytes/script
```

After:
```
run benchmark_disableLog.js 2000000
...
Iter 1970000: 41580.042/sec
Iter 1980000: 43029.260/sec
Iter 1990000: 44642.857/sec
Iter 2000000: 66137.566/sec
Best: 82576.383/sec
Ending memory: 2643886332
Used ~1083.6 bytes/script
```