### PR TITLE
BLADEBURNER: Change skill.canUpgrade and Skills UI

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -153,21 +153,17 @@ export class Bladeburner implements OperationTeam {
   /** Attempts to perform a skill upgrade, gives a message on both success and failure */
   upgradeSkill(skillName: BladeburnerSkillName, count = 1): Attempt<{ message: string }> {
     const currentSkillLevel = this.skills[skillName] ?? 0;
-    const actualCount = currentSkillLevel + count - currentSkillLevel;
-    if (actualCount === 0) {
-      return {
-        message: `Cannot upgrade ${skillName}: Due to floating-point inaccuracy and the small value of specified "count", your skill cannot be upgraded.`,
-      };
-    }
-    const availability = Skills[skillName].canUpgrade(this, actualCount);
+    const availability = Skills[skillName].canUpgrade(this, count);
     if (!availability.available) {
       return { message: `Cannot upgrade ${skillName}: ${availability.error}` };
     }
     this.skillPoints -= availability.cost;
-    this.setSkillLevel(skillName, currentSkillLevel + actualCount);
+    this.setSkillLevel(skillName, currentSkillLevel + availability.actualCount);
     return {
       success: true,
-      message: `Upgraded skill ${skillName} by ${actualCount} level${actualCount > 1 ? "s" : ""}`,
+      message: `Upgraded skill ${skillName} by ${availability.actualCount} level${
+        availability.actualCount > 1 ? "s" : ""
+      }`,
     };
   }
 

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -135,19 +135,25 @@ export class Skill {
     return result - 1;
   }
 
-  canUpgrade(bladeburner: Bladeburner, count = 1): Availability<{ cost: number }> {
+  canUpgrade(bladeburner: Bladeburner, count = 1): Availability<{ actualCount: number; cost: number }> {
     const currentLevel = bladeburner.skills[this.name] ?? 0;
-    if (!isPositiveInteger(count)) {
-      return { error: `Invalid upgrade count ${count}` };
+    const actualCount = currentLevel + count - currentLevel;
+    if (actualCount === 0) {
+      return {
+        error: `Cannot upgrade ${this.name}: Due to floating-point inaccuracy and the small value of specified "count", your skill cannot be upgraded.`,
+      };
     }
-    if (currentLevel + count > this.maxLvl) {
-      return { error: `Upgraded level ${currentLevel + count} exceeds max` };
+    if (!isPositiveInteger(actualCount)) {
+      return { error: `Invalid upgrade count ${actualCount}` };
     }
-    const cost = this.calculateCost(currentLevel, count);
+    if (currentLevel + actualCount > this.maxLvl) {
+      return { error: `Upgraded level ${currentLevel + actualCount} exceeds max` };
+    }
+    const cost = this.calculateCost(currentLevel, actualCount);
     if (cost > bladeburner.skillPoints) {
       return { error: `Insufficient skill points for upgrade` };
     }
-    return { available: true, cost };
+    return { available: true, actualCount, cost };
   }
 
   getMultiplier(name: BladeburnerMultName): number {

--- a/src/Bladeburner/ui/SkillElem.tsx
+++ b/src/Bladeburner/ui/SkillElem.tsx
@@ -18,8 +18,14 @@ export function SkillElem({ skill, bladeburner, onUpgrade }: SkillElemProps): Re
   const skillName = skill.name;
   const skillLevel = bladeburner.getSkillLevel(skillName);
   const pointCost = useMemo(() => skill.calculateCost(skillLevel), [skill, skillLevel]);
-
-  const canLevel = bladeburner.skillPoints >= pointCost;
+  // No need to support "+1" button when the skill level reaches Number.MAX_SAFE_INTEGER.
+  const isSupported = skillLevel < Number.MAX_SAFE_INTEGER;
+  // Use skill.canUpgrade() instead of reimplementing all conditional checks.
+  const canLevel = isSupported ? skill.canUpgrade(bladeburner, 1).available ?? false : false;
+  /**
+   * maxLvl is only useful when we check if we should show "MAX LEVEL". For the check of the icon button, we don't need
+   * it. This condition is checked in skill.canUpgrade().
+   */
   const maxLvl = skill.maxLvl ? skillLevel >= skill.maxLvl : false;
 
   function onClick(): void {
@@ -31,7 +37,7 @@ export function SkillElem({ skill, bladeburner, onUpgrade }: SkillElemProps): Re
     <Paper sx={{ my: 1, p: 1 }}>
       <Box display="flex" flexDirection="row" alignItems="center">
         <CopyableText variant="h6" color="primary" value={skillName} />
-        {!canLevel || maxLvl ? (
+        {!canLevel ? (
           <IconButton disabled>
             <CloseIcon />
           </IconButton>
@@ -45,7 +51,7 @@ export function SkillElem({ skill, bladeburner, onUpgrade }: SkillElemProps): Re
       {maxLvl ? (
         <Typography>MAX LEVEL</Typography>
       ) : (
-        <Typography>Skill Points required: {formatBigNumber(pointCost)}</Typography>
+        <Typography>Skill Points required: {isSupported ? formatBigNumber(pointCost) : "N/A"}</Typography>
       )}
       <Typography>{skill.desc}</Typography>
     </Paper>


### PR DESCRIPTION
This PR implements changes discussed on Discord:
- Move the check of `actualCount` to `canUpgrade`.
- Disable "+1 button" when the skill level reaches `Number.MAX_SAFE_INTEGER`.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  Player.bladeburner.skillPoints = 1e300;
  Player.bladeburner.skills.Hyperdrive = 0;
  ns.bladeburner.upgradeSkill("Hyperdrive", 1); // OK
  Player.bladeburner.skills.Hyperdrive = 1e100;
  ns.bladeburner.upgradeSkill("Hyperdrive", 1); // Error
  Player.bladeburner.skills.Overclock = 0;
  ns.bladeburner.upgradeSkill("Overclock", 90); // OK
  ns.bladeburner.upgradeSkill("Overclock", 1); // Error
}
```

Screenshot:
![Capture](https://github.com/user-attachments/assets/54e6c2a6-71de-4026-a130-d583cd98cb1b)
