### PR TITLE
MISC: Use indirect eval for terminal expr and corporation sell prices/amounts

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -206,7 +206,7 @@ export function sellMaterial(material: Material, amount: string, price: string):
   let temp = cost.replace(/MP/, "1.234e5");
   try {
     if (temp.includes("MP")) throw "Only one reference to MP is allowed in sell price.";
-    temp = eval(temp);
+    temp = eval?.(temp);
   } catch (e) {
     throw new Error("Invalid value or expression for sell price field: " + e);
   }
@@ -230,7 +230,7 @@ export function sellMaterial(material: Material, amount: string, price: string):
     tempQty = tempQty.replace(/PROD/g, material.productionAmount.toString());
     tempQty = tempQty.replace(/INV/g, material.productionAmount.toString());
     try {
-      tempQty = eval(tempQty);
+      tempQty = eval?.(tempQty);
     } catch (e) {
       throw new Error("Invalid value or expression for sell quantity field: " + e);
     }
@@ -262,7 +262,7 @@ export function sellProduct(product: Product, city: CityName, amt: string, price
     let temp = price.replace(/MP/, "1.234e5");
     try {
       if (temp.includes("MP")) throw "Only one reference to MP is allowed in sell price.";
-      temp = eval(temp);
+      temp = eval?.(temp);
     } catch (e) {
       throw new Error("Invalid value or expression for sell price field: " + e);
     }
@@ -290,7 +290,7 @@ export function sellProduct(product: Product, city: CityName, amt: string, price
     temp = temp.replace(/PROD/g, product.cityData[city].productionAmount.toString());
     temp = temp.replace(/INV/g, product.cityData[city].stored.toString());
     try {
-      temp = eval(temp);
+      temp = eval?.(temp);
     } catch (e) {
       throw new Error("Invalid value or expression for sell quantity field: " + e);
     }
@@ -579,7 +579,7 @@ Attempted export amount: ${amount}`);
     const replaced = sanitizedAmt.replace(/(MAX|IPROD|EPROD|IINV|EINV)/g, testReplacement);
     let evaluated, error;
     try {
-      evaluated = eval(replaced);
+      evaluated = eval?.(replaced);
     } catch (e) {
       error = e;
     }

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -527,7 +527,7 @@ export class Division {
               let tmp = mat.desiredSellAmount.replace(/MAX/g, adjustedQty.toString());
               tmp = tmp.replace(/PROD/g, mat.productionAmount.toString());
               try {
-                sellAmt = eval(tmp);
+                sellAmt = eval?.(tmp);
               } catch (e) {
                 dialogBoxCreate(
                   `Error evaluating your sell amount for material ${mat.name} in ${this.name}'s ${city} office. The sell amount is being set to zero`,
@@ -576,7 +576,7 @@ export class Division {
               sCost = mat.marketPrice + markupLimit;
             } else if (typeof mat.desiredSellPrice === "string") {
               sCost = mat.desiredSellPrice.replace(/MP/g, mat.marketPrice.toString());
-              sCost = eval(sCost);
+              sCost = eval?.(sCost);
             } else {
               sCost = mat.desiredSellPrice;
             }
@@ -642,7 +642,7 @@ export class Division {
                 amtStr = amtStr.replace(/IINV/g, `(${tempMaterial.stored})`);
                 let amt = 0;
                 try {
-                  amt = eval(amtStr);
+                  amt = eval?.(amtStr);
                 } catch (e) {
                   dialogBoxCreate(
                     `Calculating export for ${mat.name} in ${this.name}'s ${city} division failed with error: ${e}`,
@@ -844,7 +844,7 @@ export class Division {
             let tmp: number | string = desiredSellAmount.replace(/MAX/g, adjustedQty.toString());
             tmp = tmp.replace(/PROD/g, product.cityData[city].productionAmount.toString());
             try {
-              tmp = eval(tmp);
+              tmp = eval?.(tmp);
               if (typeof tmp !== "number") throw "";
             } catch (e) {
               dialogBoxCreate(
@@ -902,7 +902,7 @@ export class Division {
               product.markup = 1;
             }
             sCostString = sCostString.replace(/MP/g, product.cityData[city].productionCost.toString());
-            sCost = eval(sCostString);
+            sCost = eval?.(sCostString);
           } else {
             sCost = sellPrice;
           }

--- a/src/Terminal/commands/expr.ts
+++ b/src/Terminal/commands/expr.ts
@@ -8,10 +8,10 @@ export function expr(args: (string | number | boolean)[]): void {
   const expr = args.join("");
 
   // Sanitize the math expression
-  const sanitizedExpr = expr.replace(/s+/g, "").replace(/[^-()\d/*+.%]/g, "");
+  const sanitizedExpr = expr.replace(/[^-()\d/*+.%]/g, "");
   let result;
   try {
-    result = eval(sanitizedExpr);
+    result = eval?.(sanitizedExpr);
   } catch (e) {
     Terminal.error(`Could not evaluate expression: ${sanitizedExpr}`);
     return;


### PR DESCRIPTION
This closes off an exploit which allows you to break into the game's lexical context.

Demo: https://yichizhng.github.io/bitburner-src/

Sample exploit script:
```js
const EXPLOIT_STRING = 
"globalThis.webpack_require=__webpack_require__";
/** @param {NS} ns */
export async function main(ns) {
  let o = String.prototype.replace;
  String.prototype.replace = function(p, r) {
    if (this === EXPLOIT_STRING) {
      return this;
    }
    return o.apply(this, [p, r]);
  }
  
  ns.atExit(() => {
    String.prototype.replace = o;
  })
  
  return new Promise(() => 0);
}
```
Enter `expr globalThis.webpack_require=__webpack_require__` into the terminal while the script is running.