### PR TITLE
JEST: Update babel-plugin-transform-barrels to the official version 1.0.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "@typescript-eslint/parser": "^6.9.1",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.3",
-        "babel-plugin-transform-barrels": "github:cmfrydos/babel-plugin-transform-barrels#46a8aa71cf67a544f7144b47d67f3027424e5cdb",
+        "babel-plugin-transform-barrels": "^1.0.17",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^6.8.1",
         "electron": "^29.4.5",
@@ -6315,9 +6315,9 @@
       }
     },
     "node_modules/babel-plugin-transform-barrels": {
-      "version": "1.0.16",
-      "resolved": "git+ssh://git@github.com/cmfrydos/babel-plugin-transform-barrels.git#46a8aa71cf67a544f7144b47d67f3027424e5cdb",
-      "integrity": "sha512-/W8yq9bmjGmwZB3KH3np0aj2Kwq1glFSR8mlvb1LMALpNOO24XWfCTZDPO1saqR8HTcF8ZS5Gk+WSq2FeT84ZQ==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-barrels/-/babel-plugin-transform-barrels-1.0.17.tgz",
+      "integrity": "sha512-lIVai6tZ2QiWApYJa2Tw9ZfzaqzqQvffQuCMZ9jP5ZmosVziXK1dID+ENbcK8sse4PrKNu+CGK9WZb1Ng4QBTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@typescript-eslint/parser": "^6.9.1",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",
-    "babel-plugin-transform-barrels": "github:cmfrydos/babel-plugin-transform-barrels#46a8aa71cf67a544f7144b47d67f3027424e5cdb",
+    "babel-plugin-transform-barrels": "^1.0.17",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.8.1",
     "electron": "^29.4.5",


### PR DESCRIPTION
FogelAI updated their babel-plugin-transform-barrels to v1.0.17, which now works with Bitburner: https://github.com/FogelAI/babel-plugin-transform-barrels/compare/92d62c2...e3adff6
This PR changes the plugin version from my GitHub fork with superficial "fixes" to the solution provided by the official maintainer, which I found more trustworthy. The original PR that introduced the plugin was #1645.

I ran the Jest tests with the new version, and they all passed.