### PR TITLE
BUGFIX: Fix ramOverride check

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1524,7 +1524,7 @@ export const ns: InternalAPI<NSFull> = {
       return rs.ramUsage;
     }
     const newServerRamUsed = roundToTwo(server.ramUsed + (newRam - rs.ramUsage) * rs.threads);
-    if (newServerRamUsed >= server.maxRam) {
+    if (newServerRamUsed > server.maxRam) {
       // Can't allocate more RAM.
       return rs.ramUsage;
     }


### PR DESCRIPTION
ramOverride currently prevents you from actually using exactly all of a server's memory due to a bug in the ram check. Simply replace ">=" with ">" to allow the new ram to equal the max ram.

Test script:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tprint(ns.ramOverride(8));
}
```
Expected output (on fresh save):
```js
8
```
Output before this commit:
```js
1.6
```
