### PR TITLE
BUGFIX: Game takes too long to process crime work with large number of cycles

### DIFF
--- a/src/Work/CrimeWork.ts
+++ b/src/Work/CrimeWork.ts
@@ -33,6 +33,12 @@ export class CrimeWork extends Work {
   }
 
   process(cycles = 1): boolean {
+    /**
+     * Crime work is processed in a loop. If the number of cycles is too large, the loop blocks the game engine for too
+     * long. 12960000 is the number of cycles in 30 days (5 * 3600 * 24 * 30). On a very old machine, the loop takes
+     * ~800-1000 ms to process the "shoplift" crime which is the fastest crime (faster crime = more iteration).
+     */
+    cycles = Math.min(cycles, 12960000);
     this.cyclesWorked += cycles;
     const time = Object.values(Crimes).find((c) => c.type === this.crimeType)?.time ?? 0;
     this.unitCompleted += CONSTANTS.MilliPerCycle * cycles;


### PR DESCRIPTION
While making #1657, I suspected that generating CCT is not the only thing that blocks the game engine when the save file has too much bonus time. Now, when I check other mechanics, I find out that crime work also has this problem. This PR puts a cap on the number of processing cycles. Note that crime work of sleeves does not have this problem because we put a cap on sleeve's `cyclesUsed` before calling `this.currentWork.process(this, cyclesUsed);`.

How to reproduce this bug:
- Load the attached save file. `Player.lastUpdate` is 0 in that save file.
- Make sure that the game loads normally.

Save file: [test-crime-last-update-0.gz](https://github.com/user-attachments/files/17976399/test-crime-last-update-0.gz)
