### PR TITLE
UI: Hostname No Longer Resets As You Type It In The Remote File API Screen

### DIFF
--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -12,12 +12,6 @@ export const RemoteAPIPage = (): React.ReactElement => {
   function handleRemoteFileApiHostnameChange(event: React.ChangeEvent<HTMLInputElement>): void {
     let newValue = event.target.value.trim();
     // Empty string will be automatically changed to "localhost".
-    if (newValue === "") {
-      newValue = "localhost";
-    }
-    if (!isValidConnectionHostname(newValue)) {
-      return;
-    }
     setRemoteFileApiHostname(newValue);
     Settings.RemoteFileApiAddress = newValue;
   }

--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button, Link, TextField, Tooltip, Typography } from "@mui/material";
 import { GameOptionsPage } from "./GameOptionsPage";
-import { isValidConnectionHostname, isValidConnectionPort, Settings } from "../../Settings/Settings";
+import { isValidConnectionPort, Settings } from "../../Settings/Settings";
 import { ConnectionBauble } from "./ConnectionBauble";
 import { isRemoteFileApiConnectionLive, newRemoteFileApiConnection } from "../../RemoteFileAPI/RemoteFileAPI";
 
@@ -10,7 +10,7 @@ export const RemoteAPIPage = (): React.ReactElement => {
   const [remoteFileApiPort, setRemoteFileApiPort] = useState(Settings.RemoteFileApiPort);
 
   function handleRemoteFileApiHostnameChange(event: React.ChangeEvent<HTMLInputElement>): void {
-    let newValue = event.target.value.trim();
+    const newValue = event.target.value.trim();
     // Empty string will be automatically changed to "localhost".
     setRemoteFileApiHostname(newValue);
     Settings.RemoteFileApiAddress = newValue;

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -24,6 +24,7 @@ export class Remote {
       this.connection = new WebSocket(address);
     } catch (e) {
       console.error(`Invalid address, ${e}`);
+      return;
     }
 
     this.connection.addEventListener("error", (e: Event) =>

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -20,7 +20,11 @@ export class Remote {
 
   public startConnection(): void {
     const address = Remote.protocol + "://" + this.ipaddr + ":" + this.port;
-    this.connection = new WebSocket(address);
+    try {
+      this.connection = new WebSocket(address);
+    } catch (e) {
+      console.error(`Invalid address, ${e}`);
+    }
 
     this.connection.addEventListener("error", (e: Event) =>
       SnackbarEvents.emit(`Error with websocket ${address}, details: ${JSON.stringify(e)}`, ToastVariant.ERROR, 5000),


### PR DESCRIPTION
As reported in the BitBurner discord, https://discord.com/channels/415207508303544321/415213413745164318/1319747074824081508, inputting an invalid hostname into the Remote File API menu was difficult as it would simply "void" your input.
This made attempting to input certain hostnames like an ipv6 address impossible without directly pasting it in. This PR essentially removes that behaviour, however the game still does not connect to an invalid URL