### PR TITLE
BUGFIX: Editor loads scripts at wrong time

### DIFF
--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -212,13 +212,13 @@ function Root(props: IProps): React.ReactElement {
   }, 300);
 
   const parseCode = (newCode: string) => {
-    loadAllServerScripts();
     startUpdatingRAM();
     debouncedCodeParsing(newCode);
   };
 
   // When the editor is mounted
   function onMount(editor: IStandaloneCodeEditor): void {
+    loadAllServerScripts();
     // Required when switching between site navigation (e.g. from Script Editor -> Terminal and back)
     // the `useEffect()` for vim mode is called before editor is mounted.
     editorRef.current = editor;
@@ -299,6 +299,7 @@ function Root(props: IProps): React.ReactElement {
   }
 
   function onTabClick(index: number): void {
+    loadAllServerScripts();
     if (currentScript !== null) {
       // Save the current position of the cursor.
       const currentPosition = editorRef.current?.getPosition();


### PR DESCRIPTION
Test scripts:
test.ts
```js
import { multiply } from "./lib";

export async function main(ns: NS) {
  ns.print(`multiply: ${multiply(2, 3)}`);
}
```
lib.ts
```js
export const multiply = (a: number, b: number) => a * b;
```
How to reproduce this bug:
- Load a clean save file.
- Save test scripts. Reload the page.
- `nano test.ts`.
- Switch to the terminal tab, then switch back to the editor tab.

![Capture](https://github.com/user-attachments/assets/128aafca-a137-4c2c-9d14-dc5e74f32055)

`loadAllServerScripts` is called in `parseCode`. There are 2 problems:
- `loadAllServerScripts` is called every time the player edits their code. This means that it's called after every keystroke.
- Even in this case, calling it in `parseCode` is still too late. It needs to be called much earlier. The start of `onMount` is a proper place. I also call it in `onTabClick`. It may be useful if something else (via NS APIs or RFA) changes (add/edit/delete) scripts. For example, if an external editor pushes a script via RFA, we will load that new script when the player switches tabs. Technically, doing that in `debouncedCodeParsing` may be better, but I think it's overkill.