### PR TITLE
BUGFIX: Wrong parameter requirement of ns.bladeburner.setTeamSize

### DIFF
--- a/markdown/bitburner.bladeburner.setteamsize.md
+++ b/markdown/bitburner.bladeburner.setteamsize.md
@@ -22,7 +22,7 @@ setTeamSize(
 |  --- | --- | --- |
 |  type | [BladeburnerActionType](./bitburner.bladeburneractiontype.md) \| \`${[BladeburnerActionType](./bitburner.bladeburneractiontype.md)<!-- -->}\` | Type of action. |
 |  name | [BladeburnerActionName](./bitburner.bladeburneractionname.md) \| \`${[BladeburnerActionName](./bitburner.bladeburneractionname.md)<!-- -->}\` | Name of action. Must be an exact match. |
-|  size | number | Number of team members to set. Will be converted using Math.round(). |
+|  size | number | Number of team members to set. Must be a non-negative integer. |
 
 **Returns:**
 

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -47,6 +47,8 @@ import {
   PositiveNumber,
   PositiveSafeInteger,
   isPositiveSafeInteger,
+  isInteger,
+  type Integer,
 } from "../types";
 import { Engine } from "../engine";
 import { resolveFilePath, FilePath } from "../Paths/FilePath";
@@ -65,6 +67,7 @@ import { JSONMap } from "../Types/Jsonable";
 export const helpers = {
   string,
   number,
+  integer,
   positiveInteger,
   positiveSafeInteger,
   positiveNumber,
@@ -133,14 +136,23 @@ function number(ctx: NetscriptContext, argName: string, v: unknown): number {
     if (isNaN(v)) throw errorMessage(ctx, `'${argName}' is NaN.`);
     return v;
   }
-  throw errorMessage(ctx, `'${argName}' should be a number. ${debugType(v)}`, "TYPE");
+  throw errorMessage(ctx, `'${argName}' must be a number. ${debugType(v)}`, "TYPE");
+}
+
+/** Convert provided value v for argument argName to an integer, throwing if it looks like something else. */
+function integer(ctx: NetscriptContext, argName: string, v: unknown): Integer {
+  const n = number(ctx, argName, v);
+  if (!isInteger(n)) {
+    throw errorMessage(ctx, `${argName} must be an integer, was ${n}`, "TYPE");
+  }
+  return n;
 }
 
 /** Convert provided value v for argument argName to a positive integer, throwing if it looks like something else. */
 function positiveInteger(ctx: NetscriptContext, argName: string, v: unknown): PositiveInteger {
   const n = number(ctx, argName, v);
   if (!isPositiveInteger(n)) {
-    throw errorMessage(ctx, `${argName} should be a positive integer, was ${n}`, "TYPE");
+    throw errorMessage(ctx, `${argName} must be a positive integer, was ${n}`, "TYPE");
   }
   return n;
 }
@@ -149,7 +161,7 @@ function positiveInteger(ctx: NetscriptContext, argName: string, v: unknown): Po
 function positiveSafeInteger(ctx: NetscriptContext, argName: string, v: unknown): PositiveSafeInteger {
   const n = number(ctx, argName, v);
   if (!isPositiveSafeInteger(n)) {
-    throw errorMessage(ctx, `${argName} should be a positive safe integer, was ${n}`, "TYPE");
+    throw errorMessage(ctx, `${argName} must be a positive safe integer, was ${n}`, "TYPE");
   }
   return n;
 }
@@ -158,7 +170,7 @@ function positiveSafeInteger(ctx: NetscriptContext, argName: string, v: unknown)
 function positiveNumber(ctx: NetscriptContext, argName: string, v: unknown): PositiveNumber {
   const n = number(ctx, argName, v);
   if (!isPositiveNumber(n)) {
-    throw errorMessage(ctx, `${argName} should be a positive number, was ${n}`, "TYPE");
+    throw errorMessage(ctx, `${argName} must be a positive number, was ${n}`, "TYPE");
   }
   return n;
 }

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -250,7 +250,10 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     setTeamSize: (ctx) => (type, name, _size) => {
       const bladeburner = getBladeburner(ctx);
       const action = getAction(ctx, type, name);
-      const size = helpers.positiveInteger(ctx, "size", _size);
+      const size = helpers.integer(ctx, "size", _size);
+      if (size < 0) {
+        throw helpers.errorMessage(ctx, "size must be a non-negative integer", "TYPE");
+      }
       if (size > bladeburner.teamSize) {
         helpers.log(ctx, () => `Failed to set team size due to not enough team members.`);
         return -1;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3610,7 +3610,7 @@ export interface Bladeburner {
    *
    * @param type - Type of action.
    * @param name - Name of action. Must be an exact match.
-   * @param size - Number of team members to set. Will be converted using Math.round().
+   * @param size - Number of team members to set. Must be a non-negative integer.
    * @returns Number of Bladeburner team members you assigned to the specified action.
    */
   setTeamSize(


### PR DESCRIPTION
0 is a valid value of team size. We use the wrong check in `setTeamSize`.

Fixes #1671.