### PR TITLE
DOCUMENTATION: Improve ns.enableLog() docs to remove a missleading description

### DIFF
--- a/markdown/bitburner.ns.enablelog.md
+++ b/markdown/bitburner.ns.enablelog.md
@@ -26,7 +26,9 @@ void
 
 RAM cost: 0 GB
 
-Re-enables logging for the given function. If `ALL` is passed into this function as an argument, it will revert the effect of disableLog("ALL").
+Logging can be enabled for all functions by passing `ALL` as the argument.
+
+For specific interfaces, use the form "namespace.functionName". (e.g. "ui.setTheme")
 
 ## Example
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6168,8 +6168,9 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * Re-enables logging for the given function. If `ALL` is passed into this function as an argument, it will revert the
-   * effect of disableLog("ALL").
+   * Logging can be enabled for all functions by passing `ALL` as the argument.
+   *
+   * For specific interfaces, use the form "namespace.functionName". (e.g. "ui.setTheme")
    *
    * @example
    * ```js


### PR DESCRIPTION
As is noted [here](https://discord.com/channels/415207508303544321/415213435974975508/1277790941159358495) in the BitBurner Discord, there is some amount of ambiguity on what ns.enableLog actually does. As it is currently written it implies it *reverts* the effect of ns.disableLog rather than working as an inverse to ns.disableLog.
This PR changes this such that it's less an "Undo function for ns.disableLog" and more of its own function.