### PR TITLE
BUGFIX: Tail log does not render multiline logs properly in edge cases

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -415,7 +415,6 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
                         text={line}
                         color={lineColor(line)}
                         styles={{
-                          display: "inline-block",
                           fontSize: Settings.styles.tailFontSize,
                         }}
                       />


### PR DESCRIPTION
MRE:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.clearLog();
  ns.print("a\n\u001b[39mb");
}
```
In pre-v2.7.0, "a" and "b" are printed on 2 lines. In v2.7.0, they are printed on the same line. This is a regression bug caused by the `display: "inline-block"` style added in #1703.

`inline-block` is supposed to ensure that line height is displayed properly. However, when I test many combinations of tail font size and line height, it seems that we don't need to use `inline-block`.

Test code 1:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.clearLog();
  ns.print("| a");
  ns.print("| b");
}
```
Test code 2 (provided by @G4mingJon4s): https://gist.github.com/G4mingJon4s/ba804da307e356268ee1f01f20b4af19

Screenshots:
Tail font size 16, line height 1.5
![16-1 5](https://github.com/user-attachments/assets/05c52c3b-af87-4c40-bd77-3be9c8863e38)
Tail font size 20, line height 1.5
![20-1 5](https://github.com/user-attachments/assets/8eb318c1-d8e2-4288-a7e0-3f4569efd179)
Tail font size 20, line height 2
![20-2](https://github.com/user-attachments/assets/01276dd1-d02b-4f6b-815b-97bb56d80e1a)
Tail font size 25, line height 3
![25-3](https://github.com/user-attachments/assets/0eb7b8f5-f4ac-4b14-8fe8-f66dbeff5861)




