### PR TITLE
MISC: Clarify input and output of Square Root coding contract

### DIFF
--- a/src/data/codingcontracttypes.ts
+++ b/src/data/codingcontracttypes.ts
@@ -1865,7 +1865,8 @@ export const codingContractTypesMetadata: CodingContractType<any>[] = [
     name: "Square Root",
     difficulty: 5,
     desc(data: bigint): string {
-      return `You are given a ~200 digit BigInt. Find the square root of this number, to the nearest integer.
+      return `You are given a ~200 digit BigInt. Find the square root of this number, to the nearest integer.\n
+The input is a BigInt value. The answer must be the string representing the solution's BigInt value. The trailing "n" is not part of the string.\n
 Hint: If you are having trouble, you might consult https://en.wikipedia.org/wiki/Methods_of_computing_square_roots
 
 Input number:


### PR DESCRIPTION
A player tried to use "n" in the answer ("123456n" instead of "123456"). This PR clarifies data type and format of input and output.

I copied the description at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString.

![Capture](https://github.com/user-attachments/assets/7a863999-31b9-4908-9c93-c2dee66f3043)
