### PR TITLE
BLADEBURNER: Remove duplicate getRecruitmentSuccessChance

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -705,10 +705,6 @@ export class Bladeburner implements OperationTeam {
     return charismaEff;
   }
 
-  getRecruitmentSuccessChance(person: Person): number {
-    return Math.pow(person.skills.charisma, 0.45) / (this.teamSize - this.sleeveSize + 1);
-  }
-
   sleeveSupport(joining: boolean): void {
     if (joining) {
       this.sleeveSize += 1;

--- a/src/Bladeburner/ui/GeneralActionElem.tsx
+++ b/src/Bladeburner/ui/GeneralActionElem.tsx
@@ -8,6 +8,8 @@ import { Player } from "@player";
 import { Paper, Typography } from "@mui/material";
 import { useRerender } from "../../ui/React/hooks";
 import { ActionHeader } from "./ActionHeader";
+import { BladeburnerGeneralActionName } from "@enums";
+import { clampNumber } from "../../utils/helpers/clampNumber";
 
 interface GeneralActionElemProps {
   bladeburner: Bladeburner;
@@ -17,8 +19,6 @@ interface GeneralActionElemProps {
 export function GeneralActionElem({ bladeburner, action }: GeneralActionElemProps): React.ReactElement {
   const rerender = useRerender();
   const actionTime = action.getActionTime(bladeburner, Player);
-  const successChance =
-    action.name === "Recruitment" ? Math.max(0, Math.min(bladeburner.getRecruitmentSuccessChance(Player), 1)) : -1;
 
   return (
     <Paper sx={{ my: 1, p: 1 }}>
@@ -28,10 +28,11 @@ export function GeneralActionElem({ bladeburner, action }: GeneralActionElemProp
       <br />
       <Typography>
         Time Required: {convertTimeMsToTimeElapsedString(actionTime * 1000)}
-        {successChance !== -1 && (
+        {action.name === BladeburnerGeneralActionName.Recruitment && (
           <>
             <br />
-            Estimated success chance: {formatNumberNoSuffix(successChance * 100, 1)}%
+            Estimated success chance:{" "}
+            {formatNumberNoSuffix(clampNumber(action.getSuccessChance(bladeburner, Player), 0, 1) * 100, 1)}%
           </>
         )}
       </Typography>


### PR DESCRIPTION
Code in `getRecruitmentSuccessChance` is duplicate of code in `GeneralActions.ts`: https://github.com/bitburner-official/bitburner-src/blob/f7ee3a340f90f468dc5c53c9f2a5b5b58edc2d8b/src/Bladeburner/data/GeneralActions.ts#L30

I tested the change on the UI.
