### PR TITLE
API: Improve built-in print APIs when printing objects containing Map or Set

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -229,6 +229,19 @@ function spawnOptions(ctx: NetscriptContext, threadOrOption: unknown): CompleteS
   return result;
 }
 
+function mapToString(map: Map<unknown, unknown>): string {
+  const formattedMap = [...map]
+    .map((m) => {
+      return `${m[0]} => ${m[1]}`;
+    })
+    .join("; ");
+  return `< Map: ${formattedMap} >`;
+}
+
+function setToString(set: Set<unknown>): string {
+  return `< Set: ${[...set].join("; ")} >`;
+}
+
 /** Convert multiple arguments for tprint or print into a single string. */
 function argsToString(args: unknown[]): string {
   // Reduce array of args into a single output string
@@ -243,17 +256,12 @@ function argsToString(args: unknown[]): string {
 
     // Handle Map formatting, since it does not JSON stringify or toString in a helpful way
     // output is  "< Map: key1 => value1; key2 => value2 >"
-    if (nativeArg instanceof Map && [...nativeArg].length) {
-      const formattedMap = [...nativeArg]
-        .map((m) => {
-          return `${m[0]} => ${m[1]}`;
-        })
-        .join("; ");
-      return (out += `< Map: ${formattedMap} >`);
+    if (nativeArg instanceof Map) {
+      return (out += mapToString(nativeArg));
     }
     // Handle Set formatting, since it does not JSON stringify or toString in a helpful way
     if (nativeArg instanceof Set) {
-      return (out += `< Set: ${[...nativeArg].join("; ")} >`);
+      return (out += setToString(nativeArg));
     }
     if (typeof nativeArg === "object") {
       return (out += JSON.stringify(nativeArg, (_, value) => {
@@ -263,6 +271,12 @@ function argsToString(args: unknown[]): string {
          */
         if (value instanceof Promise) {
           return value.toString();
+        }
+        if (value instanceof Map) {
+          return mapToString(value);
+        }
+        if (value instanceof Set) {
+          return setToString(value);
         }
         return value;
       }));


### PR DESCRIPTION
This PR implements a change mentioned by d0sboots at https://github.com/bitburner-official/bitburner-src/pull/1710#issuecomment-2428142280.

I also made a small behavior change. Current code prints an empty string if the player passes an empty map, but it still prints `< Set:  >` if the player passes an empty Set. I removed the check `&& [...nativeArg].length`, so it will print `< Map:  >` now.