### PR TITLE
UI: Change description of Documentation button in Script Editor

### DIFF
--- a/src/ScriptEditor/ui/Toolbar.tsx
+++ b/src/ScriptEditor/ui/Toolbar.tsx
@@ -71,8 +71,8 @@ export function Toolbar({ editor, onSave }: IProps) {
           Terminal (Ctrl/Cmd + b)
         </Button>
         <Typography>
-          <Link target="_blank" href={getNsApiDocumentationUrl()}>
-            Documentation
+          <Link target="_blank" href={getNsApiDocumentationUrl()} fontSize="1.2rem">
+            NS API documentation
           </Link>
         </Typography>
       </Box>


### PR DESCRIPTION
This change was suggested on Discord. It may be clearer for new players to know that this link is for the documentation of NS API.

Before:
![before](https://github.com/user-attachments/assets/3ad47e5c-0e3f-4659-889d-0407613703e5)

After:
![after](https://github.com/user-attachments/assets/11f177b0-184c-484e-ae74-8507effc1104)
