### PR TITLE
API: Make condition of donateToFaction consistent

### DIFF
--- a/markdown/bitburner.singularity.donatetofaction.md
+++ b/markdown/bitburner.singularity.donatetofaction.md
@@ -31,3 +31,7 @@ RAM cost: 5 GB \* 16/4/1
 
 Attempts to donate money to the specified faction in exchange for reputation. Returns true if you successfully donate the money, and false otherwise.
 
+You cannot donate to your gang's faction.
+
+The specified faction must offer at least 1 type of work. You can use [getFactionWorkTypes](./bitburner.singularity.getfactionworktypes.md) to get the list of work types of a faction.
+

--- a/src/Faction/FactionInfo.tsx
+++ b/src/Faction/FactionInfo.tsx
@@ -697,6 +697,9 @@ export const FactionInfos: Record<FactionName, FactionInfo> = {
     rumorText: <>The {CompanyName.NSA} would like to have a word with you once you're ready.</>,
     inviteReqs: [haveSomeSourceFile(6, 7), haveBladeburnerRank(BladeburnerConstants.RankNeededForFaction)],
     rumorReqs: [haveSomeSourceFile(6, 7), notCondition(inBitNode(8))],
+    offerHackingWork: false,
+    offerFieldWork: false,
+    offerSecurityWork: false,
     special: true,
     assignment: (): React.ReactElement => {
       return (
@@ -790,6 +793,9 @@ export const FactionInfos: Record<FactionName, FactionInfo> = {
         },
       },
     ],
+    offerHackingWork: false,
+    offerFieldWork: false,
+    offerSecurityWork: false,
     special: true,
     keepOnInstall: true,
     assignment: (): React.ReactElement => {

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1,15 +1,7 @@
 import type { Singularity as ISingularity, Task as ITask } from "@nsdefs";
 
 import { Player } from "@player";
-import {
-  AugmentationName,
-  CityName,
-  FactionName,
-  FactionWorkType,
-  GymType,
-  LocationName,
-  UniversityClassType,
-} from "@enums";
+import { AugmentationName, CityName, FactionWorkType, GymType, LocationName, UniversityClassType } from "@enums";
 import { purchaseAugmentation, joinFaction, getFactionAugmentationsFiltered } from "../Faction/FactionHelpers";
 import { startWorkerScript } from "../NetscriptWorker";
 import { Augmentations } from "../Augmentation/Augmentations";
@@ -967,12 +959,8 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         helpers.log(ctx, () => `You can't donate to '${facName}' because you are managing a gang for it`);
         return false;
       }
-      if (
-        faction.name === FactionName.ChurchOfTheMachineGod ||
-        faction.name === FactionName.Bladeburners ||
-        faction.name === FactionName.ShadowsOfAnarchy
-      ) {
-        helpers.log(ctx, () => `You can't donate to '${facName}' because they do not accept donations`);
+      if (!faction.getInfo().offersWork()) {
+        helpers.log(ctx, () => `You can't donate to '${facName}' because this faction does not offer any type of work`);
         return false;
       }
       if (typeof amt !== "number" || amt <= 0 || isNaN(amt)) {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2294,6 +2294,10 @@ export interface Singularity {
    * Attempts to donate money to the specified faction in exchange for reputation.
    * Returns true if you successfully donate the money, and false otherwise.
    *
+   * You cannot donate to your gang's faction.
+   *
+   * The specified faction must offer at least 1 type of work. You can use {@link Singularity.getFactionWorkTypes | getFactionWorkTypes} to get the list of work types of a faction.
+   *
    * @param faction - Name of faction to donate to.
    * @param amount - Amount of money to donate.
    * @returns True if the money was donated, and false otherwise.


### PR DESCRIPTION
The "canonical" condition of the donation feature is that:
- Must not be the player's gang.
- Must offer at least 1 type of work.

https://github.com/bitburner-official/bitburner-src/blob/dad34a09dd4fcc61fa67c945d7dc5aad003210c9/src/Faction/ui/FactionRoot.tsx#L131

However, instead of checking `factionInfo.offersWork()`, `ns.singularity.donateToFaction` check a list of special factions.
https://github.com/bitburner-official/bitburner-src/blob/dad34a09dd4fcc61fa67c945d7dc5aad003210c9/src/NetscriptFunctions/Singularity.ts#L970-L974

This inconsistency is the reason that we need a bugfix like #1595. This PR replaces the check in `donateToFaction` and improves the documentation.

I also explicitly set relevant properties in `FactionInfo.tsx`. They are false by default, but it's better to be explicit.