### PR TITLE
CORPORATION: Print error message when player cannot create corporation

### DIFF
--- a/src/Corporation/ui/modals/CreateCorporationModal.tsx
+++ b/src/Corporation/ui/modals/CreateCorporationModal.tsx
@@ -11,6 +11,7 @@ import { ButtonWithTooltip } from "../../../ui/Components/ButtonWithTooltip";
 import TextField from "@mui/material/TextField";
 import { createCorporation } from "../../Actions";
 import { costOfCreatingCorporation } from "../../helpers";
+import { exceptionAlert } from "../../../utils/helpers/exceptionAlert";
 
 interface IProps {
   open: boolean;
@@ -34,7 +35,13 @@ export function CreateCorporationModal(props: IProps): React.ReactElement {
   }
 
   function createCorporationWithUI(corporationName: string, selfFund: boolean): void {
-    if (!createCorporation(corporationName, selfFund, props.restart)) {
+    const result = createCorporation(corporationName, selfFund, props.restart);
+    if (!result.success) {
+      /**
+       * This should not happen. We always check if the player can create a corporation before enabling UI elements
+       * needed to do that.
+       */
+      exceptionAlert(new Error(result.message));
       return;
     }
     props.onClose();

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -606,7 +606,11 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
       (_corporationName, _selfFund = true): boolean => {
         const corporationName = helpers.string(ctx, "corporationName", _corporationName);
         const selfFund = !!_selfFund;
-        return createCorporation(corporationName, selfFund, false);
+        const result = createCorporation(corporationName, selfFund, false);
+        if (!result.success) {
+          helpers.log(ctx, () => result.message);
+        }
+        return result.success;
       },
     getConstants: () => () => {
       /* TODO 2.2: possibly just rework the whole corp constants structure to be more readable, and just use


### PR DESCRIPTION
When the player cannot create a corporation, `ns.corporation.createCorporation` returns false without showing the reason. This PR makes that API print an error message when it happens.

Before:
![before](https://github.com/user-attachments/assets/670e97fc-95de-492a-becc-00bf4e632496)

After:
![after](https://github.com/user-attachments/assets/0262e7dc-7861-4c0f-8acc-bc75959e8527)
