### PR TITLE
MISC: Show more information about documentation in last step of tutorial

### DIFF
--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -24,6 +24,7 @@ import {
   iTutorialEnd,
 } from "../../InteractiveTutorial";
 import { useRerender } from "../React/hooks";
+import { Settings } from "../../Settings/Settings";
 
 interface IContent {
   content: React.ReactElement;
@@ -525,13 +526,27 @@ export function InteractiveTutorialRoot(): React.ReactElement {
     },
     [iTutorialSteps.DocumentationPageInfo as number]: {
       content: (
-        <Typography>
-          This page contains a lot of different documentation about the game's content and mechanics. I know it's a lot,
-          but I highly suggest you read (or at least skim) through this before you start playing.
+        <Typography component="div">
+          This page contains a lot of different documentation about the game's contents and mechanics. I know it's a
+          lot, but I highly suggest you read (or at least skim) through this before you start playing. Some pages are
+          inaccessible at the start and will be unlocked later.
           <br />
           <br />
-          The Beginner's guide contains the guide for new players, navigating you through most of early game.
+          You should at least check these pages:
+          <ul>
+            <li>
+              The Beginner's guide contains the guide for new players, navigating you through most of the early game.
+            </li>
+            <li>The NS API documentation contains reference materials for all NS APIs.</li>
+          </ul>
+          <Typography fontWeight="fontWeightBold">
+            This documentation page is the best place to get up-to-date information, especially when you get stuck. If
+            you have a question and cannot find the answer here, please ask us on Discord.
+          </Typography>
           <br />
+          <Typography color={Settings.theme.warning}>
+            The documentation at readthedocs is outdated and unmaintained. Do not use them!
+          </Typography>
           <br />
           That's the end of the tutorial. Hope you enjoy the game!
         </Typography>


### PR DESCRIPTION
I observed that new players tend to make these mistakes:
- Underestimate the importance of the Documentation tab.
- Do not know that the NS API documentation exists.
- Use readthedocs.

This PR tries to fix this problem by emphasizing documentation-related things in the last step of the tutorial.

Before:
![before](https://github.com/user-attachments/assets/a9bb3a0b-6888-43c8-927d-aba31ca28221)

After:
![after](https://github.com/user-attachments/assets/31b08d74-2ff0-4d97-9bd0-276d0eff38e7)
