### PR TITLE
MISC: Change current version to 2.7.0

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitburner",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitburner",
-      "version": "2.6.3",
+      "version": "2.7.0",
       "dependencies": {
         "electron-log": "^4.4.8",
         "electron-store": "^8.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitburner",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "A cyberpunk-themed programming incremental game",
   "main": "main.js",
   "author": "Daniel Xie, hydroflame, et al.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitburner",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitburner",
-      "version": "2.6.3",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitburner",
   "license": "SEE LICENSE IN license.txt",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "main": "electron-main.js",
   "author": {
     "name": "Daniel Xie, hydroflame, et al."

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -4,7 +4,7 @@
  * Constants for specific mechanics or features will NOT be here.
  */
 export const CONSTANTS = {
-  VersionString: "2.6.3dev",
+  VersionString: "2.7.0dev",
   isDevBranch: true,
   VersionNumber: 40,
 
@@ -109,7 +109,7 @@ export const CONSTANTS = {
 
   // Also update Documentation/doc/changelog.md when appropriate (when doing a release)
   LatestUpdate: `
-## v2.6.3 Dev: Last updated 15 August 2024
+## v2.7.0 Dev: Last updated 15 August 2024
 
 ### MAJOR ADDITIONS
 


### PR DESCRIPTION
After a long dev cycle, the current version contains tons of bugfixes, tweaks, and 2 major new features. It's best to make it a new minor version instead of a patch version. Snarling agreed on Discord.

Changing the version number is usually handled by Snarling at the start of a dev cycle (commits with `Start x.y.z dev cycle` message), but this time, we decided to do that near the end of the current dev cycle. To make sure that we don't forget doing it at release time, I decided to make this change beforehand.