### PR TITLE
UI: Make minor changes in buttons and error messages of tutorial

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -637,7 +637,7 @@ export class Terminal {
         throw new Error("Could not get n00dles server");
       }
       const errorMessageForBadCommand =
-        "Bad command. Please follow the tutorial or click 'Skip Tutorial' if you'd like to skip it.";
+        "Bad command. Please follow the tutorial or click 'Exit Tutorial' if you'd like to skip it.";
       switch (ITutorial.currStep) {
         case iTutorialSteps.TerminalHelp:
           if (commandArray.length === 1 && commandArray[0] == "help") {
@@ -778,7 +778,7 @@ export class Terminal {
           }
           break;
         default:
-          this.error("Please follow the tutorial or click 'Skip Tutorial' if you'd like to skip it");
+          this.error("Please follow the tutorial or click 'Exit Tutorial' if you'd like to skip it");
           return;
       }
     }

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -636,7 +636,8 @@ export class Terminal {
       if (n00dlesServ == null) {
         throw new Error("Could not get n00dles server");
       }
-      const errorMessageForBadCommand = "Bad command. Please follow the tutorial.";
+      const errorMessageForBadCommand =
+        "Bad command. Please follow the tutorial or click 'Skip Tutorial' if you'd like to skip it.";
       switch (ITutorial.currStep) {
         case iTutorialSteps.TerminalHelp:
           if (commandArray.length === 1 && commandArray[0] == "help") {

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -636,12 +636,13 @@ export class Terminal {
       if (n00dlesServ == null) {
         throw new Error("Could not get n00dles server");
       }
+      const errorMessageForBadCommand = "Bad command. Please follow the tutorial.";
       switch (ITutorial.currStep) {
         case iTutorialSteps.TerminalHelp:
           if (commandArray.length === 1 && commandArray[0] == "help") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -649,7 +650,7 @@ export class Terminal {
           if (commandArray.length === 1 && commandArray[0] == "ls") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -657,7 +658,7 @@ export class Terminal {
           if (commandArray.length === 1 && commandArray[0] == "scan") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -665,7 +666,7 @@ export class Terminal {
           if (commandArray.length == 1 && commandArray[0] == "scan-analyze") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -673,7 +674,7 @@ export class Terminal {
           if (commandArray.length == 2 && commandArray[0] == "scan-analyze" && commandArray[1] === 2) {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -689,7 +690,7 @@ export class Terminal {
               return;
             }
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -697,7 +698,7 @@ export class Terminal {
           if (commandArray.length === 1 && commandArray[0] === "analyze") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -705,7 +706,7 @@ export class Terminal {
           if (commandArray.length == 2 && commandArray[0] == "run" && commandArray[1] == "NUKE.exe") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -713,13 +714,13 @@ export class Terminal {
           if (commandArray.length == 1 && commandArray[0] == "hack") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
         case iTutorialSteps.TerminalHackingMechanics:
           if (commandArray.length !== 1 || !["grow", "weaken", "hack"].includes(commandArray[0] + "")) {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -727,7 +728,7 @@ export class Terminal {
           if (commandArray.length == 1 && commandArray[0] == "home") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -739,7 +740,7 @@ export class Terminal {
           ) {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -747,7 +748,7 @@ export class Terminal {
           if (commandArray.length == 1 && commandArray[0] == "free") {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -759,7 +760,7 @@ export class Terminal {
           ) {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
@@ -771,12 +772,12 @@ export class Terminal {
           ) {
             iTutorialNextStep();
           } else {
-            this.error("Bad command. Please follow the tutorial");
+            this.error(errorMessageForBadCommand);
             return;
           }
           break;
         default:
-          this.error("Please follow the tutorial, or click 'EXIT' if you'd like to skip it");
+          this.error("Please follow the tutorial or click 'Skip Tutorial' if you'd like to skip it");
           return;
       }
     }

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -593,7 +593,7 @@ export async function main(ns) {
         <br />
         <br />
         <Button onClick={iTutorialEnd}>
-          {step !== iTutorialSteps.DocumentationPageInfo ? "SKIP TUTORIAL" : "FINISH TUTORIAL"}
+          {step !== iTutorialSteps.DocumentationPageInfo ? "Skip Tutorial" : "Finish Tutorial"}
         </Button>
       </Paper>
     </>

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -60,6 +60,9 @@ export function InteractiveTutorialRoot(): React.ReactElement {
             This tutorial will show you the basics of the game. You may skip the tutorial at any time.
             <br />
             <br />
+            You can replay this tutorial by going to the Options tab and pressing "Reset tutorial".
+            <br />
+            <br />
             You can also collapse this panel to temporarily hide this tutorial.
           </Typography>
         </>

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -596,7 +596,7 @@ export async function main(ns) {
         <br />
         <br />
         <Button onClick={iTutorialEnd}>
-          {step !== iTutorialSteps.DocumentationPageInfo ? "Skip Tutorial" : "Finish Tutorial"}
+          {step !== iTutorialSteps.DocumentationPageInfo ? "Exit Tutorial" : "Finish Tutorial"}
         </Button>
       </Paper>
     </>


### PR DESCRIPTION
These changes were suggested on Discord:
- `or click 'EXIT'`: Wrong text. "EXIT" button was renamed.
- Put `"Bad command. Please follow the tutorial"` to a constant.

I also make these changes:
- Change capitalization of "Skip" button and "Finish" button. We rarely use ALL-CAPS for button description.
- Show the player how to replay the tutorial.

![Capture1](https://github.com/user-attachments/assets/9638d26c-2c91-4fb1-97d7-3aa87bf8c8e1)
![Capture2](https://github.com/user-attachments/assets/371a6526-de2b-4fbd-92be-5eb2d5861dac)
