### PR TITLE
DOCUMENTATION: Clarify experience gain of sleeves

### DIFF
--- a/src/Documentation/doc/advanced/sleeves.md
+++ b/src/Documentation/doc/advanced/sleeves.md
@@ -51,13 +51,13 @@ Shock affects the amount of experience earned by the sleeve.
 Sleeve shock slowly decreases over time.
 You can further increase the rate at which it decreases by assigning sleeves to the `Shock Recovery` task.
 
-Let `X` be the sleeve's shock and `Y` be the sleeve's synchronization.
-When the sleeve earns experience by performing a task, the sleeve gains `(100-X) %` of the amount of experience normally earned by the task.
+Let `X` be the sleeve's recover ratio (calculated as `(100 - shock) / 100`), and `Y` be the sleeve's synchronization ratio (calculated as `synchronizae / 100`).
+When performing a task would give you `A` experience normally, the sleeve gains `A * X` experience instead.
 
-The player’s original host consciousness earn `Y%` of the experience that the sleeve gained, or `(100-X)*Y/100 %` of the normal experience amount.
+The player’s original host consciousness earn fraction of the experience sleeve gained, namely `A * X * Y`.
 
 Other sleeves also earn the experience. However, their own shock affect this gain.
-Let `Z` be the receiving sleeve's shock, then it earns `(100-Z) %` of the experience the working sleeve synchronizing, or `(100-X)*Y*(100-Z)/10000 %` of the normal experience amount.
+Let `Z` be the receiving sleeve's recover ratio. It earns `A * X * Y * Z` experience.
 
 ## Augmentations
 

--- a/src/Documentation/doc/advanced/sleeves.md
+++ b/src/Documentation/doc/advanced/sleeves.md
@@ -51,13 +51,13 @@ Shock affects the amount of experience earned by the sleeve.
 Sleeve shock slowly decreases over time.
 You can further increase the rate at which it decreases by assigning sleeves to the `Shock Recovery` task.
 
-Let `X` be the sleeve's recover ratio (calculated as `(100 - shock) / 100`), and `Y` be the sleeve's synchronization ratio (calculated as `synchronize / 100`).
+Let `X` be the sleeve's recovery ratio (calculated as `(100 - shock) / 100`), and `Y` be the sleeve's synchronization ratio (calculated as `synchronize / 100`).
 When performing a task would give you `A` experience normally, the sleeve gains `A * X` experience instead.
 
-The player’s original host consciousness earn fraction of the experience sleeve gained, namely `A * X * Y`.
+The player’s original host consciousness earns a fraction of the experience the sleeve gained, namely `A * X * Y`.
 
-Other sleeves also earn the experience. However, their own shock affect this gain.
-Let `Z` be the receiving sleeve's recover ratio. It earns `A * X * Y * Z` experience.
+Other sleeves also earn the experience. However, their own shock affects this gain.
+Let `Z` be the receiving sleeve's recovery ratio. It earns `A * X * Y * Z` experience.
 
 ## Augmentations
 

--- a/src/Documentation/doc/advanced/sleeves.md
+++ b/src/Documentation/doc/advanced/sleeves.md
@@ -51,7 +51,7 @@ Shock affects the amount of experience earned by the sleeve.
 Sleeve shock slowly decreases over time.
 You can further increase the rate at which it decreases by assigning sleeves to the `Shock Recovery` task.
 
-Let `X` be the sleeve's recover ratio (calculated as `(100 - shock) / 100`), and `Y` be the sleeve's synchronization ratio (calculated as `synchronizae / 100`).
+Let `X` be the sleeve's recover ratio (calculated as `(100 - shock) / 100`), and `Y` be the sleeve's synchronization ratio (calculated as `synchronize / 100`).
 When performing a task would give you `A` experience normally, the sleeve gains `A * X` experience instead.
 
 The player’s original host consciousness earn fraction of the experience sleeve gained, namely `A * X * Y`.

--- a/src/Documentation/doc/advanced/sleeves.md
+++ b/src/Documentation/doc/advanced/sleeves.md
@@ -52,8 +52,12 @@ Sleeve shock slowly decreases over time.
 You can further increase the rate at which it decreases by assigning sleeves to the `Shock Recovery` task.
 
 Let `X` be the sleeve's shock and `Y` be the sleeve's synchronization.
-When the sleeve earns experience by performing a task, the sleeve gains `X%` of the amount of experience normally earned by the task.
-The player’s original host consciousness and all of the player's other sleeves earn `Y%` of the experience that the sleeve gained, or `X\*Y %` of the normal experience amount.
+When the sleeve earns experience by performing a task, the sleeve gains `(100-X) %` of the amount of experience normally earned by the task.
+
+The player’s original host consciousness earn `Y%` of the experience that the sleeve gained, or `(100-X)*Y/100 %` of the normal experience amount.
+
+Other sleeves also earn the experience. However, their own shock affect this gain.
+Let `Z` be the receiving sleeve's shock, then it earns `(100-Z) %` of the experience the working sleeve synchronizing, or `(100-X)*Y*(100-Z)/10000 %` of the normal experience amount.
 
 ## Augmentations
 


### PR DESCRIPTION
* Shock 100 is full shock and gain no experience, while shock 0 is no shock and gain full experience. The amount of experience should be (100-X)% rather than X%.

* https://github.com/bitburner-official/bitburner-src/pull/211 applies shock penalty on receiving sleeve, which is also needed to explain on this document.
