### PR TITLE
STANEK: Typo fix in description

### DIFF
--- a/src/Faction/FactionInfo.tsx
+++ b/src/Faction/FactionInfo.tsx
@@ -765,7 +765,7 @@ export const FactionInfos: Record<FactionName, FactionInfo> = {
         <Option
           buttonText={"Open Stanek's Gift"}
           infoText={
-            "Stanek's Gift is a powerful augmentation that powers up the stat you chose to boost." +
+            "Stanek's Gift is a powerful augmentation that powers up the stat you chose to boost. " +
             "Gaining reputation with the Church of the Machine God can only be done by charging the gift."
           }
           onClick={() => Router.toPage(Page.StaneksGift)}


### PR DESCRIPTION
Fixing a typo (missing space) in the CotMG faction info text.

Fix is so minor that I haven't bothered to recompile locally, however here is a screenshot of the typo in the current steam version:
![image](https://github.com/user-attachments/assets/2ac6ca92-0323-4dbe-ad29-2dad4857c0a5)

