### PR TITLE
BLADEBURNER: Change sleeveSize from property to getter

### DIFF
--- a/src/Bladeburner/Actions/TeamCasualties.ts
+++ b/src/Bladeburner/Actions/TeamCasualties.ts
@@ -24,7 +24,7 @@ export interface TeamActionWithCasualties {
 /**
  * Some actions (Operations and Black Operations) use teams for success bonus
  * and may result in casualties, reducing the player's hp, killing team members
- * and killing sleeves (to shock them, sleeves are immortal) *
+ * and killing sleeves (to shock them, sleeves are immortal)
  */
 export function resolveTeamCasualties(action: TeamActionWithCasualties, team: OperationTeam, success: boolean): number {
   if (action.teamCount <= 0) {

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -64,7 +64,9 @@ export class Bladeburner implements OperationTeam {
   totalSkillPoints = 0;
 
   teamSize = 0;
-  sleeveSize = 0;
+  get sleeveSize() {
+    return Player.sleevesSupportingBladeburner().length;
+  }
   teamLost = 0;
 
   storedCycles = 0;
@@ -711,10 +713,8 @@ export class Bladeburner implements OperationTeam {
 
   sleeveSupport(joining: boolean): void {
     if (joining) {
-      this.sleeveSize += 1;
       this.teamSize += 1;
     } else {
-      this.sleeveSize -= 1;
       this.teamSize -= 1;
     }
   }

--- a/src/PersonObjects/Sleeve/Work/SleeveSupportWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveSupportWork.ts
@@ -12,9 +12,7 @@ export class SleeveSupportWork extends SleeveWorkClass {
     Player.bladeburner?.sleeveSupport(true);
   }
 
-  process() {
-    return;
-  }
+  process(): void {}
 
   finish(): void {
     Player.bladeburner?.sleeveSupport(false);

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -274,7 +274,6 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
         "rank": 2000,
         "skillPoints": 666,
         "skills": {},
-        "sleeveSize": 0,
         "stamina": 1,
         "staminaBonus": 0,
         "storedCycles": 0,


### PR DESCRIPTION
I have seen at least 3 reports about weird bugs in Bladeburner. All of them are caused by wrong `sleeveSize`.

`sleeveSize` is the number of Sleeves doing `SleeveSupportWork`. It's used in 2 places:
- `resolveTeamCasualties`: Only run when the action is complete.
- `getSuccessChance` of Recruitment action.

When a sleeve is assigned this task, `sleeveSize` is increased by 1. When that sleeve is assigned another task, `sleeveSize` is decreased by 1. At any moment, `sleeveSize` is just `Player.sleevesSupportingBladeburner().length`. In those reports, `sleeveSize` value is always wrong. There is even a report with 2-digit `sleeveSize`.

I have not found the root cause of this bug. When it happens, the player usually cannot recruit team members anymore. This PR mitigates this problem by calculating `sleeveSize` when it's needed. Reasons:
- This bug is subtle. I'm not sure when we can fix it.
- After we fix it, we still need to add code to recalculate `sleeveSize` after loading to fix the potentially wrong save data.
- I don't know why this variable was added in the past. Maybe it was added to avoid checking `Player.sleeves` every time it was used. IMO, the performance gain is within margin error.

How to test:
- Load the attached save file from Discord.
- Check the success chance of Recruitment. It's 0% without this change. With this change, it's 100%.

Attached save file:
[bitburnerSave_1730536908_BN10x3.json.gz](https://github.com/user-attachments/files/17607471/bitburnerSave_1730536908_BN10x3.json.gz)
