### PR TITLE
BUGFIX: Crash in b1tflum3 and destroyW0r1dD43m0n API

### DIFF
--- a/src/BitNode/BitNodeUtils.ts
+++ b/src/BitNode/BitNodeUtils.ts
@@ -30,7 +30,7 @@ export function knowAboutBitverse(): boolean {
 
 export function getDefaultBitNodeOptions(): BitNodeOptions {
   return {
-    sourceFileOverrides: new Map<number, number>(),
+    sourceFileOverrides: new JSONMap<number, number>(),
     intelligenceOverride: undefined,
     restrictHomePCUpgrade: false,
     disableGang: false,

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -761,7 +761,7 @@ function validateBitNodeOptions(ctx: NetscriptContext, bitNodeOptions: unknown):
 
   result.sourceFileOverrides = new JSONMap(options.sourceFileOverrides);
   if (options.intelligenceOverride !== undefined) {
-    result.intelligenceOverride = number(ctx, "intelligenceOverride", options.intelligenceOverride);
+    result.intelligenceOverride = positiveInteger(ctx, "intelligenceOverride", options.intelligenceOverride);
   } else {
     result.intelligenceOverride = undefined;
   }

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -8,7 +8,7 @@ import { dialogBoxCreate } from "./ui/React/DialogBox";
 import { Router } from "./ui/GameRoot";
 import { Page } from "./ui/Router";
 import { prestigeSourceFile } from "./Prestige";
-import { setBitNodeOptions } from "./BitNode/BitNodeUtils";
+import { getDefaultBitNodeOptions, setBitNodeOptions } from "./BitNode/BitNodeUtils";
 
 function giveSourceFile(bitNodeNumber: number): void {
   const sourceFileKey = "SourceFile" + bitNodeNumber.toString();
@@ -69,12 +69,26 @@ export function enterBitNode(
   Player.bitNodeN = newBitNode;
 
   // Set BitNode options
-  setBitNodeOptions(bitNodeOptions);
+  try {
+    setBitNodeOptions(bitNodeOptions);
+  } catch (error) {
+    dialogBoxCreate(
+      <>
+        Invalid BitNode options. This is a bug. Please report it to developers.
+        <br />
+        <br />
+        {error instanceof Error ? error.stack : String(error)}
+      </>,
+    );
+    // Use default options
+    setBitNodeOptions(getDefaultBitNodeOptions());
+  }
+
+  prestigeSourceFile(isFlume);
 
   if (newBitNode === 6) {
     Router.toPage(Page.BladeburnerCinematic);
   } else {
     Router.toPage(Page.Terminal);
   }
-  prestigeSourceFile(isFlume);
 }


### PR DESCRIPTION
This PR fixes a severe bug in the new "BN options" feature.

`enterBitNode` (`src\RedPill.tsx`) calls `setBitNodeOptions` (`src\BitNode\BitNodeUtils.ts`). `setBitNodeOptions` can throw an error, but the caller does not try-catch the error. It can lead to a bug in which `enterBitNode` only runs halfway.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  // Case 1
  ns.singularity.destroyW0r1dD43m0n(2);
  // Case 2
  ns.singularity.destroyW0r1dD43m0n(2, undefined, {
    sourceFileOverrides: new Map(),
    intelligenceOverride: -1
  });
}
```

How to reproduce it:
- Load a clean save file. Use the dev menu to add SF4, SF5.
- Run 2 cases of the test code.

There are 3 concerns:
- In `src\PersonObjects\Player\PlayerObject.ts`, we duplicate the code of `getDefaultBitNodeOptions` when we initialize `bitNodeOptions`. I'm not sure if we should make `PlayerObject.ts` depend on `BitNodeUtils.ts`, so I don't call `getDefaultBitNodeOptions`.
- I don't try-catch `setBitNodeOptions(getDefaultBitNodeOptions());`. I want to hear your opinions about it. I think it's unnecessary to do that. If `setBitNodeOptions` cannot process even the default options, it's a severe bug. I'm not sure if we need to try-catch it here.
- I move the call of `prestigeSourceFile` to above the `Router.toPage`. I think it's better to run the UI-related code at the end.