### PR TITLE
MISC: Improve tutorial, documentation and discoverability of NS API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ See the [frequently asked questions](./doc/FAQ.md) for more information . To dis
 
 # Documentation
 
-The game's official documentation can be found in-game.
+There are 2 types of documentation:
 
-The [in-game documentation](./markdown/bitburner.md) is generated from the [TypeScript definitions](./src/ScriptEditor/NetscriptDefinitions.d.ts).
+- In-game documentation: It can be found in the Documentation tab. This is the best place to get up-to-date information. You can also read the web version at https://github.com/bitburner-official/bitburner-src/blob/stable/src/Documentation/doc/index.md.
+- NS API documentation: It's generated from the [TypeScript definitions](./src/ScriptEditor/NetscriptDefinitions.d.ts). You can read it at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.md.
 
 Anyone is welcome to contribute to the documentation by editing the [source
 files](/src/Documentation/doc) and then making a pull request with your contributions.

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -87,7 +87,7 @@ function Root(props: IProps): React.ReactElement {
       }
       const cleanCode = currentScript.code.replace(/\s/g, "");
       const ns1 = "while(true){hack('n00dles');}";
-      const ns2 = `exportasyncfunctionmain(ns){while(true){awaitns.hack('n00dles');}}`;
+      const ns2 = `/**@param{NS}ns*/exportasyncfunctionmain(ns){while(true){awaitns.hack("n00dles");}}`;
       if (!cleanCode.includes(ns1) && !cleanCode.includes(ns2)) {
         dialogBoxCreate("Please copy and paste the code from the tutorial!");
         return;

--- a/src/ScriptEditor/ui/Toolbar.tsx
+++ b/src/ScriptEditor/ui/Toolbar.tsx
@@ -3,7 +3,6 @@ import * as monaco from "monaco-editor";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Link from "@mui/material/Link";
 import Table from "@mui/material/Table";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
@@ -22,7 +21,7 @@ import { useBoolean } from "../../ui/React/hooks";
 import { Settings } from "../../Settings/Settings";
 import { OptionsModal, OptionsModalProps } from "./OptionsModal";
 import { useScriptEditorContext } from "./ScriptEditorContext";
-import { getNsApiDocumentationUrl } from "../../utils/StringHelperFunctions";
+import { NsApiDocumentationLink } from "../../ui/React/NsApiDocumentationLink";
 
 type IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 
@@ -71,18 +70,7 @@ export function Toolbar({ editor, onSave }: IProps) {
           Terminal (Ctrl/Cmd + b)
         </Button>
         <Typography>
-          <Link
-            target="_blank"
-            href={getNsApiDocumentationUrl()}
-            fontSize="1.2rem"
-            color={Settings.theme.info}
-            sx={{
-              textDecorationThickness: "3px",
-              textUnderlineOffset: "5px",
-            }}
-          >
-            NS API documentation
-          </Link>
+          <NsApiDocumentationLink />
         </Typography>
       </Box>
       <OptionsModal

--- a/src/ScriptEditor/ui/Toolbar.tsx
+++ b/src/ScriptEditor/ui/Toolbar.tsx
@@ -71,7 +71,16 @@ export function Toolbar({ editor, onSave }: IProps) {
           Terminal (Ctrl/Cmd + b)
         </Button>
         <Typography>
-          <Link target="_blank" href={getNsApiDocumentationUrl()} fontSize="1.2rem">
+          <Link
+            target="_blank"
+            href={getNsApiDocumentationUrl()}
+            fontSize="1.2rem"
+            color={Settings.theme.info}
+            sx={{
+              textDecorationThickness: "3px",
+              textUnderlineOffset: "5px",
+            }}
+          >
             NS API documentation
           </Link>
         </Typography>

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../InteractiveTutorial";
 import { useRerender } from "../React/hooks";
 import { Settings } from "../../Settings/Settings";
+import { NsApiDocumentationLink } from "../React/NsApiDocumentationLink";
 
 interface IContent {
   content: React.ReactElement;
@@ -353,11 +354,7 @@ export async function main(ns) {
             continuously hack the n00dles server.
             <br />
             <br />
-            To access{" "}
-            <Typography component="span" color={Settings.theme.warning}>
-              NS API documentation
-            </Typography>
-            , press the link at the bottom.
+            To access <NsApiDocumentationLink />, press the link at the bottom.
             <br />
             <br />
             To save and close the script editor, press the button at the bottom.

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -339,10 +339,11 @@ export function InteractiveTutorialRoot(): React.ReactElement {
           <Typography classes={{ root: classes.code }}>
             {
               <CopyableText
-                value={`export async function main(ns) {
-	while(true) {
-		await ns.hack('n00dles');
-	}
+                value={`/** @param {NS} ns */
+export async function main(ns) {
+  while (true) {
+    await ns.hack("n00dles");
+  }
 }`}
               />
             }
@@ -350,6 +351,13 @@ export function InteractiveTutorialRoot(): React.ReactElement {
           <Typography>
             For anyone with basic programming experience, this code should be straightforward. This script will
             continuously hack the n00dles server.
+            <br />
+            <br />
+            To access{" "}
+            <Typography component="span" color={Settings.theme.warning}>
+              NS API documentation
+            </Typography>
+            , press the link at the bottom.
             <br />
             <br />
             To save and close the script editor, press the button at the bottom.

--- a/src/ui/MD/a.tsx
+++ b/src/ui/MD/a.tsx
@@ -4,6 +4,7 @@ import { useNavigator } from "../React/Documentation";
 import { CorruptableText } from "../React/CorruptableText";
 import { Player } from "@player";
 import { getNsApiDocumentationUrl } from "../../utils/StringHelperFunctions";
+import { Settings } from "../../Settings/Settings";
 
 export const isSpoiler = (title: string): boolean => title.includes("advanced/") && Player.sourceFileLvl(1) === 0;
 
@@ -22,7 +23,16 @@ export const A = (props: React.PropsWithChildren<{ href?: string }>): React.Reac
       href = getNsApiDocumentationUrl();
     }
     return (
-      <Link rel="noopener noreferrer" href={href} target="_blank">
+      <Link
+        rel="noopener noreferrer"
+        href={href}
+        target="_blank"
+        color={Settings.theme.info}
+        sx={{
+          textDecorationThickness: "3px",
+          textUnderlineOffset: "5px",
+        }}
+      >
         {props.children}
       </Link>
     );

--- a/src/ui/React/NsApiDocumentationLink.tsx
+++ b/src/ui/React/NsApiDocumentationLink.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Link } from "@mui/material";
+import { getNsApiDocumentationUrl } from "../../utils/StringHelperFunctions";
+import { Settings } from "../../Settings/Settings";
+
+export function NsApiDocumentationLink(): React.ReactElement {
+  return (
+    <Link
+      target="_blank"
+      href={getNsApiDocumentationUrl()}
+      fontSize="1.2rem"
+      color={Settings.theme.info}
+      sx={{
+        textDecorationThickness: "3px",
+        textUnderlineOffset: "5px",
+      }}
+    >
+      NS API documentation
+    </Link>
+  );
+}


### PR DESCRIPTION
### Tutorial
- Change the example of the hack script:
  - Add `/** @param {NS} ns */`.
  - Change the tab character to double space characters.
- Mention "NS API documentation".

![Capture1](https://github.com/user-attachments/assets/d2426c95-967f-4791-81d5-13e162cfc53c)

### Documentation
Update README.md.

### Discoverability of NS API documentation:
Script Editor tab:
Before:
![before](https://github.com/user-attachments/assets/7c392538-b86e-4e10-9de5-ba3739adada5)
After:
![after](https://github.com/user-attachments/assets/b195d134-68a2-4291-944e-17f13c37102b)

Documentation tab:
Before:
![before](https://github.com/user-attachments/assets/c8df92b0-75a3-4b47-bb97-889fd334f50f)
After:
![after](https://github.com/user-attachments/assets/64fe85d1-e23f-4b21-9456-b904f122cc13)

Note: There is a "side-effect" of this change: all external links will be changed in the same way as the NS API documentation link. For example:
![Capture](https://github.com/user-attachments/assets/bd31a28a-e69f-4b79-91d2-8689f85cc0d7)

Closes #1696.