### PR TITLE
MISC: Consistently use ManualHackMoney in terminal hack and script hack

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -263,14 +263,18 @@ export class Terminal {
       Engine.Counters.checkFactionInvitations = 0;
       Engine.checkCounters();
 
-      let moneyGained = calculatePercentMoneyHacked(server, Player) * currentNodeMults.ManualHackMoney;
-      moneyGained = Math.floor(server.moneyAvailable * moneyGained);
+      let moneyDrained = Math.floor(server.moneyAvailable * calculatePercentMoneyHacked(server, Player));
 
-      if (moneyGained <= 0) {
-        moneyGained = 0;
+      if (moneyDrained <= 0) {
+        moneyDrained = 0;
       } // Safety check
 
-      server.moneyAvailable -= moneyGained;
+      server.moneyAvailable -= moneyDrained;
+      if (server.moneyAvailable < 0) {
+        server.moneyAvailable = 0;
+      }
+
+      const moneyGained = moneyDrained * currentNodeMults.ManualHackMoney;
       Player.gainMoney(moneyGained, "hacking");
       Player.gainHackingExp(expGainedOnSuccess);
       if (expGainedOnSuccess > 1) {


### PR DESCRIPTION
This PR fixes the oversight mentioned at https://github.com/bitburner-official/bitburner-src/pull/1823#issuecomment-2541019940.

Reference:
https://github.com/bitburner-official/bitburner-src/blob/bc0dc15536921fa4c7d1bd311494833cdfab821a/src/Netscript/NetscriptHelpers.tsx#L509-L529

I don't think we need `Math.floor`, but I also do not remove it. I'll do that if you want.