### PR TITLE
MISC: Update blood donation

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -102,7 +102,7 @@ export const CONSTANTS = {
   EntropyEffect: 0.98,
 
   // Number of blood, plasma, or platelet donations the developer has verified. Boosts NFG.
-  Donations: 151,
+  Donations: 179,
 
   // Only use this if a backdoor is installed in the company's server
   CompanyRequiredReputationMultiplier: 0.75,

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -450,7 +450,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
     "lastSave": 0,
     "lastUpdate": 1687611703623,
     "location": "Travel Agency",
-    "money": 1151,
+    "money": 1179,
     "moneySourceA": {
       "ctor": "MoneySourceTracker",
       "data": {


### PR DESCRIPTION
hydroflame made this change in #1655, but that PR needs to update the Jest snapshot. hydroflame is not active anymore, so that PR may be stuck for a long time. This PR just makes the same change.