### PR TITLE
UI: Remove extra "label=" text from SmartSupply interface

### DIFF
--- a/src/Corporation/ui/modals/SmartSupplyModal.tsx
+++ b/src/Corporation/ui/modals/SmartSupplyModal.tsx
@@ -48,7 +48,7 @@ function SSoption(props: ISSoptionProps): React.ReactElement {
 
   return (
     <>
-      label={<Typography>{props.warehouse.materials[props.matName].name}</Typography>}
+      {<Typography>{props.warehouse.materials[props.matName].name}</Typography>}
       <FormControlLabel
         control={<Switch checked={value == "leftovers"} onChange={onLOChange} />}
         label={<Typography>{"Use leftovers"}</Typography>}


### PR DESCRIPTION
Testing a save for an unrelated issue I noticed an additional `label=` label. It looks like it snuck in some time back around #428. The additional text isn't easily visible on default and most dark backgrounds.

Before: default theme, and then in one that's easier to see
![default](https://github.com/user-attachments/assets/2b2b91a7-f0a1-41ad-9fd3-0b9cfcba8186)
![fangs](https://github.com/user-attachments/assets/f1e3e6e3-340a-4ce4-8b17-2e908196f2d7)

Post-change:
![fixed](https://github.com/user-attachments/assets/d1cbc3cf-29fc-4a1b-8e0e-51bef2eb0d3e)