### PR TITLE
BUGFIX: Missing migration code for v0.56.0

### DIFF
--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -13,6 +13,7 @@ import {
   createUniqueRandomIp,
   AddToAllServers,
   GetServer,
+  renameServer,
 } from "./Server/AllServers";
 import { Settings } from "./Settings/Settings";
 import { loadStockMarket, StockMarket } from "./StockMarket/StockMarket";
@@ -313,6 +314,10 @@ function evaluateVersionCompatibility(ver: string | number): void {
       delete anyPlayer.companyPosition;
     }
     if (ver < "0.56.0") {
+      // In older versions, keys of AllServers are IP addresses instead of hostnames.
+      for (const server of GetAllServers()) {
+        renameServer(server.ip, server.hostname);
+      }
       for (const q of anyPlayer.queuedAugmentations) {
         if (q.name === "Graphene BranchiBlades Upgrade") {
           q.name = "Graphene BrachiBlades Upgrade";


### PR DESCRIPTION
d0sboots found an issue with loading old save files at https://github.com/bitburner-official/bitburner-src/pull/1775#issuecomment-2490276285. I also found that issue while testing StockMarket schema, but I did not bother fixing it:
- It's unrelated to that PR (#1775).
- To be honest, I always see "support migration from v0.x" as a "futile attempt". We don't have enough resources to extensively test migration code for each PR. The mentioned issue is an example. Before #1542, we don't have this issue. Without seeing the report and digging through our Git history, it's hard to believe that #1542, when combining with 2958034ad461e39b2e7da1be6da69e5fdff2616c (and next commits), can crash the game.

Nonetheless, I'll still fix it.

Starting from 2958034ad461e39b2e7da1be6da69e5fdff2616c, we started a series of commits changing how we store servers in `AllServers`:
- Before: Keys are IP addresses.
- After: Keys are hostnames.

Back then, due to how we implemented `GetServer`, the game did not crash despite missing migration code.
```js
export function GetServer(s: string): BaseServer | null {
  if (Object.hasOwn(AllServers, s)) {
    const server = AllServers[s];
    if (server) return server;
  }

  if (!isIPAddress(s)) return GetServerByHostname(s);

  const ipserver = GetServerByIP(s);
  if (ipserver !== undefined) {
    return ipserver;
  }

  return null;
}
```
In v0.56.0 and later versions, when the game loads v0.55.0 save file:
- Keys of `AllServers` are IP addresses.
- `GetServer` is called with **hostname**.

In this case, `GetServer` calls `GetServerByHostname`.

In #1542, we changed `GetServer`:
```js
export function GetServer(s: string): BaseServer | null {
  if (Object.hasOwn(AllServers, s)) {
    const server = AllServers[s];
    if (server) return server;
  }
  if (!isIPAddress(s)) return null;
  const ipserver = GetServerByIP(s);
  if (ipserver !== undefined) {
    return ipserver;
  }

  return null;
}
```
This change makes sense if we assume that keys of `AllServers` are hostnames.

In short, these changes assume different things:
- Even without migration code, changes in v0.56.0 are still fine if `GetServer` is not changed.
- Changes in #1542 are fine if we don't have to deal with old save files from v0.55.0.

How to test this PR: Build it and load the save file at https://github.com/bitburner-official/bitburner-src/pull/1775#issuecomment-2490276285.

After this PR is merged, I'll cherry-pick the change and commit it to #1774.