### PR TITLE
FIX: Resolve Alias Recursion Issue by Preventing Duplicate Rule Application

### DIFF
--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -93,7 +93,7 @@ function applyAliases(origCommand: string, depth = 0, currentlyProcessingAliases
   // First get non-global aliases, and recursively apply them
   // (unless there are any reference loops or the reference chain is too deep)
   const localAlias = Aliases.get(commandArray[0]);
-  const localrule = commandArray[0] + "->" + localAlias + "(g)";
+  const localrule = commandArray[0] + "->" + localAlias + "(l)";
   if (localAlias && !currentlyProcessingAliases.includes(localrule)) {
     const appliedAlias = applyAliases(localAlias, depth + 1, [localrule, ...currentlyProcessingAliases]);
     commandArray.splice(0, 1, ...appliedAlias.split(" "));

--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -62,9 +62,13 @@ export function removeAlias(name: string): boolean {
   return hadAlias;
 }
 
+export function clearAliases(): void {
+  Aliases.clear();
+  GlobalAliases.clear();
+}
+
 /**
  * Returns the original string with any aliases substituted in.
- * Aliases are only applied to "whole words", one level deep
  * @param origCommand the original command string
  */
 export function substituteAliases(origCommand: string): string {

--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -93,16 +93,18 @@ function applyAliases(origCommand: string, depth = 0, currentlyProcessingAliases
   // First get non-global aliases, and recursively apply them
   // (unless there are any reference loops or the reference chain is too deep)
   const localAlias = Aliases.get(commandArray[0]);
-  if (localAlias && !currentlyProcessingAliases.includes(localAlias)) {
-    const appliedAlias = applyAliases(localAlias, depth + 1, [commandArray[0], ...currentlyProcessingAliases]);
+  const localrule = commandArray[0] + "->" + localAlias + "(g)";
+  if (localAlias && !currentlyProcessingAliases.includes(localrule)) {
+    const appliedAlias = applyAliases(localAlias, depth + 1, [localrule, ...currentlyProcessingAliases]);
     commandArray.splice(0, 1, ...appliedAlias.split(" "));
   }
 
   // Once local aliasing is complete (or if none are present) handle any global aliases
   const processedCommands = commandArray.reduce((resolvedCommandArray: string[], command) => {
     const globalAlias = GlobalAliases.get(command);
-    if (globalAlias && !currentlyProcessingAliases.includes(globalAlias)) {
-      const appliedAlias = applyAliases(globalAlias, depth + 1, [command, ...currentlyProcessingAliases]);
+    const rule = command + "->" + globalAlias + "(g)";
+    if (globalAlias && !currentlyProcessingAliases.includes(rule)) {
+      const appliedAlias = applyAliases(globalAlias, depth + 1, [rule, ...currentlyProcessingAliases]);
       resolvedCommandArray.push(appliedAlias);
     } else {
       // If there is no alias, or if the alias has a circular reference, leave the command as-is

--- a/test/jest/Alias/Alias.test.ts
+++ b/test/jest/Alias/Alias.test.ts
@@ -7,7 +7,19 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=recursiveAlias");
 
     const result = substituteAliases("recursiveAlias");
-    expect(result).toEqual("d");
+    expect(result).toEqual("recursiveAlias");
+  });
+
+  it("Should gracefully handle recursive local aliases II", () => {
+    parseAliasDeclaration("recursiveAlias=recursiveAlias");
+    const result = substituteAliases("recursiveAlias");
+    expect(result).toEqual("recursiveAlias");
+  });
+
+  it("Should gracefully handle recursive local aliases II", () => {
+    parseAliasDeclaration('recursiveAlias="recursiveAlias -l"');
+    const result = substituteAliases("recursiveAlias");
+    expect(result).toEqual("recursiveAlias -l");
   });
 
   it("Should only change local aliases if they are the start of the command", () => {
@@ -27,7 +39,7 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=a", true);
 
     const result = substituteAliases("a b c d");
-    expect(result).toEqual("d a b c");
+    expect(result).toEqual("a b c d");
   });
 
   it("Should gracefully handle recursive mixed local and global aliases", () => {
@@ -37,7 +49,7 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=recursiveAlias", false);
 
     const result = substituteAliases("recursiveAlias");
-    expect(result).toEqual("d");
+    expect(result).toEqual("recursiveAlias");
   });
 
   it("Should replace chained aliases", () => {

--- a/test/jest/Alias/Alias.test.ts
+++ b/test/jest/Alias/Alias.test.ts
@@ -1,6 +1,9 @@
-import { substituteAliases, parseAliasDeclaration } from "../../../src/Alias";
+import { substituteAliases, parseAliasDeclaration, clearAliases } from "../../../src/Alias";
 describe("substituteAliases Tests", () => {
-  it("Should gracefully handle recursive local aliases", () => {
+  beforeEach(() => {
+    clearAliases();
+  });
+  it("Should gracefully handle recursive local aliases I", () => {
     parseAliasDeclaration("recursiveAlias=b");
     parseAliasDeclaration("b=c");
     parseAliasDeclaration("c=d");
@@ -16,10 +19,36 @@ describe("substituteAliases Tests", () => {
     expect(result).toEqual("recursiveAlias");
   });
 
-  it("Should gracefully handle recursive local aliases II", () => {
+  it("Should gracefully handle recursive local aliases III", () => {
+    parseAliasDeclaration('recursiveAlias="recursiveAlias"');
+    const result = substituteAliases("recursiveAlias");
+    expect(result).toEqual("recursiveAlias");
+  });
+
+  it("Should gracefully handle recursive local aliases IV", () => {
     parseAliasDeclaration('recursiveAlias="recursiveAlias -l"');
     const result = substituteAliases("recursiveAlias");
     expect(result).toEqual("recursiveAlias -l");
+  });
+
+  it("Should not substitute quoted commands I", () => {
+    parseAliasDeclaration("a=b");
+    const result = substituteAliases('"a"');
+    expect(result).toEqual('"a"');
+  });
+
+  it("Should not substitute quoted commands II", () => {
+    parseAliasDeclaration("a=b");
+    const result = substituteAliases("'a'");
+    expect(result).toEqual("'a'");
+  });
+
+  it("Should not substitute quoted commands III", () => {
+    parseAliasDeclaration("a=b");
+    parseAliasDeclaration("b='c'");
+    parseAliasDeclaration("c=d");
+    const result = substituteAliases("a");
+    //expect(result).toEqual("'c'"); // Currently FAILS
   });
 
   it("Should only change local aliases if they are the start of the command", () => {

--- a/test/jest/Alias/Alias.test.ts
+++ b/test/jest/Alias/Alias.test.ts
@@ -43,12 +43,20 @@ describe("substituteAliases Tests", () => {
     expect(result).toEqual("'a'");
   });
 
-  it("Should not substitute quoted commands III", () => {
+  it.skip("Should not substitute quoted commands III", () => {
     parseAliasDeclaration("a=b");
     parseAliasDeclaration("b='c'");
     parseAliasDeclaration("c=d");
     const result = substituteAliases("a");
-    //expect(result).toEqual("'c'"); // Currently FAILS
+    expect(result).toEqual("'c'");
+  });
+
+  it.skip("Should not substitute quoted commands IV", () => {
+    parseAliasDeclaration("a=b");
+    parseAliasDeclaration('b="c"');
+    parseAliasDeclaration("c=d");
+    const result = substituteAliases("a");
+    expect(result).toEqual('"c"');
   });
 
   it("Should only change local aliases if they are the start of the command", () => {


### PR DESCRIPTION
Closes #1647

Previously, the check was only to ensure that the right side of an alias rule does not repeat, which is not effective for endlessly expanding aliases such as buy="buy -l". Now, the implementation ensures a single alias rule is not recursively applied multiple times by remembering and checking the entire rule.

Updates expected values in tests; this change may disrupt existing setups with endless recursive aliases. Please verify if the new expected values align with your expectations. It would be possible to avoid applying the last substitution if it would result in infinite recursion, but this approach would not comply with the POSIX standard.