### PR TITLE
UI: Clarify "Company Favor" hash upgrade

### DIFF
--- a/src/Hacknet/HacknetHelpers.tsx
+++ b/src/Hacknet/HacknetHelpers.tsx
@@ -520,15 +520,14 @@ export function purchaseHashUpgrade(upgName: string, upgTarget: string, count = 
         break;
       }
       case "Improve Studying": {
-        // Multiplier handled by HashManager
+        // Multiplier is handled by HashManager
         break;
       }
       case "Improve Gym Training": {
-        // Multiplier handled by HashManager
+        // Multiplier is handled by HashManager
         break;
       }
       case "Exchange for Corporation Research": {
-        // This will throw if player doesn't have a corporation
         const corp = Player.corporation;
         if (corp === null) {
           Player.hashManager.refundUpgrade(upgName, count);
@@ -540,7 +539,6 @@ export function purchaseHashUpgrade(upgName: string, upgTarget: string, count = 
         break;
       }
       case "Exchange for Bladeburner Rank": {
-        // This will throw if player isn't in Bladeburner
         const bladeburner = Player.bladeburner;
         if (bladeburner === null) {
           Player.hashManager.refundUpgrade(upgName, count);
@@ -550,7 +548,6 @@ export function purchaseHashUpgrade(upgName: string, upgTarget: string, count = 
         break;
       }
       case "Exchange for Bladeburner SP": {
-        // This will throw if player isn't in Bladeburner
         const bladeburner = Player.bladeburner;
         if (bladeburner === null) {
           Player.hashManager.refundUpgrade(upgName, count);

--- a/src/Hacknet/HashManager.ts
+++ b/src/Hacknet/HashManager.ts
@@ -123,8 +123,8 @@ export class HashManager {
   }
 
   /**
-   * Returns boolean indicating whether or not the upgrade was successfully purchased
-   * Note that this does NOT actually implement the effect
+   * Returns boolean indicating whether or not the upgrade was successfully purchased.
+   * Note that this function does NOT actually implement the effect.
    */
   upgrade(upgName: string, count = 1): boolean {
     const upg = HashUpgrades[upgName];

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -41,7 +41,7 @@ export const HashUpgradesMetadata: HashUpgradeParams[] = [
     desc:
       "Use hashes to decrease the minimum security of a single server by 2%. " +
       "Note that a server's minimum security cannot go below 1. This effect persists " +
-      "until you install Augmentations (since servers are reset at that time)",
+      "until you install augmentations (since servers are reset at that time).",
     hasTargetServer: true,
     name: "Reduce Minimum Security",
     value: 0.98,
@@ -51,7 +51,7 @@ export const HashUpgradesMetadata: HashUpgradeParams[] = [
     desc: (
       <>
         Use hashes to increase the maximum amount of money on a single server by 2%. This effect persists until you
-        install Augmentations (since servers are reset at that time). Note that a server's maximum money is soft capped
+        install augmentations (since servers are reset at that time). Note that a server's maximum money is soft capped
         above <Money money={10e12} />
       </>
     ),
@@ -63,7 +63,7 @@ export const HashUpgradesMetadata: HashUpgradeParams[] = [
     costPerLevel: 50,
     desc:
       "Use hashes to improve the experience earned when studying at a university by 20%. " +
-      "This effect persists until you install Augmentations",
+      "This effect persists until you install augmentations.",
     name: "Improve Studying",
     effectText: (level: number): JSX.Element | null => <>Improves studying by {level * 20}%</>,
     value: 20, // Improves studying by value%
@@ -72,17 +72,17 @@ export const HashUpgradesMetadata: HashUpgradeParams[] = [
     costPerLevel: 50,
     desc:
       "Use hashes to improve the experience earned when training at the gym by 20%. This effect " +
-      "persists until you install Augmentations",
+      "persists until you install augmentations.",
     name: "Improve Gym Training",
     effectText: (level: number): JSX.Element | null => <>Improves training by {level * 20}%</>,
     value: 20, // Improves training by value%
   },
   {
     costPerLevel: 200,
-    desc: "Exchange hashes for 1k Scientific Research in all of your Corporation's Industries",
+    desc: "Exchange hashes for 1k Scientific Research in all of your corporation's divisions",
     name: "Exchange for Corporation Research",
     effectText: (level: number): JSX.Element | null => (
-      <>Acquired a total of {formatInt(level * 1000)} Scientific Research in your industries.</>
+      <>Acquired a total of {formatInt(level * 1000)} Scientific Research in your divisions.</>
     ),
     value: 1000,
   },
@@ -113,7 +113,7 @@ export const HashUpgradesMetadata: HashUpgradeParams[] = [
   },
   {
     costPerLevel: 200,
-    desc: "Use hashes to increase the favor with a company by 5. This effect is permanent.",
+    desc: "Use hashes to increase the favor with a company by 5. This effect persists until you enter a new BitNode.",
     hasTargetCompany: true,
     name: "Company Favor",
     value: 5,


### PR DESCRIPTION
Context from Discord:
```
Hacknet servers says This effect is permanent. for company favor.
I was thinking it will be permament but it seems like it only persists until you destroy the bitnode, am I right?
```