### PR TITLE
MISC: Improve discoverability of Corporation documentation

### DIFF
--- a/src/Literature/Literatures.ts
+++ b/src/Literature/Literatures.ts
@@ -22,9 +22,11 @@ export const Literatures: Record<LiteratureName, Literature> = {
       "Netscript command to copy your scripts onto these servers and then run them.",
   }),
   [LiteratureName.CorporationManagementHandbook]: new Literature({
-    title: "The Complete Handbook for Creating a Successful Corporation",
+    title: "Short Introduction for Creating a Successful Corporation",
     filename: LiteratureName.CorporationManagementHandbook,
     text:
+      "You should check the in-game Corporation documentation in the Documentation tab (Documentation -> Advanced Mechanics -> Corporation). " +
+      "It's the most useful and up-to-date resource for managing Corporation.<br><br>" +
       "<u>Getting Started with Corporations</u><br>" +
       "To get started, visit the City Hall in Sector-12 in order to create a Corporation. This requires $150b of your own money, " +
       "but this $150b will get put into your Corporation's funds. If you're in BitNode 3 you also have option to get seed money from " +

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -257,8 +257,9 @@ export function prestigeSourceFile(isFlume: boolean): void {
     // Easiest way to comply with type constraint, instead of revalidating the enum member's file path
     homeComp.messages.push(LiteratureName.CorporationManagementHandbook);
     delayedDialog(
-      "You received a copy of the Corporation Management Handbook on your home computer. " +
-        "Read it if you need help getting started with Corporations!",
+      "You received a copy of the Corporation Management Handbook on your home computer. It's a short introduction for " +
+        "managing Corporation.\n\nYou should check the in-game Corporation documentation in the Documentation tab " +
+        "(Documentation -> Advanced Mechanics -> Corporation). It's the most useful and up-to-date resource for managing Corporation.",
     );
   }
 


### PR DESCRIPTION
We have extensive documentation for Corporation, which is one of the hardest mechanics in this game, but many (or most ?) new players do not know that it exists. This PR improves its discoverability by mentioning it in more places.

![Capture1](https://github.com/user-attachments/assets/d3fb6ba5-9c6a-4d51-b9b0-f01f8755ccc0)
![Capture2](https://github.com/user-attachments/assets/b4f62f4f-048b-49bd-bdf7-d6d7936ad4e7)
