### PR TITLE
UI: Simplify Corps LimitMaterial Buttons – Remove Non-Functional and Rename Functional to LimitProduction

### DIFF
--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -74,10 +74,11 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
   }
 
   // Limit Production button
-  let limitMaterialButtonText = "Limit Material";
+  let limitProductionButtonText = "Limit Production";
   if (mat.productionLimit !== null) {
-    limitMaterialButtonText += " (" + formatCorpStat(mat.productionLimit) + ")";
+    limitProductionButtonText += " (" + formatCorpStat(mat.productionLimit) + ")";
   }
+  const showLimitButton = division.producedMaterials.includes(mat.name);
 
   // Material Gain details
   const gainBreakdown = [
@@ -158,9 +159,11 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
             open={sellMaterialOpen}
             onClose={() => setSellMaterialOpen(false)}
           />
-          <Button color={tutorial ? "error" : "primary"} onClick={() => setLimitProductionOpen(true)}>
-            {limitMaterialButtonText}
-          </Button>
+          {showLimitButton && (
+            <Button color={tutorial ? "error" : "primary"} onClick={() => setLimitProductionOpen(true)}>
+              {limitProductionButtonText}
+            </Button>
+          )}
           <LimitMaterialProductionModal
             material={mat}
             open={limitProductionOpen}


### PR DESCRIPTION
## Documentation

Consider removing the "Limit Material" button from materials that aren't being produced and renaming it to "Limit Production" to match the existing button for products.
Corps can be a bit overwhelming for new players, and having buttons that don't do anything or are mislabeled doesn't help. I understand that the production limit feature isn't working as intended, but a good first step might be to remove the button where it’s not needed.

Tobacco:
![grafik](https://github.com/user-attachments/assets/2bbc3e8f-b656-4c9a-b4fa-211b3c9a4394)

Agriculture:
![grafik](https://github.com/user-attachments/assets/d2c13a42-518c-4f7f-ab02-0b7f4bf489bb)

Just to make my point a bit clearer. This is the UI element that opens, regardless of whether you click the "Limit Material" or the "Limit Production" Button.
![grafik](https://github.com/user-attachments/assets/2189f149-271a-46b4-97ff-443a9e4c0fe7)

Also, it looks like there's no trace of a real "Limit Material" feature in the code. As a player, when I see that button, I'd expect it to limit the space in the warehouse that could be filled by that material - whether through buying, producing, or importing. It would be a cool feature to have, but as it stands, it's not in the game.

That's why I’m suggesting we rename or remove the existing buttons. If we decide to introduce a real "Limit Material" feature in the future, we can always create new buttons for it then.

This PR removes nonfunctional buttons and renames the functional ones to "Limit Production":
![grafik](https://github.com/user-attachments/assets/c552e5e6-9200-4eaf-ae7f-f84c3eee38aa)

