### PR TITLE
CONTRACT: Fix incorrect description of Hamming Codes in Integer to Encoded Binary.

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -1270,7 +1270,7 @@ export const codingContractTypesMetadata: CodingContractType<any>[] = [
         "A parity bit is inserted at position 0 and at every position N where N is a power of 2.\n",
         "Parity bits are used to make the total number of '1' bits in a given set of data even.\n",
         "The parity bit at position 0 considers all bits including parity bits.\n",
-        "Each parity bit at position 2^N alternately considers N bits then ignores N bits, starting at position 2^N.\n",
+        "Each parity bit at position 2^N alternately considers 2^N bits then ignores 2^N bits, starting at position 2^N.\n",
         "The endianness of the parity bits is reversed compared to the endianness of the data bits:\n",
         "Data bits are encoded most significant bit first and the parity bits encoded least significant bit first.\n",
         "The parity bit at position 0 is set last.\n\n",


### PR DESCRIPTION
Note that this brings Integer-To-Binary's description to match Binary-To-Integer's description.

For some reason I don't pretend to understand, the Steam release has the same typo, but *only* in the Encoded Binary to Integer contract. I don't understand how this typo moved before releasing it on Steam (or after releasing it on Steam?)