### PR TITLE
UI: Auto focus hashnet upgrade modal

### DIFF
--- a/src/Hacknet/ui/HacknetRoot.tsx
+++ b/src/Hacknet/ui/HacknetRoot.tsx
@@ -110,7 +110,7 @@ export function HacknetRoot(): React.ReactElement {
 
       {hasHacknetServers() && (
         <>
-          <Button onClick={() => setOpen(true)}>Spend Hashes on Upgrades</Button>
+          <Button focusRipple={false} onClick={() => setOpen(true)}>Spend Hashes on Upgrades</Button>
           <br />
         </>
       )}

--- a/src/Hacknet/ui/HacknetRoot.tsx
+++ b/src/Hacknet/ui/HacknetRoot.tsx
@@ -110,6 +110,12 @@ export function HacknetRoot(): React.ReactElement {
 
       {hasHacknetServers() && (
         <>
+          {/* 
+          The usage of focusRipple in this button is intentional. Without it, after closing the modal by pressing the
+          Esc button, this button has a weird ripple effect (only on Chrome).
+          The documentation says that focusRipple is false by default, but I have to explicitly set it to false to fix
+          this weird ripple effect.
+          */}
           <Button focusRipple={false} onClick={() => setOpen(true)}>
             Spend Hashes on Upgrades
           </Button>

--- a/src/Hacknet/ui/HacknetRoot.tsx
+++ b/src/Hacknet/ui/HacknetRoot.tsx
@@ -110,7 +110,9 @@ export function HacknetRoot(): React.ReactElement {
 
       {hasHacknetServers() && (
         <>
-          <Button focusRipple={false} onClick={() => setOpen(true)}>Spend Hashes on Upgrades</Button>
+          <Button focusRipple={false} onClick={() => setOpen(true)}>
+            Spend Hashes on Upgrades
+          </Button>
           <br />
         </>
       )}

--- a/src/Hacknet/ui/HashUpgradeModal.tsx
+++ b/src/Hacknet/ui/HashUpgradeModal.tsx
@@ -24,7 +24,7 @@ export function HashUpgradeModal(props: IProps): React.ReactElement {
   }
 
   return (
-    <Modal open={props.open} onClose={props.onClose}>
+    <Modal open={props.open} onClose={props.onClose} removeFocus={false}>
       <>
         <Typography>Spend your hashes on a variety of different upgrades</Typography>
         <Typography>


### PR DESCRIPTION
A player asked why they could not use the Esc button to close the hashnet upgrade modal (the modal that shows hashnet upgrades). All modal dialogs can be closed by pressing the Esc button if they are focused, but that modal is not focused by default. This PR fixes that by auto-focusing the modal.

The usage of `focusRipple` in the button is intentional. Without it, after closing the modal by pressing the Esc button, the button has a weird ripple effect (only on Chrome).
![Capture](https://github.com/user-attachments/assets/ad804354-fc5d-4561-a1b1-4a691682bc60)
The documentation says that `focusRipple` is false by default, but I have to explicitly set it to false to fix this weird ripple effect.