### PR TITLE
MISC: Include React component stack in Recovery Mode report

### DIFF
--- a/src/utils/ErrorHelper.ts
+++ b/src/utils/ErrorHelper.ts
@@ -85,7 +85,7 @@ export function getErrorMetadata(error: unknown, errorInfo?: React.ErrorInfo, pa
 
 export function getErrorForDisplay(error: unknown, errorInfo?: React.ErrorInfo, page?: Page): IErrorData {
   const metadata = getErrorMetadata(error, errorInfo, page);
-  const fileName = (metadata.error as any).fileName;
+  const fileName = String(metadata.error.fileName);
   const features =
     `lang=${metadata.features.language} cookiesEnabled=${metadata.features.cookiesEnabled.toString()}` +
     ` doNotTrack=${metadata.features.doNotTrack ?? "null"} indexedDb=${metadata.features.indexedDb.toString()}`;
@@ -104,7 +104,7 @@ Please fill this information with details if relevant.
 
 ### Environment
 
-* Error: ${metadata.error.toString() ?? "n/a"}
+* Error: ${String(metadata.error) ?? "n/a"}
 * Page: ${metadata.page ?? "n/a"}
 * Version: ${metadata.version.toDisplay()}
 * Environment: ${GameEnv[metadata.environment]}
@@ -116,6 +116,11 @@ Please fill this information with details if relevant.
 ### Stack Trace
 \`\`\`
 ${metadata.error.stack}
+\`\`\`
+
+### React Component Stack
+\`\`\`
+${metadata.errorInfo?.componentStack}
 \`\`\`
 
 ### Save


### PR DESCRIPTION
This component stack may not be useful in most cases, but having it in the report is harmless.

I use `String(metadata.error)` to suppress the false-positive `no-base-to-string` lint error. `metadata.error` is an instance of Error in most cases, but we specify the type as `Record<string, unknown>` for reasons that I don't know of.