### PR TITLE
BUGFIX: Cannot load Bladeburner tasks of Sleeves from pre-v2.6.1

### DIFF
--- a/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveBladeburnerWork.ts
@@ -100,8 +100,20 @@ export class SleeveBladeburnerWork extends SleeveWorkClass {
   /** Initializes a BladeburnerWork object from a JSON save state. */
   static fromJSON(value: IReviverValue): SleeveBladeburnerWork {
     objectAssert(value.data);
-    const actionId = loadActionIdentifier(value.data?.actionId);
-    if (!actionId) return invalidWork();
+    let actionId = loadActionIdentifier(value.data?.actionId);
+    if (!actionId) {
+      /**
+       * In pre-v2.6.1 versions, "name" and "type" of actionId are saved directly in "actionName" and "actionType", not
+       * in the actionId object.
+       */
+      if (!value.data["actionName"]) {
+        return invalidWork();
+      }
+      actionId = loadActionIdentifier({ name: value.data["actionName"], type: value.data["actionType"] });
+      if (!actionId) {
+        return invalidWork();
+      }
+    }
     value.data.actionId = actionId;
     return Generic_fromJSON(SleeveBladeburnerWork, value.data, SleeveBladeburnerWork.savedKeys);
   }


### PR DESCRIPTION
Bladeburner tasks of Sleeves were saved in a different format in pre-v2.6.1 versions, so the game cannot load them in v2.6.1 and later versions. This PR fixes this bug.

Save file: [v2.6.0-bladeburner-sleeves.json](https://github.com/user-attachments/files/17901981/v2.6.0-bladeburner-sleeves.json)
This file is generated by me. We can use it in our testing workflow.

How to test:
- Load the attached save file.
- Verify Sleeves' tasks.