### PR TITLE
CLI: Add warning when installing backdoor on backdoored server

### DIFF
--- a/src/Terminal/commands/backdoor.ts
+++ b/src/Terminal/commands/backdoor.ts
@@ -29,5 +29,12 @@ export function backdoor(args: (string | number | boolean)[], server: BaseServer
     );
     return;
   }
+
+  if (server.backdoorInstalled) {
+    Terminal.warn(
+      `You have already installed a backdoor on this server. You can check the "Backdoor" status via the "analyze" command.`,
+    );
+  }
+
   Terminal.startBackdoor();
 }


### PR DESCRIPTION
This PR adds a warning message when the player tries to install a backdoor on a backdoored server. For the reason and consideration of this addition, please check #1702.

Closes #1702.

![Capture](https://github.com/user-attachments/assets/c08f84e3-f212-4963-bf67-6b044f3bf9a6)
