### PR TITLE
BUGFIX: Saved running scripts are started before SWC is initialized

### DIFF
--- a/src/ui/LoadingScreen.tsx
+++ b/src/ui/LoadingScreen.tsx
@@ -34,9 +34,8 @@ export function LoadingScreen(): React.ReactElement {
   });
 
   useEffect(() => {
-    initSwc()
-      .then(() => load())
-      .then((saveData) => Engine.load(saveData))
+    Promise.all([initSwc(), load()])
+      .then(([__, saveData]) => Engine.load(saveData))
       .then(() => {
         pushGameReady();
         setLoaded(true);

--- a/src/ui/LoadingScreen.tsx
+++ b/src/ui/LoadingScreen.tsx
@@ -34,8 +34,9 @@ export function LoadingScreen(): React.ReactElement {
   });
 
   useEffect(() => {
-    load()
-      .then((saveData) => Promise.all([initSwc(), Engine.load(saveData)]))
+    initSwc()
+      .then(() => load())
+      .then((saveData) => Engine.load(saveData))
       .then(() => {
         pushGameReady();
         setLoaded(true);


### PR DESCRIPTION
Saved running scripts are started in `Engine.load`, but `Engine.load` is called at the same time as `initSwc`. Therefore, SWC is usually not initialized when we use it to transform TS scripts.

Fixes #1853.