### PR TITLE
BUGFIX: Wrong team size when all team members die in Bladeburner's action

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1052,7 +1052,8 @@ export class Bladeburner {
               sup[r].takeDamage(sup[r].hp.max);
               sup.splice(r, 1);
             }
-            this.teamSize += this.sleeveSize;
+            // If this happens, all team members died and some sleeves took damage. In this case, teamSize = sleeveSize.
+            this.teamSize = this.sleeveSize;
           }
           this.teamLost += losses;
           if (this.logging.blackops) {


### PR DESCRIPTION
I mentioned this bugfix in https://github.com/bitburner-official/bitburner-src/pull/1654#pullrequestreview-2310084828.

If all team members die, the team size must be the number of supporting sleeves. However, instead of an assignment, we do an addition.