### PR TITLE
UI: Disable font ligatures by default

### DIFF
--- a/src/GameOptions/ui/InterfacePage.tsx
+++ b/src/GameOptions/ui/InterfacePage.tsx
@@ -18,7 +18,7 @@ export const InterfacePage = (): React.ReactElement => {
         checked={Settings.DisableASCIIArt}
         onChange={(newValue) => (Settings.DisableASCIIArt = newValue)}
         text="Disable ascii art"
-        tooltip={<>If this is set all ASCII art will be disabled.</>}
+        tooltip={<>If this is set, all ASCII arts will be disabled.</>}
       />
       <OptionSwitch
         checked={Settings.DisableTextEffects}
@@ -35,13 +35,19 @@ export const InterfacePage = (): React.ReactElement => {
         checked={Settings.DisableOverviewProgressBars}
         onChange={(newValue) => (Settings.DisableOverviewProgressBars = newValue)}
         text="Disable Overview Progress Bars"
-        tooltip={<>If this is set, the progress bars in the character overview will be hidden.</>}
+        tooltip={<>If this is set, progress bars in the character overview will be hidden.</>}
       />
       <OptionSwitch
         checked={Settings.ShowMiddleNullTimeUnit}
         onChange={(newValue) => (Settings.ShowMiddleNullTimeUnit = newValue)}
-        text="Show all intermediary times unit, even when null."
-        tooltip={<>ex : 1 hours 13 seconds becomes 1 hours 0 minutes 13 seconds.</>}
+        text="Show all intermediary time units, even when null."
+        tooltip={<>Example: 1 hour 13 seconds becomes 1 hour 0 minutes 13 seconds.</>}
+      />
+      <OptionSwitch
+        checked={Settings.FontLigatures}
+        onChange={(newValue) => (Settings.FontLigatures = newValue)}
+        text="Use font ligatures"
+        tooltip={<>If this is set, the main UI will use font ligatures.</>}
       />
       <Tooltip
         title={

--- a/src/GameOptions/ui/InterfacePage.tsx
+++ b/src/GameOptions/ui/InterfacePage.tsx
@@ -43,12 +43,6 @@ export const InterfacePage = (): React.ReactElement => {
         text="Show all intermediary time units, even when null."
         tooltip={<>Example: 1 hour 13 seconds becomes 1 hour 0 minutes 13 seconds.</>}
       />
-      <OptionSwitch
-        checked={Settings.FontLigatures}
-        onChange={(newValue) => (Settings.FontLigatures = newValue)}
-        text="Use font ligatures"
-        tooltip={<>If this is set, the main UI will use font ligatures.</>}
-      />
       <Tooltip
         title={
           <Typography>

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -137,7 +137,7 @@ export const Settings = {
   MonacoFontFamily: "JetBrainsMono",
   /** Text size for script editor. */
   MonacoFontSize: 20,
-  /** Whether to use font ligatures */
+  /** Whether to use font ligatures in the script editor */
   MonacoFontLigatures: false,
   /** Whether to use Vim mod by default in the script editor */
   MonacoDefaultToVim: false,
@@ -155,6 +155,8 @@ export const Settings = {
   useEngineeringNotation: false,
   /** Whether to disable suffixes and always use exponential form (scientific or engineering). */
   disableSuffixes: false,
+  /** Whether to use font ligatures in the main UI */
+  FontLigatures: false,
 
   load(saveString: string) {
     const save = JSON.parse(saveString);

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -155,8 +155,6 @@ export const Settings = {
   useEngineeringNotation: false,
   /** Whether to disable suffixes and always use exponential form (scientific or engineering). */
   disableSuffixes: false,
-  /** Whether to use font ligatures in the main UI */
-  FontLigatures: false,
 
   load(saveString: string) {
     const save = JSON.parse(saveString);

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -204,6 +204,8 @@ export function GameRoot(): React.ReactElement {
     Router.toPage(Page.Terminal);
   }
 
+  document.body.style.fontVariantLigatures = Settings.FontLigatures ? "normal" : "none";
+
   let mainPage = <Typography>Cannot load</Typography>;
   let withSidebar = true;
   const hidePopups = Router.hidingMessages();

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -204,8 +204,6 @@ export function GameRoot(): React.ReactElement {
     Router.toPage(Page.Terminal);
   }
 
-  document.body.style.fontVariantLigatures = Settings.FontLigatures ? "normal" : "none";
-
   let mainPage = <Typography>Cannot load</Typography>;
   let withSidebar = true;
   const hidePopups = Router.hidingMessages();

--- a/src/ui/LoadingScreen.tsx
+++ b/src/ui/LoadingScreen.tsx
@@ -24,6 +24,8 @@ export function LoadingScreen(): React.ReactElement {
     document.title = `Bitburner ${version}`;
   }
 
+  document.body.style.fontVariantLigatures = "none";
+
   useEffect(() => {
     const id = setTimeout(() => {
       if (!loaded) setShow(true);


### PR DESCRIPTION
Using font ligatures may confuse the player:
- Ligatures may not be what they want. For example: `| >` will look like a triangle.
- The progress bar looks weird when it's near 100%.

This PR disables font ligatures by default. If the player wants to use that "feature", they can enable it in the Options page.

Example code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tprint("|>");
  ns.tprint("|||||-");
}
```

Before:
![before](https://github.com/user-attachments/assets/ea32c0d2-2289-4110-9fee-b715576fad78)

After:
![after](https://github.com/user-attachments/assets/7b8e998a-dd5a-4de0-82e4-d35fa05b8735)
