### PR TITLE
UI: Change description and add tooltip for HackMoney-related multipliers

### DIFF
--- a/markdown/bitburner.bitnodemultipliers.manualhackmoney.md
+++ b/markdown/bitburner.bitnodemultipliers.manualhackmoney.md
@@ -4,7 +4,7 @@
 
 ## BitNodeMultipliers.ManualHackMoney property
 
-Influences how much money can be stolen from a server when the player performs a hack against it through the Terminal.
+Influences how much money is stolen from a server when the player performs a hack against it through the terminal.
 
 **Signature:**
 

--- a/markdown/bitburner.bitnodemultipliers.manualhackmoney.md
+++ b/markdown/bitburner.bitnodemultipliers.manualhackmoney.md
@@ -4,7 +4,7 @@
 
 ## BitNodeMultipliers.ManualHackMoney property
 
-Influences how much money is stolen from a server when the player performs a hack against it through the terminal.
+Influences how much money the player actually gains when they hack a server via the terminal. This is different from ScriptHackMoney. When the player hack a server via the terminal, the amount of money in that server is reduced, but they do not gain that same amount.
 
 **Signature:**
 

--- a/markdown/bitburner.bitnodemultipliers.md
+++ b/markdown/bitburner.bitnodemultipliers.md
@@ -51,14 +51,14 @@ interface BitNodeMultipliers
 |  [HomeComputerRamCost](./bitburner.bitnodemultipliers.homecomputerramcost.md) |  | number | Influences how much money it costs to upgrade your home computer's RAM |
 |  [InfiltrationMoney](./bitburner.bitnodemultipliers.infiltrationmoney.md) |  | number | Influences how much money is gained when the player infiltrates a company. |
 |  [InfiltrationRep](./bitburner.bitnodemultipliers.infiltrationrep.md) |  | number | Influences how much rep the player can gain from factions when selling stolen documents and secrets |
-|  [ManualHackMoney](./bitburner.bitnodemultipliers.manualhackmoney.md) |  | number | Influences how much money can be stolen from a server when the player performs a hack against it through the Terminal. |
+|  [ManualHackMoney](./bitburner.bitnodemultipliers.manualhackmoney.md) |  | number | Influences how much money is stolen from a server when the player performs a hack against it through the terminal. |
 |  [PurchasedServerCost](./bitburner.bitnodemultipliers.purchasedservercost.md) |  | number | Influence how much it costs to purchase a server |
 |  [PurchasedServerLimit](./bitburner.bitnodemultipliers.purchasedserverlimit.md) |  | number | Influences the maximum number of purchased servers you can have |
 |  [PurchasedServerMaxRam](./bitburner.bitnodemultipliers.purchasedservermaxram.md) |  | number | Influences the maximum allowed RAM for a purchased server |
 |  [PurchasedServerSoftcap](./bitburner.bitnodemultipliers.purchasedserversoftcap.md) |  | number | Influence how much it costs to purchase a server |
 |  [RepToDonateToFaction](./bitburner.bitnodemultipliers.reptodonatetofaction.md) |  | number | Influences the minimum favor the player must have with a faction before they can donate to gain rep. |
-|  [ScriptHackMoney](./bitburner.bitnodemultipliers.scripthackmoney.md) |  | number | Influences how much money can be stolen from a server when a script performs a hack against it. |
-|  [ScriptHackMoneyGain](./bitburner.bitnodemultipliers.scripthackmoneygain.md) |  | number | The amount of money actually gained when a script hacks a server. This is different than the above because you can reduce the amount of money but not gain that same amount. |
+|  [ScriptHackMoney](./bitburner.bitnodemultipliers.scripthackmoney.md) |  | number | Influences how much money is stolen from a server when a script performs a hack against it. |
+|  [ScriptHackMoneyGain](./bitburner.bitnodemultipliers.scripthackmoneygain.md) |  | number | Influences how much money the player actually gains when a script hacks a server. This is different from ScriptHackMoney. When a script hacks a server, the amount of money in that server is reduced, but the player does not gain that same amount. |
 |  [ServerGrowthRate](./bitburner.bitnodemultipliers.servergrowthrate.md) |  | number | Influences the growth percentage per cycle against a server. |
 |  [ServerMaxMoney](./bitburner.bitnodemultipliers.servermaxmoney.md) |  | number | Influences the maximum money that a server can grow to. |
 |  [ServerStartingMoney](./bitburner.bitnodemultipliers.serverstartingmoney.md) |  | number | Influences the initial money that a server starts with. |

--- a/markdown/bitburner.bitnodemultipliers.md
+++ b/markdown/bitburner.bitnodemultipliers.md
@@ -51,13 +51,13 @@ interface BitNodeMultipliers
 |  [HomeComputerRamCost](./bitburner.bitnodemultipliers.homecomputerramcost.md) |  | number | Influences how much money it costs to upgrade your home computer's RAM |
 |  [InfiltrationMoney](./bitburner.bitnodemultipliers.infiltrationmoney.md) |  | number | Influences how much money is gained when the player infiltrates a company. |
 |  [InfiltrationRep](./bitburner.bitnodemultipliers.infiltrationrep.md) |  | number | Influences how much rep the player can gain from factions when selling stolen documents and secrets |
-|  [ManualHackMoney](./bitburner.bitnodemultipliers.manualhackmoney.md) |  | number | Influences how much money is stolen from a server when the player performs a hack against it through the terminal. |
+|  [ManualHackMoney](./bitburner.bitnodemultipliers.manualhackmoney.md) |  | number | Influences how much money the player actually gains when they hack a server via the terminal. This is different from ScriptHackMoney. When the player hack a server via the terminal, the amount of money in that server is reduced, but they do not gain that same amount. |
 |  [PurchasedServerCost](./bitburner.bitnodemultipliers.purchasedservercost.md) |  | number | Influence how much it costs to purchase a server |
 |  [PurchasedServerLimit](./bitburner.bitnodemultipliers.purchasedserverlimit.md) |  | number | Influences the maximum number of purchased servers you can have |
 |  [PurchasedServerMaxRam](./bitburner.bitnodemultipliers.purchasedservermaxram.md) |  | number | Influences the maximum allowed RAM for a purchased server |
 |  [PurchasedServerSoftcap](./bitburner.bitnodemultipliers.purchasedserversoftcap.md) |  | number | Influence how much it costs to purchase a server |
 |  [RepToDonateToFaction](./bitburner.bitnodemultipliers.reptodonatetofaction.md) |  | number | Influences the minimum favor the player must have with a faction before they can donate to gain rep. |
-|  [ScriptHackMoney](./bitburner.bitnodemultipliers.scripthackmoney.md) |  | number | Influences how much money is stolen from a server when a script performs a hack against it. |
+|  [ScriptHackMoney](./bitburner.bitnodemultipliers.scripthackmoney.md) |  | number | Influences how much money is stolen from a server when the player performs a hack against it. |
 |  [ScriptHackMoneyGain](./bitburner.bitnodemultipliers.scripthackmoneygain.md) |  | number | Influences how much money the player actually gains when a script hacks a server. This is different from ScriptHackMoney. When a script hacks a server, the amount of money in that server is reduced, but the player does not gain that same amount. |
 |  [ServerGrowthRate](./bitburner.bitnodemultipliers.servergrowthrate.md) |  | number | Influences the growth percentage per cycle against a server. |
 |  [ServerMaxMoney](./bitburner.bitnodemultipliers.servermaxmoney.md) |  | number | Influences the maximum money that a server can grow to. |

--- a/markdown/bitburner.bitnodemultipliers.scripthackmoney.md
+++ b/markdown/bitburner.bitnodemultipliers.scripthackmoney.md
@@ -4,7 +4,7 @@
 
 ## BitNodeMultipliers.ScriptHackMoney property
 
-Influences how much money is stolen from a server when a script performs a hack against it.
+Influences how much money is stolen from a server when the player performs a hack against it.
 
 **Signature:**
 

--- a/markdown/bitburner.bitnodemultipliers.scripthackmoney.md
+++ b/markdown/bitburner.bitnodemultipliers.scripthackmoney.md
@@ -4,7 +4,7 @@
 
 ## BitNodeMultipliers.ScriptHackMoney property
 
-Influences how much money can be stolen from a server when a script performs a hack against it.
+Influences how much money is stolen from a server when a script performs a hack against it.
 
 **Signature:**
 

--- a/markdown/bitburner.bitnodemultipliers.scripthackmoneygain.md
+++ b/markdown/bitburner.bitnodemultipliers.scripthackmoneygain.md
@@ -4,7 +4,7 @@
 
 ## BitNodeMultipliers.ScriptHackMoneyGain property
 
-The amount of money actually gained when a script hacks a server. This is different than the above because you can reduce the amount of money but not gain that same amount.
+Influences how much money the player actually gains when a script hacks a server. This is different from ScriptHackMoney. When a script hacks a server, the amount of money in that server is reduced, but the player does not gain that same amount.
 
 **Signature:**
 

--- a/src/BitNode/BitNodeMultipliers.ts
+++ b/src/BitNode/BitNodeMultipliers.ts
@@ -115,8 +115,9 @@ export class BitNodeMultipliers {
   InfiltrationRep = 1;
 
   /**
-   * Influences how much money is stolen from a server when the player performs a hack against it through
-   * the terminal.
+   * Influences how much money the player actually gains when they hack a server via the terminal. This is different
+   * from ScriptHackMoney. When the player hack a server via the terminal, the amount of money in that server is
+   * reduced, but they do not gain that same amount.
    */
   ManualHackMoney = 1;
 
@@ -135,7 +136,7 @@ export class BitNodeMultipliers {
   /** Influences the minimum favor the player must have with a faction before they can donate to gain rep. */
   RepToDonateToFaction = 1;
 
-  /** Influences how much money is stolen from a server when a script performs a hack against it. */
+  /** Influences how much money is stolen from a server when the player performs a hack against it. */
   ScriptHackMoney = 1;
 
   /**

--- a/src/BitNode/BitNodeMultipliers.ts
+++ b/src/BitNode/BitNodeMultipliers.ts
@@ -115,8 +115,8 @@ export class BitNodeMultipliers {
   InfiltrationRep = 1;
 
   /**
-   * Influences how much money can be stolen from a server when the player performs a hack against it through
-   * the Terminal.
+   * Influences how much money is stolen from a server when the player performs a hack against it through
+   * the terminal.
    */
   ManualHackMoney = 1;
 
@@ -135,12 +135,12 @@ export class BitNodeMultipliers {
   /** Influences the minimum favor the player must have with a faction before they can donate to gain rep. */
   RepToDonateToFaction = 1;
 
-  /** Influences how much money can be stolen from a server when a script performs a hack against it. */
+  /** Influences how much money is stolen from a server when a script performs a hack against it. */
   ScriptHackMoney = 1;
 
   /**
-   * The amount of money actually gained when a script hacks a server. This is
-   * different than the above because you can reduce the amount of money but
+   * Influences how much money the player actually gains when a script hacks a server. This is different from
+   * ScriptHackMoney. When a script hacks a server, the amount of money in that server is reduced, but the player does
    * not gain that same amount.
    */
   ScriptHackMoneyGain = 1;

--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -1,6 +1,15 @@
 import React from "react";
-import { uniqueId } from "lodash";
-import { Box, Collapse, ListItemButton, ListItemText, Paper, Table, TableBody, Typography } from "@mui/material";
+import {
+  Box,
+  Collapse,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Table,
+  TableBody,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import ExpandLess from "@mui/icons-material/ExpandLess";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 
@@ -70,6 +79,7 @@ type IBNMultRows = PartialRecord<
     name: string;
     content?: string;
     color?: string;
+    tooltipText?: string;
   }
 >;
 
@@ -82,14 +92,26 @@ interface IBNMultTableProps {
 const BNMultTable = (props: IBNMultTableProps): React.ReactElement => {
   const rowsArray = getRecordEntries(props.rowData)
     .filter(([key]) => props.mults[key] !== defaultMultipliers[key])
-    .map(([key, value]) => (
-      <StatsRow
-        key={uniqueId()}
-        name={value.name}
-        data={{ content: value.content ?? `${(props.mults[key] * 100).toFixed(3)}%` }}
-        color={value.color ?? Settings.theme.primary}
-      />
-    ));
+    .map(([key, value]) => {
+      const name = value.tooltipText ? (
+        <Tooltip title={<span>{value.tooltipText}</span>}>
+          <span>
+            {value.name}
+            <sup>(*)</sup>
+          </span>
+        </Tooltip>
+      ) : (
+        value.name
+      );
+      return (
+        <StatsRow
+          key={`${props.sectionName}-${value.name}`}
+          name={name}
+          data={{ content: value.content ?? `${(props.mults[key] * 100).toFixed(3)}%` }}
+          color={value.color ?? Settings.theme.primary}
+        />
+      );
+    });
 
   return rowsArray.length > 0 ? (
     <span style={{ display: "inline-block", width: "100%", marginBottom: "16px" }}>
@@ -241,16 +263,20 @@ function HackingMults({ mults }: IMultsProps): React.ReactElement {
     ServerStartingSecurity: { name: "Server Starting Security" },
     ServerWeakenRate: { name: "Server Weaken Rate" },
     ManualHackMoney: {
-      name: "Manual Hack Money",
+      name: "Stolen Money From Manual Hack",
       color: Settings.theme.money,
+      tooltipText:
+        "Influences how much money is stolen from a server when the player performs a hack against it through the terminal",
     },
     ScriptHackMoney: {
-      name: "Script Hack Money",
+      name: "Stolen Money From Script Hack",
       color: Settings.theme.money,
+      tooltipText: "Influences how much money is stolen from a server when a script performs a hack against it",
     },
     ScriptHackMoneyGain: {
-      name: "Money Gained From Hack",
+      name: "Money Gained From Script Hack",
       color: Settings.theme.money,
+      tooltipText: `Influences how much money the player actually gains when a script hacks a server. This is different from "Stolen Money From Script Hack". When a script hacks a server, the amount of money in that server is reduced, but the player does not gain that same amount.`,
     },
   };
 

--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -263,20 +263,19 @@ function HackingMults({ mults }: IMultsProps): React.ReactElement {
     ServerStartingSecurity: { name: "Server Starting Security" },
     ServerWeakenRate: { name: "Server Weaken Rate" },
     ManualHackMoney: {
-      name: "Stolen Money From Manual Hack",
+      name: "Money Gained From Manual Hack",
       color: Settings.theme.money,
-      tooltipText:
-        "Influences how much money is stolen from a server when the player performs a hack against it through the terminal",
+      tooltipText: `Influences how much money the player actually gains when they hack a server via the terminal. This is different from "Stolen Money From Hack". When the player hack a server via the terminal, the amount of money in that server is reduced, but they do not gain that same amount.`,
     },
     ScriptHackMoney: {
-      name: "Stolen Money From Script Hack",
+      name: "Stolen Money From Hack",
       color: Settings.theme.money,
-      tooltipText: "Influences how much money is stolen from a server when a script performs a hack against it",
+      tooltipText: "Influences how much money is stolen from a server when the player performs a hack against it.",
     },
     ScriptHackMoneyGain: {
       name: "Money Gained From Script Hack",
       color: Settings.theme.money,
-      tooltipText: `Influences how much money the player actually gains when a script hacks a server. This is different from "Stolen Money From Script Hack". When a script hacks a server, the amount of money in that server is reduced, but the player does not gain that same amount.`,
+      tooltipText: `Influences how much money the player actually gains when a script hacks a server. This is different from "Stolen Money From Hack". When a script hacks a server, the amount of money in that server is reduced, but the player does not gain that same amount.`,
     },
   };
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -728,8 +728,8 @@ interface BitNodeMultipliers {
   /** Influences how much rep the player can gain from factions when selling stolen documents and secrets */
   InfiltrationRep: number;
   /**
-   * Influences how much money can be stolen from a server when the player performs a hack against it through
-   * the Terminal.
+   * Influences how much money is stolen from a server when the player performs a hack against it through
+   * the terminal.
    */
   ManualHackMoney: number;
   /** Influence how much it costs to purchase a server */
@@ -742,11 +742,11 @@ interface BitNodeMultipliers {
   PurchasedServerMaxRam: number;
   /** Influences the minimum favor the player must have with a faction before they can donate to gain rep. */
   RepToDonateToFaction: number;
-  /** Influences how much money can be stolen from a server when a script performs a hack against it. */
+  /** Influences how much money is stolen from a server when a script performs a hack against it. */
   ScriptHackMoney: number;
   /**
-   * The amount of money actually gained when a script hacks a server. This is
-   * different than the above because you can reduce the amount of money but
+   * Influences how much money the player actually gains when a script hacks a server. This is different from
+   * ScriptHackMoney. When a script hacks a server, the amount of money in that server is reduced, but the player does
    * not gain that same amount.
    */
   ScriptHackMoneyGain: number;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -728,8 +728,9 @@ interface BitNodeMultipliers {
   /** Influences how much rep the player can gain from factions when selling stolen documents and secrets */
   InfiltrationRep: number;
   /**
-   * Influences how much money is stolen from a server when the player performs a hack against it through
-   * the terminal.
+   * Influences how much money the player actually gains when they hack a server via the terminal. This is different
+   * from ScriptHackMoney. When the player hack a server via the terminal, the amount of money in that server is
+   * reduced, but they do not gain that same amount.
    */
   ManualHackMoney: number;
   /** Influence how much it costs to purchase a server */
@@ -742,7 +743,7 @@ interface BitNodeMultipliers {
   PurchasedServerMaxRam: number;
   /** Influences the minimum favor the player must have with a faction before they can donate to gain rep. */
   RepToDonateToFaction: number;
-  /** Influences how much money is stolen from a server when a script performs a hack against it. */
+  /** Influences how much money is stolen from a server when the player performs a hack against it. */
   ScriptHackMoney: number;
   /**
    * Influences how much money the player actually gains when a script hacks a server. This is different from

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -109,7 +109,9 @@ function CurrentBitNode(): React.ReactElement {
         <Typography variant="h5">
           BitNode {Player.bitNodeN}: {BitNodes[index].name} (Level {lvl})
         </Typography>
-        <Typography sx={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>{BitNodes[index].info}</Typography>
+        <Typography component="div" sx={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>
+          {BitNodes[index].info}
+        </Typography>
       </Paper>
     );
   }

--- a/src/ui/React/StatsRow.tsx
+++ b/src/ui/React/StatsRow.tsx
@@ -12,7 +12,7 @@ interface ITableRowData {
 }
 
 interface IProps {
-  name: string;
+  name: string | React.ReactElement;
   color: string;
   data?: ITableRowData;
   children?: React.ReactElement;


### PR DESCRIPTION
When a player enters BN8, they usually ask us why their hacking scripts do not gain money despite "Script Hack Money" being 30%. With the current description of HackMoney-related multipliers, it's hard to know the reason. This PR changes the description and adds tooltips for those multipliers.

Before:
![before](https://github.com/user-attachments/assets/51996a16-9b7d-4b5e-8d62-b5177f31d11f)

After:
![after](https://github.com/user-attachments/assets/59660fb9-da8b-476b-8a69-f78b17a1f3a9)
