### PR TITLE
IPVGO: Add "No AI" to GoOpponent type

### DIFF
--- a/markdown/bitburner.go.getopponent.md
+++ b/markdown/bitburner.go.getopponent.md
@@ -9,9 +9,9 @@ Returns the name of the opponent faction in the current subnet.
 **Signature:**
 
 ```typescript
-getOpponent(): GoOpponent | "No AI";
+getOpponent(): GoOpponent;
 ```
 **Returns:**
 
-[GoOpponent](./bitburner.goopponent.md) \| "No AI"
+[GoOpponent](./bitburner.goopponent.md)
 

--- a/markdown/bitburner.goopponent.md
+++ b/markdown/bitburner.goopponent.md
@@ -9,6 +9,7 @@
 
 ```typescript
 type GoOpponent =
+  | "No AI"
   | "Netburners"
   | "Slum Snakes"
   | "The Black Hand"

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4265,6 +4265,7 @@ export interface Gang {
 
 /** @public */
 type GoOpponent =
+  | "No AI"
   | "Netburners"
   | "Slum Snakes"
   | "The Black Hand"
@@ -4661,7 +4662,7 @@ export interface Go {
   /**
    * Returns the name of the opponent faction in the current subnet.
    */
-  getOpponent(): GoOpponent | "No AI";
+  getOpponent(): GoOpponent;
 
   /**
    * Gets new IPvGO subnet with the specified size owned by the listed faction, ready for the player to make a move.


### PR DESCRIPTION
This is only problematic if resetBoardState can be crashed if the opponent is "No AI", but it's not the case. "No AI" has already been in our internal enum GoOpponent.

Closes #1841.