### PR TITLE
MISC: Expose more information of HiveMind augmentation

### DIFF
--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -883,7 +883,9 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
         "exactly the implant does, but they promise that it will greatly " +
         "enhance your abilities.",
       hacking_grow: 3,
-      stats: "",
+      stats:
+        `Many hackers says that they can spoof money much better than normal after installing this augmentation. ` +
+        `A leaked document from ${FactionName.ECorp} contains this weird message: "vnmehidi's gorw oprwe si ebesaccisl aiv sliguntayir".`,
       factions: [FactionName.ECorp],
     },
     [AugmentationName.HuntOfArtemis]: {

--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -884,7 +884,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
         "enhance your abilities.",
       hacking_grow: 3,
       stats:
-        `Many hackers says that they can spoof money much better than normal after installing this augmentation. ` +
+        `Many hackers say that they can spoof money much better than normal after installing this augmentation. ` +
         `A leaked document from ${FactionName.ECorp} contains this weird message: "vnmehidi's gorw oprwe si ebesaccisl aiv sliguntayir".`,
       factions: [FactionName.ECorp],
     },


### PR DESCRIPTION
The specific detail of this augmentation's effect is hidden by using an empty string as its `stats`. In the past, it might be intentional due to lore-related reasons, but I'm not convinced that it's a good idea to hide information from the player, even when it gives the game/faction/augmentation "flavor". There are tons of players asking about its effect on Discord, so I believe that we should expose more information.

This change gained support on Discord in the #suggestion channel, so I think it's a good one. There are also concerns that if we plainly expose the effect, this augmentation will lose its "mysterious" feeling. There are other good ideas: use corruptable text, put it in a document on Ecorp's server, etc. This PR tried to balance between "having enough information" and "it gives the game/faction flavor":
- State its effect (spoof money better), but not the specific number.
- Give a hint on how to get the specific number.
- The hint is a scrambled text, in the same way we do the corruptable text.
- Minimal change in the source code. Use `CorruptableText` directly will be too troublesome for little benefits.

![Capture](https://github.com/user-attachments/assets/8b5c041a-a7cd-48f3-8b5d-3deed28bcd71)

`vnmehidi's gorw oprwe si ebesaccisl aiv sliguntayir` = "HiveMind's grow power is accessible via Singularity".

Technically, mentioning Singularity is a spoiler, but I think it's not a problem:
- We have already had a "Singularity" namespace in the NS API.
- It gives the player incentive to explore more things.