### PR TITLE
API: Allow passing 0 SkillPoints to skillMaxUpgradeCount

### DIFF
--- a/markdown/bitburner.bladeburnerformulas.skillmaxupgradecount.md
+++ b/markdown/bitburner.bladeburnerformulas.skillmaxupgradecount.md
@@ -22,7 +22,7 @@ skillMaxUpgradeCount(
 |  --- | --- | --- |
 |  name | [BladeburnerSkillName](./bitburner.bladeburnerskillname.md) \| \`${[BladeburnerSkillName](./bitburner.bladeburnerskillname.md)<!-- -->}\` | Skill name. It's case-sensitive and must be an exact match. |
 |  level | number | Skill level. It must be a non-negative number. |
-|  skillPoints | number | Number of skill points to upgrade the skill. It must be a positive number. |
+|  skillPoints | number | Number of skill points to upgrade the skill. It must be a non-negative number. |
 
 **Returns:**
 

--- a/src/NetscriptFunctions/Formulas.ts
+++ b/src/NetscriptFunctions/Formulas.ts
@@ -52,6 +52,7 @@ import { getEnumHelper } from "../utils/EnumHelper";
 import { CompanyPositions } from "../Company/CompanyPositions";
 import { findCrime } from "../Crime/CrimeHelpers";
 import { Skills } from "../Bladeburner/data/Skills";
+import type { PositiveNumber } from "../types";
 
 export function NetscriptFormulas(): InternalAPI<IFormulas> {
   const checkFormulasAccess = function (ctx: NetscriptContext): void {
@@ -433,15 +434,21 @@ export function NetscriptFormulas(): InternalAPI<IFormulas> {
         checkFormulasAccess(ctx);
         const name = getEnumHelper("BladeburnerSkillName").nsGetMember(ctx, _name, "name");
         const level = helpers.number(ctx, "level", _level);
-        if (level < 0) {
-          throw new Error(`Level must be a non-negative number.`);
+        if (!Number.isFinite(level) || level < 0) {
+          throw new Error(`Level must be a finite, non-negative number. Its value is ${level}.`);
         }
-        const skillPoints = helpers.positiveNumber(ctx, "skillPoints", _skillPoints);
+        const skillPoints = helpers.number(ctx, "skillPoints", _skillPoints);
+        if (!Number.isFinite(skillPoints) || skillPoints < 0) {
+          throw new Error(`SkillPoints must be a finite, non-negative number. Its value is ${skillPoints}.`);
+        }
         const skill = Skills[name];
         if (level >= skill.maxLvl) {
           return 0;
         }
-        return skill.calculateMaxUpgradeCount(level, skillPoints);
+        if (skillPoints === 0) {
+          return 0;
+        }
+        return skill.calculateMaxUpgradeCount(level, skillPoints as PositiveNumber);
       },
     },
   };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5396,7 +5396,7 @@ interface BladeburnerFormulas {
    *
    * @param name - Skill name. It's case-sensitive and must be an exact match.
    * @param level - Skill level. It must be a non-negative number.
-   * @param skillPoints - Number of skill points to upgrade the skill. It must be a positive number.
+   * @param skillPoints - Number of skill points to upgrade the skill. It must be a non-negative number.
    * @returns Number of times that you can upgrade the skill.
    */
   skillMaxUpgradeCount(


### PR DESCRIPTION
As we discussed on Discord, I decided to loosen the requirement of "SkillPoints" parameter as requested. The player won't need to check the SP value (0 is a valid value of SP) before passing it to skillMaxUpgradeCount.

Small behavior change: "level" cannot be Infinity now. I don't think this change is a problem. Infinity level is nonsense anyway.