### PR TITLE
BUGFIX: Follow-up of #1658 (Wrong team size in Bladeburner)

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -769,7 +769,8 @@ export class Bladeburner {
           sup[r].takeDamage(sup[r].hp.max);
           sup.splice(r, 1);
         }
-        this.teamSize += this.sleeveSize;
+        // If this happens, all team members died and some sleeves took damage. In this case, teamSize = sleeveSize.
+        this.teamSize = this.sleeveSize;
       }
       this.teamLost += losses;
       if (this.logging.ops && losses > 0) {


### PR DESCRIPTION
This PR applies the same fix in #1658 to the duplicate code in `completeOperation`. In a normal situation, I'll refactor those duplicate parts, but I'll leave that task to #1654 in this case.