### PR TITLE
UI: Change order of information in stats progress bar

### DIFF
--- a/src/ui/React/StatsProgressBar.tsx
+++ b/src/ui/React/StatsProgressBar.tsx
@@ -30,10 +30,10 @@ export function StatsProgressBar({
   const tooltip = (
     <Typography sx={{ textAlign: "right" }}>
       <strong>Progress:</strong>&nbsp;
-      {formatExp(current)} / {formatExp(max - min)}
+      {formatExp(current)} ({progress.toFixed(2)}%)
       <br />
       <strong>Remaining:</strong>&nbsp;
-      {formatExp(remaining)} ({progress.toFixed(2)}%)
+      {formatExp(remaining)} / {formatExp(max - min)}
     </Typography>
   );
 


### PR DESCRIPTION
This PR implements the suggestion at https://discord.com/channels/415207508303544321/415213413745164318/1299024230268276827.
In short, the percentage is weird/misleading when it's on the "Remaining" line.

Before:
![before](https://github.com/user-attachments/assets/c763717d-2942-4ee5-a250-ef579c2e02fc)

After:
![after](https://github.com/user-attachments/assets/44a2e707-949d-40a4-9233-f606c2451de2)
