### PR TITLE
MISC: Add error cause to exceptionAlert and Recovery mode

### DIFF
--- a/src/ui/React/AlertManager.tsx
+++ b/src/ui/React/AlertManager.tsx
@@ -50,18 +50,22 @@ export function AlertManager({ hidden }: { hidden: boolean }): React.ReactElemen
     if (typeof text === "string") {
       return cyrb53(text);
     }
-    let propsAsString: string;
     /**
-     * JSON.stringify can throw an error in edge cases. One of them is "TypeError: Converting circular structure to
-     * JSON". If it happens, we use the Unix timestamp as the fallback value.
+     * JSON.stringify may throw an error in edge cases. One possible error is "TypeError: Converting circular structure
+     * to JSON". It may happen in very special cases. This is the flow of one of them:
+     * - An error occurred in GameRoot.tsx and we show a warning popup by calling "exceptionAlert" without delaying.
+     * - "exceptionAlert" constructs a React element and passes it via "dialogBoxCreate" -> "AlertEvents.emit".
+     * - When we receive the final React element here, the element's "props" property may contain a circular structure.
      */
+    let textPropsAsString;
     try {
-      propsAsString = JSON.stringify(text.props);
-    } catch (error) {
-      console.error(error);
-      propsAsString = Date.now().toString();
+      textPropsAsString = JSON.stringify(text.props);
+    } catch (e) {
+      console.error(e);
+      // Use the current timestamp as the fallback value.
+      textPropsAsString = Date.now().toString();
     }
-    return cyrb53(propsAsString);
+    return cyrb53(textPropsAsString);
   }
 
   function close(): void {

--- a/src/ui/React/AlertManager.tsx
+++ b/src/ui/React/AlertManager.tsx
@@ -50,7 +50,18 @@ export function AlertManager({ hidden }: { hidden: boolean }): React.ReactElemen
     if (typeof text === "string") {
       return cyrb53(text);
     }
-    return cyrb53(JSON.stringify(text.props));
+    let propsAsString: string;
+    /**
+     * JSON.stringify can throw an error in edge cases. One of them is "TypeError: Converting circular structure to
+     * JSON". If it happens, we use the Unix timestamp as the fallback value.
+     */
+    try {
+      propsAsString = JSON.stringify(text.props);
+    } catch (error) {
+      console.error(error);
+      propsAsString = Date.now().toString();
+    }
+    return cyrb53(propsAsString);
   }
 
   function close(): void {

--- a/src/utils/ErrorHelper.ts
+++ b/src/utils/ErrorHelper.ts
@@ -54,6 +54,26 @@ export interface IErrorData {
 
 export const newIssueUrl = `https://github.com/bitburner-official/bitburner-src/issues/new`;
 
+export function parseUnknownError(error: unknown): { errorAsString: string; stack?: string; cause?: string } {
+  const errorAsString = String(error);
+  let stack: string | undefined = undefined;
+  let cause: string | undefined = undefined;
+  if (error instanceof Error) {
+    stack = error.stack;
+    // If error.cause is an error, we use error.cause.stack; otherwise, we parse error.cause to a string.
+    if (error.cause instanceof Error) {
+      cause = error.cause.stack;
+    } else if (error.cause != null) {
+      cause = String(error.cause);
+    }
+  }
+  return {
+    errorAsString,
+    stack,
+    cause,
+  };
+}
+
 export function getErrorMetadata(error: unknown, errorInfo?: React.ErrorInfo, page?: Page): IErrorMetadata {
   const isElectron = navigator.userAgent.toLowerCase().includes(" electron/");
   const env = process.env.NODE_ENV === "development" ? GameEnv.Development : GameEnv.Production;
@@ -85,12 +105,21 @@ export function getErrorMetadata(error: unknown, errorInfo?: React.ErrorInfo, pa
 
 export function getErrorForDisplay(error: unknown, errorInfo?: React.ErrorInfo, page?: Page): IErrorData {
   const metadata = getErrorMetadata(error, errorInfo, page);
+  const errorData = parseUnknownError(error);
   const fileName = String(metadata.error.fileName);
   const features =
     `lang=${metadata.features.language} cookiesEnabled=${metadata.features.cookiesEnabled.toString()}` +
     ` doNotTrack=${metadata.features.doNotTrack ?? "null"} indexedDb=${metadata.features.indexedDb.toString()}`;
 
   const title = `${metadata.error.name}: ${metadata.error.message} (at "${metadata.page}")`;
+  const cause = errorData.cause
+    ? `
+### Error cause
+\`\`\`
+${errorData.cause}
+\`\`\`
+`
+    : "";
   const body = `
 ## ${title}
 
@@ -104,7 +133,7 @@ Please fill this information with details if relevant.
 
 ### Environment
 
-* Error: ${String(metadata.error) ?? "n/a"}
+* Error: ${errorData.errorAsString ?? "n/a"}
 * Page: ${metadata.page ?? "n/a"}
 * Version: ${metadata.version.toDisplay()}
 * Environment: ${GameEnv[metadata.environment]}
@@ -115,9 +144,9 @@ Please fill this information with details if relevant.
 
 ### Stack Trace
 \`\`\`
-${metadata.error.stack}
+${errorData.stack}
 \`\`\`
-
+${cause}
 ### React Component Stack
 \`\`\`
 ${metadata.errorInfo?.componentStack}

--- a/src/utils/ErrorHelper.ts
+++ b/src/utils/ErrorHelper.ts
@@ -54,23 +54,30 @@ export interface IErrorData {
 
 export const newIssueUrl = `https://github.com/bitburner-official/bitburner-src/issues/new`;
 
-export function parseUnknownError(error: unknown): { errorAsString: string; stack?: string; cause?: string } {
+export function parseUnknownError(error: unknown): {
+  errorAsString: string;
+  stack?: string;
+  causeAsString?: string;
+  causeStack?: string;
+} {
   const errorAsString = String(error);
   let stack: string | undefined = undefined;
-  let cause: string | undefined = undefined;
+  let causeAsString: string | undefined = undefined;
+  let causeStack: string | undefined = undefined;
   if (error instanceof Error) {
     stack = error.stack;
-    // If error.cause is an error, we use error.cause.stack; otherwise, we parse error.cause to a string.
-    if (error.cause instanceof Error) {
-      cause = error.cause.stack;
-    } else if (error.cause != null) {
-      cause = String(error.cause);
+    if (error.cause != null) {
+      causeAsString = String(error.cause);
+      if (error.cause instanceof Error) {
+        causeStack = error.cause.stack;
+      }
     }
   }
   return {
     errorAsString,
     stack,
-    cause,
+    causeAsString,
+    causeStack,
   };
 }
 
@@ -112,14 +119,18 @@ export function getErrorForDisplay(error: unknown, errorInfo?: React.ErrorInfo, 
     ` doNotTrack=${metadata.features.doNotTrack ?? "null"} indexedDb=${metadata.features.indexedDb.toString()}`;
 
   const title = `${metadata.error.name}: ${metadata.error.message} (at "${metadata.page}")`;
-  const cause = errorData.cause
+  let causeAndCauseStack = errorData.causeAsString
     ? `
-### Error cause
-\`\`\`
-${errorData.cause}
-\`\`\`
+### Error cause: ${errorData.causeAsString}
 `
     : "";
+  if (errorData.causeStack) {
+    causeAndCauseStack += `Cause stack:
+\`\`\`
+${errorData.causeStack}
+\`\`\`
+`;
+  }
   const body = `
 ## ${title}
 
@@ -146,7 +157,7 @@ Please fill this information with details if relevant.
 \`\`\`
 ${errorData.stack}
 \`\`\`
-${cause}
+${causeAndCauseStack}
 ### React Component Stack
 \`\`\`
 ${metadata.errorInfo?.componentStack}

--- a/src/utils/helpers/exceptionAlert.tsx
+++ b/src/utils/helpers/exceptionAlert.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import Typography from "@mui/material/Typography";
-import { getErrorMetadata } from "../ErrorHelper";
+import { parseUnknownError } from "../ErrorHelper";
 import { cyrb53 } from "../StringHelperFunctions";
+import { commitHash } from "./commitHash";
 
 const errorSet = new Set<string>();
 
@@ -17,31 +18,33 @@ const errorSet = new Set<string>();
  */
 export function exceptionAlert(error: unknown, showOnlyOnce = false): void {
   console.error(error);
-  const errorAsString = String(error);
-  const errorStackTrace = error instanceof Error ? error.stack : undefined;
+  const errorData = parseUnknownError(error);
   if (showOnlyOnce) {
     // Calculate the "id" of the error.
-    const errorId = cyrb53(errorAsString + errorStackTrace);
+    const errorId = cyrb53(errorData.errorAsString + errorData.stack);
     // Check if we showed it
     if (errorSet.has(errorId)) {
       return;
-    } else {
-      errorSet.add(errorId);
     }
+    errorSet.add(errorId);
   }
-  const errorMetadata = getErrorMetadata(error);
 
   dialogBoxCreate(
     <>
-      Caught an exception: {errorAsString}
+      Caught an exception: {errorData.errorAsString}
       <br />
       <br />
-      {errorStackTrace && (
+      {errorData.stack && (
         <Typography component="div" style={{ whiteSpace: "pre-wrap" }}>
-          Stack: {errorStackTrace}
+          Stack: {errorData.stack}
         </Typography>
       )}
-      Commit: {errorMetadata.version.commitHash}
+      {errorData.cause && (
+        <Typography component="div" style={{ whiteSpace: "pre-wrap" }}>
+          Error cause: {errorData.cause}
+        </Typography>
+      )}
+      Commit: {commitHash()}
       <br />
       UserAgent: {navigator.userAgent}
       <br />

--- a/src/utils/helpers/exceptionAlert.tsx
+++ b/src/utils/helpers/exceptionAlert.tsx
@@ -39,11 +39,21 @@ export function exceptionAlert(error: unknown, showOnlyOnce = false): void {
           Stack: {errorData.stack}
         </Typography>
       )}
-      {errorData.cause && (
-        <Typography component="div" style={{ whiteSpace: "pre-wrap" }}>
-          Error cause: {errorData.cause}
-        </Typography>
+      {errorData.causeAsString && (
+        <>
+          <br />
+          <Typography component="div" style={{ whiteSpace: "pre-wrap" }}>
+            Error cause: {errorData.causeAsString}
+            {errorData.causeStack && (
+              <>
+                <br />
+                Cause stack: {errorData.causeStack}
+              </>
+            )}
+          </Typography>
+        </>
       )}
+      <br />
       Commit: {commitHash()}
       <br />
       UserAgent: {navigator.userAgent}


### PR DESCRIPTION
Let's check this code:
```js
function throw1() {
  throw new Error("throw1");
}

function throw2() {
  throw new Error("throw2");
}

function test() {
  try {
    if (Date.now() % 2 === 0) {
      throw1();
    } else {
      throw2();
    }
  } catch (e) {
    throw new Error("test", { cause: e });
  }
}

/** @param {NS} ns */
export async function main(ns) {
  console.clear();
  try {
    test();
  } catch (e) {
    console.log(String(e));
    console.log(String(e.stack));
    console.log(String(e.cause.stack));
  }
}
```
Example output:
```
Error: test
Error: test
    at test (a.js:17:11)
    at main (a.js:25:5)
    at startNetscript2Script (NetscriptWorker.ts:87:9)
Error: throw1
    at throw1 (a.js:2:9)
    at test (a.js:12:7)
    at main (a.js:25:5)
    at startNetscript2Script (NetscriptWorker.ts:87:9)
```
```
Error: test
Error: test
    at test (a.js:17:11)
    at main (a.js:25:5)
    at startNetscript2Script (NetscriptWorker.ts:87:9)
Error: throw2
    at throw2 (a.js:6:9)
    at test (a.js:14:7)
    at main (a.js:25:5)
    at startNetscript2Script (NetscriptWorker.ts:87:9)
```
Without `e.cause`, we cannot know the root cause (was the error thrown by `throw1` or `throw2`?). This PR adds the `error.cause` to relevant error reporting UI.

Screenshots:
![Capture1](https://github.com/user-attachments/assets/a1602d1f-19a0-45a7-b286-fdaaaf5bd30e)
![Capture2](https://github.com/user-attachments/assets/973feec3-c233-47bd-8666-ce49d826fcea)
