### PR TITLE
UI: Remove mention of passive reputation gain when player is in BN2

### DIFF
--- a/src/Faction/ui/Info.tsx
+++ b/src/Faction/ui/Info.tsx
@@ -17,7 +17,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Box from "@mui/material/Box";
 import { useCycleRerender } from "../../ui/React/hooks";
 import { calculateFavorAfterResetting } from "../formulas/favor";
-import { Player } from "@player";
+import { knowAboutBitverse } from "../../BitNode/BitNodeUtils";
 
 interface IProps {
   faction: Faction;
@@ -35,8 +35,9 @@ function DefaultAssignment(): React.ReactElement {
   return (
     <Typography>
       Perform work/carry out assignments for your faction to help further its cause! By doing so, you will earn
-      reputation for your faction.&nbsp;
-      {Player.bitNodeN !== 2 && <>You will also gain reputation passively over time, although at a very slow rate. </>}
+      reputation for your faction. You will also gain reputation passively over time, although at a very slow
+      rate.&nbsp;
+      {knowAboutBitverse() && <>Note that the passive reputation gain is disabled in BitNode 2. </>}
       Earning reputation will allow you to purchase augmentations through this faction, which are powerful upgrades that
       enhance your abilities.
     </Typography>

--- a/src/Faction/ui/Info.tsx
+++ b/src/Faction/ui/Info.tsx
@@ -17,6 +17,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Box from "@mui/material/Box";
 import { useCycleRerender } from "../../ui/React/hooks";
 import { calculateFavorAfterResetting } from "../formulas/favor";
+import { Player } from "@player";
 
 interface IProps {
   faction: Faction;
@@ -33,9 +34,10 @@ const useStyles = makeStyles()({
 function DefaultAssignment(): React.ReactElement {
   return (
     <Typography>
-      Perform work/carry out assignments for your faction to help further its cause! By doing so you will earn
-      reputation for your faction. You will also gain reputation passively over time, although at a very slow rate.
-      Earning reputation will allow you to purchase Augmentations through this faction, which are powerful upgrades that
+      Perform work/carry out assignments for your faction to help further its cause! By doing so, you will earn
+      reputation for your faction.&nbsp;
+      {Player.bitNodeN !== 2 && <>You will also gain reputation passively over time, although at a very slow rate. </>}
+      Earning reputation will allow you to purchase augmentations through this faction, which are powerful upgrades that
       enhance your abilities.
     </Typography>
   );


### PR DESCRIPTION
Context from Discord:
```
Really minor, and I'm not sure the cleanest way to address it, but I just started BN2, and I noticed that the text from [this line](https://github.com/bitburner-official/bitburner-src/blob/dev/src/Faction/ui/Info.tsx#L37) mentions passive rep gain, despite that being disabled in BN2.
```
Screenshots:
BN2:
![bn2](https://github.com/user-attachments/assets/ade2aebe-7df4-4f29-8f0d-0213ec0d0276)
Other BNs:
![non-bn2](https://github.com/user-attachments/assets/b55b9d28-e1be-4f50-82b5-8b97be807859)
