### PR TITLE
UI: Add grafting to sidebar

### DIFF
--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -13,7 +13,7 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 
-import ComputerIcon from "@mui/icons-material/Computer";
+import ComputerIcon from "@mui/icons-material/Computer"; // Hacking
 import LastPageIcon from "@mui/icons-material/LastPage"; // Terminal
 import CreateIcon from "@mui/icons-material/Create"; // Create Script
 import StorageIcon from "@mui/icons-material/Storage"; // Active Scripts
@@ -33,12 +33,13 @@ import SportsMmaIcon from "@mui/icons-material/SportsMma"; // Gang
 import CheckIcon from "@mui/icons-material/Check"; // Milestones
 import HelpIcon from "@mui/icons-material/Help"; // Tutorial
 import SettingsIcon from "@mui/icons-material/Settings"; // options
-import DeveloperBoardIcon from "@mui/icons-material/DeveloperBoard"; // Dev
+import DeveloperBoardIcon from "@mui/icons-material/DeveloperBoard"; // Stanek + Dev
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents"; // Achievements
-import AccountBoxIcon from "@mui/icons-material/AccountBox";
-import PublicIcon from "@mui/icons-material/Public";
-import LiveHelpIcon from "@mui/icons-material/LiveHelp";
-import BorderInnerSharp from "@mui/icons-material/BorderInnerSharp";
+import AccountBoxIcon from "@mui/icons-material/AccountBox"; // Character
+import PublicIcon from "@mui/icons-material/Public"; // World
+import LiveHelpIcon from "@mui/icons-material/LiveHelp"; // Help
+import BorderInnerSharpIcon from "@mui/icons-material/BorderInnerSharp"; // IPvGO
+import BiotechIcon from "@mui/icons-material/Biotech"; // Grafting
 
 import { Router } from "../../ui/GameRoot";
 import { Page, isSimplePage } from "../../ui/Router";
@@ -48,7 +49,7 @@ import { CONSTANTS } from "../../Constants";
 import { iTutorialSteps, iTutorialNextStep, ITutorial } from "../../InteractiveTutorial";
 import { getAvailableCreatePrograms } from "../../Programs/ProgramHelpers";
 import { Settings } from "../../Settings/Settings";
-import { AugmentationName } from "@enums";
+import { AugmentationName, CityName } from "@enums";
 
 import { ProgramsSeen } from "../../Programs/ui/ProgramsRoot";
 import { InvitationsSeen } from "../../Faction/ui/FactionsRoot";
@@ -151,6 +152,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
     Player.exploits.length > 0;
 
   const canOpenSleeves = Player.sleeves.length > 0;
+  const canOpenGrafting = Player.canAccessGrafting() && Player.city === CityName.NewTokyo;
 
   const canCorporation = !!Player.corporation;
   const canGang = !!Player.gang;
@@ -318,7 +320,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
             canOpenFactions && {
               key_: Page.Factions,
               icon: ContactsIcon,
-              active: [Page.Factions as Page, Page.Faction].includes(props.page),
+              active: [Page.Factions, Page.Faction].includes(props.page),
               count: invitationsCount,
             },
             canOpenAugmentations && {
@@ -328,6 +330,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
             },
             { key_: Page.Hacknet, icon: AccountTreeIcon },
             canOpenSleeves && { key_: Page.Sleeves, icon: PeopleAltIcon },
+            canOpenGrafting && { key_: Page.Grafting, icon: BiotechIcon },
           ]}
         />
         <Divider />
@@ -343,7 +346,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
             {
               key_: Page.City,
               icon: LocationCityIcon,
-              active: [Page.City as Page, Page.Grafting, Page.Location].includes(props.page),
+              active: [Page.City, Page.Location].includes(props.page),
             },
             { key_: Page.Travel, icon: AirplanemodeActiveIcon },
             canJob && { key_: Page.Job, icon: WorkIcon },
@@ -351,7 +354,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
             canBladeburner && { key_: Page.Bladeburner, icon: FormatBoldIcon },
             canCorporation && { key_: Page.Corporation, icon: BusinessIcon },
             canGang && { key_: Page.Gang, icon: SportsMmaIcon },
-            canIPvGO && { key_: Page.Go, icon: BorderInnerSharp },
+            canIPvGO && { key_: Page.Go, icon: BorderInnerSharpIcon },
           ]}
         />
         <Divider />


### PR DESCRIPTION
This PR implements the idea in #1613. I tried to do that with minimal change. There is no change in our requirements for grafting. The addition is only for UI. The player still needs to go to New Tokyo to see the new tab.

Screenshot:
![Capture](https://github.com/user-attachments/assets/ddb4e558-3735-4510-98fb-72ef6f3fab8a)

Closes #1613.