### PR TITLE
BUGFIX: Wrong calculation in team casualties of Bladeburner action

### DIFF
--- a/src/Bladeburner/Actions/TeamCasualties.ts
+++ b/src/Bladeburner/Actions/TeamCasualties.ts
@@ -26,22 +26,33 @@ export interface TeamActionWithCasualties {
  * and may result in casualties, reducing the player's hp, killing team members
  * and killing sleeves (to shock them, sleeves are immortal) *
  */
-export function resolveTeamCasualties(action: TeamActionWithCasualties, team: OperationTeam, success: boolean) {
-  const severity = success ? CasualtyFactor.LOW_CASUALTIES : CasualtyFactor.HIGH_CASUALTIES;
-  const radius = action.teamCount * severity;
-  const worstCase = severity < 1 ? Math.ceil(radius) : Math.floor(radius);
-  /** Best case is always no deaths */
-  const deaths = team.getTeamCasualtiesRoll(action.getMinimumCasualties(), worstCase);
-  const humans = action.teamCount - team.sleeveSize;
-  const humanDeaths = Math.min(humans, deaths);
-  /** Supporting Sleeves take damage when they are part of losses,
-   *   e.g. 8 sleeves + 3 team members with 4 losses -> 1 sleeve takes damage */
-  team.killRandomSupportingSleeves(deaths - humanDeaths);
+export function resolveTeamCasualties(action: TeamActionWithCasualties, team: OperationTeam, success: boolean): number {
+  if (action.teamCount <= 0) {
+    return 0;
+  }
 
-  /** Clamped, bugfix for PR#1659
-   * "BUGFIX: Wrong team size when all team members die in Bladeburner's action" */
-  team.teamSize = Math.max(team.teamSize - humanDeaths, team.sleeveSize);
-  team.teamLost += deaths;
+  // Operation actions and Black Operation actions have different min casualties: Min of Ops = 0. Min of BlackOps = 1.
+  const minCasualties = action.getMinimumCasualties();
+  const maxCasualties = success
+    ? Math.ceil(action.teamCount * CasualtyFactor.LOW_CASUALTIES)
+    : Math.floor(action.teamCount * CasualtyFactor.HIGH_CASUALTIES);
+  /**
+   * In the current state, it's safe to assume that minCasualties <= maxCasualties. However, in the future, if we change
+   * min casualties, LOW_CASUALTIES, or HIGH_CASUALTIES, the call of getTeamCasualtiesRoll may crash.
+   * getTeamCasualtiesRoll is just getRandomIntInclusive, and that function's parameters need to be in the form of
+   * (min, max).
+   */
+  const losses =
+    minCasualties <= maxCasualties
+      ? team.getTeamCasualtiesRoll(minCasualties, maxCasualties)
+      : team.getTeamCasualtiesRoll(maxCasualties, minCasualties);
+  team.teamSize -= losses;
+  if (team.teamSize < team.sleeveSize) {
+    team.killRandomSupportingSleeves(team.sleeveSize - team.teamSize);
+    // If this happens, all team members died and some sleeves took damage. In this case, teamSize = sleeveSize.
+    team.teamSize = team.sleeveSize;
+  }
+  team.teamLost += losses;
 
-  return deaths;
+  return losses;
 }

--- a/src/Bladeburner/Actions/TeamCasualties.ts
+++ b/src/Bladeburner/Actions/TeamCasualties.ts
@@ -43,9 +43,7 @@ export function resolveTeamCasualties(action: TeamActionWithCasualties, team: Op
    * (min, max).
    */
   const losses =
-    minCasualties <= maxCasualties
-      ? team.getTeamCasualtiesRoll(minCasualties, maxCasualties)
-      : team.getTeamCasualtiesRoll(maxCasualties, minCasualties);
+    minCasualties <= maxCasualties ? team.getTeamCasualtiesRoll(minCasualties, maxCasualties) : minCasualties;
   team.teamSize -= losses;
   if (team.teamSize < team.sleeveSize) {
     team.killRandomSupportingSleeves(team.sleeveSize - team.teamSize);

--- a/test/jest/Bladeburner/TeamCasualties.test.ts
+++ b/test/jest/Bladeburner/TeamCasualties.test.ts
@@ -18,7 +18,7 @@ import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
  */
 describe("Bladeburner Team", () => {
   const MAX_ROLL = (_: number, high: number) => high;
-  const MIN_ROLL = (low: number, _: number) => low;
+  const MIN_ROLL = (low: number, __: number) => low;
   const BLACK_OP = BlackOperation.createId(BladeburnerBlackOpName.OperationAnnihilus);
   const OP = Operation.createId(BladeburnerOperationName.Assassination);
 
@@ -96,6 +96,15 @@ describe("Bladeburner Team", () => {
   });
 
   describe("Casualties", () => {
+    it.each([[OP], [BLACK_OP]])(
+      "no change in team size when not using team. Action: %s",
+      (op: ActionIdFor<BlackOperation> | ActionIdFor<Operation>) => {
+        teamSize(0), supportingSleeves(3), startAction(op), teamUsed(0), actionFails();
+        expect(inst.teamSize).toBe(3);
+        expect(inst.teamLost).toBe(0);
+      },
+    );
+
     it("do not affect contracts", () => {
       teamSize(3);
       inst.action = Contract.createId(BladeburnerContractName.Tracking);


### PR DESCRIPTION
There are at least 2 regression bugs caused by the refactor in #1654.

Bug 1:

`resolveTeamCasualties` does not short-circuit when `teamCount` is 0.

With BlackOps, `minCasualties` is 1. If `teamCount` is 0, `worstCase` is 0. When we call `team.getTeamCasualtiesRoll(action.getMinimumCasualties(), worstCase)`, it will call `getRandomIntInclusive(1, 0)`. `getRandomIntInclusive` only accepts parameters in the form of `(min, max)`.

![Exception](https://github.com/user-attachments/assets/fd776d21-d0b8-402e-bb60-cf851bea01d3)

Bug 2:

`humans` is not "clamped" properly. It should be `const humans = Math.max(action.teamCount - team.sleeveSize, 0);`.
If `humans` becomes negative, all following calculations are wrong.
For example: TeamSize = 3; SleeveSize = 3; TeamCount = 0; deaths = 1. In this case:
- `humans` is `-3`.
- `humanDeaths` is `-3`.
- `team.killRandomSupportingSleeves` is called with `1 - (-3) = 4`.
- `team.teamSize` = Math.max(3 - (-3), 3) = 6;

These bugs were introduced because `resolveTeamCasualties` does not reuse the old logic:
- It does not short-circuit when `teamCount` is 0.
- It introduces the new logic of `humans` and `humanDeaths`.

This PR rewrites the entire `resolveTeamCasualties` and reuses the old logic.

For quick reference, this is how it was implemented:

Operation:
```js
const teamCount = action.teamCount;
if (teamCount >= 1) {
  const maxLosses = success ? Math.ceil(teamCount / 2) : Math.floor(teamCount);
  const losses = getRandomIntInclusive(0, maxLosses);
  this.teamSize -= losses;
  if (this.teamSize < this.sleeveSize) {
    const sup = Player.sleeves.filter((x) => isSleeveSupportWork(x.currentWork));
    for (let i = 0; i > this.teamSize - this.sleeveSize; i--) {
      const r = Math.floor(Math.random() * sup.length);
      sup[r].takeDamage(sup[r].hp.max);
      sup.splice(r, 1);
    }
    // If this happens, all team members died and some sleeves took damage. In this case, teamSize = sleeveSize.
    this.teamSize = this.sleeveSize;
  }
  this.teamLost += losses;
  if (this.logging.ops && losses > 0) {
    this.log("Lost " + formatNumberNoSuffix(losses, 0) + " team members during this " + action.name);
  }
}
```

Black Operation:
```js
if (teamCount >= 1) {
  const losses = getRandomIntInclusive(1, teamLossMax);
  this.teamSize -= losses;
  if (this.teamSize < this.sleeveSize) {
    const sup = Player.sleeves.filter((x) => isSleeveSupportWork(x.currentWork));
    for (let i = 0; i > this.teamSize - this.sleeveSize; i--) {
      const r = Math.floor(Math.random() * sup.length);
      sup[r].takeDamage(sup[r].hp.max);
      sup.splice(r, 1);
    }
    // If this happens, all team members died and some sleeves took damage. In this case, teamSize = sleeveSize.
    this.teamSize = this.sleeveSize;
  }
  this.teamLost += losses;
  if (this.logging.blackops) {
    this.log(
      `${person.whoAmI()}:  You lost ${formatNumberNoSuffix(losses, 0)} team members during ${action.name}.`,
    );
  }
}
```