### PR TITLE
API: Improve built-in print APIs when printing Promise objects

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -256,7 +256,16 @@ function argsToString(args: unknown[]): string {
       return (out += `< Set: ${[...nativeArg].join("; ")} >`);
     }
     if (typeof nativeArg === "object") {
-      return (out += JSON.stringify(nativeArg));
+      return (out += JSON.stringify(nativeArg, (_, value) => {
+        /**
+         * If the property is a promise, we will return a string that clearly states that it's a promise object, not a
+         * normal object. If we don't do that, all promises will be serialized into "{}".
+         */
+        if (value instanceof Promise) {
+          return value.toString();
+        }
+        return value;
+      }));
     }
 
     return (out += `${nativeArg}`);


### PR DESCRIPTION
When the player prints Promise objects, those objects are serialized into `{}`. This may be confusing in some cases. This PR adds a special case in `argsToString` to handle this situation.

Closes #1706.

Before:
![before](https://github.com/user-attachments/assets/5938e88e-6bbb-423b-bd67-b42beffd1c20)

After:
![after](https://github.com/user-attachments/assets/1979d013-ec6c-49df-b1d7-c8bacff87245)
