### PR TITLE
GANG: Show confirmation popup if player enables territory clashes while being too weak

### DIFF
--- a/src/Gang/AllGangs.ts
+++ b/src/Gang/AllGangs.ts
@@ -48,3 +48,9 @@ export function resetGangs(): void {
 export function loadAllGangs(saveString: string): void {
   AllGangs = JSON.parse(saveString, Reviver);
 }
+
+export function getClashWinChance(thisGang: string, otherGang: string): number {
+  const thisGangPower = AllGangs[thisGang].power;
+  const otherGangPower = AllGangs[otherGang].power;
+  return thisGangPower / (thisGangPower + otherGangPower);
+}

--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -18,7 +18,7 @@ import { GangConstants } from "./data/Constants";
 import { GangMemberTasks } from "./GangMemberTasks";
 import { IAscensionResult } from "./IAscensionResult";
 
-import { AllGangs } from "./AllGangs";
+import { AllGangs, getClashWinChance } from "./AllGangs";
 import { GangMember } from "./GangMember";
 
 import { WorkerScript } from "../Netscript/WorkerScript";
@@ -236,11 +236,7 @@ export class Gang {
           if (!(Math.random() < this.territoryClashChance)) continue;
         }
 
-        const thisPwr = AllGangs[thisGang].power;
-        const otherPwr = AllGangs[otherGang].power;
-        const thisChance = thisPwr / (thisPwr + otherPwr);
-
-        if (Math.random() < thisChance) {
+        if (Math.random() < getClashWinChance(thisGang, otherGang)) {
           if (AllGangs[otherGang].territory <= 0) return;
           const territoryGain = calculateTerritoryGain(thisGang, otherGang);
           AllGangs[thisGang].territory += territoryGain;

--- a/src/Gang/ui/TerritorySubpage.tsx
+++ b/src/Gang/ui/TerritorySubpage.tsx
@@ -5,10 +5,11 @@ import { Help } from "@mui/icons-material";
 
 import { formatNumberNoSuffix, formatPercent } from "../../ui/formatNumber";
 
-import { AllGangs } from "../AllGangs";
+import { AllGangs, getClashWinChance } from "../AllGangs";
 
 import { useGang } from "./Context";
 import { TerritoryInfoModal } from "./TerritoryInfoModal";
+import { PromptEvent } from "../../ui/React/PromptManager";
 
 /** React Component for the territory subpage. */
 export function TerritorySubpage(): React.ReactElement {
@@ -37,7 +38,34 @@ export function TerritorySubpage(): React.ReactElement {
           control={
             <Switch
               checked={gang.territoryWarfareEngaged}
-              onChange={(event) => (gang.territoryWarfareEngaged = event.target.checked)}
+              onChange={(event) => {
+                let canWinAtLeastOneGang = false;
+                for (const gangName of Object.keys(AllGangs)) {
+                  if (gang.facName === gangName) {
+                    continue;
+                  }
+                  if (getClashWinChance(gang.facName, gangName) >= 0.5) {
+                    canWinAtLeastOneGang = true;
+                    break;
+                  }
+                }
+                /**
+                 * Show a confirmation popup if the player tries to enable the territory clash when their gang is too 
+                 * weak and cannot win any other gangs.
+                 */
+                if (event.target.checked && !canWinAtLeastOneGang) {
+                  PromptEvent.emit({
+                    txt: "Your gang is too weak. Its win chances against all other gangs are below 50%.\nOn average, you will always lose territory when being engaged in clashes.\n\nDo you really want to engage in territory clashes?",
+                    resolve: (value: string | boolean) => {
+                      if (value === true) {
+                        gang.territoryWarfareEngaged = true;
+                      }
+                    },
+                  });
+                } else {
+                  gang.territoryWarfareEngaged = event.target.checked;
+                }
+              }}
             />
           }
           label={
@@ -114,20 +142,17 @@ interface ITerritoryProps {
 
 function OtherGangTerritory(props: ITerritoryProps): React.ReactElement {
   const gang = useGang();
-  const playerPower = AllGangs[gang.facName].power;
-  const power = AllGangs[props.name].power;
-  const clashVictoryChance = playerPower / (power + playerPower);
   const territory = AllGangs[props.name].territory;
-  const opacity = territory ? 1 : 0.75;
+  const opacity = (territory > 0) ? 1 : 0.75;
   return (
     <Box component={Paper} sx={{ p: 1, opacity }}>
       <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
         {props.name}
       </Typography>
       <Typography>
-        <b>Power:</b> {formatNumberNoSuffix(power, 3)} <br />
+        <b>Power:</b> {formatNumberNoSuffix(AllGangs[props.name].power, 3)} <br />
         <b>Territory:</b> {formatTerritory(territory)}% <br />
-        <b>Clash Win Chance:</b> {formatPercent(clashVictoryChance, 3)}
+        <b>Clash Win Chance:</b> {formatPercent(getClashWinChance(gang.facName, props.name), 3)}
       </Typography>
     </Box>
   );

--- a/src/Gang/ui/TerritorySubpage.tsx
+++ b/src/Gang/ui/TerritorySubpage.tsx
@@ -50,7 +50,7 @@ export function TerritorySubpage(): React.ReactElement {
                   }
                 }
                 /**
-                 * Show a confirmation popup if the player tries to enable the territory clash when their gang is too 
+                 * Show a confirmation popup if the player tries to enable the territory clash when their gang is too
                  * weak and cannot win any other gangs.
                  */
                 if (event.target.checked && !canWinAtLeastOneGang) {
@@ -143,7 +143,7 @@ interface ITerritoryProps {
 function OtherGangTerritory(props: ITerritoryProps): React.ReactElement {
   const gang = useGang();
   const territory = AllGangs[props.name].territory;
-  const opacity = (territory > 0) ? 1 : 0.75;
+  const opacity = territory > 0 ? 1 : 0.75;
   return (
     <Box component={Paper} sx={{ p: 1, opacity }}>
       <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>


### PR DESCRIPTION
In the past, the player could enable territory clashes in the main page of Gang UI (Management tab). We removed that toggle, so now the toggle is only on the Territory tab.

I accidentally stumbled on the old (heated) discussion about this change. I agree that having that toggle on the main page is a newbie trap. After reading the whole discussion, I want to implement the second point of Snarling's idea in this comment: https://discord.com/channels/415207508303544321/459097632896188436/1149047761044512799.

Quote:
> Warning dialog? I think it would be a huge improvement to implement a conditional warning dialog for enabling territory warfare if the player has less than a 50% chance to win clashes. Attempting to enable while you have a <50% chance of winning is a pretty good indicator that the player does not know what they're doing and are about to ruin their gang. If they have a >=50% chance to win clashes, no reason to show a dialog because the player seems to know what they are doing. Simple dialog like "You are about to enable Territory Warfare, but you only have a 42% chance to win Territory Clashes, are you sure? Y/N". I don't think the cooldown where clash chance slowly falls back down to 0% is the important thing to highlight here, since that's not what makes enabling warfare a bad decision.

Screenshot:
![Capture](https://github.com/user-attachments/assets/5173f84a-393a-4447-9879-c6ef0c18129d)
