### PR TITLE
CORPORATION: Fix wrong initial productionMult of new division

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -67,7 +67,7 @@ export class Division {
   aiCoreFactor = 0;
   advertisingFactor = 0;
 
-  productionMult = 0; //Production multiplier
+  productionMult = 1; //Production multiplier
 
   //Financials
   lastCycleRevenue = 0;


### PR DESCRIPTION
`productionMult` of a division is updated in all states except START, and it cannot be smaller than 1:
https://github.com/bitburner-official/bitburner-src/blob/596a621c6279c725d6952b31999a6a7bd0b6d8d1/src/Corporation/Division.ts#L135

However, when a new division is created, we initialize `productionMult` with 0 instead of 1. It does not make sense because:
- We have an explicit min value for it in `calculateProductionFactors`.
- It's a "bonus" multiplier from boost materials. If the player does not have boost materials in their warehouses, the bonus multiplier is always 1.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.corporation.createCorporation("Corp", false);
  ns.corporation.expandIndustry("Agriculture", "A");
  ns.print(
    `State: ${ns.corporation.getCorporation().prevState}, productionMult: ${ns.corporation.getDivision("A").productionMult}`
  );
  await ns.corporation.nextUpdate();
  ns.print(
    `State: ${ns.corporation.getCorporation().prevState}, productionMult: ${ns.corporation.getDivision("A").productionMult}`
  );
  await ns.corporation.nextUpdate();
  ns.print(
    `State: ${ns.corporation.getCorporation().prevState}, productionMult: ${ns.corporation.getDivision("A").productionMult}`
  );
}
```
Before:
```
State: SALE, productionMult: 0
State: START, productionMult: 0
State: PURCHASE, productionMult: 1
```
After:
```
State: SALE, productionMult: 1
State: START, productionMult: 1
State: PURCHASE, productionMult: 1
```