### PR TITLE
UI: Remove unnecessary newlines when augmentation does not have stats

### DIFF
--- a/src/Augmentation/ui/PurchasableAugmentations.tsx
+++ b/src/Augmentation/ui/PurchasableAugmentations.tsx
@@ -168,9 +168,13 @@ export function PurchasableAugmentation(props: IPurchasableAugProps): React.Reac
   const description = (
     <>
       {info}
-      <br />
-      <br />
-      {aug.stats}
+      {aug.stats && (
+        <>
+          <br />
+          <br />
+          {aug.stats}
+        </>
+      )}
     </>
   );
 


### PR DESCRIPTION
This "problem" was reported as a bug on Discord, but I think this PR is just a small UI change, not a bugfix. Those `<br />` tags are unnecessary when the augmentation does not have stats.

Before:
![before](https://github.com/user-attachments/assets/bc95ab1c-52f9-4b51-aa86-3e0d33d01837)

After:
![after](https://github.com/user-attachments/assets/155fe465-d980-4929-9970-09ec91c2ea68)
