### PR TITLE
UI: Add filter tool to list of installed augmentations

### DIFF
--- a/src/Augmentation/ui/InstalledAugmentations.tsx
+++ b/src/Augmentation/ui/InstalledAugmentations.tsx
@@ -9,6 +9,8 @@ import { Box, ListItemButton, Paper, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
 import List from "@mui/material/List";
 import Tooltip from "@mui/material/Tooltip";
+import TextField from "@mui/material/TextField";
+import Search from "@mui/icons-material/Search";
 import React, { useState } from "react";
 import { OwnedAugmentationsOrderSetting } from "../../Settings/SettingEnums";
 import { Settings } from "../../Settings/Settings";
@@ -23,8 +25,21 @@ export function InstalledAugmentations(): React.ReactElement {
 
   const [selectedAug, setSelectedAug] = useState(sourceAugs[0]);
 
+  const [filterText, setFilterText] = useState("");
+  const matches = (s1: string, s2: string) => s1.toLowerCase().includes(s2.toLowerCase());
+  const filteredSourceAugs = sourceAugs.filter((aug) => {
+    if (filterText === "") {
+      return true;
+    }
+    return (
+      matches(Augmentations[aug.name].name, filterText) ||
+      matches(Augmentations[aug.name].info, filterText) ||
+      matches(Augmentations[aug.name].stats, filterText)
+    );
+  });
+
   if (Settings.OwnedAugmentationsOrder === OwnedAugmentationsOrderSetting.Alphabetically) {
-    sourceAugs.sort((aug1, aug2) => {
+    filteredSourceAugs.sort((aug1, aug2) => {
       return aug1.name.localeCompare(aug2.name);
     });
   }
@@ -59,8 +74,16 @@ export function InstalledAugmentations(): React.ReactElement {
       {sourceAugs.length > 0 ? (
         <Paper sx={{ display: "grid", gridTemplateColumns: "1fr 3fr" }}>
           <Box>
+            <TextField
+              style={{ width: "100%" }}
+              value={filterText}
+              onChange={(e) => {
+                setFilterText(e.target.value);
+              }}
+              InputProps={{ startAdornment: <Search /> }}
+            />
             <List sx={{ height: 400, overflowY: "scroll", borderRight: `1px solid ${Settings.theme.welllight}` }}>
-              {sourceAugs.map((k, i) => (
+              {filteredSourceAugs.map((k, i) => (
                 <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
                   <Typography>{k.name}</Typography>
                 </ListItemButton>


### PR DESCRIPTION
I reused UI and code of grafting UI.

Note: Code for filtering in `src\Augmentation\ui\InstalledAugmentations.tsx`, `src\Faction\ui\AugmentationsPage.tsx`, and `src\PersonObjects\Grafting\ui\GraftingRoot.tsx` is somewhat similar, but I'm not sure if it's worth the effort to refactor them, so I have not done that.

Grafting:
![Capture](https://github.com/user-attachments/assets/c541ac52-5737-43f3-bb59-326a8e8641d5)

Before:
![before](https://github.com/user-attachments/assets/780f15cb-148a-42a1-bfef-36210b8e0312)

After:
![after](https://github.com/user-attachments/assets/313a86e2-8dca-49ca-8276-81100a71a4d3)

