### PR TITLE
BUGFIX: Generic Reviver does not handle Message class

### DIFF
--- a/src/utils/GenericReviver.ts
+++ b/src/utils/GenericReviver.ts
@@ -16,6 +16,7 @@ export function Reviver(_key: string, value: unknown): any {
     // Known missing constructors with special handling.
     switch (value.ctor) {
       case "AllServersMap": // Reviver removed in v0.43.1
+      case "Message": // Reviver removed in v1.6.4
       case "Industry": // No longer part of save data since v2.3.0
       case "Employee": // Entire object removed from game in v2.2.0 (employees abstracted)
       case "Company": // Reviver removed in v2.6.1


### PR DESCRIPTION
In pre-v1.6.4 versions, we serialized `Message` (`src\Message\Message.ts`) data to save data. We stopped doing that at 501b69bbc2291eb466ffeb49c0d27d20b67b0efe, but `Reviver` does not handle this missing case. When the player loads a save file from pre-v1.6.4, the recovery mode UI is activated with `Error: Error: Could not locate constructor named Message. If the save data is valid, this is a bug.`.

How to test this bug:
- Load the attached save file.
- Make sure that the game loads normally.

Save file: [bitburnerSave_BN6x0_1627521283_edited.json](https://github.com/user-attachments/files/17893607/bitburnerSave_BN6x0_1627521283_edited.json)
Note: This save file is an edited one. The original save file was contributed by @mageking17 on Discord. They granted us their consent to use their save file in our testing workflow.