### PR TITLE
MISC: Remove mention of Hacking Mission

### DIFF
--- a/markdown/bitburner.singularity.isbusy.md
+++ b/markdown/bitburner.singularity.isbusy.md
@@ -21,5 +21,5 @@ True if the player is currently performing an ‘action’, false otherwise.
 
 RAM cost: 0.5 GB \* 16/4/1
 
-Returns a boolean indicating whether or not the player is currently performing an ‘action’. These actions include working for a company/faction, studying at a university, working out at a gym, creating a program, committing a crime, or carrying out a Hacking Mission.
+Returns a boolean indicating whether or not the player is currently performing an ‘action’. These actions include working for a company/faction, studying at a university, working out at a gym, creating a program, committing a crime, etc.
 

--- a/src/Faction/ui/Option.tsx
+++ b/src/Faction/ui/Option.tsx
@@ -1,7 +1,6 @@
 /**
- * React component for a selectable option on the Faction UI. These
- * options including working for the faction, hacking missions, purchasing
- * augmentations, etc.
+ * React component for a selectable option on the Faction UI. These options including working for the faction,
+ * purchasing augmentations, etc.
  */
 import * as React from "react";
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1898,7 +1898,7 @@ export interface Singularity {
    *
    * Returns a boolean indicating whether or not the player is currently performing an
    * ‘action’. These actions include working for a company/faction, studying at a university,
-   * working out at a gym, creating a program, committing a crime, or carrying out a Hacking Mission.
+   * working out at a gym, creating a program, committing a crime, etc.
    *
    * @returns True if the player is currently performing an ‘action’, false otherwise.
    */

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -43,8 +43,7 @@ export abstract class BaseServer implements IServer {
   // Coding Contract files on this server
   contracts: CodingContract[] = [];
 
-  // How many CPU cores this server has. Maximum of 8.
-  // Currently, this only affects hacking missions
+  // How many CPU cores this server has.
   cpuCores = 1;
 
   // Flag indicating whether the FTP port is open


### PR DESCRIPTION
Hacking Mission was a minigame. It was removed a long time ago.

Closes #1681.