### PR TITLE
GANG: Show error popup when there are errors

### DIFF
--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -97,9 +97,6 @@ export class Gang {
 
   /** Main process function called by the engine loop every game cycle */
   process(numCycles = 1): void {
-    if (isNaN(numCycles)) {
-      console.error(`NaN passed into Gang.process(): ${numCycles}`);
-    }
     this.storedCycles += numCycles;
     if (this.storedCycles < GangConstants.minCyclesToProcess) return;
 
@@ -112,7 +109,7 @@ export class Gang {
       this.processTerritoryAndPowerGains(cycles);
       this.storedCycles -= cycles;
     } catch (e: unknown) {
-      console.error("Exception caught when processing Gang", e);
+      exceptionAlert(e);
     }
 
     // Handle "nextUpdate" resolver after this update

--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -109,7 +109,7 @@ export class Gang {
       this.processTerritoryAndPowerGains(cycles);
       this.storedCycles -= cycles;
     } catch (e: unknown) {
-      exceptionAlert(e);
+      exceptionAlert(e, true);
     }
 
     // Handle "nextUpdate" resolver after this update

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -170,7 +170,10 @@ const Engine: {
 
   decrementAllCounters: function (numCycles = 1) {
     for (const [counterName, counter] of Object.entries(Engine.Counters)) {
-      if (counter === undefined) throw new Error("counter should not be undefined");
+      if (counter === undefined) {
+        exceptionAlert(new Error(`counter value is undefined. counterName: ${counterName}.`), true);
+        continue;
+      }
       Engine.Counters[counterName] = counter - numCycles;
     }
   },
@@ -207,7 +210,7 @@ const Engine: {
         try {
           Player.bladeburner.process();
         } catch (e) {
-          exceptionAlert(e);
+          exceptionAlert(e, true);
         }
       }
       Engine.Counters.mechanicProcess = 5;

--- a/src/utils/helpers/exceptionAlert.tsx
+++ b/src/utils/helpers/exceptionAlert.tsx
@@ -2,19 +2,43 @@ import React from "react";
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import Typography from "@mui/material/Typography";
 import { getErrorMetadata } from "../ErrorHelper";
+import { cyrb53 } from "../StringHelperFunctions";
 
-export function exceptionAlert(e: unknown): void {
-  console.error(e);
-  const errorMetadata = getErrorMetadata(e);
+const errorSet = new Set<string>();
+
+/**
+ * Show the error in a popup:
+ * - Indicate that this is a bug and should be reported to developers.
+ * - Automatically include debug information (e.g., stack trace, commit id, user agent).
+ *
+ * @param error Error
+ * @param showOnlyOnce Set to true if you want to show the error only once, even when it happens many times. Default: false.
+ * @returns
+ */
+export function exceptionAlert(error: unknown, showOnlyOnce = false): void {
+  console.error(error);
+  const errorAsString = String(error);
+  const errorStackTrace = error instanceof Error ? error.stack : undefined;
+  if (showOnlyOnce) {
+    // Calculate the "id" of the error.
+    const errorId = cyrb53(errorAsString + errorStackTrace);
+    // Check if we showed it
+    if (errorSet.has(errorId)) {
+      return;
+    } else {
+      errorSet.add(errorId);
+    }
+  }
+  const errorMetadata = getErrorMetadata(error);
 
   dialogBoxCreate(
     <>
-      Caught an exception: {String(e)}
+      Caught an exception: {errorAsString}
       <br />
       <br />
-      {e instanceof Error && (
+      {errorStackTrace && (
         <Typography component="div" style={{ whiteSpace: "pre-wrap" }}>
-          Stack: {e.stack?.toString()}
+          Stack: {errorStackTrace}
         </Typography>
       )}
       Commit: {errorMetadata.version.commitHash}


### PR DESCRIPTION
This PR makes 2 changes:
- Remove the useless check `isNaN(numCycles)`:
  - `process` is only called from `src\engine.tsx`. I checked its callers. `numCycles` cannot be invalid.
  - If `numCycles` is invalid, that check only prints to the console without doing anything else. It's useless anyway.
- When there are errors while processing gang data, show an error popup instead of printing to the console.