### PR TITLE
FIX: import resolution in code editor

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -162,8 +162,12 @@ function Root(props: IProps): React.ReactElement {
   }
 
   function loadAllServerScripts(): void {
-    let server;
-    if (!currentScript || !(server = GetServer(currentScript.hostname))) {
+    if (!currentScript) {
+      return;
+    }
+
+    const server = GetServer(currentScript.hostname);
+    if (!server) {
       return;
     }
 

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -161,6 +161,28 @@ function Root(props: IProps): React.ReactElement {
     }
   }
 
+  function loadAllServerScripts(): void {
+    let server;
+    if (!currentScript || !(server = GetServer(currentScript.hostname))) {
+      return;
+    }
+
+    server.scripts.forEach((s) => {
+      const uri = monaco.Uri.from({
+        scheme: "file",
+        path: `${s.server}/${s.filename}`,
+      });
+
+      const model = monaco.editor.getModel(uri);
+      if (model !== null && !model.isDisposed()) {
+        // there's already a model, don't overwrite
+        return;
+      }
+
+      makeModel(server.hostname, s.filename, s.code);
+    });
+  }
+
   const debouncedCodeParsing = debounce((newCode: string) => {
     let server;
     if (!currentScript || !hasScriptExtension(currentScript.path) || !(server = GetServer(currentScript.hostname))) {
@@ -183,6 +205,7 @@ function Root(props: IProps): React.ReactElement {
   }, 300);
 
   const parseCode = (newCode: string) => {
+    loadAllServerScripts();
     startUpdatingRAM();
     debouncedCodeParsing(newCode);
   };


### PR DESCRIPTION
After switching to the dev build to be able to use Typescript, I noticed that import resolution fails most of the time. Not always, though. This is what it looks like:
![image](https://github.com/user-attachments/assets/806c7eb3-ca24-4ac2-8a73-762685b12771)

As you can see in the screenshot, it doesn't matter whether or not a file extension is provided. Additionally, I noticed that if an imported file is opened before the 'importee' file, the import resolution does seem to work fine. Unfortunately, I've not come around with why this happens and what the underlying problem is. I believe it's related to the virtual filesystem which Bitburner implements and that monaco doesn't know how to find source files automatically in there.

As a workaround, I opted to implement a callback which loads all imported files into the typescript worker in the background whenever a model changes. The callback does not reload scripts which are already open, so dirty files which are currently open will not be overwritten.

With the fix in place, import resolution and type annotations for imported types/functions now works correctly:
![image](https://github.com/user-attachments/assets/6cf671d1-0da9-4d18-9f24-befd34620ab5)
![image](https://github.com/user-attachments/assets/12de8b8d-e7e5-4f98-8ae7-80bfa7873952)

