### PR TITLE
CODEBASE: Recheck all usages of typecasting with JSON.parse

### DIFF
--- a/src/CotMG/Helper.tsx
+++ b/src/CotMG/Helper.tsx
@@ -7,20 +7,21 @@ import { StaneksGift } from "./StaneksGift";
 export let staneksGift = new StaneksGift();
 
 export function loadStaneksGift(saveString: string): void {
-  if (saveString) {
-    const staneksGiftData: unknown = JSON.parse(saveString, Reviver);
-    if (!(staneksGiftData instanceof StaneksGift)) {
-      console.error("Invalid StaneksGiftSave:", saveString);
-      setTimeout(() => {
-        dialogBoxCreate("Cannot load data of Stanek's Gift from the save string. StaneksGift is reset.");
-      }, 1000);
-      staneksGift = new StaneksGift();
-      return;
-    }
-    staneksGift = staneksGiftData;
-  } else {
-    staneksGift = new StaneksGift();
+  let staneksGiftData: unknown;
+  try {
+    staneksGiftData = JSON.parse(saveString, Reviver);
+  } catch (error) {
+    console.error(error);
   }
+  if (!(staneksGiftData instanceof StaneksGift)) {
+    console.error("Invalid StaneksGiftSave:", saveString);
+    staneksGift = new StaneksGift();
+    setTimeout(() => {
+      dialogBoxCreate("Cannot load data of Stanek's Gift. Stanek's Gift is reset.");
+    }, 1000);
+    return;
+  }
+  staneksGift = staneksGiftData;
 }
 
 export function zeros(width: number, height: number): number[][] {

--- a/src/CotMG/Helper.tsx
+++ b/src/CotMG/Helper.tsx
@@ -7,7 +7,11 @@ export let staneksGift = new StaneksGift();
 
 export function loadStaneksGift(saveString: string): void {
   if (saveString) {
-    staneksGift = JSON.parse(saveString, Reviver) as StaneksGift;
+    const staneksGiftData: unknown = JSON.parse(saveString, Reviver);
+    if (!(staneksGiftData instanceof StaneksGift)) {
+      throw new Error(`Cannot load data of Stanek's Gift from the save string. saveString: ${saveString}`);
+    }
+    staneksGift = staneksGiftData;
   } else {
     staneksGift = new StaneksGift();
   }

--- a/src/CotMG/Helper.tsx
+++ b/src/CotMG/Helper.tsx
@@ -1,3 +1,4 @@
+import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { Reviver } from "../utils/JSONReviver";
 import { BaseGift } from "./BaseGift";
 
@@ -9,7 +10,12 @@ export function loadStaneksGift(saveString: string): void {
   if (saveString) {
     const staneksGiftData: unknown = JSON.parse(saveString, Reviver);
     if (!(staneksGiftData instanceof StaneksGift)) {
-      throw new Error(`Cannot load data of Stanek's Gift from the save string. saveString: ${saveString}`);
+      console.error("Invalid StaneksGiftSave:", saveString);
+      setTimeout(() => {
+        dialogBoxCreate("Cannot load data of Stanek's Gift from the save string. StaneksGift is reset.");
+      }, 1000);
+      staneksGift = new StaneksGift();
+      return;
     }
     staneksGift = staneksGiftData;
   } else {

--- a/src/CotMG/Helper.tsx
+++ b/src/CotMG/Helper.tsx
@@ -10,14 +10,15 @@ export function loadStaneksGift(saveString: string): void {
   let staneksGiftData: unknown;
   try {
     staneksGiftData = JSON.parse(saveString, Reviver);
+    if (!(staneksGiftData instanceof StaneksGift)) {
+      throw new Error(`Data of Stanek's Gift is not an instance of "StaneksGift"`);
+    }
   } catch (error) {
     console.error(error);
-  }
-  if (!(staneksGiftData instanceof StaneksGift)) {
     console.error("Invalid StaneksGiftSave:", saveString);
     staneksGift = new StaneksGift();
     setTimeout(() => {
-      dialogBoxCreate("Cannot load data of Stanek's Gift. Stanek's Gift is reset.");
+      dialogBoxCreate(`Cannot load data of Stanek's Gift. Stanek's Gift is reset. Error: ${error}.`);
     }, 1000);
     return;
   }

--- a/src/CotMG/Helper.tsx
+++ b/src/CotMG/Helper.tsx
@@ -26,7 +26,7 @@ export function loadStaneksGift(saveString: string): void {
 }
 
 export function zeros(width: number, height: number): number[][] {
-  const array: number[][] = [];
+  const array = [];
 
   for (let i = 0; i < width; ++i) {
     array.push(Array<number>(height).fill(0));
@@ -36,14 +36,16 @@ export function zeros(width: number, height: number): number[][] {
 }
 
 export function calculateGrid(gift: BaseGift): number[][] {
-  const newgrid = zeros(gift.width(), gift.height()) as unknown as number[][];
+  const newGrid = zeros(gift.width(), gift.height());
   for (let i = 0; i < gift.width(); i++) {
     for (let j = 0; j < gift.height(); j++) {
       const fragment = gift.fragmentAt(i, j);
-      if (!fragment) continue;
-      newgrid[i][j] = 1;
+      if (!fragment) {
+        continue;
+      }
+      newGrid[i][j] = 1;
     }
   }
 
-  return newgrid;
+  return newGrid;
 }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -11,6 +11,11 @@ export function setPlayer(playerObj: PlayerObject): void {
 }
 
 export function loadPlayer(saveString: string): PlayerObject {
+  /**
+   * If we want to check player with "instanceof PlayerObject", we have to import PlayerObject normally (not "import
+   * type"). It will create a cyclic dependency. Fixing this cyclic dependency is really hard. It's not worth the
+   * effort, so we typecast it here.
+   */
   const player = JSON.parse(saveString, Reviver) as PlayerObject;
   player.money = parseFloat(player.money + "");
   player.exploits = sanitizeExploits(player.exploits);

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -40,6 +40,10 @@ export class Remote {
 }
 
 function handleMessageEvent(this: WebSocket, e: MessageEvent): void {
+  /**
+   * Validating e.data and the result of JSON.parse() is too troublesome, so we typecast them here. If the data is
+   * invalid, it means the RFA "client" (the tool that the player is using) is buggy, but that's not our problem.
+   */
   const msg = JSON.parse(e.data as string) as RFAMessage;
 
   if (!msg.method || !RFARequestHandler[msg.method]) {

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -45,7 +45,7 @@ import { downloadContentAsFile } from "./utils/FileUtils";
 import { showAPIBreaks } from "./utils/APIBreaks/APIBreak";
 import { breakInfos261 } from "./utils/APIBreaks/2.6.1";
 import { handleGetSaveDataInfoError } from "./Netscript/ErrorMessages";
-import { isObject, objectAssert } from "./utils/helpers/typeAssertion";
+import { isObject } from "./utils/helpers/typeAssertion";
 
 /* SaveObject.js
  *  Defines the object used to save/load games

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -220,11 +220,13 @@ class BitburnerSaveObject {
     }
 
     if (!decodedSaveData || decodedSaveData === "") {
-      return Promise.reject(new Error("Save game is invalid"));
+      console.error("decodedSaveData:", decodedSaveData);
+      return Promise.reject(new Error("Save game is invalid. The save data cannot be decoded."));
     }
 
     let parsedSaveData;
     try {
+      // Typecasting here is fine. We will validate parsedSaveData immediately after this line.
       parsedSaveData = JSON.parse(decodedSaveData) as {
         ctor: string;
         data: {
@@ -235,8 +237,14 @@ class BitburnerSaveObject {
       console.error(error); // We'll handle below
     }
 
-    if (!parsedSaveData || parsedSaveData.ctor !== "BitburnerSaveObject" || !parsedSaveData.data) {
-      return Promise.reject(new Error("Save game did not seem valid"));
+    if (
+      !parsedSaveData ||
+      parsedSaveData.ctor !== "BitburnerSaveObject" ||
+      !parsedSaveData.data ||
+      !parsedSaveData.data.PlayerSave
+    ) {
+      console.error("decodedSaveData:", decodedSaveData);
+      return Promise.reject(new Error("Save game is invalid. The decoded save data is not valid."));
     }
 
     const data: ImportData = {

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -45,6 +45,7 @@ import { downloadContentAsFile } from "./utils/FileUtils";
 import { showAPIBreaks } from "./utils/APIBreaks/APIBreak";
 import { breakInfos261 } from "./utils/APIBreaks/2.6.1";
 import { handleGetSaveDataInfoError } from "./Netscript/ErrorMessages";
+import { isObject, objectAssert } from "./utils/helpers/typeAssertion";
 
 /* SaveObject.js
  *  Defines the object used to save/load games
@@ -224,24 +225,18 @@ class BitburnerSaveObject {
       return Promise.reject(new Error("Save game is invalid. The save data cannot be decoded."));
     }
 
-    let parsedSaveData;
+    let parsedSaveData: unknown;
     try {
-      // Typecasting here is fine. We will validate parsedSaveData immediately after this line.
-      parsedSaveData = JSON.parse(decodedSaveData) as {
-        ctor: string;
-        data: {
-          PlayerSave: string;
-        };
-      };
+      parsedSaveData = JSON.parse(decodedSaveData);
     } catch (error) {
       console.error(error); // We'll handle below
     }
 
     if (
-      !parsedSaveData ||
+      !isObject(parsedSaveData) ||
       parsedSaveData.ctor !== "BitburnerSaveObject" ||
-      !parsedSaveData.data ||
-      !parsedSaveData.data.PlayerSave
+      !isObject(parsedSaveData.data) ||
+      typeof parsedSaveData.data.PlayerSave !== "string"
     ) {
       console.error("decodedSaveData:", decodedSaveData);
       return Promise.reject(new Error("Save game is invalid. The decoded save data is not valid."));

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -3,6 +3,7 @@ import { defaultTheme } from "../Themes/Themes";
 import { defaultStyles } from "../Themes/Styles";
 import { CursorStyle, CursorBlinking, WordWrapOptions } from "../ScriptEditor/ui/Options";
 import { defaultMonacoTheme } from "../ScriptEditor/ui/themes";
+import { objectAssert } from "../utils/helpers/typeAssertion";
 
 /**
  * This function won't be able to catch **all** invalid hostnames, and it's still fine. In order to validate a hostname
@@ -157,12 +158,8 @@ export const Settings = {
   disableSuffixes: false,
 
   load(saveString: string) {
-    const save = JSON.parse(saveString) as {
-      theme?: typeof Settings.theme;
-      styles?: typeof Settings.styles;
-      overview?: typeof Settings.overview;
-      EditorTheme?: typeof Settings.EditorTheme;
-    };
+    const save: unknown = JSON.parse(saveString);
+    objectAssert(save);
     save.theme && Object.assign(Settings.theme, save.theme);
     save.styles && Object.assign(Settings.styles, save.styles);
     save.overview && Object.assign(Settings.overview, save.overview);

--- a/src/utils/helpers/typeAssertion.ts
+++ b/src/utils/helpers/typeAssertion.ts
@@ -35,6 +35,10 @@ function getFriendlyType(v: unknown): string {
   return v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
 }
 
+export function isObject(v: unknown): v is Record<string, unknown> {
+  return getFriendlyType(v) === "object";
+}
+
 //All assertion functions used here should return the friendlyType of the input.
 
 /** For non-objects, and for array/null, throws an error with the friendlyType of v. */

--- a/src/utils/helpers/typeAssertion.ts
+++ b/src/utils/helpers/typeAssertion.ts
@@ -39,8 +39,6 @@ export function isObject(v: unknown): v is Record<string, unknown> {
   return getFriendlyType(v) === "object";
 }
 
-//All assertion functions used here should return the friendlyType of the input.
-
 /** For non-objects, and for array/null, throws an error with the friendlyType of v. */
 export function objectAssert(v: unknown): asserts v is Record<string, unknown> {
   const type = getFriendlyType(v);

--- a/test/jest/FullSave.test.ts
+++ b/test/jest/FullSave.test.ts
@@ -10,9 +10,9 @@ import { Companies } from "../../src/Company/Companies";
 
 describe("Check Save File Continuity", () => {
   establishInitialConditions();
-  // Calling getSaveString forces save info to update
-  saveObject.getSaveData().catch((error) => {
-    console.error(error);
+  beforeAll(async () => {
+    // Calling getSaveString forces save info to update
+    await saveObject.getSaveData();
   });
 
   const savesToTest = ["FactionsSave", "PlayerSave", "CompaniesSave", "GoSave"] as const;

--- a/test/jest/FullSave.test.ts
+++ b/test/jest/FullSave.test.ts
@@ -11,12 +11,14 @@ import { Companies } from "../../src/Company/Companies";
 describe("Check Save File Continuity", () => {
   establishInitialConditions();
   // Calling getSaveString forces save info to update
-  saveObject.getSaveData();
+  saveObject.getSaveData().catch((error) => {
+    console.error(error);
+  });
 
   const savesToTest = ["FactionsSave", "PlayerSave", "CompaniesSave", "GoSave"] as const;
   for (const saveToTest of savesToTest) {
     test(`${saveToTest} continuity`, () => {
-      const parsed = JSON.parse(saveObject[saveToTest]);
+      const parsed: unknown = JSON.parse(saveObject[saveToTest]);
       expect(parsed).toMatchSnapshot();
     });
   }


### PR DESCRIPTION
While we search and fix lint errors, we (kind of) agree that we should not typecast the result of `JSON.parse` (e.g., `JSON.parse(saveString, Reviver) as Something`. This PR searches all references of `JSON.parse` and checks if they are typecasting in a questionable way. My guideline:
- It's fine to typecast to `unknown`.
- It's fine to typecast after or immediately before the validation code.
- Compromises:
  - If invalid data comes from a third-party tool (RFA client).
  - If proper validation requires an overcomplicated and risky refactor (the god object PlayerObject).