### PR TITLE
SCRIPTS: Allow importing from an index file by using a directory name

### DIFF
--- a/src/utils/ScriptTransformer.ts
+++ b/src/utils/ScriptTransformer.ts
@@ -110,14 +110,18 @@ export function getModuleScript(
       throw new ModuleResolutionError(`Invalid module: "${moduleName}". Base module: "${baseModule}".`);
     }
     script = scripts.get(filename);
-    if (script) {
-      break;
+    if (script) return script;
+  }
+  // If no script was found with the base name, check for a folder with index file
+  for (const extension of validScriptExtensions) {
+    const filename = resolveScriptFilePath(`${moduleName}/index`, baseModule, extension);
+    if (!filename) {
+      throw new ModuleResolutionError(`Invalid module: "${moduleName}". Base module: "${baseModule}".`);
     }
+    script = scripts.get(filename);
+    if (script) return script;
   }
-  if (!script) {
-    throw new ModuleResolutionError(`Invalid module: "${moduleName}". Base module: "${baseModule}".`);
-  }
-  return script;
+  throw new ModuleResolutionError(`Invalid module: "${moduleName}". Base module: "${baseModule}".`);
 }
 
 /**


### PR DESCRIPTION
I was revising some of my own scripts when I noticed that importing from an index file (by just importing from the directory name) was not yet supported. This should add support for that.