### PR TITLE
BLADE: Fix population estimate percent growth when estimate is 0

### DIFF
--- a/src/Bladeburner/City.ts
+++ b/src/Bladeburner/City.ts
@@ -35,9 +35,9 @@ export class City {
   improvePopulationEstimateByCount(n: number): void {
     n = clampInteger(n, 0);
     const diff = Math.abs(this.popEst - this.pop);
-    // Chgnge would overshoot actual population -> make estimate accurate
+    // Change would overshoot actual population -> make estimate accurate
     if (diff <= n) this.popEst = this.pop;
-    // Otherwise make enstimate closer by n
+    // Otherwise make estimate closer by n
     else if (this.popEst < this.pop) this.popEst += n;
     else this.popEst -= n;
   }
@@ -46,10 +46,10 @@ export class City {
   improvePopulationEstimateByPercentage(p: number, skillMult = 1): void {
     p = clampNumber((p * skillMult) / 100);
     const diff = Math.abs(this.popEst - this.pop);
-    // Chgnge would overshoot actual population -> make estimate accurate
+    // Change would overshoot actual population -> make estimate accurate
     if (diff <= p * this.popEst) this.popEst = this.pop;
-    // Otherwise make enstimate closer by n
-    else if (this.popEst < this.pop) this.popEst = clampNumber(this.popEst * (1 + p));
+    // Otherwise make estimate closer by n
+    else if (this.popEst < this.pop) this.popEst = clampNumber(this.popEst * (1 + p), 1);
     else this.popEst = clampNumber(this.popEst * (1 - p));
   }
 


### PR DESCRIPTION
# BLADE: Fix population estimate percent growth when estimate is 0

In Bladeburners, there are 4 methods to improve the player's population estimate, 3 of which are percentage-based. However, if the estimate is at 0.00000 population, then Field Analysis, Investigation, and Undercover Operation are all unable to improve estimate counts, even if the actual estimate recovers.

This PR clamps the estimate change to a minimum of +1 in the circumstance that the actual population is a positive number and the estimated population is less. 

This does NOT change the percentage calculations, it only clamps that a "too low" population estimate increase is guaranteed to discover at least 1.00 new synthoid.

Tested by reducing Sector 12 to 0 and then letting passive population growth kick in during bonus time.

Before: 
![image](https://github.com/user-attachments/assets/4a30577a-ebd5-45f1-ae7a-f0b7188003b9)

After:
![image](https://github.com/user-attachments/assets/876550a9-c0bc-4475-a607-4e27d010db34)

# Bug fix

- [x] Include how it was tested
- [x] Include screenshot / gif (if possible)
- [x] Make sure you run `npm run format` and `npm run lint` before pushing.
