### PR TITLE
BUGFIX: Missing error handler when calling libarg

### DIFF
--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -18,10 +18,16 @@ export function runScript(path: ScriptFilePath, commandArgs: (string | number | 
   if (!script) return Terminal.error(`Script ${path} does not exist on this server.`);
 
   const runArgs = { "--tail": Boolean, "-t": Number, "--ram-override": Number };
-  const flags = libarg(runArgs, {
-    permissive: true,
-    argv: commandArgs,
-  });
+  let flags;
+  try {
+    flags = libarg(runArgs, {
+      permissive: true,
+      argv: commandArgs,
+    });
+  } catch (error) {
+    Terminal.error(`Invalid arguments. ${String(error)}.`);
+    return;
+  }
   const tailFlag = flags["--tail"] === true;
   const numThreads = parseFloat(flags["-t"] ?? 1);
   const ramOverride = flags["--ram-override"] != null ? roundToTwo(parseFloat(flags["--ram-override"])) : null;

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -276,10 +276,21 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
     if (!loadedModule || !loadedModule.autocomplete) return; // Doesn't have an autocomplete function.
 
     const runArgs = { "--tail": Boolean, "-t": Number, "--ram-override": Number };
-    const flags = libarg(runArgs, {
-      permissive: true,
-      argv: command.slice(2),
-    });
+    let flags = {
+      _: [],
+    };
+    try {
+      flags = libarg(runArgs, {
+        permissive: true,
+        argv: command.slice(2),
+      });
+    } catch (error) {
+      /**
+       * This error can only happen when the player specifies "-t" or "--ram-override", then presses [Tab] without
+       * giving a number. We don't need to show an error here.
+       */
+      console.warn(error);
+    }
     const flagFunc = Flags(flags._);
     const autocompleteData: AutocompleteData = {
       servers: GetAllServers()


### PR DESCRIPTION
Test code:
```js
export function autocomplete(data, flags) {
  return data.servers;
}

/** @param {NS} ns */
export async function main(ns) {
}
```

How to reproduce it:
- Create `test.js` with the code above.
- Test 2 cases:
  - `run test.js -t`[Press Tab]
  - `run test.js -t`[Press Enter]

### Before
[Tab]:
![Capture 2](https://github.com/user-attachments/assets/d5c6df1d-6d4c-4114-8dee-fce4f7d51e61)

[Enter]
![Capture 1](https://github.com/user-attachments/assets/9a431f25-25eb-4a3a-bb56-b32a4e9be8f7)

### After
[Tab]: No error. We only show a console warning.

[Enter]:

![Capture](https://github.com/user-attachments/assets/c6171dc2-dfcb-429a-81dd-7eaf4490f937)