### PR TITLE
REFACTOR: Handle migration of ActionIdentifier in Bladeburner code instead of GenericReviver

### DIFF
--- a/src/utils/GenericReviver.ts
+++ b/src/utils/GenericReviver.ts
@@ -1,4 +1,3 @@
-import { loadActionIdentifier } from "../Bladeburner/utils/loadActionIdentifier";
 import { constructorsForReviver, isReviverValue } from "./JSONReviver";
 import { validateObject } from "./Validator";
 
@@ -21,10 +20,9 @@ export function Reviver(_key: string, value: unknown): any {
       case "Employee": // Entire object removed from game in v2.2.0 (employees abstracted)
       case "Company": // Reviver removed in v2.6.1
       case "Faction": // Reviver removed in v2.6.1
+      case "ActionIdentifier": // No longer a class as of v2.6.1
         console.warn(`Legacy load type ${value.ctor} converted to expected format while loading.`);
         return value.data;
-      case "ActionIdentifier": // No longer a class as of v2.6.1
-        return loadActionIdentifier(value.data);
     }
     // Missing constructor with no special handling. Throw error.
     throw new Error(`Could not locate constructor named ${value.ctor}. If the save data is valid, this is a bug.`);


### PR DESCRIPTION
d0sboots mentioned this change at https://github.com/bitburner-official/bitburner-src/pull/1792#discussion_r1855299550.

How to test this PR:
- Load attached save files.
- Verify `action`, `automateActionHigh`, and `automateActionLow` in `Player.bladeburner`.

Save files:
- [v2.6.0-bladeburner.json](https://github.com/user-attachments/files/17900697/v2.6.0-bladeburner.json). This file is generated by me. We can use it in our testing workflow.
- [bitburnerSave_BN6x0_1627521283.json](https://github.com/user-attachments/files/17900705/bitburnerSave_BN6x0_1627521283.json). This file was contributed by @MageKing17 on Discord. They granted us their consent to use their save file in our testing workflow. Note: To test this save file, your build must have fixes from #1796 and #1798.

