### PR TITLE
BUGFIX: Hashserver UI shows wrong server list when purchasing upgrades

### DIFF
--- a/src/ui/React/ServerDropdown.tsx
+++ b/src/ui/React/ServerDropdown.tsx
@@ -38,8 +38,8 @@ export function ServerDropdown(props: IProps): React.ReactElement {
    */
   function isValidServer(baseServer: BaseServer): boolean {
     /**
-     * isOwnedServer is true if baseServer is home, private servers, or hacknet servers. Note that home satisfies the
-     * condition: (baseServer instanceof Server && baseServer.purchasedByPlayer).
+     * isOwnedServer is true if baseServer is home, private servers, or hacknet servers. Note that, with home computer,
+     * baseServer.purchasedByPlayer is true.
      */
     const isOwnedServer =
       (baseServer instanceof Server && baseServer.purchasedByPlayer) || baseServer instanceof HacknetServer;
@@ -53,10 +53,10 @@ export function ServerDropdown(props: IProps): React.ReactElement {
           return false;
         }
         // If the player has not installed TRP, exclude WD server.
-        if (!Player.hasAugmentation(AugmentationName.TheRedPill, true)) {
-          return baseServer.hostname !== SpecialServers.WorldDaemon;
-        }
-        return true;
+        return (
+          Player.hasAugmentation(AugmentationName.TheRedPill, true) ||
+          baseServer.hostname !== SpecialServers.WorldDaemon
+        );
       case ServerType.Owned:
         return isOwnedServer;
       case ServerType.Purchased:

--- a/src/ui/React/ServerDropdown.tsx
+++ b/src/ui/React/ServerDropdown.tsx
@@ -13,19 +13,20 @@ import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
 import { AugmentationName } from "@enums";
+import { SpecialServers } from "../../Server/data/SpecialServers";
+import { throwIfReachable } from "../../utils/helpers/throwIfReachable";
 
-// TODO make this an enum when this gets converted to TypeScript
-export const ServerType = {
-  All: 0,
-  Foreign: 1, // Hackable, non-owned servers
-  Owned: 2, // Home Computer, Purchased Servers, and Hacknet Servers
-  Purchased: 3, // Everything from Owned except home computer
-};
+export enum ServerType {
+  All = 0,
+  Foreign = 1, // Non-owned servers
+  Owned = 2, // Home Computer, Purchased Servers, and Hacknet Servers
+  Purchased = 3, // Everything from Owned except home computer
+}
 
 interface IProps {
   purchase: () => void;
   canPurchase: boolean;
-  serverType: number;
+  serverType: ServerType;
   onChange: (event: SelectChangeEvent) => void;
   value: string;
 }
@@ -35,24 +36,35 @@ export function ServerDropdown(props: IProps): React.ReactElement {
    * Checks if the server should be shown in the dropdown menu, based on the
    * 'serverType' property
    */
-  function isValidServer(s: BaseServer): boolean {
-    const purchased = (s instanceof Server && s.purchasedByPlayer) || s instanceof HacknetServer;
+  function isValidServer(baseServer: BaseServer): boolean {
+    /**
+     * isOwnedServer is true if baseServer is home, private servers, or hacknet servers. Note that home satisfies the
+     * condition: (baseServer instanceof Server && baseServer.purchasedByPlayer).
+     */
+    const isOwnedServer =
+      (baseServer instanceof Server && baseServer.purchasedByPlayer) || baseServer instanceof HacknetServer;
     const type = props.serverType;
     switch (type) {
       case ServerType.All:
         return true;
       case ServerType.Foreign:
-        return s.hostname !== "home" && !purchased && !Player.hasAugmentation(AugmentationName.TheRedPill, true)
-          ? s.hostname !== "w0r1d_d43m0n"
-          : true;
+        // Exclude home, private servers, hacknet servers.
+        if (isOwnedServer) {
+          return false;
+        }
+        // If the player has not installed TRP, exclude WD server.
+        if (!Player.hasAugmentation(AugmentationName.TheRedPill, true)) {
+          return baseServer.hostname !== SpecialServers.WorldDaemon;
+        }
+        return true;
       case ServerType.Owned:
-        return purchased || s.hostname === "home";
+        return isOwnedServer;
       case ServerType.Purchased:
-        return purchased;
+        return isOwnedServer && baseServer.hostname !== SpecialServers.Home;
       default:
-        console.warn(`Invalid ServerType specified for ServerDropdown component: ${type}`);
-        return false;
+        throwIfReachable(type);
     }
+    return false;
   }
 
   const servers = [];


### PR DESCRIPTION
#1779 accidentally reverts the fix in #1665 and adds unexpected servers to the server list. How to reproduce this regression bug:
- Load a clean save file with SF9.
- Buy a hashserver.
- Buy a private server (p-server-0).
- Hacknet -> Spend Hashes on Upgrades -> Reduce Minimum Security -> Open the drop-down list. It will contain home, p-server-0, and hacknet-server-0.

The problem is in this code:
```js
return s.hostname !== "home" && !purchased && !Player.hasAugmentation(AugmentationName.TheRedPill, true)
  ? s.hostname !== "w0r1d_d43m0n"
  : true;
```
When s is home, private servers, or hashservers, it always returns true.

While fixing this bug, I spotted other wrong logic in this file, so I fixed all of them in this PR. Those code paths are currently not used (`ServerDropdown` is only used by `src\Hacknet\ui\HacknetUpgradeElem.tsx`, and `HacknetUpgradeElem.tsx` only uses `ServerType.Foreign`.), so it's not a problem.

Code in `isValidServer` does not check members of ServerType properly:
- `purchased` is checked by `(s instanceof Server && s.purchasedByPlayer) || s instanceof HacknetServer`, but home also satisfies `s instanceof Server && s.purchasedByPlayer`, so `purchased` is in fact `isOwnedServer` (home, private servers, hashservers), not `Everything from Owned except home computer`.
- `s.hostname !== "home"` is used in wrong places.

@d0sboots To avoid making a breaking change with `ns.hacknet.spendHashes` (https://github.com/bitburner-official/bitburner-src/blob/d824cd4fa6692ca1e04173b892278b79587a88fb/src/Hacknet/HacknetHelpers.tsx), I don't touch it in this PR, but I want to hear your opinions about it:
- When it sees a hashserver, it returns false without printing a warning.
- Home and private servers are valid targets. It's inconsistent with how we determine the target in the UI. It's not exploitable, so it's not urgent.

Screenshot:
![Capture](https://github.com/user-attachments/assets/ff63f27d-5007-4f46-8700-786914cb93dd)
