### PR TITLE
API: Change type of skill name parameter of skillMaxUpgradeCount API

### DIFF
--- a/markdown/bitburner.bladeburnerformulas.skillmaxupgradecount.md
+++ b/markdown/bitburner.bladeburnerformulas.skillmaxupgradecount.md
@@ -9,14 +9,18 @@ Calculate the number of times that you can upgrade a skill.
 **Signature:**
 
 ```typescript
-skillMaxUpgradeCount(name: string, level: number, skillPoints: number): number;
+skillMaxUpgradeCount(
+    name: BladeburnerSkillName | `${BladeburnerSkillName}`,
+    level: number,
+    skillPoints: number,
+  ): number;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  name | string | Skill name. It's case-sensitive and must be an exact match. |
+|  name | [BladeburnerSkillName](./bitburner.bladeburnerskillname.md) \| \`${[BladeburnerSkillName](./bitburner.bladeburnerskillname.md)<!-- -->}\` | Skill name. It's case-sensitive and must be an exact match. |
 |  level | number | Skill level. It must be a non-negative number. |
 |  skillPoints | number | Number of skill points to upgrade the skill. It must be a positive number. |
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5332,7 +5332,11 @@ interface BladeburnerFormulas {
    * @param skillPoints - Number of skill points to upgrade the skill. It must be a positive number.
    * @returns Number of times that you can upgrade the skill.
    */
-  skillMaxUpgradeCount(name: string, level: number, skillPoints: number): number;
+  skillMaxUpgradeCount(
+    name: BladeburnerSkillName | `${BladeburnerSkillName}`,
+    level: number,
+    skillPoints: number,
+  ): number;
 }
 
 /**


### PR DESCRIPTION
It's just as the title said.

Originally, I wanted to make this change in a PR that solves https://github.com/bitburner-official/bitburner-src/issues/1693. However, I don't have enough free time to find a solution for that issue right now, so I move this change to a separate PR.