### PR TITLE
BUGFIX: Editor shows error popup when opening scripts on "." server

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -176,7 +176,7 @@ function Root(props: IProps): React.ReactElement {
 
     server.scripts.forEach((s) => {
       const uri = monaco.Uri.from({
-        scheme: "file",
+        scheme: "memory",
         path: `${s.server}/${s.filename}`,
       });
 

--- a/src/ScriptEditor/ui/utils.ts
+++ b/src/ScriptEditor/ui/utils.ts
@@ -25,7 +25,7 @@ function reorder(list: unknown[], startIndex: number, endIndex: number): void {
 }
 function makeModel(hostname: string, filename: string, code: string) {
   const uri = Uri.from({
-    scheme: "file",
+    scheme: "memory",
     path: `${hostname}/${filename}`,
   });
   let language;


### PR DESCRIPTION
This regression bug appeared when we updated monaco-editor in #1468.

How to reproduce it: Open any scripts on "." server.

![Capture](https://github.com/user-attachments/assets/a373063c-9bca-4c1d-93d8-9bd11defc42f)

Relevant code:
https://github.com/microsoft/TypeScript/blob/56a08250f3516b3f5bc120d6c7ab4450a9a69352/src/compiler/path.ts#L632-L649

`file:///./a.js` is normalized to `file:///a.js`, but the model URI is still `file:///./a.js`. With another scheme (e.g., "memory"), `normalizePath` does not strip the "./" part. For example, with "memory" scheme, URI of "a.js" in "." server is `memory:./a.js`.

If you are curious about why it does not happen in old version, you can check the change in `getOrCreateSourceFileByPath` in https://github.com/microsoft/TypeScript/commit/5aa0053c74f0c67b2cbedf9cee6607ead3b9dc45.
