### PR TITLE
CCT: Add new Square Root coding contract

### DIFF
--- a/src/CodingContracts.ts
+++ b/src/CodingContracts.ts
@@ -1,20 +1,12 @@
 import type { FactionName } from "@enums";
-import { codingContractTypesMetadata, type CodingContractType } from "./data/codingcontracttypes";
+import { codingContractTypesMetadata } from "./data/codingcontracttypes";
 
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, constructorsForReviver } from "./utils/JSONReviver";
 import { CodingContractEvent } from "./ui/React/CodingContractModal";
 import { ContractFilePath, resolveContractFilePath } from "./Paths/ContractFilePath";
 
 /* Contract Types */
-export const CodingContractTypes: Record<string, CodingContractType<unknown>> = {};
-
-for (const md of codingContractTypesMetadata) {
-  // Because functions are contravariant with their parameters, we can't
-  // consider arbitrary CodingContractTypes as CodingContractType<unknown>
-  // directly. However, we do want that as the final type, to enforce that the
-  // state and data are unknown. So we cast through CodingContractType<any>.
-  CodingContractTypes[md.name] = md as CodingContractType<any>;
-}
+export const CodingContractTypes = Object.fromEntries(codingContractTypesMetadata.map((x) => [x.name, x]));
 
 // Numeric enum
 /** Enum representing the different types of rewards a Coding Contract can give */

--- a/src/utils/helpers/randomBigIntExclusive.ts
+++ b/src/utils/helpers/randomBigIntExclusive.ts
@@ -1,0 +1,38 @@
+/**
+ * Return a uniform random number in [0, size).
+ * Adjusting the range can be done with addition. Because bigints are more
+ * expensive, it makes more sense to have the 0-based version as a primitive.
+ */
+export function randomBigIntExclusive(size: bigint): bigint {
+  // Sadly, the easiest/most efficient way to operate on bigints bitwise is to
+  // deal with the hex string representation. In particular, this is the
+  // fastest general way to find the size (number of bits) of the bigint.
+  const bits = size.toString(16);
+  if (bits.length <= 12) {
+    // bigint is at most 48 bits. We can resolve this with a single random()
+    // call, and that will save special cases below.
+    return BigInt(Math.floor(Math.random() * Number(size)));
+  }
+  // We add 1 to the highest-order random digits, to ensure we cover the
+  // entire range. If we end up getting a number that is too big we toss it
+  // and try again. This seems wasteful, but it's actually one of the only
+  // ways to get a truly uniform result. Since the high-order part is > 2^44
+  // by the nature of it having 12 hex digits, we will need to restart at
+  // *most* 2^-44 of the time, in the pathological cases.
+  const highpart = parseInt(bits.slice(0, 12), 16) + 1;
+  let result: bigint;
+  do {
+    let str = "0x" + Math.floor(Math.random() * highpart).toString(16);
+    let i = 12;
+    for (; i + 12 < bits.length; i += 12) {
+      str += Math.floor(Math.random() * 2 ** 48).toString(16);
+    }
+    // Have to be careful to avoid 32-bit integer shift limit
+    // By the logic above, this shift will always be > 0, and so we're always
+    // adding at least one hex digit.
+    const halfmul = 1 << (2 * (bits.length - i));
+    str += Math.floor(Math.random() * halfmul * halfmul).toString(16);
+    result = BigInt(str);
+  } while (result >= size);
+  return result;
+}


### PR DESCRIPTION
To make this simpler, there is now a general-purpose util for getting random bigints. I don't know if anyone else will use it, but it makes this code simpler.

I also rejiggered the type-checking on contracts a little more, because the previous refactor didn't quite catch all the mistakes that could be made.

## Testing

Tested adding extra keys, dropping needed keys, and leaving `getData` out when it was needed. The typechecking catches all of these, as long as the `satisfies` conditions are used right.

The new contract functions properly (tested hundreds of iterations on dummy contracts). The nature of the CCT inherently tests edge cases more.