### PR TITLE
BUGFIX: Scripts are killed too late when prestiging

### DIFF
--- a/src/Augmentation/AugmentationHelpers.ts
+++ b/src/Augmentation/AugmentationHelpers.ts
@@ -12,6 +12,7 @@ import { Router } from "../ui/GameRoot";
 import { Page } from "../ui/Router";
 import { mergeMultipliers } from "../PersonObjects/Multipliers";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
+import { prestigeWorkerScripts } from "../NetscriptWorker";
 
 const soaAugmentationNames = [
   AugmentationName.BeautyOfAphrodite,
@@ -67,6 +68,10 @@ export function installAugmentations(force?: boolean): boolean {
     dialogBoxCreate("You have not purchased any Augmentations to install!");
     return false;
   }
+
+  // We must kill all scripts before installing augmentations.
+  prestigeWorkerScripts();
+
   let augmentationList = "";
   let nfgIndex = -1;
   for (let i = Player.queuedAugmentations.length - 1; i >= 0; i--) {
@@ -93,7 +98,7 @@ export function installAugmentations(force?: boolean): boolean {
     augmentationList += aug.name + level + "\n";
   }
   Player.queuedAugmentations = [];
-  if (!force) {
+  if (!force && augmentationList !== "") {
     dialogBoxCreate(
       "You slowly drift to sleep as scientists put you under in order " +
         "to install the following Augmentations:\n" +

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -61,11 +61,11 @@ export function prestigeAugmentation(): void {
     }
   }
 
-  Player.prestigeAugmentation();
-  Go.prestigeAugmentation();
-
   // Delete all Worker Scripts objects
   prestigeWorkerScripts();
+
+  Player.prestigeAugmentation();
+  Go.prestigeAugmentation();
 
   const homeComp = Player.getHomeComputer();
   // Delete all servers except home computer
@@ -190,10 +190,10 @@ export function prestigeAugmentation(): void {
 export function prestigeSourceFile(isFlume: boolean): void {
   initBitNodeMultipliers();
 
+  prestigeWorkerScripts(); // Delete all Worker Scripts objects
+
   Player.prestigeSourceFile();
   Go.prestigeSourceFile();
-
-  prestigeWorkerScripts(); // Delete all Worker Scripts objects
 
   const homeComp = Player.getHomeComputer();
 

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -48,6 +48,9 @@ function setInitialExpForPlayer() {
 
 // Prestige by purchasing augmentation
 export function prestigeAugmentation(): void {
+  // We must kill all scripts before doing anything else.
+  prestigeWorkerScripts();
+
   initBitNodeMultipliers();
 
   // Maintain invites to factions with the 'keepOnInstall' flag, and rumors about others
@@ -60,9 +63,6 @@ export function prestigeAugmentation(): void {
       maintainRumors.add(facName);
     }
   }
-
-  // Delete all Worker Scripts objects
-  prestigeWorkerScripts();
 
   Player.prestigeAugmentation();
   Go.prestigeAugmentation();
@@ -188,9 +188,10 @@ export function prestigeAugmentation(): void {
 
 // Prestige by destroying Bit Node and gaining a Source File
 export function prestigeSourceFile(isFlume: boolean): void {
-  initBitNodeMultipliers();
+  // We must kill all scripts before doing anything else.
+  prestigeWorkerScripts();
 
-  prestigeWorkerScripts(); // Delete all Worker Scripts objects
+  initBitNodeMultipliers();
 
   Player.prestigeSourceFile();
   Go.prestigeSourceFile();

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -9,6 +9,7 @@ import { Router } from "./ui/GameRoot";
 import { Page } from "./ui/Router";
 import { prestigeSourceFile } from "./Prestige";
 import { getDefaultBitNodeOptions, setBitNodeOptions } from "./BitNode/BitNodeUtils";
+import { prestigeWorkerScripts } from "./NetscriptWorker";
 
 function giveSourceFile(bitNodeNumber: number): void {
   const sourceFileKey = "SourceFile" + bitNodeNumber.toString();
@@ -56,6 +57,9 @@ export function enterBitNode(
   newBitNode: number,
   bitNodeOptions: BitNodeOptions,
 ): void {
+  // We must kill all scripts before setting up BitNode data and performing the prestige.
+  prestigeWorkerScripts();
+
   if (!isFlume) {
     giveSourceFile(destroyedBitNode);
   } else if (Player.sourceFileLvl(5) === 0 && newBitNode !== 5) {


### PR DESCRIPTION
A player reports a bug with stock, `ns.atExit` and soft reset. The gist is that when they sell the stock in `ns.atExit`, the profit is added to the player's money after the soft reset.

MRE:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.stock.buyStock("JGN", 100);
  ns.atExit(() => ns.stock.sellStock("JGN", 100));
  setTimeout(() => ns.singularity.softReset(), 10)
  while (true) await ns.asleep(100);
}
```
After the soft reset, the player has "initital money" + profit instead of just "initital money".

The bug happens because `prestigeWorkerScripts()` is called after `Player.prestigeAugmentation()` and before `initStockMarket`. The flow:
- `Player.prestigeAugmentation()`: Reset the player's money.
- `prestigeWorkerScripts()`: call `ns.atExit`.
- `ns.atExit` sells stocks and adds the profit to the player's money.
- `initStockMarket`: reset the stock market.

The fix is fairly simple: We only need to call `prestigeWorkerScripts()` before `Player.prestigeAugmentation()`. However, the problem is more complicated than that. Because `prestigeWorkerScripts()` will run `ns.atExit`, it allows the player to run arbitrary code when the game logic is performing the prestige and be in an incomplete transition state. This can create many subtle bugs/weird behaviors/exploits. This is an exploit that I come up with:

MRE:
```js
/** @param {NS} ns */
export async function main(ns) {
  Player.money = 76e12;
  Player.receiveInvite("Illuminati");
  Factions.Illuminati.alreadyInvited = true;
  Factions.Illuminati.playerReputation = 1e12;
  Player.augmentations = [];
  Player.queuedAugmentations = [];

  ns.singularity.joinFaction("Illuminati");
  ns.singularity.purchaseAugmentation("Illuminati", "Synfibril Muscle");
  ns.atExit(() => {
    ns.singularity.purchaseAugmentation("Illuminati", "QLink")
    ns.singularity.installAugmentations();
  });
  ns.singularity.installAugmentations();
}
```

In this PoC:
- Set up test data (you need to expose `Player` and `Factions`; you can use the dev tool as an alternative way):
  - Receive the invitation of Illuminati.
  - Have tons of reputation with Illuminati.
  - Have 76e12 cash: It's not enough to buy Synfibril Muscle and QLink in a single run, but it's enough to buy both augmentations if we can find a way to "reset" the cost requirement halfway.
- Join Illuminati.
- Buy Synfibril Muscle.
- Set up `ns.atExit`.
- Call `ns.singularity.installAugmentations()`.

The cost of QLink will be increased after we buy Synfibril Muscle, but we can "reset" that cost requirement with this exploit.

To prevent this kind of problem, this PR does these things:
- Call `prestigeWorkerScripts` as early as possible in `prestigeAugmentation` and `prestigeSourceFile`.
- Check all callers of `prestigeAugmentation` and `prestigeSourceFile`. If those callers modify the game state (installing augmentations, setting BitNode data, etc.), we call `prestigeWorkerScripts` before those code.