### PR TITLE
MISC: Update monaco-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jsdom": "^20.0.3",
         "lodash": "^4.17.21",
-        "monaco-editor": "^0.50.0",
+        "monaco-editor": "^0.52.0",
         "monaco-editor-webpack-plugin": "^7.1.0",
         "prettier": "^2.8.8",
         "react-refresh": "^0.14.0",
@@ -14446,9 +14446,10 @@
       "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "node_modules/monaco-editor": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
-      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA=="
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
+      "license": "MIT"
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^20.0.3",
     "lodash": "^4.17.21",
-    "monaco-editor": "^0.50.0",
+    "monaco-editor": "^0.52.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "prettier": "^2.8.8",
     "react-refresh": "^0.14.0",


### PR DESCRIPTION
Although I don't mark this PR as a bugfix one, it still fixes the "Unexpected usage: loadForeignModule" error. This error is caused by monaco-editor when it cannot load the language worker. It's hard to know why the language worker cannot be loaded. It may be caused by:
- Network error.
- Browser's extensions.
- Other software blocks access to relevant JS files (e.g., antivirus).
- Corrupted installation (Steam app).

How to reproduce it:
- Build the app without this PR's change.
- Delete `ts.worker.js`.
- Run `nano test.js`.

This problem is gone when we update `monaco-editor` to the latest version.

Closes #1408.