### PR TITLE
BUGFIX: nano and vim use wrong template for text files

### DIFF
--- a/src/Terminal/commands/common/editor.ts
+++ b/src/Terminal/commands/common/editor.ts
@@ -16,7 +16,7 @@ interface EditorParameters {
 }
 
 function getScriptTemplate(path: string): string {
-  if (isLegacyScript(path)) {
+  if (hasTextExtension(path) || isLegacyScript(path)) {
     return "";
   }
   const fileTypeFeature = getFileTypeFeature(getFileType(path));


### PR DESCRIPTION
It's just as the title said.

How to reproduce the bug: run `nano test.json`, then check the default text in the editor.

Before:
![before](https://github.com/user-attachments/assets/eceecf04-b1b4-4300-afb0-e8f7941b408f)

After:
![after](https://github.com/user-attachments/assets/1c02a51c-b122-4171-9462-7cee72445f7f)
