### PR TITLE
NETSCRIPT: Don't make dynamicLoadedFns entries for free functions.

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -343,6 +343,7 @@ function netscriptDelay(ctx: NetscriptContext, time: number): Promise<void> {
 
 /** Adds to dynamic ram cost when calling new ns functions from a script */
 function updateDynamicRam(ctx: NetscriptContext, ramCost: number): void {
+  if (ramCost === 0) return;
   const ws = ctx.workerScript;
   const fnName = ctx.function;
   if (ws.dynamicLoadedFns[fnName]) return;

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -103,7 +103,9 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
       throw new Error(`Invalid function specified: [${fnPath.toString()}]`);
     }
 
-    expect(workerScript.dynamicLoadedFns).toHaveProperty(fnName);
+    if (expectedRamCost !== 0) {
+      expect(workerScript.dynamicLoadedFns).toHaveProperty(fnName);
+    }
     expect(workerScript.dynamicRamUsage).toBeCloseTo(Math.min(expectedRamCost + baseCost, maxCost), 5);
     expect(workerScript.dynamicRamUsage).toBeCloseTo(scriptRef.ramUsage - extraLayerCost, 5);
   }


### PR DESCRIPTION
A followup to #1589. Saves a bit of (IRL) ram when calling free functions like `disableLog`.