### PR TITLE
JEST: Move TerminalMatching.test.ts

### DIFF
--- a/test/jest/Bladeburner/TerminalMatching.test.ts
+++ b/test/jest/Bladeburner/TerminalMatching.test.ts
@@ -1,4 +1,4 @@
-import { autoCompleteTypeShorthand, TerminalShorthands } from "../../../../src/Bladeburner/utils/terminalShorthands";
+import { autoCompleteTypeShorthand, TerminalShorthands } from "../../../src/Bladeburner/utils/terminalShorthands";
 import {
   BladeburnerActionType,
   BladeburnerBlackOpName,


### PR DESCRIPTION
This test file is not related to Netscript, so I moved it to `test\jest\Bladeburner`.