### PR TITLE
DOCUMENTATION: Add more information for deprecated nFormat API

### DIFF
--- a/markdown/bitburner.ns.hackanalyzethreads.md
+++ b/markdown/bitburner.ns.hackanalyzethreads.md
@@ -29,7 +29,7 @@ The number of threads needed to hack the server for hackAmount money.
 
 RAM cost: 1 GB
 
-This function returns the decimal number of script threads you need when running the hack command to steal the specified amount of money from the target server. If hackAmount is less than zero or greater than the amount of money available on the server, then this function returns -1.
+This function returns the decimal number of script threads you need when running the hack command to steal the specified amount of money from the target server. If hackAmount is less than zero, greater than the amount of money available on the server, or your hacking level is below the required level for the target server, then this function returns -1.
 
 ## Example
 

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -134,7 +134,7 @@ export async function main(ns) {
 |  [moveTail(x, y, pid)](./bitburner.ns.movetail.md) | Move a tail window. |
 |  [mv(host, source, destination)](./bitburner.ns.mv.md) | Move a file on the target server. |
 |  [nextPortWrite(port)](./bitburner.ns.nextportwrite.md) | Listen for a port write. |
-|  [nFormat(n, format)](./bitburner.ns.nformat.md) | Format a number using the numeral library. This function is deprecated and will be removed in 2.4. |
+|  [nFormat(n, format)](./bitburner.ns.nformat.md) | Format a number using the numeral library. This function is deprecated and will be removed in a later version. |
 |  [nuke(host)](./bitburner.ns.nuke.md) | Runs NUKE.exe on a server. |
 |  [peek(portNumber)](./bitburner.ns.peek.md) | Get a copy of the data from a port without popping it. |
 |  [print(args)](./bitburner.ns.print.md) | Prints one or more values or variables to the script’s logs. |

--- a/markdown/bitburner.ns.nformat.md
+++ b/markdown/bitburner.ns.nformat.md
@@ -6,10 +6,14 @@
 
 > Warning: This API is now obsolete.
 > 
-> Use ns.formatNumber, formatRam, or formatPercent instead. Will be removed in 2.4.
+> Use alternatives:
+> 
+> - NS APIs: ns.formatNumber, ns.formatRam, ns.formatPercent
+> 
+> - JS built-in objects/functions: Intl.NumberFormat, Intl.PluralRules, Intl.Locale, etc.
 > 
 
-Format a number using the numeral library. This function is deprecated and will be removed in 2.4.
+Format a number using the numeral library. This function is deprecated and will be removed in a later version.
 
 **Signature:**
 
@@ -35,6 +39,4 @@ Formatted number.
 RAM cost: 0 GB
 
 Converts a number into a string with the specified format options. See http://numeraljs.com/\#format for documentation on format strings supported.
-
-This function is deprecated and will be removed in 2.3.
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1635,7 +1635,8 @@ export const ns: InternalAPI<NSFull> = {
   nFormat: (ctx) => (_n, _format) => {
     deprecationWarning(
       "ns.nFormat",
-      "Use ns.formatNumber, formatRam, formatPercent, or js builtins like Intl.NumberFormat instead.",
+      "Use ns.formatNumber, ns.formatRam, ns.formatPercent, or JS built-in objects/functions (e.g., Intl namespace) instead. " +
+        "Check the NS API documentation for details.",
     );
     const n = helpers.number(ctx, "n", _n);
     const format = helpers.string(ctx, "format", _format);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7637,15 +7637,21 @@ export interface NS {
   formatPercent(n: number, fractionalDigits?: number, suffixStart?: number): string;
 
   /**
-   * Format a number using the numeral library. This function is deprecated and will be removed in 2.4.
-   * @deprecated Use ns.formatNumber, formatRam, or formatPercent instead. Will be removed in 2.4.
+   * Format a number using the numeral library. This function is deprecated and will be removed in a later version.
+   *
+   * @deprecated
+   *
+   * Use alternatives:
+   *
+   * - NS APIs: ns.formatNumber, ns.formatRam, ns.formatPercent
+   *
+   * - JS built-in objects/functions: Intl.NumberFormat, Intl.PluralRules, Intl.Locale, etc.
+   *
    * @remarks
    * RAM cost: 0 GB
    *
    * Converts a number into a string with the specified format options.
    * See http://numeraljs.com/#format for documentation on format strings supported.
-   *
-   * This function is deprecated and will be removed in 2.3.
    *
    * @param n - Number to format.
    * @param format - Formatting options. See http://numeraljs.com/#format for valid formats.


### PR DESCRIPTION
A player asked how to format the ordinal indicator without using the deprecated `nFormat`. After answering that question, I decide to add more information about alternatives for that API using the Intl namespace.

Closes #1759.