### PR TITLE
CODEBASE: Use "esnext" target when transforming code with swc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {
-        "@babel/standalone": "^7.24.4",
+        "@babel/standalone": "^7.26.2",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@material-ui/core": "^4.12.4",
@@ -18,7 +18,7 @@
         "@mui/material": "^5.14.12",
         "@mui/styles": "^5.14.12",
         "@mui/system": "^5.14.12",
-        "@swc/wasm-web": "^1.4.14",
+        "@swc/wasm-web": "^1.9.3",
         "@types/estree": "^1.0.2",
         "@types/react-syntax-highlighter": "^15.5.8",
         "acorn": "^8.11.3",
@@ -57,7 +57,7 @@
         "@microsoft/api-documenter": "~7.23.38",
         "@microsoft/api-extractor": "^7.47.5",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-        "@swc/core": "^1.4.14",
+        "@swc/core": "^1.9.3",
         "@types/babel__standalone": "^7.1.7",
         "@types/bcryptjs": "^2.4.4",
         "@types/escodegen": "^0.0.7",
@@ -1875,9 +1875,10 @@
       }
     },
     "node_modules/@babel/standalone": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.24.4.tgz",
-      "integrity": "sha512-V4uqWeedadiuiCx5P5OHYJZ1PehdMpcBccNCEptKFGPiZIY3FI5f2ClxUl4r5wZ5U+ohcQ+4KW6jX2K6xXzq4Q==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.26.2.tgz",
+      "integrity": "sha512-i2VbegsRfwa9yq3xmfDX3tG2yh9K0cCqwpSyVG2nPxifh0EOnucAZUeO/g4lW2Zfg03aPJNtPfxQbDHzXc7H+w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4412,14 +4413,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.14.tgz",
-      "integrity": "sha512-tHXg6OxboUsqa/L7DpsCcFnxhLkqN/ht5pCwav1HnvfthbiNIJypr86rNx4cUnQDJepETviSqBTIjxa7pSpGDQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.9.3.tgz",
+      "integrity": "sha512-oRj0AFePUhtatX+BscVhnzaAmWjpfAeySpM1TCbxA1rtBDeH/JDhi5yYzAKneDYtVtBvA7ApfeuzhMC9ye4xSg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.2",
-        "@swc/types": "^0.1.5"
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.17"
       },
       "engines": {
         "node": ">=10"
@@ -4429,19 +4431,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.4.14",
-        "@swc/core-darwin-x64": "1.4.14",
-        "@swc/core-linux-arm-gnueabihf": "1.4.14",
-        "@swc/core-linux-arm64-gnu": "1.4.14",
-        "@swc/core-linux-arm64-musl": "1.4.14",
-        "@swc/core-linux-x64-gnu": "1.4.14",
-        "@swc/core-linux-x64-musl": "1.4.14",
-        "@swc/core-win32-arm64-msvc": "1.4.14",
-        "@swc/core-win32-ia32-msvc": "1.4.14",
-        "@swc/core-win32-x64-msvc": "1.4.14"
+        "@swc/core-darwin-arm64": "1.9.3",
+        "@swc/core-darwin-x64": "1.9.3",
+        "@swc/core-linux-arm-gnueabihf": "1.9.3",
+        "@swc/core-linux-arm64-gnu": "1.9.3",
+        "@swc/core-linux-arm64-musl": "1.9.3",
+        "@swc/core-linux-x64-gnu": "1.9.3",
+        "@swc/core-linux-x64-musl": "1.9.3",
+        "@swc/core-win32-arm64-msvc": "1.9.3",
+        "@swc/core-win32-ia32-msvc": "1.9.3",
+        "@swc/core-win32-x64-msvc": "1.9.3"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "*"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -4450,13 +4452,14 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.14.tgz",
-      "integrity": "sha512-8iPfLhYNspBl836YYsfv6ErXwDUqJ7IMieddV3Ey/t/97JAEAdNDUdtTKDtbyP0j/Ebyqyn+fKcqwSq7rAof0g==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.9.3.tgz",
+      "integrity": "sha512-hGfl/KTic/QY4tB9DkTbNuxy5cV4IeejpPD4zo+Lzt4iLlDWIeANL4Fkg67FiVceNJboqg48CUX+APhDHO5G1w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4466,13 +4469,14 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.14.tgz",
-      "integrity": "sha512-9CqSj8uRZ92cnlgAlVaWMaJJBdxtNvCzJxaGj5KuIseeG6Q0l1g+qk8JcU7h9dAsH9saHTNwNFBVGKQo0W0ujg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.9.3.tgz",
+      "integrity": "sha512-IaRq05ZLdtgF5h9CzlcgaNHyg4VXuiStnOFpfNEMuI5fm5afP2S0FHq8WdakUz5WppsbddTdplL+vpeApt/WCQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4482,13 +4486,14 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.14.tgz",
-      "integrity": "sha512-mfd5JArPITTzMjcezH4DwMw+BdjBV1y25Khp8itEIpdih9ei+fvxOOrDYTN08b466NuE2dF2XuhKtRLA7fXArQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.9.3.tgz",
+      "integrity": "sha512-Pbwe7xYprj/nEnZrNBvZfjnTxlBIcfApAGdz2EROhjpPj+FBqBa3wOogqbsuGGBdCphf8S+KPprL1z+oDWkmSQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4498,13 +4503,14 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.14.tgz",
-      "integrity": "sha512-3Lqlhlmy8MVRS9xTShMaPAp0oyUt0KFhDs4ixJsjdxKecE0NJSV/MInuDmrkij1C8/RQ2wySRlV9np5jK86oWw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.9.3.tgz",
+      "integrity": "sha512-AQ5JZiwNGVV/2K2TVulg0mw/3LYfqpjZO6jDPtR2evNbk9Yt57YsVzS+3vHSlUBQDRV9/jqMuZYVU3P13xrk+g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4514,13 +4520,14 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.14.tgz",
-      "integrity": "sha512-n0YoCa64TUcJrbcXIHIHDWQjdUPdaXeMHNEu7yyBtOpm01oMGTKP3frsUXIABLBmAVWtKvqit4/W1KVKn5gJzg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.9.3.tgz",
+      "integrity": "sha512-tzVH480RY6RbMl/QRgh5HK3zn1ZTFsThuxDGo6Iuk1MdwIbdFYUY034heWUTI4u3Db97ArKh0hNL0xhO3+PZdg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4530,13 +4537,14 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.14.tgz",
-      "integrity": "sha512-CGmlwLWbfG1dB4jZBJnp2IWlK5xBMNLjN7AR5kKA3sEpionoccEnChOEvfux1UdVJQjLRKuHNV9yGyqGBTpxfQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.9.3.tgz",
+      "integrity": "sha512-ivXXBRDXDc9k4cdv10R21ccBmGebVOwKXT/UdH1PhxUn9m/h8erAWjz5pcELwjiMf27WokqPgaWVfaclDbgE+w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4546,13 +4554,14 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.14.tgz",
-      "integrity": "sha512-xq4npk8YKYmNwmr8fbvF2KP3kUVdZYfXZMQnW425gP3/sn+yFQO8Nd0bGH40vOVQn41kEesSe0Z5O/JDor2TgQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.9.3.tgz",
+      "integrity": "sha512-ILsGMgfnOz1HwdDz+ZgEuomIwkP1PHT6maigZxaCIuC6OPEhKE8uYna22uU63XvYcLQvZYDzpR3ms47WQPuNEg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4562,13 +4571,14 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.14.tgz",
-      "integrity": "sha512-imq0X+gU9uUe6FqzOQot5gpKoaC00aCUiN58NOzwp0QXEupn8CDuZpdBN93HiZswfLruu5jA1tsc15x6v9p0Yg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.9.3.tgz",
+      "integrity": "sha512-e+XmltDVIHieUnNJHtspn6B+PCcFOMYXNJB1GqoCcyinkEIQNwC8KtWgMqUucUbEWJkPc35NHy9k8aCXRmw9Kg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4578,13 +4588,14 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.14.tgz",
-      "integrity": "sha512-cH6QpXMw5D3t+lpx6SkErHrxN0yFzmQ0lgNAJxoDRiaAdDbqA6Col8UqUJwUS++Ul6aCWgNhCdiEYehPaoyDPA==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.9.3.tgz",
+      "integrity": "sha512-rqpzNfpAooSL4UfQnHhkW8aL+oyjqJniDP0qwZfGnjDoJSbtPysHg2LpcOBEdSnEH+uIZq6J96qf0ZFD8AGfXA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4594,13 +4605,14 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.14.tgz",
-      "integrity": "sha512-FmZ4Tby4wW65K/36BKzmuu7mlq7cW5XOxzvufaSNVvQ5PN4OodAlqPjToe029oma4Av+ykJiif64scMttyNAzg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.9.3.tgz",
+      "integrity": "sha512-3YJJLQ5suIEHEKc1GHtqVq475guiyqisKSoUnoaRtxkDaW5g1yvPt9IoSLOe2mRs7+FFhGGU693RsBUSwOXSdQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4613,21 +4625,24 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
-      "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@swc/wasm-web": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/wasm-web/-/wasm-web-1.4.14.tgz",
-      "integrity": "sha512-AE9TBrhFnV0bt38ZPfgkT8SmqhYY4RzxoZcf6eNKC7dRQXlobQLi4+qwdjHSp+BE3EQ02U3gUwctsK6Nr7Pqaw=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/wasm-web/-/wasm-web-1.9.3.tgz",
+      "integrity": "sha512-4mv9dNeQ1djo2so+OVLEdgwkHnVPTKY5dwntxRNexRozjb5+WYntoSRQW0Ph76qgfF2t2h+yEX2bAb7p0E1aTg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/bitburner-official/bitburner-src/issues"
   },
   "dependencies": {
-    "@babel/standalone": "^7.24.4",
+    "@babel/standalone": "^7.26.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@material-ui/core": "^4.12.4",
@@ -18,7 +18,7 @@
     "@mui/material": "^5.14.12",
     "@mui/styles": "^5.14.12",
     "@mui/system": "^5.14.12",
-    "@swc/wasm-web": "^1.4.14",
+    "@swc/wasm-web": "^1.9.3",
     "@types/estree": "^1.0.2",
     "@types/react-syntax-highlighter": "^15.5.8",
     "acorn": "^8.11.3",
@@ -58,7 +58,7 @@
     "@microsoft/api-documenter": "~7.23.38",
     "@microsoft/api-extractor": "^7.47.5",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-    "@swc/core": "^1.4.14",
+    "@swc/core": "^1.9.3",
     "@types/babel__standalone": "^7.1.7",
     "@types/bcryptjs": "^2.4.4",
     "@types/escodegen": "^0.0.7",

--- a/src/utils/ScriptTransformer.ts
+++ b/src/utils/ScriptTransformer.ts
@@ -152,7 +152,8 @@ export function transformScript(code: string, fileType: FileType): string | null
   return transformSync(code, {
     jsc: {
       parser: parserConfig,
-      target: "es2020",
+      // @ts-expect-error -- jsc supports "esnext" target, but the definition in wasm-web.d.ts is outdated. Ref: https://github.com/swc-project/swc/issues/9495
+      target: "esnext",
     },
   }).code;
 }


### PR DESCRIPTION
d0sboots requested this change at https://github.com/bitburner-official/bitburner-src/pull/1216#discussion_r1669358105. There is a bug in swc-wasm (https://github.com/swc-project/swc/issues/9495) blocking this change. It's only a minor bug in the definition file, so I decided to just ignore it and make this change.