### PR TITLE
DOCS: Correct function signature for hashUpgradeCost

### DIFF
--- a/markdown/bitburner.hacknetserversformulas.hashupgradecost.md
+++ b/markdown/bitburner.hacknetserversformulas.hashupgradecost.md
@@ -9,14 +9,14 @@ Calculate hash cost of an upgrade.
 **Signature:**
 
 ```typescript
-hashUpgradeCost(upgName: number, level: number): number;
+hashUpgradeCost(upgName: string, level: number): number;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  upgName | number | name of the upgrade |
+|  upgName | string | name of the upgrade |
 |  level | number | level of the upgrade |
 
 **Returns:**

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5231,7 +5231,7 @@ interface HacknetServersFormulas {
    * @param level - level of the upgrade
    * @returns The calculated hash cost.
    */
-  hashUpgradeCost(upgName: number, level: number): number;
+  hashUpgradeCost(upgName: string, level: number): number;
   /**
    * Calculate the cost of a hacknet server.
    * @param n - number of the hacknet server


### PR DESCRIPTION
(Versions 2.6.2 and 2.6.3dev)

# Correct function signature for hashUpgradeCost

The typescript definition for `HacknetServersFormulas.hashUpgradeCost()` lists the upgrade name being a number, when it's supposed to be the name of the upgrade as a string. This affects the generated documentation plus user-facing typescript definition files.

Old:
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/6df48b3b-2b10-4326-b3df-75c40bad72ed">

New:
<img width="999" alt="image" src="https://github.com/user-attachments/assets/daa26000-7d05-44b8-b55c-50effb975906">

This is the intended mechanism for how the formulas function is written, in which `upgName` is cast into a string:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/4b83728a-068b-4100-b6c6-effbffb0cf92">

The hash manager then takes that string and returns the corresponding record for `HashUpgrades: Record<string, HashUpgrade>`.

# Documentation

- [x] If your PR includes ns API function changes, do not manually modify markdown files.
- [x] Instead, you can run `npm run doc` to autogenerate new markdown files that reflect your submitted API changes.

[Issue reported by Yeraze on Discord](https://discord.com/channels/415207508303544321/415207923506216971/1275069620759560233)