### PR TITLE
BLADE: Use "grow" semantics for population estimate

### DIFF
--- a/src/Bladeburner/City.ts
+++ b/src/Bladeburner/City.ts
@@ -44,13 +44,17 @@ export class City {
 
   /** @param {number} p - the percentage change, not the multiplier. e.g. pass in p = 5 for 5% */
   improvePopulationEstimateByPercentage(p: number, skillMult = 1): void {
-    p = clampNumber((p * skillMult) / 100);
-    const diff = Math.abs(this.popEst - this.pop);
-    // Change would overshoot actual population -> make estimate accurate
-    if (diff <= p * this.popEst) this.popEst = this.pop;
-    // Otherwise make estimate closer by n
-    else if (this.popEst < this.pop) this.popEst = clampNumber(this.popEst * (1 + p), 1);
-    else this.popEst = clampNumber(this.popEst * (1 - p));
+    const percentage = clampNumber(p * skillMult);
+    const m = percentage / 100;
+    if (this.popEst < this.pop) {
+      // We use an additive factor so we don't get "stuck" at 0.
+      const popGrown = (this.popEst + percentage) * (1 + m);
+      this.popEst = clampNumber(popGrown, 0, this.pop);
+    } else {
+      // We use an subtractive factor so we can reach 0 in finite steps.
+      const popShrunk = (this.popEst - percentage) / (1 + m);
+      this.popEst = clampNumber(popShrunk, this.pop);
+    }
   }
 
   /**


### PR DESCRIPTION
This changes the way percantage-based population estimates work, so that they have a similar mechanism to grow(). This allows natural recovery from 0, and also falling to 0 in finite steps.

This also changes the formula for reducing estimates to `est / (1 + p)` instead of `est * (1 - p)`. The latter becomes overpowered at large p, we've seen this formula issue elsewhere (such as BN modifiers).

## Testing

I did some basic Bladeburner testing, and populate estimates seem to still work.