### PR TITLE
MISC: Remove duplicate usages of special server's hostname

### DIFF
--- a/src/Server/data/SpecialServers.ts
+++ b/src/Server/data/SpecialServers.ts
@@ -1,18 +1,5 @@
 /* Holds IP of Special Servers */
-export const SpecialServers: {
-  [key: string]: string | undefined;
-
-  Home: string;
-  FulcrumSecretTechnologies: string;
-  CyberSecServer: string;
-  NiteSecServer: string;
-  TheBlackHandServer: string;
-  BitRunnersServer: string;
-  TheDarkArmyServer: string;
-  DaedalusServer: string;
-  WorldDaemon: string;
-  DarkWeb: string;
-} = {
+export const SpecialServers = {
   Home: "home",
   FulcrumSecretTechnologies: "fulcrumassets",
   CyberSecServer: "CSEC",
@@ -23,4 +10,4 @@ export const SpecialServers: {
   DaedalusServer: "The-Cave",
   WorldDaemon: "w0r1d_d43m0n",
   DarkWeb: "darkweb",
-};
+} as const;

--- a/src/Server/data/servers.ts
+++ b/src/Server/data/servers.ts
@@ -286,7 +286,7 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 99,
-    hostname: "fulcrumassets",
+    hostname: SpecialServers.FulcrumSecretTechnologies,
     moneyAvailable: 1e6,
     networkLayer: 15,
     numOpenPortsRequired: 5,
@@ -1428,7 +1428,7 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 0,
-    hostname: "run4theh111z",
+    hostname: SpecialServers.BitRunnersServer,
     literature: [LiteratureName.SimulatedReality, LiteratureName.TheNewGod],
     maxRamExponent: {
       max: 9,
@@ -1447,7 +1447,7 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 0,
-    hostname: "I.I.I.I",
+    hostname: SpecialServers.TheBlackHandServer,
     literature: [LiteratureName.DemocracyIsDead],
     maxRamExponent: {
       max: 8,
@@ -1456,7 +1456,7 @@ export const serverMetadata: IServerMetadata[] = [
     moneyAvailable: 0,
     networkLayer: 5,
     numOpenPortsRequired: 3,
-    organizationName: "I.I.I.I",
+    organizationName: SpecialServers.TheBlackHandServer,
     requiredHackingSkill: {
       max: 365,
       min: 340,
@@ -1466,7 +1466,7 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 0,
-    hostname: "avmnite-02h",
+    hostname: SpecialServers.NiteSecServer,
     literature: [LiteratureName.DemocracyIsDead],
     maxRamExponent: {
       max: 7,
@@ -1485,12 +1485,12 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 0,
-    hostname: ".",
+    hostname: SpecialServers.TheDarkArmyServer,
     maxRamExponent: 4,
     moneyAvailable: 0,
     networkLayer: 13,
     numOpenPortsRequired: 4,
-    organizationName: ".",
+    organizationName: SpecialServers.TheDarkArmyServer,
     requiredHackingSkill: {
       max: 550,
       min: 505,
@@ -1500,7 +1500,7 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 0,
-    hostname: "CSEC",
+    hostname: SpecialServers.CyberSecServer,
     literature: [LiteratureName.DemocracyIsDead],
     maxRamExponent: 3,
     moneyAvailable: 0,
@@ -1516,7 +1516,7 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 0,
-    hostname: "The-Cave",
+    hostname: SpecialServers.DaedalusServer,
     literature: [LiteratureName.AlphaOmega],
     moneyAvailable: 0,
     networkLayer: 15,
@@ -1528,10 +1528,10 @@ export const serverMetadata: IServerMetadata[] = [
   },
   {
     hackDifficulty: 0,
-    hostname: "w0r1d_d43m0n",
+    hostname: SpecialServers.WorldDaemon,
     moneyAvailable: 0,
     numOpenPortsRequired: 5,
-    organizationName: "w0r1d_d43m0n",
+    organizationName: SpecialServers.WorldDaemon,
     requiredHackingSkill: 3000,
     serverGrowth: 0,
     specialName: SpecialServers.WorldDaemon,

--- a/src/ui/React/ServerDropdown.tsx
+++ b/src/ui/React/ServerDropdown.tsx
@@ -13,7 +13,6 @@ import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
 import { AugmentationName } from "@enums";
-import { SpecialServers } from "../../Server/data/SpecialServers";
 
 // TODO make this an enum when this gets converted to TypeScript
 export const ServerType = {
@@ -44,7 +43,7 @@ export function ServerDropdown(props: IProps): React.ReactElement {
         return true;
       case ServerType.Foreign:
         return s.hostname !== "home" && !purchased && !Player.hasAugmentation(AugmentationName.TheRedPill, true)
-          ? s.hostname !== SpecialServers.WorldDaemon
+          ? s.hostname !== "w0r1d_d43m0n"
           : true;
       case ServerType.Owned:
         return purchased || s.hostname === "home";

--- a/src/ui/React/ServerDropdown.tsx
+++ b/src/ui/React/ServerDropdown.tsx
@@ -13,6 +13,7 @@ import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
 import { AugmentationName } from "@enums";
+import { SpecialServers } from "../../Server/data/SpecialServers";
 
 // TODO make this an enum when this gets converted to TypeScript
 export const ServerType = {
@@ -43,7 +44,7 @@ export function ServerDropdown(props: IProps): React.ReactElement {
         return true;
       case ServerType.Foreign:
         return s.hostname !== "home" && !purchased && !Player.hasAugmentation(AugmentationName.TheRedPill, true)
-          ? s.hostname !== "w0r1d_d43m0n"
+          ? s.hostname !== SpecialServers.WorldDaemon
           : true;
       case ServerType.Owned:
         return purchased || s.hostname === "home";


### PR DESCRIPTION
When I look at the new change in #1779, I see the usage of "w0r1d_d43m0n" string. We have `SpecialServers` (`src\Server\data\SpecialServers.ts`), so it's best to use it.

This PR also checks `src\Server\data\servers.ts`. For most special servers, `hostname`, `organizationName`, and `specialName` have the same value (some special servers have special values for `organizationName`, though).

@d0sboots We use the "home" string in too many places in our codebase. I'm not sure if we should change all of them to `SpecialServers.Home`, so I have not touched them.

Edit: I reverted the change in `src\ui\React\ServerDropdown.tsx`. I made necessary changes in #1782.