### PR TITLE
CODEBASE: Change signature of interpolate function in Infiltration code

### DIFF
--- a/src/Infiltration/ui/Difficulty.ts
+++ b/src/Infiltration/ui/Difficulty.ts
@@ -10,9 +10,9 @@ interface DifficultySettings {
 // I could use `any` to simply some of this but I also want to take advantage
 // of the type safety that typescript provides. I'm just not sure how in this
 // case.
-export function interpolate(settings: DifficultySettings, n: number, out: DifficultySetting): DifficultySetting {
+export function interpolate(settings: DifficultySettings, n: number, out: DifficultySetting): void {
   // interpolates between 2 difficulties.
-  function lerpD(a: DifficultySetting, b: DifficultySetting, t: number): DifficultySetting {
+  function lerpD(a: DifficultySetting, b: DifficultySetting, t: number): void {
     // interpolates between 2 numbers.
     function lerp(x: number, y: number, t: number): number {
       return (1 - t) * x + t * y;
@@ -20,7 +20,6 @@ export function interpolate(settings: DifficultySettings, n: number, out: Diffic
     for (const key of Object.keys(a)) {
       out[key] = lerp(a[key], b[key], t);
     }
-    return a;
   }
   if (n < 0) return lerpD(settings.Trivial, settings.Trivial, 0);
   if (n >= 0 && n < 1) return lerpD(settings.Trivial, settings.Normal, n);


### PR DESCRIPTION
This function is pretty weird. It receives an object ("out"), does its job, mutates "out" to output the result, then returns the "min setting". All callers use it to mutate their internal "difficulty" value and ignore the returned value. When I read its implementation, I thought that it was wrong (why does it mutate "out" but then return "a"?), until I found out that all callers ignored the returned value.