### PR TITLE
MISC: remove google analytics tracking id

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,9 +57,6 @@ module.exports = (env, argv) => {
     template: "src/index.html",
     filename: isDevServer ? "index.html" : "../index.html",
     favicon: "favicon.ico",
-    googleAnalytics: {
-      trackingId: "UA-100157497-1",
-    },
     meta: {},
     minify: isDevelopment
       ? false


### PR DESCRIPTION
google analytics isnt used anymore but its still referenced in the webpack config