### PR TITLE
MISC: Remove or change popup shown when system clock moved backward

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -63,15 +63,6 @@ declare global {
   };
 }
 
-// Only show warning if the time diff is greater than this value.
-const thresholdOfTimeDiffForShowingWarningAboutSystemClock = CONSTANTS.MillisecondsPerFiveMinutes;
-
-function showWarningAboutSystemClock(timeDiff: number) {
-  AlertEvents.emit(
-    `Warning: The system clock moved backward: ${convertTimeMsToTimeElapsedString(Math.abs(timeDiff))}.`,
-  );
-}
-
 export const GameCycleEvents = new EventEmitter<[]>();
 
 /** Game engine. Handles the main game loop. */
@@ -274,12 +265,6 @@ const Engine: {
       const lastUpdate = Player.lastUpdate;
       let timeOffline = Engine._lastUpdate - lastUpdate;
       if (timeOffline < 0) {
-        if (Math.abs(timeOffline) > thresholdOfTimeDiffForShowingWarningAboutSystemClock) {
-          const timeDiff = timeOffline;
-          setTimeout(() => {
-            showWarningAboutSystemClock(timeDiff);
-          }, 250);
-        }
         timeOffline = 0;
       }
       const numCyclesOffline = Math.floor(timeOffline / CONSTANTS.MilliPerCycle);
@@ -430,9 +415,6 @@ const Engine: {
     const _thisUpdate = new Date().getTime();
     let diff = _thisUpdate - Engine._lastUpdate;
     if (diff < 0) {
-      if (Math.abs(diff) > thresholdOfTimeDiffForShowingWarningAboutSystemClock) {
-        showWarningAboutSystemClock(diff);
-      }
       diff = 0;
       Engine._lastUpdate = _thisUpdate;
       Player.lastUpdate = _thisUpdate;


### PR DESCRIPTION
When we detect that the system clock moved backward, we will show a popup warning the player. After this change, we have received some reports from players asking what it means. In the dev branch, the threshold was changed to 5 minutes to make it less sensitive to NTP. When I look at this change again, I wonder if it's a useful feature or just a new source of confusion for players.
- Some (or many) players do not know why the system clock matters and why it may be changed without their notice.
- When we receive reports like that, there is nothing that we can do. The problem is simple; it's exactly what the popup says: the system clock moved backward. However, there is no way for us to "fix" that. It's the problem with the player's machine. In edge cases, if they modify Date's prototype or do other unexpected things, this popup can still be shown.

IMO, this warning popup does not help the player at all. It tells something that many players do not comprehend. Even if they understand what happened, there are not many things that they (or we) can do. Those reports just become unsolvable problems. It's very likely that it's just a problem with their machines, but it's hard to tell them, "That's your problem, not ours.".

Based on what I saw on Discord after I posted this suggestion:
- The popup is not helpful.
- Alternative option: change from a popup to a toast.

I'll change it to a toast if the maintainer wants.

Closes #1738.