### PR TITLE
DEVMENU: Reset other gangs when leaving gang

### DIFF
--- a/src/DevMenu/ui/General.tsx
+++ b/src/DevMenu/ui/General.tsx
@@ -24,6 +24,7 @@ import { GangConstants } from "../../Gang/data/Constants";
 import { checkForMessagesToSend } from "../../Message/MessageHelpers";
 import { getEnumHelper } from "../../utils/EnumHelper";
 import { formatRam } from "../../ui/formatNumber";
+import { resetGangs } from "../../Gang/AllGangs";
 
 export function General({ parentRerender }: { parentRerender: () => void }): React.ReactElement {
   const rerender = useRerender(400);
@@ -87,6 +88,7 @@ export function General({ parentRerender }: { parentRerender: () => void }): Rea
   };
   const stopGang = () => {
     Player.gang = null;
+    resetGangs();
     parentRerender();
   };
   const setGangFactionDropdown = (event: SelectChangeEvent) => {

--- a/src/Gang/AllGangs.ts
+++ b/src/Gang/AllGangs.ts
@@ -6,39 +6,8 @@ interface GangTerritory {
   territory: number;
 }
 
-export let AllGangs: Record<string, GangTerritory> = {
-  [FactionName.SlumSnakes]: {
-    power: 1,
-    territory: 1 / 7,
-  },
-  [FactionName.Tetrads]: {
-    power: 1,
-    territory: 1 / 7,
-  },
-  [FactionName.TheSyndicate]: {
-    power: 1,
-    territory: 1 / 7,
-  },
-  [FactionName.TheDarkArmy]: {
-    power: 1,
-    territory: 1 / 7,
-  },
-  [FactionName.SpeakersForTheDead]: {
-    power: 1,
-    territory: 1 / 7,
-  },
-  [FactionName.NiteSec]: {
-    power: 1,
-    territory: 1 / 7,
-  },
-  [FactionName.TheBlackHand]: {
-    power: 1,
-    territory: 1 / 7,
-  },
-};
-
-export function resetGangs(): void {
-  AllGangs = {
+function getDefaultAllGangs() {
+  return {
     [FactionName.SlumSnakes]: {
       power: 1,
       territory: 1 / 7,
@@ -68,6 +37,12 @@ export function resetGangs(): void {
       territory: 1 / 7,
     },
   };
+}
+
+export let AllGangs: Record<string, GangTerritory> = getDefaultAllGangs();
+
+export function resetGangs(): void {
+  AllGangs = getDefaultAllGangs();
 }
 
 export function loadAllGangs(saveString: string): void {


### PR DESCRIPTION
When we use the "Leave Gang" button, other gangs' data like power and territory are not reset. This PR fixes that.