### PR TITLE
BUGFIX: add stopFlag check before running main

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -56,6 +56,9 @@ async function startNetscript2Script(workerScript: WorkerScript): Promise<void> 
 
   const loadedModule = await compile(script, scripts);
 
+  // if for whatever reason the stopFlag is already set we abort
+  if (workerScript.env.stopFlag) return;
+
   if (!loadedModule) throw `${script.filename} cannot be run because the script module won't load`;
   const mainFunc = loadedModule.main;
   // TODO unplanned: Better error for "unexpected reserved word" when using await in non-async function?


### PR DESCRIPTION
There are two edge cases where the stopFlag of a script can be set 
inbetween ns.exec/ns.run and the main function of that new script beeing called

 1:  when the script needs to compile and the player kills the script before that is done
 2:  when an atExit callback starts a new script instance while the game is cleaning up in the prestige code
 
 
test script (make sure to the reload the page inbetween runs to guarantee a not compiled "noNS.js")
```js
export async function main(ns) {
  // case 1 
  ns.write("noNS.js", noNS, "w")
  const pid = ns.run("noNS.js")
  ns.kill(pid)
  await ns.sleep(0)
  // case 2
  ns.atExit(() => ns.run("noNS.js"))
  ns.singularity.softReset()
}

const noNS = `
export function main(ns) {
  console.log("i ran")
  try {
    ns.tail()
  } catch (e) {
    console.log(e)
  }
}`
```

i truly believe that when the stopFlag is already set we shouldnt even start the main function
yes that could break player scripts that rely on these edge cases but they can still get a "dead script running" 
without these edgecases


edit.: i  should add that i tested the change quickly on the current web dev version and my modified version
 on the current web dev version it wrote to the console and on the modified version it didnt