### PR TITLE
MISC: Show user-friendly error message when script is empty

### DIFF
--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -81,6 +81,9 @@ function generateLoadedModule(script: Script, scripts: Map<ScriptFilePath, Scrip
     return script.mod;
   }
 
+  if (script.code === "") {
+    throw new Error(`Script content is an empty string. Filename: ${script.filename}, server: ${script.server}.`);
+  }
   let scriptCode;
   const fileType = getFileType(script.filename);
   switch (fileType) {


### PR DESCRIPTION
A player on Discord reported an issue with running their script. The problem is their setup of the external editor, not our code. However, the error message in that report is not useful for this error case. This PR checks this error case and throws an error with a user-friendly error message.

Before:
![before](https://github.com/user-attachments/assets/fdc692f0-b0c1-4c64-85f7-ce237edb8b25)

After:
![after](https://github.com/user-attachments/assets/bf562d70-2710-413c-887a-6ef59281d9bd)
