### PR TITLE
BLADEBURNER: test cover console commands

### DIFF
--- a/test/jest/Bladeburner/BladeburnerConsole.test.ts
+++ b/test/jest/Bladeburner/BladeburnerConsole.test.ts
@@ -6,52 +6,53 @@ import { Contract } from "../../../src/Bladeburner/Actions";
 
 describe("Bladeburner Console", () => {
   let inst: Bladeburner;
-  const FEEDBACK_CMDS = [["skill"], ["start"], ["help"], ["log"], ["automate"]];
-  const SILENT_CMDS = [["cls"], ["clear"], ["stop"]];
-  const CLEAR_CMDS = [["cls"], ["clear"]];
+
+  function initBladeburner(player: PlayerObject): player is PlayerObject & { bladeburner: Bladeburner } {
+    player.init();
+    player.startBladeburner();
+    return true;
+  }
 
   beforeEach(() => {
     setPlayer(new PlayerObject());
-    Player.init();
-    Player.startBladeburner();
-
-    if (!Player.bladeburner) throw new Error();
-    inst = Player.bladeburner;
-    inst.clearConsole();
+    if (initBladeburner(Player)) {
+      inst = Player.bladeburner;
+      inst.clearConsole();
+    }
   });
 
   it("May concatenate multiple commands with ';'", () => {
     inst.startAction(Contract.createId(BladeburnerContractName.Tracking));
-    bb("stop;start contract Retirement;help cls;");
+    execute("stop;start contract Retirement;help cls;");
     expect(inst.consoleLogs).not.toContainEqual("Invalid console command");
   });
 
-  describe.each(FEEDBACK_CMDS)("%s", (cmd: string) => {
+  describe.each(["skill", "start", "help", "log", "automate"])("%s", (cmd: string) => {
     it("provides valid console feedback", () => {
-      bb(cmd);
+      execute(cmd);
       expect(inst.consoleLogs.length).toBeGreaterThan(0);
       expect(inst.consoleLogs).not.toContainEqual("Invalid console command");
     });
   });
 
-  describe.each([...FEEDBACK_CMDS, ...SILENT_CMDS])("%s", (cmd: string) => {
+  describe.each(["skill", "start", "help", "log", "automate", "clear", "stop"])("%s", (cmd: string) => {
     it("provides help", () => {
-      bb(`help ${cmd}`);
+      execute(`help ${cmd}`);
       expect(inst.consoleLogs.length).toBeGreaterThan(0);
     });
   });
 
-  describe.each(CLEAR_CMDS)("%s", (cmd: string) => {
+  describe.each(["cls", "clear"])("%s", (cmd: string) => {
     it("wipes logs clean", () => {
-      bb("help");
-      bb(cmd);
+      execute("help");
+      execute(cmd);
       expect(inst.consoleLogs).toHaveLength(0);
     });
   });
 
   describe("start", () => {
     it("starts bladeburner action", () => {
-      bb("start contract Tracking");
+      execute("start contract Tracking");
       expect(inst.action).toMatchObject(Contract.createId(BladeburnerContractName.Tracking));
     });
   });
@@ -59,34 +60,34 @@ describe("Bladeburner Console", () => {
   describe("stop", () => {
     it("clears current action", () => {
       inst.startAction(Contract.createId(BladeburnerContractName.Tracking));
-      bb("stop");
+      execute("stop");
       expect(inst.action).toBeNull();
     });
   });
 
   describe("automate", () => {
     it("sets high threshold", () => {
-      bb("automate stamina 100 high");
+      execute("automate stamina 100 high");
       expect(inst.automateThreshHigh).toBe(100);
     });
 
     it("sets low threshold", () => {
-      bb("automate stamina 50 low");
+      execute("automate stamina 50 low");
       expect(inst.automateThreshLow).toBe(50);
     });
 
     it("queues action at high threshold", () => {
-      bb("automate contract Tracking high");
+      execute("automate contract Tracking high");
       expect(inst.automateActionHigh).toMatchObject(Contract.createId(BladeburnerContractName.Tracking));
     });
 
     it("queues action at low threshold", () => {
-      bb("automate contract Tracking low");
+      execute("automate contract Tracking low");
       expect(inst.automateActionLow).toMatchObject(Contract.createId(BladeburnerContractName.Tracking));
     });
   });
 
-  function bb(cmd: string) {
+  function execute(cmd: string) {
     inst.executeConsoleCommands(cmd);
   }
 });

--- a/test/jest/Bladeburner/BladeburnerConsole.test.ts
+++ b/test/jest/Bladeburner/BladeburnerConsole.test.ts
@@ -1,0 +1,87 @@
+import type { Bladeburner } from "../../../src/Bladeburner/Bladeburner";
+import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
+import { Player, setPlayer } from "@player";
+import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
+import { BladeburnerContractName } from "@enums";
+import { Contract } from "../../../src/Bladeburner/Actions";
+
+describe("Bladeburner Console", () => {
+  let inst: Bladeburner;
+  const FEEDBACK_CMDS = [["skill"], ["start"], ["help"], ["log"], ["automate"]];
+  const SILENT_CMDS = [["cls"], ["clear"], ["stop"]];
+  const CLEAR_CMDS = [["cls"], ["clear"]];
+
+  beforeEach(() => {
+    setPlayer(new PlayerObject());
+    Player.init();
+    Player.startBladeburner();
+
+    if (!Player.bladeburner) throw new Error();
+    inst = Player.bladeburner;
+    inst.clearConsole();
+  });
+
+  describe.each(FEEDBACK_CMDS)("%s", (cmd: string) => {
+    it("provides valid console feedback", () => {
+      bb(cmd);
+      expect(inst.consoleLogs.length).toBeGreaterThan(0);
+      expect(inst.consoleLogs).not.toContainEqual("Invalid console command");
+    });
+  });
+
+  describe.each([...FEEDBACK_CMDS, ...SILENT_CMDS])("%s", (cmd: string) => {
+    it("provides help", () => {
+      bb(`help ${cmd}`);
+      expect(inst.consoleLogs.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe.each(CLEAR_CMDS)("%s", (cmd: string) => {
+    it("wipes logs clean", () => {
+      bb("help");
+      bb(cmd);
+      expect(inst.consoleLogs).toHaveLength(0);
+    });
+  });
+
+  describe("start", () => {
+    it("starts bladeburner action", () => {
+      bb("start contract Tracking");
+      expect(inst.action).toMatchObject(Contract.createId(BladeburnerContractName.Tracking));
+    });
+  });
+
+  describe("stop", () => {
+    it("clears current action", () => {
+      inst.startAction(Contract.createId(BladeburnerContractName.Tracking));
+      bb("stop");
+      expect(inst.action).toBeNull();
+    });
+  });
+
+  describe("automate", () => {
+    it("sets high threshold", () => {
+      bb("automate stamina 100 high");
+      expect(inst.automateThreshHigh).toBe(100);
+    });
+
+    it("sets low threshold", () => {
+      bb("automate stamina 50 low");
+      expect(inst.automateThreshLow).toBe(50);
+    });
+
+    it("queues action at high threshold", () => {
+      bb("automate contract Tracking high");
+      expect(inst.automateActionHigh).toMatchObject(Contract.createId(BladeburnerContractName.Tracking));
+    });
+
+    it("queues action at low threshold", () => {
+      bb("automate contract Tracking low");
+      expect(inst.automateActionLow).toMatchObject(Contract.createId(BladeburnerContractName.Tracking));
+    });
+  });
+
+  function bb(cmd: string) {
+    inst.executeConsoleCommand(cmd);
+  }
+});

--- a/test/jest/Bladeburner/BladeburnerConsole.test.ts
+++ b/test/jest/Bladeburner/BladeburnerConsole.test.ts
@@ -1,5 +1,4 @@
 import type { Bladeburner } from "../../../src/Bladeburner/Bladeburner";
-import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
 import { Player, setPlayer } from "@player";
 import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
 import { BladeburnerContractName } from "@enums";
@@ -19,6 +18,12 @@ describe("Bladeburner Console", () => {
     if (!Player.bladeburner) throw new Error();
     inst = Player.bladeburner;
     inst.clearConsole();
+  });
+
+  it("May concatenate multiple commands with ';'", () => {
+    inst.startAction(Contract.createId(BladeburnerContractName.Tracking));
+    bb("stop;start contract Retirement;help cls;");
+    expect(inst.consoleLogs).not.toContainEqual("Invalid console command");
   });
 
   describe.each(FEEDBACK_CMDS)("%s", (cmd: string) => {
@@ -82,6 +87,6 @@ describe("Bladeburner Console", () => {
   });
 
   function bb(cmd: string) {
-    inst.executeConsoleCommand(cmd);
+    inst.executeConsoleCommands(cmd);
   }
 });


### PR DESCRIPTION
# Motivation
In line with recent refactoring PRs, this one includes _only_ the test coverage for existing code.
I've noticed certain areas were hiding bugs and I made a few clerical errors along the way. Going forward I'd like to start with test coverage on the old implementation first. 

# New Coverage
- bladeburner console: help for all commands
- bladeburner console: behaviors of action commands
- bladeburner console: command concatenation