### PR TITLE
UI: Increase number of displayed digits for StaneksGiftExtraSize

### DIFF
--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -337,7 +337,7 @@ function BladeburnerMults({ mults }: IMultsProps): React.ReactElement {
 function StanekMults({ mults }: IMultsProps): React.ReactElement {
   if (!Player.canAccessCotMG()) return <></>;
 
-  const extraSize = mults.StaneksGiftExtraSize.toFixed(3);
+  const extraSize = mults.StaneksGiftExtraSize.toFixed(5);
   const rows: IBNMultRows = {
     StaneksGiftPowerMultiplier: { name: "Gift Power" },
     StaneksGiftExtraSize: {


### PR DESCRIPTION
Context: https://discord.com/channels/415207508303544321/415213413745164318/1162451770174353508
```
Minor thing: upon entering BN12.35, I notice that under BN multipliers, the Base Size Modifier of Stanek's Gift is listed as "+2.000"... but Stanek's gift is the same size it was in BN12.34, when it was listed as "+1.9"-something. I'm sure it's just that it's actually +1.9995 or something, and thus not boosting the size of the Stanek grid, but I thought I'd point it out.
```
Before:
![before](https://github.com/user-attachments/assets/2e808ed9-760c-4c7e-8848-caced8ea3b61)
After:
![after](https://github.com/user-attachments/assets/ed4eba74-8267-4302-be86-6fec03fc0be9)

Closes #1876.