### PR TITLE
BUGFIX: Wrong skill multipliers in Bladeburner

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -751,7 +751,7 @@ export class Bladeburner {
       const level = this.getSkillLevel(skill.name);
       if (!level) continue;
       for (const [name, baseMult] of getRecordEntries(skill.mults)) {
-        const mult = 1 + baseMult * level / 100;
+        const mult = 1 + (baseMult * level) / 100;
         this.skillMultipliers[name] = clampNumber(this.getSkillMult(name) * mult, 0);
       }
     }

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -254,7 +254,7 @@ export class Bladeburner {
   getSkillMultsDisplay(): string[] {
     const display: string[] = [];
     for (const [multName, mult] of getRecordEntries(this.skillMultipliers)) {
-      display.push(`${multName}: x${formatNumberNoSuffix(mult, 3)}`);
+      display.push(`${multName}: x${formatBigNumber(mult)}`);
     }
     return display;
   }
@@ -751,8 +751,8 @@ export class Bladeburner {
       const level = this.getSkillLevel(skill.name);
       if (!level) continue;
       for (const [name, baseMult] of getRecordEntries(skill.mults)) {
-        const mult = baseMult * level;
-        this.skillMultipliers[name] = clampNumber(this.getSkillMult(name) + mult / 100, 0);
+        const mult = 1 + baseMult * level / 100;
+        this.skillMultipliers[name] = clampNumber(this.getSkillMult(name) * mult, 0);
       }
     }
   }


### PR DESCRIPTION
I found this bug when I checked an int grinding save file of a player. This bug was introduced when we refactored Bladeburner in 2.6.1.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.clearLog();
  Player.bladeburner.skillPoints = 1e6;
  Player.bladeburner.skills = {};
  ns.bladeburner.upgradeSkill("Reaper", 10);
  ns.bladeburner.upgradeSkill("Evasive System", 10);
}
```

How to reproduce it:
- Load a clean save file. Use the dev menu to add SF7. Expose the Player object.
- Run test code.
- Check Effective Dexterity and Effective Agility in the `Skills` tab.
  - v2.6.0: x1.680
  - v2.6.3: x1.600

v2.6.0:
```js
updateSkillMultipliers(): void {
  this.resetSkillMultipliers();
  for (const skillName of Object.keys(this.skills)) {
    if (Object.hasOwn(this.skills, skillName)) {
      const skill = Skills[skillName];
      if (skill == null) {
        throw new Error("Could not find Skill Object for: " + skillName);
      }
      const level = this.skills[skillName];
      if (level == null || level <= 0) {
        continue;
      } //Not upgraded

      const multiplierNames = Object.keys(this.skillMultipliers);
      for (let i = 0; i < multiplierNames.length; ++i) {
        const multiplierName = multiplierNames[i];
        if (skill.getMultiplier(multiplierName) != null && !isNaN(skill.getMultiplier(multiplierName))) {
          const value = skill.getMultiplier(multiplierName) * level;
          let multiplierValue = 1 + value / 100;
          if (multiplierName === "actionTime") {
            multiplierValue = 1 - value / 100;
          }
          this.skillMultipliers[multiplierName] *= multiplierValue;
        }
      }
    }
  }
}
```

v2.6.3:
```js
updateSkillMultipliers(): void {
  this.skillMultipliers = {};
  for (const skill of Object.values(Skills)) {
    const level = this.getSkillLevel(skill.name);
    if (!level) continue;
    for (const [name, baseMult] of getRecordEntries(skill.mults)) {
      const mult = baseMult * level;
      this.skillMultipliers[name] = clampNumber(this.getSkillMult(name) + mult / 100, 0);
    }
  }
}
```

I also make a small change in the UI:
v2.6.0:
![2 6 0](https://github.com/user-attachments/assets/c1d76f10-233d-4dd6-b4fa-806b3f773ad6)

v2.6.3:
![2 6 3](https://github.com/user-attachments/assets/d6882bd7-9cfb-4260-a5b2-5f0bdc7850be)

That change restores the number format of v2.6.0.

Note: the way that we multiply effects from different skills makes Dexterity and Agility much "better"/"more efficient" than Strength and Defense. This PR is a bugfix one, so I don't touch that part.