### PR TITLE
BUGFIX: Fix Text Effect Preventing Company Name Updates

### DIFF
--- a/src/ui/React/CorruptableText.tsx
+++ b/src/ui/React/CorruptableText.tsx
@@ -30,11 +30,11 @@ export function CorruptableText(props: CorruptableTextProps): JSX.Element {
   const [content, setContent] = useState(props.content);
 
   useEffect(() => {
+    setContent(props.content);
+
     if (Settings.DisableTextEffects) {
       return;
     }
-
-    setContent(props.content);
 
     let counter = 5;
     const timers: number[] = [];


### PR DESCRIPTION
Closes #1827

Testing steps:
- Used Dev menu to backdoor two servers, get stats to take jobs 
- Got a position with the two companies who were backdoored, and one that was not
- Under Options, disabled Text Effects
- Went to Jobs page
- Pressed 'Previous Job' and 'Next Job'
- Observed that the company name updated properly for all cases (backdoor-> backdoor, backdoor->secure, secure-> backdoor)