### PR TITLE
BUGFIX: Wrong usage of delete operator in Settings.load

### DIFF
--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -164,11 +164,12 @@ export const Settings = {
     save.styles && Object.assign(Settings.styles, save.styles);
     save.overview && Object.assign(Settings.overview, save.overview);
     save.EditorTheme && Object.assign(Settings.EditorTheme, save.EditorTheme);
-    delete save.theme;
-    delete save.styles;
-    delete save.overview;
-    delete save.EditorTheme;
-    Object.assign(Settings, save);
+    Object.assign(Settings, save, {
+      theme: Settings.theme,
+      styles: Settings.styles,
+      overview: Settings.overview,
+      EditorTheme: Settings.EditorTheme,
+    });
     /**
      * The hostname and port of RFA have not been validated properly, so the save data may contain invalid data. In that
      * case, we set them to the default value.

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -164,7 +164,10 @@ export const Settings = {
     save.styles && Object.assign(Settings.styles, save.styles);
     save.overview && Object.assign(Settings.overview, save.overview);
     save.EditorTheme && Object.assign(Settings.EditorTheme, save.EditorTheme);
-    delete save.theme, save.styles, save.overview, save.EditorTheme;
+    delete save.theme;
+    delete save.styles;
+    delete save.overview;
+    delete save.EditorTheme;
     Object.assign(Settings, save);
     /**
      * The hostname and port of RFA have not been validated properly, so the save data may contain invalid data. In that


### PR DESCRIPTION
I found this bug while implementing #1789.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  const object = {
    prop1: 1,
    prop2: 2,
  };
  delete object.prop1, object.prop2; // Wrong
  // delete object.prop1; delete object.prop2; // Correct
  ns.print(object);
}
```