### PR TITLE
DOCUMENTATION: Fix typo of CrimeStats

### DIFF
--- a/markdown/bitburner.crimestats.agility_success_weight.md
+++ b/markdown/bitburner.crimestats.agility_success_weight.md
@@ -4,7 +4,7 @@
 
 ## CrimeStats.agility\_success\_weight property
 
-agility level impact on success change of the crime
+Impact of agility level on success chance of the crime
 
 **Signature:**
 

--- a/markdown/bitburner.crimestats.charisma_success_weight.md
+++ b/markdown/bitburner.crimestats.charisma_success_weight.md
@@ -4,7 +4,7 @@
 
 ## CrimeStats.charisma\_success\_weight property
 
-charisma level impact on success change of the crime
+Impact of charisma level on success chance of the crime
 
 **Signature:**
 

--- a/markdown/bitburner.crimestats.defense_success_weight.md
+++ b/markdown/bitburner.crimestats.defense_success_weight.md
@@ -4,7 +4,7 @@
 
 ## CrimeStats.defense\_success\_weight property
 
-defense level impact on success change of the crime
+Impact of defense level on success chance of the crime
 
 **Signature:**
 

--- a/markdown/bitburner.crimestats.dexterity_success_weight.md
+++ b/markdown/bitburner.crimestats.dexterity_success_weight.md
@@ -4,7 +4,7 @@
 
 ## CrimeStats.dexterity\_success\_weight property
 
-dexterity level impact on success change of the crime
+Impact of dexterity level on success chance of the crime
 
 **Signature:**
 

--- a/markdown/bitburner.crimestats.hacking_success_weight.md
+++ b/markdown/bitburner.crimestats.hacking_success_weight.md
@@ -4,7 +4,7 @@
 
 ## CrimeStats.hacking\_success\_weight property
 
-hacking level impact on success change of the crime
+Impact of hacking level on success chance of the crime
 
 **Signature:**
 

--- a/markdown/bitburner.crimestats.md
+++ b/markdown/bitburner.crimestats.md
@@ -17,22 +17,22 @@ interface CrimeStats
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
 |  [agility\_exp](./bitburner.crimestats.agility_exp.md) |  | number | agility exp gained from crime |
-|  [agility\_success\_weight](./bitburner.crimestats.agility_success_weight.md) |  | number | agility level impact on success change of the crime |
+|  [agility\_success\_weight](./bitburner.crimestats.agility_success_weight.md) |  | number | Impact of agility level on success chance of the crime |
 |  [charisma\_exp](./bitburner.crimestats.charisma_exp.md) |  | number | charisma exp gained from crime |
-|  [charisma\_success\_weight](./bitburner.crimestats.charisma_success_weight.md) |  | number | charisma level impact on success change of the crime |
+|  [charisma\_success\_weight](./bitburner.crimestats.charisma_success_weight.md) |  | number | Impact of charisma level on success chance of the crime |
 |  [defense\_exp](./bitburner.crimestats.defense_exp.md) |  | number | defense exp gained from crime |
-|  [defense\_success\_weight](./bitburner.crimestats.defense_success_weight.md) |  | number | defense level impact on success change of the crime |
+|  [defense\_success\_weight](./bitburner.crimestats.defense_success_weight.md) |  | number | Impact of defense level on success chance of the crime |
 |  [dexterity\_exp](./bitburner.crimestats.dexterity_exp.md) |  | number | dexterity exp gained from crime |
-|  [dexterity\_success\_weight](./bitburner.crimestats.dexterity_success_weight.md) |  | number | dexterity level impact on success change of the crime |
+|  [dexterity\_success\_weight](./bitburner.crimestats.dexterity_success_weight.md) |  | number | Impact of dexterity level on success chance of the crime |
 |  [difficulty](./bitburner.crimestats.difficulty.md) |  | number | Number representing the difficulty of the crime. Used for success chance calculations |
 |  [hacking\_exp](./bitburner.crimestats.hacking_exp.md) |  | number | hacking exp gained from crime |
-|  [hacking\_success\_weight](./bitburner.crimestats.hacking_success_weight.md) |  | number | hacking level impact on success change of the crime |
+|  [hacking\_success\_weight](./bitburner.crimestats.hacking_success_weight.md) |  | number | Impact of hacking level on success chance of the crime |
 |  [intelligence\_exp](./bitburner.crimestats.intelligence_exp.md) |  | number | intelligence exp gained from crime |
 |  [karma](./bitburner.crimestats.karma.md) |  | number | Amount of karma lost for successfully committing this crime |
 |  [kills](./bitburner.crimestats.kills.md) |  | number | How many people die as a result of this crime |
 |  [money](./bitburner.crimestats.money.md) |  | number | How much money is given |
 |  [strength\_exp](./bitburner.crimestats.strength_exp.md) |  | number | strength exp gained from crime |
-|  [strength\_success\_weight](./bitburner.crimestats.strength_success_weight.md) |  | number | strength level impact on success change of the crime |
+|  [strength\_success\_weight](./bitburner.crimestats.strength_success_weight.md) |  | number | Impact of strength level on success chance of the crime |
 |  [time](./bitburner.crimestats.time.md) |  | number | Milliseconds it takes to attempt the crime |
 |  [type](./bitburner.crimestats.type.md) |  | string | Description of the crime activity |
 

--- a/markdown/bitburner.crimestats.strength_success_weight.md
+++ b/markdown/bitburner.crimestats.strength_success_weight.md
@@ -4,7 +4,7 @@
 
 ## CrimeStats.strength\_success\_weight property
 
-strength level impact on success change of the crime
+Impact of strength level on success chance of the crime
 
 **Signature:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -344,17 +344,17 @@ interface CrimeStats {
   time: number;
   /** Description of the crime activity */
   type: string;
-  /** hacking level impact on success change of the crime */
+  /** Impact of hacking level on success chance of the crime */
   hacking_success_weight: number;
-  /** strength level impact on success change of the crime */
+  /** Impact of strength level on success chance of the crime */
   strength_success_weight: number;
-  /** defense level impact on success change of the crime */
+  /** Impact of defense level on success chance of the crime */
   defense_success_weight: number;
-  /** dexterity level impact on success change of the crime */
+  /** Impact of dexterity level on success chance of the crime */
   dexterity_success_weight: number;
-  /** agility level impact on success change of the crime */
+  /** Impact of agility level on success chance of the crime */
   agility_success_weight: number;
-  /** charisma level impact on success change of the crime */
+  /** Impact of charisma level on success chance of the crime */
   charisma_success_weight: number;
   /** hacking exp gained from crime */
   hacking_exp: number;


### PR DESCRIPTION
This PR fixes small typos in NetscriptDefinitions.d.ts: "success change" -> "success chance".