### PR TITLE
BLADEBURNER: UI now shows tooltips on action success chance to show stat scaling

### DIFF
--- a/src/Bladeburner/Actions/Action.ts
+++ b/src/Bladeburner/Actions/Action.ts
@@ -12,6 +12,7 @@ import { clampNumber } from "../../utils/helpers/clampNumber";
 
 export interface ActionParams {
   desc: string;
+  successScaling?: string;
   baseDifficulty?: number;
   rewardFac?: number;
   rankGain?: number;
@@ -25,6 +26,7 @@ export interface ActionParams {
 
 export abstract class ActionClass {
   desc = "";
+  successScaling = "";
   // For LevelableActions, the base difficulty can be increased based on action level
   baseDifficulty = 100;
 
@@ -61,6 +63,7 @@ export abstract class ActionClass {
   constructor(params: ActionParams | null = null) {
     if (!params) return;
     this.desc = params.desc;
+    if (params.successScaling) this.successScaling = params.successScaling;
     if (params.baseDifficulty) this.baseDifficulty = addOffset(params.baseDifficulty, 10);
 
     if (params.rankGain) this.rankGain = params.rankGain;
@@ -140,6 +143,7 @@ export abstract class ActionClass {
     function clamp(x: number): number {
       return Math.max(0, Math.min(x, 1));
     }
+
     const est = this.getSuccessChance(bladeburner, person, { est: true });
     const real = this.getSuccessChance(bladeburner, person);
     const diff = Math.abs(real - est);

--- a/src/Bladeburner/data/Contracts.ts
+++ b/src/Bladeburner/data/Contracts.ts
@@ -12,6 +12,8 @@ export function createContracts(): Record<BladeburnerContractName, Contract> {
         "engage. Stealth is of the utmost importance.\n\n" +
         "Successfully completing Tracking contracts will slightly improve your Synthoid population estimate for whatever " +
         "city you are currently in.",
+      successScaling:
+        "Significantly affected by Dexterity and Agility. Minor bonus from combat stats and Charisma. Unaffected by Hacking skill.",
       baseDifficulty: 125,
       difficultyFac: 1.02,
       rewardFac: 1.041,
@@ -45,6 +47,8 @@ export function createContracts(): Record<BladeburnerContractName, Contract> {
         "Hunt down and capture fugitive Synthoids. These Synthoids are wanted alive.\n\n" +
         "Successfully completing a Bounty Hunter contract will lower the population in your current city, and will also " +
         "increase its chaos level.",
+      successScaling:
+        "Significantly affected by Dexterity and Agility. Minor bonus from combat stats and Charisma. Unaffected by Hacking skill.",
       baseDifficulty: 250,
       difficultyFac: 1.04,
       rewardFac: 1.085,
@@ -78,6 +82,7 @@ export function createContracts(): Record<BladeburnerContractName, Contract> {
         "Hunt down and retire (kill) rogue Synthoids.\n\n" +
         "Successfully completing a Retirement contract will lower the population in your current city, and will also " +
         "increase its chaos level.",
+      successScaling: "Affected by combat stats. Minor bonus from Charisma. Unaffected by Hacking skill.",
       baseDifficulty: 200,
       difficultyFac: 1.03,
       rewardFac: 1.065,

--- a/src/Bladeburner/data/GeneralActions.ts
+++ b/src/Bladeburner/data/GeneralActions.ts
@@ -32,6 +32,7 @@ export const GeneralActions: Record<BladeburnerGeneralActionName, GeneralAction>
     desc:
       "Attempt to recruit members for your Bladeburner team. These members can help you conduct operations.\n\n" +
       "Does NOT require stamina.",
+    successScaling: "Success chance is affected by Charisma.",
   }),
   [BladeburnerGeneralActionName.Diplomacy]: new GeneralAction({
     name: BladeburnerGeneralActionName.Diplomacy,

--- a/src/Bladeburner/data/Operations.ts
+++ b/src/Bladeburner/data/Operations.ts
@@ -12,6 +12,7 @@ export function createOperations(): Record<BladeburnerOperationName, Operation> 
         "As a field agent, investigate and identify Synthoid populations, movements, and operations.\n\n" +
         "Successful Investigation ops will increase the accuracy of your synthoid data.\n\n" +
         "You will NOT lose HP from failed Investigation ops.",
+      successScaling: "Significantly affected by Hacking skill and Charisma. Minor bonus from combat stats.",
       baseDifficulty: 400,
       difficultyFac: 1.03,
       rewardFac: 1.07,
@@ -44,6 +45,8 @@ export function createOperations(): Record<BladeburnerOperationName, Operation> 
       desc:
         "Conduct undercover operations to identify hidden and underground Synthoid communities and organizations.\n\n" +
         "Successful Undercover ops will increase the accuracy of your synthoid data.",
+      successScaling:
+        "Affected by Hacking skill, Dexterity, Agility and Charisma. Minor bonus from Defense and Strength.",
       baseDifficulty: 500,
       difficultyFac: 1.04,
       rewardFac: 1.09,
@@ -75,6 +78,8 @@ export function createOperations(): Record<BladeburnerOperationName, Operation> 
     [BladeburnerOperationName.Sting]: new Operation({
       name: BladeburnerOperationName.Sting,
       desc: "Conduct a sting operation to bait and capture particularly notorious Synthoid criminals.",
+      successScaling:
+        "Significantly affected by Hacking skill and Dexterity. Major bonus from Charisma. Minor bonus from combat stats.",
       baseDifficulty: 650,
       difficultyFac: 1.04,
       rewardFac: 1.095,
@@ -107,6 +112,7 @@ export function createOperations(): Record<BladeburnerOperationName, Operation> 
       desc:
         "Lead an assault on a known Synthoid community. Note that there must be an existing Synthoid community in your " +
         "current city in order for this Operation to be successful.",
+      successScaling: "Affected by combat stats. Minor bonus from Hacking skill. Unaffected by Charisma.",
       baseDifficulty: 800,
       difficultyFac: 1.045,
       rewardFac: 1.1,
@@ -143,6 +149,8 @@ export function createOperations(): Record<BladeburnerOperationName, Operation> 
       desc:
         "Lead a covert operation to retire Synthoids. The objective is to complete the task without drawing any " +
         "attention. Stealth and discretion are key.",
+      successScaling:
+        "Significantly affected by Dexterity and Agility. Minor bonus from combat stats and Hacking skill. Unaffected by Charisma.",
       baseDifficulty: 1000,
       difficultyFac: 1.05,
       rewardFac: 1.11,
@@ -176,6 +184,9 @@ export function createOperations(): Record<BladeburnerOperationName, Operation> 
       desc:
         "Assassinate Synthoids that have been identified as important, high-profile social and political leaders in the " +
         "Synthoid communities.",
+      successScaling:
+        "Significantly affected by Dexterity and Agility. Minor bonus from combat stats and Hacking skill.\n" +
+        "Unaffected by Charisma.",
       baseDifficulty: 1500,
       difficultyFac: 1.06,
       rewardFac: 1.14,

--- a/src/Bladeburner/ui/BlackOpPage.tsx
+++ b/src/Bladeburner/ui/BlackOpPage.tsx
@@ -42,7 +42,8 @@ export function BlackOpPage({ bladeburner }: BlackOpPageProps): React.ReactEleme
         <br />
         <br />
         Like normal operations, you may use a team for Black Ops. Failing a black op will incur heavy HP and rank
-        losses.
+        losses. Black Ops success significantly affected by combat stats. Many Ops benefit from Hacking skill.
+        Unaffected by Charisma.
       </Typography>
       {bladeburner.numBlackOpsComplete >= blackOpsArray.length ? (
         <Button sx={{ my: 1, p: 1 }} onClick={finishBitNode}>

--- a/src/Bladeburner/ui/SuccessChance.tsx
+++ b/src/Bladeburner/ui/SuccessChance.tsx
@@ -7,6 +7,7 @@ import { Player } from "@player";
 import { formatPercent } from "../../ui/formatNumber";
 import { StealthIcon } from "./StealthIcon";
 import { KillIcon } from "./KillIcon";
+import { Tooltip, Typography } from "@mui/material";
 
 interface SuccessChanceProps {
   bladeburner: Bladeburner;
@@ -20,7 +21,13 @@ export function SuccessChance({ bladeburner, action }: SuccessChanceProps): Reac
 
   return (
     <>
-      Estimated success chance: {chance} {action.isStealth ? <StealthIcon /> : <></>}
+      <Tooltip title={action.successScaling ? <Typography>{action.successScaling}</Typography> : ""}>
+        <span>
+          Estimated success chance: {chance}
+          {/* Intentional space*/}{" "}
+        </span>
+      </Tooltip>
+      {action.isStealth ? <StealthIcon /> : <></>}
       {action.isKill ? <KillIcon /> : <></>}
     </>
   );


### PR DESCRIPTION
# BLADEBURNER: UI now shows tooltips on action success chance to show stat scaling

Hovering over the "estimated success chance" text now shows what stats it scales from. Plus description for Black Ops to keep them focused on the lore text.

# Motivation

Joining bladeburner requires 100 combat stats but it's never explained how or why it is relevant to gameplay. Hoping this tooltip will help connect the dots.

Looking for review/feedback on:
- wording, spacing
- tooltip alternatives
- tooltip shape
- (optional) whether to generate the tooltips from weights