### PR TITLE
BUGFIX: Missing tooltip when doing faction work

### DIFF
--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -378,6 +378,7 @@ function Work(): React.ReactElement {
 
   if (isFactionWork(Player.currentWork)) {
     const factionWork = Player.currentWork;
+    details = <>Doing {factionWork.factionWorkType} work</>;
     header = (
       <>
         Working for <strong>{factionWork.factionName}</strong>
@@ -395,11 +396,7 @@ function Work(): React.ReactElement {
     const companyWork = Player.currentWork;
     const job = Player.jobs[companyWork.companyName];
     if (!job) return <></>;
-    details = (
-      <>
-        {job} at <strong>{companyWork.companyName}</strong>
-      </>
-    );
+    details = <>{job}</>;
 
     header = (
       <>


### PR DESCRIPTION
All types of "work" have a tooltip (`details`), except the faction work. This PR fixes it.

I also make a small change in the tooltip of the company work. The company name is in the "header" of the work, so I think it's unnecessary to repeat it in the tooltip. I can remove this change or move it to another PR if the maintainer wants.

Before:
![before](https://github.com/user-attachments/assets/32f5e768-7c9d-4152-a069-5c61d031b114)

After:
![after](https://github.com/user-attachments/assets/e4eecef7-9132-4e5c-95c3-e7853bc26602)
