### PR TITLE
UI: Synchronize Corps Material Production Limits

### DIFF
--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -613,11 +613,19 @@ export function limitProductProduction(product: Product, cityName: CityName, qua
   }
 }
 
-export function limitMaterialProduction(material: Material, quantity: number): void {
-  if (quantity < 0 || isNaN(quantity)) {
-    material.productionLimit = null;
-  } else {
-    material.productionLimit = quantity;
+export function limitMaterialProduction(
+  material: Material,
+  division: Division,
+  cityName: CityName,
+  quantity: number,
+): void {
+  const limit = quantity < 0 || isNaN(quantity) ? null : quantity;
+  material.productionLimit = limit;
+  if (division.producedMaterials.includes(material.name)) {
+    // Set limit of all Materials to this amount, since they are produced together
+    for (const materialName of division.producedMaterials) {
+      division.warehouses[cityName]!.materials[materialName].productionLimit = quantity;
+    }
   }
 }
 

--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -163,6 +163,8 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
           </Button>
           <LimitMaterialProductionModal
             material={mat}
+            division={division}
+            city={city}
             open={limitProductionOpen}
             onClose={() => setLimitProductionOpen(false)}
           />

--- a/src/Corporation/ui/modals/LimitMaterialProductionModal.tsx
+++ b/src/Corporation/ui/modals/LimitMaterialProductionModal.tsx
@@ -6,11 +6,15 @@ import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import { KEY } from "../../../utils/helpers/keyCodes";
 import { Material } from "../../Material";
+import { Division } from "../../Division";
+import { CityName } from "../../../Enums";
 
 interface IProps {
   open: boolean;
   onClose: () => void;
   material: Material;
+  division: Division;
+  city: CityName;
 }
 
 // Create a popup that lets the player limit the production of a product
@@ -27,7 +31,7 @@ export function LimitMaterialProductionModal(props: IProps): React.ReactElement 
   function limitMaterialProduction(): void {
     let qty = limit;
     if (qty === null) qty = -1;
-    actions.limitMaterialProduction(props.material, qty);
+    actions.limitMaterialProduction(props.material, props.division, props.city, qty);
     props.onClose();
   }
 

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -408,7 +408,12 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       const cityName = getEnumHelper("CityName").nsGetMember(ctx, _cityName);
       const materialName = getEnumHelper("CorpMaterialName").nsGetMember(ctx, _materialName, "materialName");
       const qty = helpers.number(ctx, "qty", _qty);
-      limitMaterialProduction(getMaterial(divisionName, cityName, materialName), qty);
+      limitMaterialProduction(
+        getMaterial(divisionName, cityName, materialName),
+        getDivision(divisionName),
+        cityName,
+        qty,
+      );
     },
     setMaterialMarketTA1: (ctx) => (_divisionName, _cityName, _materialName, _on) => {
       checkAccess(ctx, CorpUnlockName.WarehouseAPI);


### PR DESCRIPTION
## Documentation

Currently, the material production limits in Corps are not functioning correctly when a division produces multiple materials, such as ore and minerals in mining. If you set the production limit for the first material, both materials' production will be limited. However, if you set the limit for the second material, no production limits will be applied. This issue arises because the production of these materials is currently synchronized, meaning that you cannot produce one without producing the other. Whether this synchronization is intended game design is not the focus of this PR.

Additionally, a separate issue in division.ts causes only the production limit for the first output material to be checked and applied.

This PR addresses these issues by synchronizing the production limits for all materials that a division produces. This change will provide players with accurate feedback, indicating that setting a limit for one material will affect the others, and ensure that the displayed production limits match the applied limits.

Note: The term "set production limit" refers to the amount being set using the "Limit Material" button. This button controls the production limits in the city, not the material quantities in the warehouse. A different PR addresses this separate ssue: https://github.com/bitburner-official/bitburner-src/pull/1638

## Screenshot visualising the solution:

![grafik](https://github.com/user-attachments/assets/e382fbcc-8b0a-4a9d-a153-089f12eff314)

**Before:** Both limits could be set separately, but only one limit had an effect on both materials' production.

**After:** The limits are synchronized; changing the limit for one material now updates the limit for the other material as well.