### PR TITLE
BUGFIX: Change generation rate of CCTs

### DIFF
--- a/src/CodingContractGenerator.ts
+++ b/src/CodingContractGenerator.ts
@@ -14,6 +14,24 @@ import { BaseServer } from "./Server/BaseServer";
 
 import { getRandomIntInclusive } from "./utils/helpers/getRandomIntInclusive";
 import { ContractFilePath, resolveContractFilePath } from "./Paths/ContractFilePath";
+import { clampNumber } from "./utils/helpers/clampNumber";
+
+export function tryGeneratingRandomContract(numberOfTries: number): void {
+  // We try to generate a contract every 10 minutes. 525600 is the number of tries in 10 years. There is no reason to
+  // support anything above that.
+  numberOfTries = clampNumber(0, 525600);
+  let currentNumberOfContracts = GetAllServers().reduce((sum, server) => {
+    return sum + server.contracts.length;
+  }, 0);
+  for (let i = 0; i < numberOfTries; ++i) {
+    const random = Math.random();
+    if (random > 0.25 / (1 + Math.exp(0.0012 * currentNumberOfContracts - 6))) {
+      continue;
+    }
+    generateRandomContract();
+    ++currentNumberOfContracts;
+  }
+}
 
 export function generateRandomContract(): void {
   // First select a random problem type

--- a/src/CodingContractGenerator.ts
+++ b/src/CodingContractGenerator.ts
@@ -17,8 +17,11 @@ import { ContractFilePath, resolveContractFilePath } from "./Paths/ContractFileP
 import { clampNumber } from "./utils/helpers/clampNumber";
 
 export function tryGeneratingRandomContract(numberOfTries: number): void {
-  // We try to generate a contract every 10 minutes. 525600 is the number of tries in 10 years. There is no reason to
-  // support anything above that.
+  /**
+   * We try to generate a contract every 10 minutes. 525600 is the number of tries in 10 years. There is no reason to
+   * support anything above that. We tested this number (525600) on a very old machine. It took only 300-350ms to
+   * loop 525600 times and generate ~9137 contracts on that machine.
+   */
   numberOfTries = clampNumber(Math.floor(numberOfTries), 0, 525600);
   if (numberOfTries < 1) {
     return;
@@ -28,7 +31,40 @@ export function tryGeneratingRandomContract(numberOfTries: number): void {
   }, 0);
   for (let i = 0; i < numberOfTries; ++i) {
     const random = Math.random();
-    if (random > 0.25 / (1 + Math.exp(0.0012 * currentNumberOfContracts - 6))) {
+    /**
+     * When currentNumberOfContracts is small, the probability is ~0.25. 25% is the "reasonable" chance of getting a
+     * contract in normal situations (low currentNumberOfContracts). We have used this probability for a long time as a
+     * constant before we decide to switch to a new function that is based on currentNumberOfContracts.
+     *
+     * This function was chosen due to these characteristics:
+     * - The probability is exactly 0.25 if currentNumberOfContracts is 0.
+     * - The probability is ~0.25 if currentNumberOfContracts is small (near 0).
+     * - The probability approaches 0 when currentNumberOfContracts becomes unusually large:
+     *   - If currentNumberOfContracts is 2500, the probability is 0.23861.
+     *   - If currentNumberOfContracts is 5000, the probability is 0.12462.
+     *   - If currentNumberOfContracts is 7500, the probability is 0.01176.
+     *   - If currentNumberOfContracts is 10000, the probability is 0.0006129.
+     *
+     * With this function, we ensure that:
+     * - The player gets a reasonable amount of contracts in normal situations.
+     * - If the offline time is unusually large (being offline for years, editing save file, tampering function prototype,
+     * etc.), the game will not hang when it tries to generate contracts.
+     *
+     * These are some data for reference:
+     * - 1 month: ~1077 contracts.
+     * - 3 months: ~3157 contracts.
+     * - 6 months: ~5296 contracts.
+     * - 12 months: ~6678 contracts.
+     * - 2 years: ~7570 contracts.
+     * - 5 years: ~8504 contracts.
+     * - 10 years: ~9137 contracts.
+     * - 25 years: ~9936 contracts.
+     * - 50 years: ~10526 contracts.
+     *
+     * Those numbers mean: If the player does not have any contracts and is online (or loads a save file with equivalent
+     * offline time) for X months/years, they will have ~Y contracts.
+     */
+    if (random > 100 / (399 + Math.exp(0.0012 * currentNumberOfContracts))) {
       continue;
     }
     generateRandomContract();

--- a/src/CodingContractGenerator.ts
+++ b/src/CodingContractGenerator.ts
@@ -19,7 +19,10 @@ import { clampNumber } from "./utils/helpers/clampNumber";
 export function tryGeneratingRandomContract(numberOfTries: number): void {
   // We try to generate a contract every 10 minutes. 525600 is the number of tries in 10 years. There is no reason to
   // support anything above that.
-  numberOfTries = clampNumber(0, 525600);
+  numberOfTries = clampNumber(Math.floor(numberOfTries), 0, 525600);
+  if (numberOfTries < 1) {
+    return;
+  }
   let currentNumberOfContracts = GetAllServers().reduce((sum, server) => {
     return sum + server.contracts.length;
   }, 0);

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -52,10 +52,6 @@ export const CONSTANTS = {
   IntelligenceSingFnBaseExpGain: 1.5,
 
   // Time-related constants
-  MillisecondsPer30Days: 2592000000,
-
-  MillisecondsPer24Hours: 86400000,
-
   MillisecondsPer20Hours: 72000000,
   GameCyclesPer20Hours: 72000000 / 200,
 
@@ -79,6 +75,8 @@ export const CONSTANTS = {
 
   MillisecondsPerQuarterHour: 900000,
   GameCyclesPerQuarterHour: 900000 / 200,
+
+  MillisecondsPerTenMinutes: 600000,
 
   MillisecondsPerFiveMinutes: 300000,
   GameCyclesPerFiveMinutes: 300000 / 200,

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -52,6 +52,10 @@ export const CONSTANTS = {
   IntelligenceSingFnBaseExpGain: 1.5,
 
   // Time-related constants
+  MillisecondsPer30Days: 2592000000,
+
+  MillisecondsPer24Hours: 86400000,
+
   MillisecondsPer20Hours: 72000000,
   GameCyclesPer20Hours: 72000000 / 200,
 

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -2,7 +2,7 @@ import { convertTimeMsToTimeElapsedString } from "./utils/StringHelperFunctions"
 import { AugmentationName, ToastVariant } from "@enums";
 import { initBitNodeMultipliers } from "./BitNode/BitNode";
 import { initSourceFiles } from "./SourceFile/SourceFiles";
-import { generateRandomContract } from "./CodingContractGenerator";
+import { tryGeneratingRandomContract } from "./CodingContractGenerator";
 import { CONSTANTS } from "./Constants";
 import { Factions } from "./Faction/Factions";
 import { staneksGift } from "./CotMG/Helper";
@@ -223,10 +223,7 @@ const Engine: {
     }
 
     if (Engine.Counters.contractGeneration <= 0) {
-      // X% chance of a contract being generated
-      if (Math.random() <= 0.25) {
-        generateRandomContract();
-      }
+      tryGeneratingRandomContract(1);
       Engine.Counters.contractGeneration = 3000;
     }
 
@@ -288,29 +285,7 @@ const Engine: {
       const numCyclesOffline = Math.floor(timeOffline / CONSTANTS.MilliPerCycle);
 
       // Generate bonus CCTs
-      let numContracts = 0;
-      if (timeOffline < CONSTANTS.MillisecondsPer30Days) {
-        // Calculate the number of chances for a contract the player had whilst offline
-        const contractChancesWhileOffline = Math.floor(timeOffline / (1000 * 60 * 10));
-
-        // Generate coding contracts
-        if (contractChancesWhileOffline > 100) {
-          numContracts += Math.floor(contractChancesWhileOffline * 0.25);
-        }
-        if (contractChancesWhileOffline > 0 && contractChancesWhileOffline <= 100) {
-          for (let i = 0; i < contractChancesWhileOffline; ++i) {
-            if (Math.random() <= 0.25) {
-              numContracts++;
-            }
-          }
-        }
-      } else {
-        const offlineDay = timeOffline / CONSTANTS.MillisecondsPer24Hours;
-        numContracts = 6500 / (1 + Math.exp(-0.02 * offlineDay + 2.2));
-      }
-      for (let i = 0; i < numContracts; i++) {
-        generateRandomContract();
-      }
+      tryGeneratingRandomContract(timeOffline / CONSTANTS.MillisecondsPerTenMinutes);
 
       let offlineReputation = 0;
       const offlineHackingIncome =

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -287,20 +287,26 @@ const Engine: {
       }
       const numCyclesOffline = Math.floor(timeOffline / CONSTANTS.MilliPerCycle);
 
-      // Calculate the number of chances for a contract the player had whilst offline
-      const contractChancesWhileOffline = Math.floor(timeOffline / (1000 * 60 * 10));
-
-      // Generate coding contracts
+      // Generate bonus CCTs
       let numContracts = 0;
-      if (contractChancesWhileOffline > 100) {
-        numContracts += Math.floor(contractChancesWhileOffline * 0.25);
-      }
-      if (contractChancesWhileOffline > 0 && contractChancesWhileOffline <= 100) {
-        for (let i = 0; i < contractChancesWhileOffline; ++i) {
-          if (Math.random() <= 0.25) {
-            numContracts++;
+      if (timeOffline < CONSTANTS.MillisecondsPer30Days) {
+        // Calculate the number of chances for a contract the player had whilst offline
+        const contractChancesWhileOffline = Math.floor(timeOffline / (1000 * 60 * 10));
+
+        // Generate coding contracts
+        if (contractChancesWhileOffline > 100) {
+          numContracts += Math.floor(contractChancesWhileOffline * 0.25);
+        }
+        if (contractChancesWhileOffline > 0 && contractChancesWhileOffline <= 100) {
+          for (let i = 0; i < contractChancesWhileOffline; ++i) {
+            if (Math.random() <= 0.25) {
+              numContracts++;
+            }
           }
         }
+      } else {
+        const offlineDay = timeOffline / CONSTANTS.MillisecondsPer24Hours;
+        numContracts = 6500 / (1 + Math.exp(-0.02 * offlineDay + 2.2));
       }
       for (let i = 0; i < numContracts; i++) {
         generateRandomContract();


### PR DESCRIPTION
When the game loads a save file that has too much bonus time, it tries to generate a massive amount of CCTs. This may take a very long time, and the player will think that the game hangs forever. This PR fixes this problem by changing how we generate CCTs at loading time.

New change: We have a new threshold: 30 days. If the offline time is below this threshold, we generate CCTs as normal; otherwise, we use a new formula to calculate the number of "bonus" CCTs.

Current generation rate: 25% chance of 1 CCT per 10 minutes. Average: 1.5 CCT/hour.

We have 2 formulas:
Current [1]:
$$y = 24 \ast 1.5 \ast x$$
New [2]:
$$y = \frac{6500}{1 + e ^ {-0.02 \ast x + 2.2}}$$

Graph:
![Capture](https://github.com/user-attachments/assets/30fe42ba-f7d6-4c7d-ad2c-535476c7d0d4)

Desmos link: https://www.desmos.com/calculator/pxm0lgovvp

Rationale behind the new change:
- No change in the generation rate when the player is online or when the offline time is below the threshold, so there is no need to debate about the balance.
- After being offline for 1 month (~30 days), the player will receive ~1100 bonus CCTs in [1]. Having 1100 bonus CCTs is a decent offline bonus.
- The cap of [2] is 6500. 6500 CCTs is the amount of CCTs that the player will receive if they are online for half a year **without** resetting. There is no point in rewarding them more than that. Generating 6500 CCTs is also very fast. On my 8-year-old machine, it takes only ~300ms to do that.

Fixes #1629.