### PR TITLE
BLADEBURNER: Test cover action completion

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,7 @@ node_modules/
 dist
 input
 assets
+coverage
 doc
 markdown
 electron

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 Changelog.txt
 Netburner.txt
+/coverage
 /doc/build
 /node_modules
 /electron/node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@ package.json
 dist
 doc/build
 doc/source
+coverage
 .build
 .package
 .app

--- a/test/jest/Bladeburner/Actions.test.ts
+++ b/test/jest/Bladeburner/Actions.test.ts
@@ -1,20 +1,72 @@
 import type { Bladeburner } from "../../../src/Bladeburner/Bladeburner";
 import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
 import { Player, setPlayer } from "@player";
-import { Contract } from "../../../src/Bladeburner/Actions";
-import { BladeburnerContractName } from "@enums";
+import { Contract, GeneralAction, Operation } from "../../../src/Bladeburner/Actions";
+import { BladeburnerContractName, BladeburnerGeneralActionName, BladeburnerOperationName, CrimeType } from "@enums";
 import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
+import { CrimeWork } from "../../../src/Work/CrimeWork";
+import type { ActionIdentifier } from "../../../src/Bladeburner/Types";
+import type { Skills } from "../../../src/PersonObjects/Skills";
+
+type StatKey = keyof Skills;
 
 describe("Bladeburner Actions", () => {
-  const REASONABLE_TIME_TO_COMPLETE_ANY_ACTION = 1e50;
+  const Tracking = Contract.createId(BladeburnerContractName.Tracking);
+  const Diplomacy = GeneralAction.createId(BladeburnerGeneralActionName.Diplomacy);
+  const Assassination = Operation.createId(BladeburnerOperationName.Assassination);
+  const Recruitment = GeneralAction.createId(BladeburnerGeneralActionName.Recruitment);
+  const ENOUGH_TIME_TO_FINISH_ACTION = 1e5;
 
   let inst: Bladeburner;
 
-  function initBladeburner(player: PlayerObject): player is PlayerObject & { bladeburner: Bladeburner } {
-    player.init();
-    player.startBladeburner();
-    return true;
-  }
+  /** All the tests depend on this assumption */
+  it("always succeeds with optimal stats, rank, stamina and city chaos levels", () => {
+    guaranteeSuccess(), start(Assassination), finish();
+    expect(inst.getActionObject(Assassination).getSuccessChance(inst, Player, { est: false })).toBe(1);
+  });
+
+  describe("Without Simulacrum", () => {
+    it("Starting an action cancels player's work immediately", () => {
+      Player.startWork(new CrimeWork({ crimeType: CrimeType.assassination, singularity: false }));
+      start(Diplomacy);
+      expect(Player.currentWork).toBeNull();
+    });
+  });
+
+  describe("Upon successful completion", () => {
+    it("Contracts give the player money", () => {
+      const moneyBefore = Player.money;
+      guaranteeSuccess(), start(Tracking), finish();
+      expect(Player.money).toBeGreaterThan(moneyBefore);
+    });
+
+    it.each(<StatKey[]>["strength", "dexterity", "defense", "dexterity"])(
+      "Operations provide combat skill XP: %s",
+      (stat: StatKey) => {
+        const statsBefore = Object.assign({}, Player.skills);
+        guaranteeSuccess(), start(Assassination), finish();
+        expect(Player.skills[stat]).toBeGreaterThan(statsBefore[stat]);
+      },
+    );
+
+    describe("Recruitment", () => {
+      it("provides charisma", () => {
+        const { charisma } = Player.skills;
+        guaranteeSuccess(), start(Recruitment), finish();
+        expect(Player.skills.charisma).toBeGreaterThan(charisma);
+      });
+
+      it("hires team member", () => {
+        guaranteeSuccess(), start(Recruitment), finish();
+        expect(inst.teamSize).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it("have a minimum duration of 1 second", () => {
+    start(Tracking);
+    expect(inst.actionTimeToComplete).toBeGreaterThanOrEqual(1);
+  });
 
   beforeAll(() => {
     /* Initialise Formatters. Dependency of Bladeburner */
@@ -29,10 +81,32 @@ describe("Bladeburner Actions", () => {
     }
   });
 
-  it("an action is never instant", () => {
-    inst.startAction(Contract.createId(BladeburnerContractName.Tracking));
-    inst.getActionObject(Contract.createId(BladeburnerContractName.Tracking)).count = 5;
-    inst.clearConsole();
-    inst.processAction(0);
-  });
+  function initBladeburner(player: PlayerObject): player is PlayerObject & { bladeburner: Bladeburner } {
+    player.init();
+    player.startBladeburner();
+    return true;
+  }
+
+  function guaranteeSuccess() {
+    Player.gainStrengthExp(1e200);
+    Player.gainAgilityExp(1e200);
+    Player.gainDexterityExp(1e200);
+    Player.gainDefenseExp(1e200);
+    inst.calculateMaxStamina();
+    inst.stamina = inst.maxStamina;
+    inst.rank = 1e10;
+    inst.cities[inst.city].chaos = 0;
+    inst.cities[inst.city].comms = 100;
+    inst.cities[inst.city].pop = 1e9;
+  }
+
+  function start(id: ActionIdentifier) {
+    const action = inst.getActionObject(id);
+    if ("count" in action) action.count = 1;
+    inst.startAction(id);
+  }
+
+  function finish() {
+    inst.processAction(ENOUGH_TIME_TO_FINISH_ACTION);
+  }
 });

--- a/test/jest/Bladeburner/Actions.test.ts
+++ b/test/jest/Bladeburner/Actions.test.ts
@@ -1,0 +1,38 @@
+import type { Bladeburner } from "../../../src/Bladeburner/Bladeburner";
+import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
+import { Player, setPlayer } from "@player";
+import { Contract } from "../../../src/Bladeburner/Actions";
+import { BladeburnerContractName } from "@enums";
+import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
+
+describe("Bladeburner Actions", () => {
+  const REASONABLE_TIME_TO_COMPLETE_ANY_ACTION = 1e50;
+
+  let inst: Bladeburner;
+
+  function initBladeburner(player: PlayerObject): player is PlayerObject & { bladeburner: Bladeburner } {
+    player.init();
+    player.startBladeburner();
+    return true;
+  }
+
+  beforeAll(() => {
+    /* Initialise Formatters. Dependency of Bladeburner */
+    FormatsNeedToChange.emit();
+  });
+
+  beforeEach(() => {
+    setPlayer(new PlayerObject());
+    if (initBladeburner(Player)) {
+      inst = Player.bladeburner;
+      inst.clearConsole();
+    }
+  });
+
+  it("an action is never instant", () => {
+    inst.startAction(Contract.createId(BladeburnerContractName.Tracking));
+    inst.getActionObject(Contract.createId(BladeburnerContractName.Tracking)).count = 5;
+    inst.clearConsole();
+    inst.processAction(0);
+  });
+});

--- a/test/jest/Bladeburner/Actions.test.ts
+++ b/test/jest/Bladeburner/Actions.test.ts
@@ -46,71 +46,71 @@ describe("Bladeburner Actions", () => {
     let pop, before, after;
 
     describe(BladeburnerGeneralActionName.Training, () => {
-      const Training = GeneralAction.createId(BladeburnerGeneralActionName.Training);
+      const train = GeneralAction.createId(BladeburnerGeneralActionName.Training);
 
       it("increases max stamina", () => {
-        (before = bb.maxStamina), complete(Training);
+        (before = bb.maxStamina), complete(train);
         expect(bb.maxStamina).toBeGreaterThan(before);
       });
 
       it.each(<(keyof Skills)[]>["strength", "dexterity", "agility"])("awards %s exp", (stat: keyof Skills) => {
-        (before = Player.exp[stat]), complete(Training);
+        (before = Player.exp[stat]), complete(train);
         expect(Player.exp[stat]).toBeGreaterThan(before);
       });
     });
 
     describe(BladeburnerGeneralActionName.HyperbolicRegen, () => {
-      const Regen = GeneralAction.createId(BladeburnerGeneralActionName.HyperbolicRegen);
+      const regen = GeneralAction.createId(BladeburnerGeneralActionName.HyperbolicRegen);
 
       it("heals the player", () => {
-        Player.takeDamage(Player.hp.max / 2), (before = Player.hp.current), complete(Regen);
+        Player.takeDamage(Player.hp.max / 2), (before = Player.hp.current), complete(regen);
         expect(Player.hp.current).toBeGreaterThan(before);
       });
 
       it("regains stamina", () => {
-        (bb.stamina = 0), complete(Regen);
+        (bb.stamina = 0), complete(regen);
         expect(bb.stamina).toBeGreaterThan(0);
       });
     });
 
     describe(BladeburnerGeneralActionName.Diplomacy, () => {
-      const Diplomacy = GeneralAction.createId(BladeburnerGeneralActionName.Diplomacy);
+      const diplomacy = GeneralAction.createId(BladeburnerGeneralActionName.Diplomacy);
 
       it("mildly reduces chaos in the current city", () => {
         let chaos;
-        allCitiesHighChaos(), ({ chaos } = bb.getCurrentCity()), complete(Diplomacy);
+        allCitiesHighChaos(), ({ chaos } = bb.getCurrentCity()), complete(diplomacy);
         expect(bb.getCurrentCity().chaos).toBeGreaterThan(chaos * 0.9);
         expect(bb.getCurrentCity().chaos).toBeLessThan(chaos);
       });
 
       it("effect scales significantly with player charisma", () => {
-        Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(Diplomacy);
+        Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(diplomacy);
         expect(bb.getCurrentCity().chaos).toBe(0);
       });
 
       it("does NOT affect chaos in other cities", () => {
         const otherCity = <CityName>cities.find((c) => c !== bb.getCurrentCity().name);
         /** Testing against a guaranteed 0-chaos level of charisma */
-        Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(Diplomacy);
+        Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(diplomacy);
         expect(bb.cities[otherCity].chaos).toBeGreaterThan(0);
       });
     });
 
     describe(BladeburnerGeneralActionName.FieldAnalysis, () => {
-      const Field = GeneralAction.createId(BladeburnerGeneralActionName.FieldAnalysis);
+      const fa = GeneralAction.createId(BladeburnerGeneralActionName.FieldAnalysis);
 
       it("improves population estimate", () => {
-        ({ pop, popEst: before } = bb.getCurrentCity()), complete(Field), ({ popEst: after } = bb.getCurrentCity());
+        ({ pop, popEst: before } = bb.getCurrentCity()), complete(fa), ({ popEst: after } = bb.getCurrentCity());
         expect(Math.abs(after - pop)).toBeLessThan(Math.abs(before - pop));
       });
 
       it.each(<(keyof Skills)[]>["hacking", "charisma"])("awards %s exp", (stat: keyof Skills) => {
-        (before = Player.exp[stat]), complete(Field, forceSuccess);
+        (before = Player.exp[stat]), complete(fa, forceSuccess);
         expect(Player.exp[stat]).toBeGreaterThan(before);
       });
 
       it("provides a minor increase in rank", () => {
-        ({ rank: before } = bb), complete(Field, forceSuccess);
+        ({ rank: before } = bb), complete(fa, forceSuccess);
         expect(bb.rank).toBeGreaterThan(before);
       });
     });
@@ -139,18 +139,18 @@ describe("Bladeburner Actions", () => {
     });
 
     describe(BladeburnerGeneralActionName.InciteViolence, () => {
-      const Incite = GeneralAction.createId(BladeburnerGeneralActionName.InciteViolence);
+      const iv = GeneralAction.createId(BladeburnerGeneralActionName.InciteViolence);
       let chaos;
 
       it("generates available contracts", () => {
         const { count } = bb.getActionObject(SampleContract);
-        complete(Incite, forceSuccess);
+        complete(iv, forceSuccess);
         expect(bb.getActionObject(SampleContract).count).toBeGreaterThan(count);
       });
 
       it("generates available operations", () => {
         const { count } = bb.getActionObject(SampleOperation);
-        complete(Incite, forceSuccess);
+        complete(iv, forceSuccess);
         expect(bb.getActionObject(SampleOperation).count).toBeGreaterThan(count);
       });
 
@@ -159,7 +159,7 @@ describe("Bladeburner Actions", () => {
        * - having chaos rate affect only one city
        */
       it.each(cities)("SIGNIFICANTLY increases chaos in all cities when chaos is LOW: %s", (city: CityName) => {
-        ({ chaos } = bb.cities[city]), complete(Incite, forceSuccess);
+        ({ chaos } = bb.cities[city]), complete(iv, forceSuccess);
         expect(bb.cities[city].chaos).toBeGreaterThan(chaos * 2);
       });
 
@@ -168,21 +168,21 @@ describe("Bladeburner Actions", () => {
        * - having chaos rate affect only one city
        */
       it.each(cities)("MILDLY increases chaos in all cities when chaos is HIGH: %s", (city: CityName) => {
-        allCitiesHighChaos(), ({ chaos } = bb.cities[city]), complete(Incite, forceSuccess);
+        allCitiesHighChaos(), ({ chaos } = bb.cities[city]), complete(iv, forceSuccess);
         expect(bb.cities[city].chaos).toBeGreaterThan(chaos * 1.05);
       });
     });
 
     describe(BladeburnerGeneralActionName.Recruitment, () => {
-      const Recruitment = GeneralAction.createId(BladeburnerGeneralActionName.Recruitment);
+      const recruit = GeneralAction.createId(BladeburnerGeneralActionName.Recruitment);
 
       it("awards charisma exp", () => {
-        (before = Player.exp.charisma), complete(Recruitment, forceSuccess);
+        (before = Player.exp.charisma), complete(recruit, forceSuccess);
         expect(Player.exp.charisma).toBeGreaterThan(before);
       });
 
       it("hires team member", () => {
-        complete(Recruitment, forceSuccess);
+        complete(recruit, forceSuccess);
         expect(bb.teamSize).toBeGreaterThan(0);
       });
     });

--- a/test/jest/Bladeburner/Actions.test.ts
+++ b/test/jest/Bladeburner/Actions.test.ts
@@ -49,12 +49,14 @@ describe("Bladeburner Actions", () => {
       const train = GeneralAction.createId(BladeburnerGeneralActionName.Training);
 
       it("increases max stamina", () => {
-        (before = bb.maxStamina), complete(train);
+        before = bb.maxStamina;
+        complete(train);
         expect(bb.maxStamina).toBeGreaterThan(before);
       });
 
       it.each(<(keyof Skills)[]>["strength", "dexterity", "agility"])("awards %s exp", (stat: keyof Skills) => {
-        (before = Player.exp[stat]), complete(train);
+        before = Player.exp[stat];
+        complete(train);
         expect(Player.exp[stat]).toBeGreaterThan(before);
       });
     });
@@ -63,12 +65,15 @@ describe("Bladeburner Actions", () => {
       const regen = GeneralAction.createId(BladeburnerGeneralActionName.HyperbolicRegen);
 
       it("heals the player", () => {
-        Player.takeDamage(Player.hp.max / 2), (before = Player.hp.current), complete(regen);
+        Player.takeDamage(Player.hp.max / 2);
+        before = Player.hp.current;
+        complete(regen);
         expect(Player.hp.current).toBeGreaterThan(before);
       });
 
       it("regains stamina", () => {
-        (bb.stamina = 0), complete(regen);
+        bb.stamina = 0;
+        complete(regen);
         expect(bb.stamina).toBeGreaterThan(0);
       });
     });
@@ -77,21 +82,26 @@ describe("Bladeburner Actions", () => {
       const diplomacy = GeneralAction.createId(BladeburnerGeneralActionName.Diplomacy);
 
       it("mildly reduces chaos in the current city", () => {
-        let chaos;
-        allCitiesHighChaos(), ({ chaos } = bb.getCurrentCity()), complete(diplomacy);
+        allCitiesHighChaos();
+        let { chaos } = bb.getCurrentCity();
+        complete(diplomacy);
         expect(bb.getCurrentCity().chaos).toBeGreaterThan(chaos * 0.9);
         expect(bb.getCurrentCity().chaos).toBeLessThan(chaos);
       });
 
       it("effect scales significantly with player charisma", () => {
-        Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(diplomacy);
+        Player.gainCharismaExp(1e500);
+        allCitiesHighChaos();
+        complete(diplomacy);
         expect(bb.getCurrentCity().chaos).toBe(0);
       });
 
       it("does NOT affect chaos in other cities", () => {
         const otherCity = <CityName>cities.find((c) => c !== bb.getCurrentCity().name);
         /** Testing against a guaranteed 0-chaos level of charisma */
-        Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(diplomacy);
+        Player.gainCharismaExp(1e500);
+        allCitiesHighChaos();
+        complete(diplomacy);
         expect(bb.cities[otherCity].chaos).toBeGreaterThan(0);
       });
     });
@@ -100,17 +110,21 @@ describe("Bladeburner Actions", () => {
       const fa = GeneralAction.createId(BladeburnerGeneralActionName.FieldAnalysis);
 
       it("improves population estimate", () => {
-        ({ pop, popEst: before } = bb.getCurrentCity()), complete(fa), ({ popEst: after } = bb.getCurrentCity());
+        ({ pop, popEst: before } = bb.getCurrentCity());
+        complete(fa);
+        ({ popEst: after } = bb.getCurrentCity());
         expect(Math.abs(after - pop)).toBeLessThan(Math.abs(before - pop));
       });
 
       it.each(<(keyof Skills)[]>["hacking", "charisma"])("awards %s exp", (stat: keyof Skills) => {
-        (before = Player.exp[stat]), complete(fa, forceSuccess);
+        before = Player.exp[stat];
+        complete(fa, forceSuccess);
         expect(Player.exp[stat]).toBeGreaterThan(before);
       });
 
       it("provides a minor increase in rank", () => {
-        ({ rank: before } = bb), complete(fa, forceSuccess);
+        before = bb.rank;
+        complete(fa, forceSuccess);
         expect(bb.rank).toBeGreaterThan(before);
       });
     });
@@ -119,7 +133,8 @@ describe("Bladeburner Actions", () => {
       "non-general actions increase rank",
       (id) => {
         it(`${id.type}`, () => {
-          (before = bb.rank), complete(id, forceSuccess);
+          before = bb.rank;
+          complete(id, forceSuccess);
           expect(bb.rank).toBeGreaterThan(before);
         });
       },
@@ -132,8 +147,12 @@ describe("Bladeburner Actions", () => {
         { major: SampleBlackOp, minor: SampleOperation },
         { major: SampleOperation, minor: SampleContract },
       ])("$major.type reward significantly more rank than $minor.type", ({ major, minor }) => {
-        (beforeMinor = bb.rank), complete(minor, forceSuccess), (minorGain = bb.rank - beforeMinor);
-        (beforeMajor = bb.rank), complete(major, forceSuccess), (majorGain = bb.rank - beforeMajor);
+        beforeMinor = bb.rank;
+        complete(minor, forceSuccess);
+        minorGain = bb.rank - beforeMinor;
+        beforeMajor = bb.rank;
+        complete(major, forceSuccess);
+        majorGain = bb.rank - beforeMajor;
         expect(majorGain).toBeGreaterThan(minorGain);
       });
     });
@@ -159,7 +178,8 @@ describe("Bladeburner Actions", () => {
        * - having chaos rate affect only one city
        */
       it.each(cities)("SIGNIFICANTLY increases chaos in all cities when chaos is LOW: %s", (city: CityName) => {
-        ({ chaos } = bb.cities[city]), complete(iv, forceSuccess);
+        ({ chaos } = bb.cities[city]);
+        complete(iv, forceSuccess);
         expect(bb.cities[city].chaos).toBeGreaterThan(chaos * 2);
       });
 
@@ -168,7 +188,9 @@ describe("Bladeburner Actions", () => {
        * - having chaos rate affect only one city
        */
       it.each(cities)("MILDLY increases chaos in all cities when chaos is HIGH: %s", (city: CityName) => {
-        allCitiesHighChaos(), ({ chaos } = bb.cities[city]), complete(iv, forceSuccess);
+        allCitiesHighChaos();
+        ({ chaos } = bb.cities[city]);
+        complete(iv, forceSuccess);
         expect(bb.cities[city].chaos).toBeGreaterThan(chaos * 1.05);
       });
     });
@@ -177,7 +199,8 @@ describe("Bladeburner Actions", () => {
       const recruit = GeneralAction.createId(BladeburnerGeneralActionName.Recruitment);
 
       it("awards charisma exp", () => {
-        (before = Player.exp.charisma), complete(recruit, forceSuccess);
+        before = Player.exp.charisma;
+        complete(recruit, forceSuccess);
         expect(Player.exp.charisma).toBeGreaterThan(before);
       });
 
@@ -189,7 +212,8 @@ describe("Bladeburner Actions", () => {
 
     describe.each(contracts.map(({ id }) => ({ id })))("$id.name", ({ id }) => {
       it("all contracts award money", () => {
-        (before = Player.money), complete(id, forceSuccess);
+        before = Player.money;
+        complete(id, forceSuccess);
         expect(Player.money).toBeGreaterThan(before);
       });
     });
@@ -198,7 +222,8 @@ describe("Bladeburner Actions", () => {
     /** Checking all of them to avoid regressions */
     describe.each(nonGeneralActions.flatMap(actionIdWithIndividualStat))("$id.name", ({ id, stat }) => {
       it(`awards ${stat} exp`, () => {
-        (before = Player.exp[stat]), complete(id, forceSuccess);
+        before = Player.exp[stat];
+        complete(id, forceSuccess);
         expect(Player.exp[stat]).toBeGreaterThan(before);
       });
     });
@@ -209,7 +234,8 @@ describe("Bladeburner Actions", () => {
 
     describe.each([SampleOperation, SampleBlackOp])("operations and black operations decrease rank", (id) => {
       it(`${id.type}`, () => {
-        (before = bb.rank), complete(id, forceFailure);
+        before = bb.rank;
+        complete(id, forceFailure);
         expect(bb.rank).toBeLessThan(before);
       });
     });

--- a/test/jest/Bladeburner/Actions.test.ts
+++ b/test/jest/Bladeburner/Actions.test.ts
@@ -1,8 +1,16 @@
-import type { Bladeburner } from "../../../src/Bladeburner/Bladeburner";
+import { Bladeburner } from "../../../src/Bladeburner/Bladeburner";
 import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
 import { Player, setPlayer } from "@player";
 import { BlackOperation, Contract, GeneralAction, Operation } from "../../../src/Bladeburner/Actions";
-import { BladeburnerContractName, BladeburnerGeneralActionName, BladeburnerOperationName, CrimeType } from "@enums";
+import {
+  BladeburnerActionType,
+  BladeburnerContractName,
+  BladeburnerGeneralActionName,
+  BladeburnerOperationName,
+  BladeburnerSkillName,
+  CityName,
+  CrimeType,
+} from "@enums";
 import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
 import { CrimeWork } from "../../../src/Work/CrimeWork";
 import type { Action, ActionIdentifier } from "../../../src/Bladeburner/Types";
@@ -10,73 +18,232 @@ import type { Skills } from "@nsdefs";
 import { BlackOperations } from "../../../src/Bladeburner/data/BlackOperations";
 
 describe("Bladeburner Actions", () => {
-  const Tracking = Contract.createId(BladeburnerContractName.Tracking);
-  const Diplomacy = GeneralAction.createId(BladeburnerGeneralActionName.Diplomacy);
-  const Assassination = Operation.createId(BladeburnerOperationName.Assassination);
-  const Recruitment = GeneralAction.createId(BladeburnerGeneralActionName.Recruitment);
+  const SampleContract = Contract.createId(BladeburnerContractName.Tracking);
+  const SampleGeneralAction = GeneralAction.createId(BladeburnerGeneralActionName.Diplomacy);
+  const SampleOperation = Operation.createId(BladeburnerOperationName.Assassination);
+  const SampleBlackOp = BlackOperations["Operation Centurion"].id;
   const ENOUGH_TIME_TO_FINISH_ACTION = 1e5;
+
+  /** Why 1e14? The stat tests need to be able to detect an EXP change of cca. 0.01
+   * 1e14 is the last threshold where 1e14 + 0.01 > 1e14
+   *
+   * Bug? Coincidentally this also means that stat gains stop at that level unless
+   * exp multipliers play a significant role
+   *
+   * Example: 1e14 strength exp gives ~~831 strength skill without augs/modifiers
+   */
+  const HIGH_STAT_EXP = 1e14;
+  const LOW_STAT_EXP = 1e6;
 
   let inst: Bladeburner;
 
+  const instanceUsedForTestGeneration = new Bladeburner();
+  const CITIES = <CityName[]>Object.keys(instanceUsedForTestGeneration.cities);
+
   /** All the tests depend on this assumption */
   it("always succeeds with optimal stats, rank, stamina and city chaos levels", () => {
-    guaranteeSuccess(), start(Assassination), finish();
-    expect(inst.getActionObject(Assassination).getSuccessChance(inst, Player, { est: false })).toBe(1);
+    guaranteeSuccess(), complete(SampleOperation);
+    const action = inst.getActionObject(SampleOperation);
+    expect(action.getSuccessChance(inst, Player, { est: false })).toBe(1);
+    expect(action.successes).toBeGreaterThan(0);
   });
 
   describe("Without Simulacrum", () => {
     it("Starting an action cancels player's work immediately", () => {
       Player.startWork(new CrimeWork({ crimeType: CrimeType.assassination, singularity: false }));
-      start(Diplomacy);
+      start(SampleGeneralAction);
       expect(Player.currentWork).toBeNull();
     });
   });
 
   describe("Upon successful completion", () => {
-    it("Contracts give the player money", () => {
-      const moneyBefore = Player.money;
-      guaranteeSuccess(), start(Tracking), finish();
-      expect(Player.money).toBeGreaterThan(moneyBefore);
+    /** Repetitive snapshot declarations in most tests below */
+    let pop, before, after;
+
+    describe(BladeburnerGeneralActionName.Training, () => {
+      const Training = GeneralAction.createId(BladeburnerGeneralActionName.Training);
+
+      it("increases max stamina", () => {
+        basicStats(), (before = inst.maxStamina), complete(Training);
+        expect(inst.maxStamina).toBeGreaterThan(before);
+      });
+
+      it.each(<(keyof Skills)[]>["strength", "dexterity", "agility"])("awards %s exp", (stat: keyof Skills) => {
+        guaranteeSuccess(), (before = Player.exp[stat]), complete(Training);
+        expect(Player.exp[stat]).toBeGreaterThan(before);
+      });
     });
 
-    describe("provides skill EXP for influencing stats (weight > 0)", () => {
-      it.each(<[ActionIdentifier, keyof Skills][]>[...ActionIdWithIndividualStat(NonGeneralActions())])(
-        "%s -> %s",
-        (id: ActionIdentifier, stat: keyof Skills) => {
-          const before = Player.exp[stat];
-          guaranteeSuccess(), start(id), finish();
-          expect(Player.exp[stat]).toBeGreaterThan(before);
-        },
-      );
+    describe(BladeburnerGeneralActionName.HyperbolicRegen, () => {
+      const Regen = GeneralAction.createId(BladeburnerGeneralActionName.HyperbolicRegen);
+
+      it("heals the player", () => {
+        basicStats(), Player.takeDamage(Player.hp.max / 2), (before = Player.hp.current), complete(Regen);
+        expect(Player.hp.current).toBeGreaterThan(before);
+      });
+
+      it("regains stamina", () => {
+        basicStats(), (inst.stamina = 0), complete(Regen);
+        expect(inst.stamina).toBeGreaterThan(0);
+      });
     });
 
-    describe("Recruitment", () => {
-      it("provides charisma", () => {
-        const { charisma } = Player.exp;
-        guaranteeSuccess(), start(Recruitment), finish();
-        expect(Player.exp.charisma).toBeGreaterThan(charisma);
+    describe(BladeburnerGeneralActionName.Diplomacy, () => {
+      const Diplomacy = GeneralAction.createId(BladeburnerGeneralActionName.Diplomacy);
+
+      it("mildly reduces chaos in the current city", () => {
+        let chaos;
+        basicStats(), allCitiesHighChaos(), ({ chaos } = inst.getCurrentCity()), complete(Diplomacy);
+        expect(inst.getCurrentCity().chaos).toBeGreaterThan(chaos * 0.9);
+        expect(inst.getCurrentCity().chaos).toBeLessThan(chaos);
+      });
+
+      it("effect scales significantly with player charisma", () => {
+        basicStats(), Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(Diplomacy);
+        expect(inst.getCurrentCity().chaos).toBe(0);
+      });
+
+      it("does NOT affect chaos in other cities", () => {
+        const otherCity = <CityName>CITIES.find((c) => c !== inst.getCurrentCity().name);
+        /** Testing against a guaranteed 0-chaos level of charisma */
+        basicStats(), Player.gainCharismaExp(1e500), allCitiesHighChaos(), complete(Diplomacy);
+        expect(inst.cities[otherCity].chaos).toBeGreaterThan(0);
+      });
+    });
+
+    describe(BladeburnerGeneralActionName.FieldAnalysis, () => {
+      const Field = GeneralAction.createId(BladeburnerGeneralActionName.FieldAnalysis);
+
+      it("improves population estimate", () => {
+        basicStats(),
+          ({ pop, popEst: before } = inst.getCurrentCity()),
+          complete(Field),
+          finish(),
+          ({ popEst: after } = inst.getCurrentCity());
+        expect(Math.abs(after - pop)).toBeLessThan(Math.abs(before - pop));
+      });
+
+      it.each(<(keyof Skills)[]>["hacking", "charisma"])("awards %s exp", (stat: keyof Skills) => {
+        basicStats(), (before = Player.exp[stat]), complete(Field);
+        expect(Player.exp[stat]).toBeGreaterThan(before);
+      });
+
+      it("provides a minor increase in rank", () => {
+        basicStats(), ({ rank: before } = inst), complete(Field);
+        expect(inst.rank).toBeGreaterThan(before);
+      });
+    });
+
+    describe.each([SampleContract, SampleOperation, BlackOperations["Operation Archangel"].id])(
+      "non-general actions increase rank",
+      (id) => {
+        it(`${id.type}`, () => {
+          guaranteeSuccess(), (before = inst.rank), complete(id);
+          expect(inst.rank).toBeGreaterThan(before);
+        });
+      },
+    );
+
+    describe("non-general actions increase rank", () => {
+      let beforeMinor, minorGain, beforeMajor, majorGain;
+
+      it.each([
+        { major: SampleBlackOp, minor: SampleOperation },
+        { major: SampleOperation, minor: SampleContract },
+      ])("$major.type reward significantly more rank than $minor.type", ({ major, minor }) => {
+        guaranteeSuccess(), (beforeMinor = inst.rank), complete(minor), finish(), (minorGain = inst.rank - beforeMinor);
+        guaranteeSuccess(), (beforeMajor = inst.rank), complete(major), finish(), (majorGain = inst.rank - beforeMajor);
+        expect(majorGain).toBeGreaterThan(minorGain);
+      });
+    });
+
+    describe(BladeburnerGeneralActionName.InciteViolence, () => {
+      const Incite = GeneralAction.createId(BladeburnerGeneralActionName.InciteViolence);
+      let chaos;
+
+      it("generates available contracts", () => {
+        const { count } = inst.getActionObject(SampleContract);
+        guaranteeSuccess(), complete(Incite);
+        expect(inst.getActionObject(SampleContract).count).toBeGreaterThan(count);
+      });
+
+      it("generates available operations", () => {
+        const { count } = inst.getActionObject(SampleOperation);
+        guaranteeSuccess(), complete(Incite);
+        expect(inst.getActionObject(SampleOperation).count).toBeGreaterThan(count);
+      });
+
+      /** Relates to all issues mentioned in PR-1586 */
+      it.each(CITIES)("SIGNIFICANTLY increases chaos in all cities when chaos is LOW: %s", (city: CityName) => {
+        guaranteeSuccess(), ({ chaos } = inst.cities[city]), complete(Incite);
+        expect(inst.cities[city].chaos).toBeGreaterThan(chaos * 2);
+      });
+
+      /** Relates to all issues mentioned in PR-1586 */
+      it.each(CITIES)("MILDLY increases chaos in all cities when chaos is HIGH: %s", (city: CityName) => {
+        guaranteeSuccess(), allCitiesHighChaos(), ({ chaos } = inst.cities[city]), complete(Incite);
+        expect(inst.cities[city].chaos).toBeGreaterThan(chaos * 1.05);
+      });
+    });
+
+    describe(BladeburnerGeneralActionName.Recruitment, () => {
+      const Recruitment = GeneralAction.createId(BladeburnerGeneralActionName.Recruitment);
+
+      it("awards charisma exp", () => {
+        guaranteeSuccess(), (before = Player.exp.charisma), complete(Recruitment);
+        expect(Player.exp.charisma).toBeGreaterThan(before);
       });
 
       it("hires team member", () => {
-        guaranteeSuccess(), start(Recruitment), finish();
+        guaranteeSuccess(), complete(Recruitment);
         expect(inst.teamSize).toBeGreaterThan(0);
+      });
+    });
+
+    describe.each([...actionId(contracts())])("$id.name", ({ id }) => {
+      it("all contracts award money", () => {
+        guaranteeSuccess(), (before = Player.money), complete(id);
+        expect(Player.money).toBeGreaterThan(before);
+      });
+    });
+
+    /** Stat EXP check for all actions */
+    /** Checking all of them to avoid regressions */
+    describe.each([...actionIdWithIndividualStat(nonGeneralActions())])("$id.name", ({ id, stat }) => {
+      it(`awards ${stat} exp`, () => {
+        guaranteeSuccess(), (before = Player.exp[stat]), complete(id);
+        expect(Player.exp[stat]).toBeGreaterThan(before);
+      });
+    });
+  });
+
+  describe("Upon failed completion", () => {
+    let before;
+
+    describe.each([SampleOperation, SampleBlackOp])("operations and black operations decrease rank", (id) => {
+      it(`${id.type}`, () => {
+        guaranteeFailure(), (before = inst.rank), complete(id);
+        expect(inst.rank).toBeLessThan(before);
       });
     });
   });
 
   it("have a minimum duration of 1 second", () => {
-    start(Tracking);
+    complete(SampleContract);
     expect(inst.actionTimeToComplete).toBeGreaterThanOrEqual(1);
   });
 
   beforeAll(() => {
-    /* Initialise Formatters. Dependency of Bladeburner */
+    /* Initialise Formatters. Dependency of Bladeburner Logs/Console */
     FormatsNeedToChange.emit();
   });
 
   beforeEach(() => {
     setPlayer(new PlayerObject());
-    Player.sourceFiles.set(5, 3); // Need BN5 to receive Int EXP
+
+    /** Need BN5 to receive Int EXP */
+    Player.sourceFiles.set(5, 3);
+
     if (initBladeburner(Player)) {
       inst = Player.bladeburner;
       inst.clearConsole();
@@ -84,48 +251,108 @@ describe("Bladeburner Actions", () => {
   });
 
   function initBladeburner(player: PlayerObject): player is PlayerObject & { bladeburner: Bladeburner } {
-    player.init();
     player.startBladeburner();
     return true;
   }
 
-  function guaranteeSuccess() {
-    Player.gainStrengthExp(1e200);
-    Player.gainAgilityExp(1e200);
-    Player.gainDexterityExp(1e200);
-    Player.gainDefenseExp(1e200);
+  function basicStats() {
+    inst.rank = 1;
+    inst.changeRank(Player, 10);
+    Player.gainStrengthExp(LOW_STAT_EXP);
+    Player.gainDefenseExp(LOW_STAT_EXP);
+    Player.gainAgilityExp(LOW_STAT_EXP);
+    Player.gainDexterityExp(LOW_STAT_EXP);
+
     inst.calculateMaxStamina();
     inst.stamina = inst.maxStamina;
-    inst.rank = 1e10;
+
+    resetCity();
+  }
+
+  function guaranteeSuccess() {
+    inst.rank = 1;
+    inst.changeRank(Player, 1e10);
+
+    Player.gainStrengthExp(HIGH_STAT_EXP);
+    Player.gainDefenseExp(HIGH_STAT_EXP);
+    Player.gainAgilityExp(HIGH_STAT_EXP);
+    Player.gainDexterityExp(HIGH_STAT_EXP);
+    inst.setSkillLevel(BladeburnerSkillName.BladesIntuition, 1e12);
+    inst.setSkillLevel(BladeburnerSkillName.Cloak, 1e12);
+    inst.setSkillLevel(BladeburnerSkillName.DigitalObserver, 1e12);
+    inst.setSkillLevel(BladeburnerSkillName.Reaper, 1e12);
+
+    inst.calculateMaxStamina();
+    inst.stamina = inst.maxStamina;
+
+    resetCity();
+  }
+
+  function guaranteeFailure() {
+    inst.rank = 1;
+    inst.changeRank(Player, 400e3); // Minimum to attempt to fail hardest op
+    Player.gainAgilityExp(1e50);
+    inst.calculateMaxStamina();
+    inst.stamina = 0;
+
+    resetCity();
+  }
+
+  function resetCity() {
     inst.cities[inst.city].chaos = 0;
     inst.cities[inst.city].comms = 100;
     inst.cities[inst.city].pop = 1e9;
+
+    /** Disable random event */
+    inst.randomEventCounter = Infinity;
+  }
+
+  function allCitiesHighChaos() {
+    for (const city of Object.values(inst.cities)) {
+      city.chaos = 1e12;
+    }
+  }
+
+  function complete(id: ActionIdentifier) {
+    start(id), finish();
   }
 
   function start(id: ActionIdentifier) {
     const action = inst.getActionObject(id);
     if ("count" in action) action.count = 1;
+    if (action.type === BladeburnerActionType.Operation) action.autoLevel = true;
     if (id.type === "Black Operations") inst.numBlackOpsComplete = (<BlackOperation>action).n;
     inst.startAction(id);
   }
 
   function finish() {
     inst.processAction(ENOUGH_TIME_TO_FINISH_ACTION);
+    inst.calculateMaxStamina();
   }
 
-  function* NonGeneralActions() {
-    if (!initBladeburner(Player)) return;
-
-    yield* Object.values(Player.bladeburner.contracts);
-    yield* Object.values(Player.bladeburner.operations);
+  function* nonGeneralActions() {
+    yield* contracts();
+    yield* operations();
     yield* Object.values(BlackOperations);
   }
 
-  function* ActionIdWithIndividualStat(actions: Iterable<Action>) {
+  function* contracts() {
+    yield* Object.values(instanceUsedForTestGeneration.contracts);
+  }
+
+  function* operations() {
+    yield* Object.values(instanceUsedForTestGeneration.operations);
+  }
+
+  function* actionId(actions: Iterable<Action>) {
+    for (const action of actions) yield { id: action.id };
+  }
+
+  function* actionIdWithIndividualStat(actions: Iterable<Action>) {
     for (const action of actions) {
       yield* Object.entries(action.weights)
         .filter(([__, value]) => value > 0)
-        .map(([stat]) => [action.id, stat]);
+        .map(([stat]) => ({ id: action.id, stat } as { id: ActionIdentifier; stat: keyof Skills }));
     }
   }
 });


### PR DESCRIPTION
# BLADEBURNER: Test cover action completion

## Things covered
- main effect of general actions
- stat exp, int exp, money and rank rewards for contracts, operations, black ops
- simulacrum effect on work
- scaling and proportion of reward vs risk (ie. black ops give more rank than ops, stages of scaling of charisma with diplomacy and incite violence depending on chaos levels)

## Not covered in this PR
- the process loop. Has a dependency to the React router. It's a minor refactor but I was avoiding all source code changes in this stage
- random city events
- stat rewards on failure. Without **explicitly** measuring exact formulas and random rolls, the detection between low and high reward is very flaky
- precise measurements of stat gain and modifiers, can test that separately through skills
- player and sleeve damage—that's mostly already covered by casualties tests
- sleeve complete action—sadly a bit more involved to control and simulate due to the process loops overlapping. Requires a minor refactor. Next round.
- skill rankups and various scaling

## Outcomes

Bladeburner line coverage is now up to 60%. Branch cover is slightly lower than that due to the branches produced by overlaps with data and react components.

This PR makes it easier to perform changes in the following areas:
- Stat XP distribution for actions
- Chaos changes and stat scaling for things like Diplomacy and Incite Violence
- Larger refactors in the action scheduling area
- Adding new missions without requiring involved balance simulations

# Linked issues

- related to PR-1586 https://github.com/bitburner-official/bitburner-src/pull/1586
- related to PR-1664 https://github.com/bitburner-official/bitburner-src/pull/1664

# Documentation

No NS api changes or source changes in any production-facing code.
