### PR TITLE
CORPORATION: Improve FAQ and .lit file

### DIFF
--- a/src/Documentation/doc/advanced/corporation/faq.md
+++ b/src/Documentation/doc/advanced/corporation/faq.md
@@ -16,11 +16,11 @@ No.
 
 No.
 
-#### Why can I not buy back anything? It's ridiculous.
+#### Why can I not buy back my shares?
 
-You can only buy back shares that were issued. The shares that were owned by the government (when we use seed money) and investors cannot be bought back.
+You can buy back shares that were issued. Shares that were given to the government (when you use seed money) and investors (when you take investment offers) cannot be bought back.
 
-One thing to remember: this is a game, not real life. In this game, you always have total control over your corporation. When your profit hits exponential growth, the share percentage means nothing. If your corporation's profit is 1e90/s and you only have 1% shares, you still have 1e88/s.
+You always have total control over your corporation, so you don't have to worry about "ownership". When your profit hits exponential growth, the share percentage means nothing. If your corporation's profit is 1e90/s and you only have 1% shares, you still get 1e88/s.
 
 #### My corporation generates profit. Why does my money not increase?
 
@@ -137,9 +137,9 @@ They are used for calculating `employeeProductionByJob`, then that property is u
 
 #### What do Interns do?
 
-Don't bother with that job. Its only purpose is to maintain energy and morale. A tea/party script can do it for you, and it is very simple to implement.
+They maintain energy and morale. You should only use them if you don't want to write scripts. A tea/party script can maintain energy and morale for you, and it is very simple to implement. It's recommended to implement that script instead of wasting employees on the "Intern" job.
 
-#### Everybody tells me to use 1/9 as Intern ratio, but when I use it, energy and morale still drop.
+#### I use 1/9 as Intern ratio, but energy and morale still drop.
 
 You can only use that ratio when your corporation works fine (funds > 0 or profit > 0). If it does not, use 1/6.
 

--- a/src/Literature/Literatures.ts
+++ b/src/Literature/Literatures.ts
@@ -27,54 +27,54 @@ export const Literatures: Record<LiteratureName, Literature> = {
     text:
       "You should check the in-game Corporation documentation in the Documentation tab (Documentation -> Advanced Mechanics -> Corporation). " +
       "It's the most useful and up-to-date resource for managing Corporation.<br><br>" +
-      "<u>Getting Started with Corporations</u><br>" +
-      "To get started, visit the City Hall in Sector-12 in order to create a Corporation. This requires $150b of your own money, " +
-      "but this $150b will get put into your Corporation's funds. If you're in BitNode 3 you also have option to get seed money from " +
-      "the government in exchange for 500m shares. Your Corporation can have many different divisions, each in a different Industry. " +
-      "There are many different types of Industries, each with different properties. To create your first division, click the 'Expand' " +
-      "(into new Industry) button at the top of the management UI. The Agriculture industry is recommended for your first division.<br><br>" +
+      "<u>Getting Started with Corporation</u><br><br>" +
+      "To get started, visit the city hall in Sector-12 in order to create a corporation. This requires $150b of your own money, " +
+      "but this $150b will get put into your corporation's funds. If you're in BitNode 3, you also have the option to get seed money from " +
+      "the government in exchange for 500m shares. Your corporation can have many different divisions, each in a different industry. " +
+      "There are many different types of industries, each with different properties. To create your first division, click the 'Expand' " +
+      "button at the top of the management UI. The agriculture industry is recommended for your first division.<br><br>" +
       "The first thing you'll need to do is hire some employees. Employees can be assigned to five different positions. Each position has a " +
-      "different effect on various aspects of your Corporation. It is recommended to have at least one employee at each position.<br><br>" +
-      "Each industry uses some combination of Materials in order to produce other Materials and/or create Products. Specific information " +
+      "different effect on various aspects of your corporation. It is recommended to have at least one employee at each position.<br><br>" +
+      "Each industry uses some combination of materials in order to produce other materials and/or create products. Specific information " +
       "about this is displayed in each of your divisions' UI.<br><br>" +
-      "Products are special, industry-specific objects. They are different than Materials because you must manually choose to develop them, " +
-      "and you can choose to develop any number of Products. Developing a Product takes time, but a Product typically generates significantly " +
-      "more revenue than any Material. Not all industries allow you to create Products. To create a Product, look for a button in the top-left " +
-      "panel of the division UI (e.g. For the Software Industry, the button says 'Develop Software').<br><br>" +
-      "To get your supply chain system started, purchase the Materials that your industry needs to produce other Materials/Products. This can be " +
-      "done by clicking the 'Buy' button next to the corresponding Material(s). After you have the required Materials, you will immediately start " +
-      "production. The amount and quality/effective rating of Materials/Products you produce is based on a variety of factors, such as your employees " +
+      "Products are special, industry-specific objects. They are different than materials because you must manually choose to develop them, " +
+      "and you can choose to develop any number of products. Developing a product takes time, but a product typically generates significantly " +
+      "more revenue than any material. Not all industries allow you to create products. To create a product, look for a button in the top-left " +
+      "panel of the division UI (e.g., for the software industry, the button says 'Develop Software').<br><br>" +
+      "To get your supply chain system started, purchase the materials that your industry needs to produce other materials/products. This can be " +
+      "done by clicking the 'Buy' button next to the corresponding material(s). After you have the required materials, you will immediately start " +
+      "production. The amount and quality/effective rating of materials/products you produce is based on a variety of factors, such as your employees " +
       "and their productivity and the quality of materials used for production.<br><br>" +
-      "Once you start producing Materials/Products, you can sell them in order to start earning revenue. This can be done by clicking the 'Sell' " +
-      "button next to the corresponding Material or Product. The amount of Material/Product you sell is dependent on a wide variety of different factors. " +
-      "In order to produce and sell a Product you'll have to fully develop it first.<br><br>" +
-      "These are the basics of getting your Corporation up and running! Now, you can start purchasing upgrades to improve your bottom line. " +
+      "Once you start producing materials/products, you can sell them in order to start earning revenue. This can be done by clicking the 'Sell' " +
+      "button next to the corresponding material or product. The amount of material/product you sell is dependent on a wide variety of different factors. " +
+      "In order to produce and sell a product, you'll have to fully develop it first.<br><br>" +
+      "These are the basics of getting your corporation up and running! Now, you can start purchasing upgrades to improve your bottom line. " +
       "If you need money, consider looking for seed investors, who will give you money in exchange for stock shares. Otherwise, once you feel " +
-      "you are ready, take your Corporation public! Once your Corporation goes public, you can no longer find investors. Instead, your Corporation " +
-      "will be publicly traded and its stock price will change based on how well it's performing financially. In order to make money for yourself you " +
-      "can set dividends for a solid reliable income or you can sell your stock shares in order to make quick money.<br><br>" +
+      "you are ready, take your corporation public! Once your corporation goes public, you can no longer find investors. Instead, your corporation " +
+      "will be publicly traded, and its stock price will change based on how well it's performing financially. In order to make money for yourself, you " +
+      "can set dividends for a solid, reliable income, or you can sell your stock shares in order to make quick money.<br><br>" +
       "<u>Tips/Pointers</u><br>" +
-      "-Start with one division, such as Agriculture. Get it profitable on it's own, then expand to a division that consumes/produces " +
+      "-Start with one division, such as Agriculture. Get it profitable on its own, then expand to a division that consumes/produces " +
       "a material that the division you selected produces/consumes.<br><br>" +
-      "-Materials are profitable, but Products are where the real money is, although if the product had a low development budget or is " +
-      "produced with low quality materials it won't sell well.<br><br>" +
+      "-Materials are profitable, but products are where the real money is, although if the product has a low development budget or is " +
+      "produced with low-quality materials, it won't sell well.<br><br>" +
       "-The 'Smart Supply' upgrade is extremely useful. Consider purchasing it as soon as possible.<br><br>" +
       "-Purchasing Hardware, Robots, AI Cores, and Real Estate can potentially increase your production. The effects of these depend on " +
       "what industry you are in.<br><br>" +
-      "-In order to optimize your production, you will need a good balance of all employee positions, about 1/9 should be interning<br><br>" +
+      "-In order to optimize your production, you will need a good balance of all employee positions.<br><br>" +
       "-Quality of materials used for production affects the quality/effective rating of materials/products produced, so vertical integration " +
       "is important for high profits.<br><br>" +
       "-Materials purchased from the open market are always of quality 1.<br><br>" +
-      "-The price at which you can sell your Materials/Products is highly affected by the quality/effective rating<br><br>" +
-      "-When developing a product, different employee positions affect the development process differently, " +
-      "some improve the development speed, some improve the rating of the finished product.<br><br>" +
+      "-The price at which you can sell your materials/products is highly affected by the quality/effective rating.<br><br>" +
+      "-When developing a product, different employee positions affect the development process differently. " +
+      "Some improve the development speed, some improve the rating of the finished product.<br><br>" +
       "-If your employees have low morale or energy, their production will greatly suffer. Having enough interns will make sure those stats get " +
-      "high and stay high.<br><br>" +
+      "high and stay high. 1/9 is a good ratio for interns (number of interns / office size). If morale and energy still drop, use 1/6.<br><br>" +
       "-Don't forget to advertise your company. You won't have any business if nobody knows you.<br><br>" +
       "-Having company awareness is great, but what's really important is your company's popularity. Try to keep your popularity as high as " +
-      "possible to see the biggest benefit for your sales<br><br>" +
+      "possible to see the biggest benefit for your sales.<br><br>" +
       "-Remember, you need to spend money to make money!<br><br>" +
-      "-Corporations do not reset when installing Augmentations, but they do reset when destroying a BitNode",
+      "-Your corporation does not reset when installing Augmentations, but it does reset when destroying a BitNode.",
   }),
   [LiteratureName.HistoryOfSynthoids]: new Literature({
     title: "A Brief History of Synthoids",


### PR DESCRIPTION
On Discord, a player asked why the .lit file recommends using Interns with 1/9 ratio, but FAQ tells them not to use Interns. This PR made these changes:
- Minor changes in the .lit file: capitalization, missing comma, typo error, etc.
- Add information of 1/6 ratio to the .lit file.
- Rewording FAQ. Generally, I tried to "tone down" the language. Currently, maybe it sounds a bit aggressive.