### PR TITLE
API: Reduce NS costs for static information functions to 0

### DIFF
--- a/markdown/bitburner.bladeburner.getblackopnames.md
+++ b/markdown/bitburner.bladeburner.getblackopnames.md
@@ -19,7 +19,7 @@ Array of strings containing the names of all Bladeburner Black Ops.
 
 ## Remarks
 
-RAM cost: 0.4 GB
+RAM cost: 0 GB
 
 Returns an array of strings containing the names of all Bladeburner Black Ops.
 

--- a/markdown/bitburner.bladeburner.getcontractnames.md
+++ b/markdown/bitburner.bladeburner.getcontractnames.md
@@ -19,7 +19,7 @@ Array of strings containing the names of all Bladeburner contracts.
 
 ## Remarks
 
-RAM cost: 0.4 GB
+RAM cost: 0 GB
 
 Returns an array of strings containing the names of all Bladeburner contracts.
 

--- a/markdown/bitburner.bladeburner.getgeneralactionnames.md
+++ b/markdown/bitburner.bladeburner.getgeneralactionnames.md
@@ -19,7 +19,7 @@ Array of strings containing the names of all general Bladeburner actions.
 
 ## Remarks
 
-RAM cost: 0.4 GB
+RAM cost: 0 GB
 
 Returns an array of strings containing the names of all general Bladeburner actions.
 

--- a/markdown/bitburner.bladeburner.getoperationnames.md
+++ b/markdown/bitburner.bladeburner.getoperationnames.md
@@ -19,7 +19,7 @@ Array of strings containing the names of all Bladeburner operations.
 
 ## Remarks
 
-RAM cost: 0.4 GB
+RAM cost: 0 GB
 
 Returns an array of strings containing the names of all Bladeburner operations.
 

--- a/markdown/bitburner.bladeburner.getskillnames.md
+++ b/markdown/bitburner.bladeburner.getskillnames.md
@@ -19,7 +19,7 @@ Array of strings containing the names of all general Bladeburner skills.
 
 ## Remarks
 
-RAM cost: 0.4 GB
+RAM cost: 0 GB
 
 Returns an array of strings containing the names of all general Bladeburner skills.
 

--- a/markdown/bitburner.codingcontract.getcontracttypes.md
+++ b/markdown/bitburner.codingcontract.getcontracttypes.md
@@ -17,5 +17,5 @@ string\[\]
 
 ## Remarks
 
-RAM cost: 2 GB
+RAM cost: 0 GB
 

--- a/markdown/bitburner.gang.getequipmentnames.md
+++ b/markdown/bitburner.gang.getequipmentnames.md
@@ -19,7 +19,7 @@ Names of all Equipments/Augmentations.
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 
 Get the name of all possible equipment/upgrades you can purchase for your Gang Members. This includes Augmentations.
 

--- a/markdown/bitburner.gang.gettasknames.md
+++ b/markdown/bitburner.gang.gettasknames.md
@@ -19,7 +19,7 @@ All valid tasks that Gang members can be assigned to.
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 
 Get the name of all valid tasks that Gang members can be assigned to.
 

--- a/markdown/bitburner.infiltration.getpossiblelocations.md
+++ b/markdown/bitburner.infiltration.getpossiblelocations.md
@@ -19,5 +19,5 @@ all locations that can be infiltrated.
 
 ## Remarks
 
-RAM cost: 5 GB
+RAM cost: 0 GB
 

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -75,11 +75,11 @@ export const RamCostConstants = {
   StanekPlace: 5,
   StanekFragmentAt: 2,
   StanekDeleteAt: 0.15,
+  StanekAcceptGift: 2,
+
   InfiltrationCalculateDifficulty: 2.5,
   InfiltrationCalculateRewards: 2.5,
-  InfiltrationGetLocations: 5,
   InfiltrationGetInfiltrations: 15,
-  StanekAcceptGift: 2,
 
   CycleTiming: 1,
 } as const;
@@ -235,10 +235,10 @@ const gang = {
   getRecruitsAvailable: RamCostConstants.GangApiBase / 4,
   respectForNextRecruit: RamCostConstants.GangApiBase / 4,
   recruitMember: RamCostConstants.GangApiBase / 2,
-  getTaskNames: RamCostConstants.GangApiBase / 4,
+  getTaskNames: 0,
   getTaskStats: RamCostConstants.GangApiBase / 4,
   setMemberTask: RamCostConstants.GangApiBase / 2,
-  getEquipmentNames: RamCostConstants.GangApiBase / 4,
+  getEquipmentNames: 0,
   getEquipmentCost: RamCostConstants.GangApiBase / 2,
   getEquipmentType: RamCostConstants.GangApiBase / 2,
   getEquipmentStats: RamCostConstants.GangApiBase / 2,
@@ -282,13 +282,13 @@ const go = {
 // Bladeburner API
 const bladeburner = {
   inBladeburner: RamCostConstants.BladeburnerApiBase / 4,
-  getContractNames: RamCostConstants.BladeburnerApiBase / 10,
-  getOperationNames: RamCostConstants.BladeburnerApiBase / 10,
-  getBlackOpNames: RamCostConstants.BladeburnerApiBase / 10,
+  getContractNames: 0,
+  getOperationNames: 0,
+  getBlackOpNames: 0,
   getNextBlackOp: RamCostConstants.BladeburnerApiBase / 2,
   getBlackOpRank: RamCostConstants.BladeburnerApiBase / 2,
-  getGeneralActionNames: RamCostConstants.BladeburnerApiBase / 10,
-  getSkillNames: RamCostConstants.BladeburnerApiBase / 10,
+  getGeneralActionNames: 0,
+  getSkillNames: 0,
   startAction: RamCostConstants.BladeburnerApiBase,
   stopBladeburnerAction: RamCostConstants.BladeburnerApiBase / 2,
   getCurrentAction: RamCostConstants.BladeburnerApiBase / 4,
@@ -323,7 +323,7 @@ const bladeburner = {
 } as const;
 
 const infiltration = {
-  getPossibleLocations: RamCostConstants.InfiltrationGetLocations,
+  getPossibleLocations: 0,
   getInfiltration: RamCostConstants.InfiltrationGetInfiltrations,
 } as const;
 
@@ -335,7 +335,7 @@ const codingcontract = {
   getDescription: RamCostConstants.CodingContractBase / 2,
   getNumTriesRemaining: RamCostConstants.CodingContractBase / 5,
   createDummyContract: RamCostConstants.CodingContractBase / 5,
-  getContractTypes: RamCostConstants.CodingContractBase / 5,
+  getContractTypes: 0,
 } as const;
 
 // Duplicate Sleeve API

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3175,7 +3175,7 @@ export interface Bladeburner {
   /**
    * List all contracts.
    * @remarks
-   * RAM cost: 0.4 GB
+   * RAM cost: 0 GB
    *
    * Returns an array of strings containing the names of all Bladeburner contracts.
    *
@@ -3186,7 +3186,7 @@ export interface Bladeburner {
   /**
    * List all operations.
    * @remarks
-   * RAM cost: 0.4 GB
+   * RAM cost: 0 GB
    *
    * Returns an array of strings containing the names of all Bladeburner operations.
    *
@@ -3197,7 +3197,7 @@ export interface Bladeburner {
   /**
    * List all black ops.
    * @remarks
-   * RAM cost: 0.4 GB
+   * RAM cost: 0 GB
    *
    * Returns an array of strings containing the names of all Bladeburner Black Ops.
    *
@@ -3220,7 +3220,7 @@ export interface Bladeburner {
   /**
    * List all general actions.
    * @remarks
-   * RAM cost: 0.4 GB
+   * RAM cost: 0 GB
    *
    * Returns an array of strings containing the names of all general Bladeburner actions.
    *
@@ -3231,7 +3231,7 @@ export interface Bladeburner {
   /**
    * List all skills.
    * @remarks
-   * RAM cost: 0.4 GB
+   * RAM cost: 0 GB
    *
    * Returns an array of strings containing the names of all general Bladeburner skills.
    *
@@ -3851,7 +3851,7 @@ export interface CodingContract {
   /**
    * List all contract types.
    * @remarks
-   * RAM cost: 2 GB
+   * RAM cost: 0 GB
    */
   getContractTypes(): string[];
 }
@@ -3996,7 +3996,7 @@ export interface Gang {
   /**
    * List member task names.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * Get the name of all valid tasks that Gang members can be assigned to.
    *
@@ -4033,7 +4033,7 @@ export interface Gang {
   /**
    * List equipment names.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * Get the name of all possible equipment/upgrades you can purchase for your Gang Members.
    * This includes Augmentations.
@@ -5503,7 +5503,7 @@ interface Infiltration {
   /**
    * Get all locations that can be infiltrated.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 0 GB
    *
    * @returns all locations that can be infiltrated.
    */


### PR DESCRIPTION
# API: Reduce NS costs for static information functions to 0

This PR implements the top change outlined in #1621 by reducing NS costs for functions which serve only serve to provide the user with constant string values.

Currently, the workflow for these functions is "run it once, copy the data, save as a hardcoded array/hash, never use it again." This is a type of antipattern behavior.

Turning the data into useful attribute-constants will be a follow-up PR at a later date; today, the goal is simply to reduce a barrier-of-entry by zeroing-out these costs. This fulfills the top portion of the linked issue.

# Documentation

- [x] If your PR includes ns API function changes, do not manually modify markdown files.
- [x] Instead, you can run `npm run doc` to autogenerate new markdown files that reflect your submitted API changes.
- [x] Make sure you run `npm run format` and `npm run lint` before pushing.

![image](https://github.com/user-attachments/assets/16ace33c-75e8-44bc-8770-b41d4220aa75)

