### PR TITLE
UI: Remove WD from Hashnet server list if TRP not installed

### DIFF
--- a/src/ui/React/ServerDropdown.tsx
+++ b/src/ui/React/ServerDropdown.tsx
@@ -7,11 +7,12 @@ import React from "react";
 import { GetAllServers } from "../../Server/AllServers";
 import { Server } from "../../Server/Server";
 import { BaseServer } from "../../Server/BaseServer";
-
+import { Player } from "@player";
 import { HacknetServer } from "../../Hacknet/HacknetServer";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
+import { AugmentationName } from "@enums";
 
 // TODO make this an enum when this gets converted to TypeScript
 export const ServerType = {
@@ -41,7 +42,9 @@ export function ServerDropdown(props: IProps): React.ReactElement {
       case ServerType.All:
         return true;
       case ServerType.Foreign:
-        return s.hostname !== "home" && !purchased;
+        return s.hostname !== "home" && !purchased && !Player.hasAugmentation(AugmentationName.TheRedPill, true)
+          ? s.hostname !== "w0r1d_d43m0n"
+          : true;
       case ServerType.Owned:
         return purchased || s.hostname === "home";
       case ServerType.Purchased:


### PR DESCRIPTION
#1665 fixed Hacknet Servers not counting as player-owned, this PR is to also filter out the World Daemon if the Red Pill isn't present.