### PR TITLE
CODEBASE: Show error dialog when finding out old bugs in pre-v2.4.0

### DIFF
--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -283,6 +283,7 @@ export function startWorkerScript(runningScript: RunningScript, server: BaseServ
       new Error(
         `Tried to launch a worker script on a different server ${server.hostname} than the runningScript's server ${runningScript.server}`,
       ),
+      true,
     );
     return 0;
   }

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -37,6 +37,7 @@ import { CompleteRunOptions, getRunningScriptsByArgs } from "./Netscript/Netscri
 import { handleUnknownError } from "./utils/ErrorHandler";
 import { isLegacyScript, legacyScriptExtension, resolveScriptFilePath, ScriptFilePath } from "./Paths/ScriptFilePath";
 import { root } from "./Paths/Directory";
+import { exceptionAlert } from "./utils/helpers/exceptionAlert";
 
 export const NetscriptPorts = new Map<PortNumber, Port>();
 
@@ -278,8 +279,10 @@ function processNetscript1Imports(code: string, workerScript: WorkerScript): { c
 export function startWorkerScript(runningScript: RunningScript, server: BaseServer, parent?: WorkerScript): number {
   if (server.hostname !== runningScript.server) {
     // Temporarily adding a check here to see if this ever triggers
-    console.error(
-      `Tried to launch a worker script on a different server ${server.hostname} than the runningScript's server ${runningScript.server}`,
+    exceptionAlert(
+      new Error(
+        `Tried to launch a worker script on a different server ${server.hostname} than the runningScript's server ${runningScript.server}`,
+      ),
     );
     return 0;
   }

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -213,6 +213,7 @@ export function prestigeHomeComputer(homeComp: Server): void {
           homeComp.runningScriptMap.keys(),
         )}`,
       ),
+      true,
     );
     for (const [scriptKey, byPidMap] of homeComp.runningScriptMap) {
       console.error(`script key: ${scriptKey}: ${byPidMap.size} scripts`, byPidMap);

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -11,6 +11,7 @@ import { Server as IServer } from "@nsdefs";
 import { workerScripts } from "../Netscript/WorkerScripts";
 import { killWorkerScriptByPid } from "../Netscript/killWorkerScript";
 import { serverMetadata } from "./data/servers";
+import { exceptionAlert } from "../utils/helpers/exceptionAlert";
 
 /**
  * Constructs a new server, while also ensuring that the new server
@@ -206,9 +207,15 @@ export function prestigeHomeComputer(homeComp: Server): void {
   homeComp.messages.push(LiteratureName.HackersStartingHandbook);
   if (homeComp.runningScriptMap.size !== 0) {
     // Temporary verbose logging section to gather data on a bug
-    console.error("Some runningScripts were still present on home during prestige");
+    exceptionAlert(
+      new Error(
+        `Some runningScripts were still present on home during prestige. runningScripts: ${Array.from(
+          homeComp.runningScriptMap.keys(),
+        )}`,
+      ),
+    );
     for (const [scriptKey, byPidMap] of homeComp.runningScriptMap) {
-      console.error(`script key: ${scriptKey}: ${byPidMap.size} scripts`);
+      console.error(`script key: ${scriptKey}: ${byPidMap.size} scripts`, byPidMap);
       for (const pid of byPidMap.keys()) {
         if (workerScripts.has(pid)) killWorkerScriptByPid(pid);
       }

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -480,7 +480,7 @@ Error: ${e}`,
       );
   }
   if (ver < 33) {
-    // 2.3.2 fixed what should be the last issue with scripts having the wrong server assigned..
+    // 2.4.0 fixed what should be the last issue with scripts having the wrong server assigned
     for (const server of GetAllServers()) {
       for (const script of server.scripts.values()) {
         if (script.server !== server.hostname) {


### PR DESCRIPTION
In 40babcb2ee674f445ec2e364f49a75b83da9a1df (v2.3.1), we added debug code to find bugs:
- `runningScriptMap` is not cleared before `prestigeHomeComputer`. [1]
- `runningScript.server` is not `server.hostname`. [2]

[2] can happen if the player loads a save file from old versions that save IP addresses as keys of servers instead of hostnames.

In a4b826683e8482323a79e4b5b8a44adf2146df6f (v2.4.0), we added migration code to fix [2].

If [1] and [2] still happen, current debug code does not help us discover the bugs because it does not notify the player (and us) about those bugs. This PR replaces `console.error` with `exceptionAlert`.

After we release this change for 1 or 2 versions, if we don't receive any reports about those bugs, we can remove the debug code.