### PR TITLE
BUGFIX: Grow log shows invalid values in edge cases

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -298,24 +298,23 @@ export const ns: InternalAPI<NSFull> = {
       }
       const moneyBefore = server.moneyAvailable;
       const growth = processSingleServerGrowth(server, threads, host.cpuCores);
-      const growthPercentForLogging = growth !== 0 ? growth - 1 : 0;
       const moneyAfter = server.moneyAvailable;
       ctx.workerScript.scriptRef.recordGrow(server.hostname, threads);
       const expGain = calculateHackingExpGain(server, Player) * threads;
       helpers.log(
         ctx,
         () =>
-          `Available money on '${server.hostname}' grown by ${formatPercent(
-            growthPercentForLogging,
-            6,
-          )}. Gained ${formatExp(expGain)} hacking exp (t=${formatThreads(threads)}).`,
+          `Available money on '${server.hostname}' grown by ${formatPercent(growth - 1, 6)}. Gained ${formatExp(
+            expGain,
+          )} hacking exp (t=${formatThreads(threads)}).`,
       );
       ctx.workerScript.scriptRef.onlineExpGained += expGain;
       Player.gainHackingExp(expGain);
       if (stock) {
         influenceStockThroughServerGrow(server, moneyAfter - moneyBefore);
       }
-      return Promise.resolve(growth);
+      // growth can only be 1 if server.moneyMax is 0. In that case, this API returns 0.
+      return Promise.resolve(growth !== 1 ? growth : 0);
     });
   },
   growthAnalyze:

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -296,25 +296,26 @@ export const ns: InternalAPI<NSFull> = {
       if (host === null) {
         throw helpers.errorMessage(ctx, `Cannot find host of WorkerScript. Hostname: ${ctx.workerScript.hostname}.`);
       }
-      const moneyBefore = server.moneyAvailable <= 0 ? 1 : server.moneyAvailable;
-      processSingleServerGrowth(server, threads, host.cpuCores);
+      const moneyBefore = server.moneyAvailable;
+      const growth = processSingleServerGrowth(server, threads, host.cpuCores);
+      const growthPercentForLogging = growth !== 0 ? growth - 1 : 0;
       const moneyAfter = server.moneyAvailable;
       ctx.workerScript.scriptRef.recordGrow(server.hostname, threads);
       const expGain = calculateHackingExpGain(server, Player) * threads;
-      const logGrowPercent = moneyAfter / moneyBefore - 1;
       helpers.log(
         ctx,
         () =>
-          `Available money on '${server.hostname}' grown by ${formatPercent(logGrowPercent, 6)}. Gained ${formatExp(
-            expGain,
-          )} hacking exp (t=${formatThreads(threads)}).`,
+          `Available money on '${server.hostname}' grown by ${formatPercent(
+            growthPercentForLogging,
+            6,
+          )}. Gained ${formatExp(expGain)} hacking exp (t=${formatThreads(threads)}).`,
       );
       ctx.workerScript.scriptRef.onlineExpGained += expGain;
       Player.gainHackingExp(expGain);
       if (stock) {
         influenceStockThroughServerGrow(server, moneyAfter - moneyBefore);
       }
-      return Promise.resolve(moneyAfter / moneyBefore);
+      return Promise.resolve(growth);
     });
   },
   growthAnalyze:

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -313,8 +313,7 @@ export const ns: InternalAPI<NSFull> = {
       if (stock) {
         influenceStockThroughServerGrow(server, moneyAfter - moneyBefore);
       }
-      // growth can only be 1 if server.moneyMax is 0. In that case, this API returns 0.
-      return Promise.resolve(growth !== 1 ? growth : 0);
+      return Promise.resolve(server.moneyMax === 0 ? 0 : growth);
     });
   },
   growthAnalyze:

--- a/src/Script/ScriptHelpers.ts
+++ b/src/Script/ScriptHelpers.ts
@@ -33,19 +33,24 @@ export function scriptCalculateOfflineProduction(runningScript: RunningScript): 
       if (runningScript.dataMap[hostname][2] == 0 || runningScript.dataMap[hostname][2] == null) {
         continue;
       }
-      const serv = GetServer(hostname);
-      if (serv == null) {
+      const server = GetServer(hostname);
+      if (server == null) {
         continue;
       }
       const timesGrown = Math.round(
         ((0.5 * runningScript.dataMap[hostname][2]) / runningScript.onlineRunningTime) * timePassed,
       );
-      runningScript.log(`Called on ${serv.hostname} ${timesGrown} times while offline`);
+      runningScript.log(`Called on ${server.hostname} ${timesGrown} times while offline`);
       const host = GetServer(runningScript.server);
-      if (host === null) throw new Error("getServer of null key?");
-      if (!(serv instanceof Server)) throw new Error("trying to grow a non-normal server");
-      const growth = processSingleServerGrowth(serv, timesGrown, host.cpuCores);
-      runningScript.log(`'${serv.hostname}' grown by ${formatPercent(growth - 1, 6)} while offline`);
+      if (host === null) {
+        throw new Error("getServer of null key?");
+      }
+      if (!(server instanceof Server)) {
+        throw new Error("trying to grow a non-normal server");
+      }
+      const growth = processSingleServerGrowth(server, timesGrown, host.cpuCores);
+      const growthPercentForLogging = growth !== 0 ? growth - 1 : 0;
+      runningScript.log(`'${server.hostname}' grown by ${formatPercent(growthPercentForLogging, 6)} while offline`);
     }
   }
 

--- a/src/Script/ScriptHelpers.ts
+++ b/src/Script/ScriptHelpers.ts
@@ -49,8 +49,7 @@ export function scriptCalculateOfflineProduction(runningScript: RunningScript): 
         throw new Error("trying to grow a non-normal server");
       }
       const growth = processSingleServerGrowth(server, timesGrown, host.cpuCores);
-      const growthPercentForLogging = growth !== 0 ? growth - 1 : 0;
-      runningScript.log(`'${server.hostname}' grown by ${formatPercent(growthPercentForLogging, 6)} while offline`);
+      runningScript.log(`'${server.hostname}' grown by ${formatPercent(growth - 1, 6)} while offline`);
     }
   }
 

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -190,7 +190,7 @@ export function processSingleServerGrowth(server: Server, threads: number, cores
   }
   // Prevent returning NaN. This happens when server.moneyMax is 0.
   if (server.moneyAvailable === 0 && oldMoneyAvailable === 0) {
-    return 0;
+    return 1;
   }
   // Prevent returning Infinity. If server's money before growing is 0, we "pretend" that it's 1.
   if (oldMoneyAvailable === 0) {

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -188,6 +188,14 @@ export function processSingleServerGrowth(server: Server, threads: number, cores
     usedCycles = Math.min(Math.max(0, Math.ceil(usedCycles)), threads);
     server.fortify(2 * ServerConstants.ServerFortifyAmount * usedCycles);
   }
+  // Prevent returning NaN. This happens when server.moneyMax is 0.
+  if (server.moneyAvailable === 0 && oldMoneyAvailable === 0) {
+    return 0;
+  }
+  // Prevent returning Infinity. If server's money before growing is 0, we "pretend" that it's 1.
+  if (oldMoneyAvailable === 0) {
+    return server.moneyAvailable;
+  }
   return server.moneyAvailable / oldMoneyAvailable;
 }
 

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -306,14 +306,16 @@ export class Terminal {
     if (!(server instanceof Server)) throw new Error("server should be normal server");
     const expGain = calculateHackingExpGain(server, Player);
     const oldSec = server.hackDifficulty;
-    const growth = processSingleServerGrowth(server, 25, server.cpuCores) - 1;
+    const growth = processSingleServerGrowth(server, 25, server.cpuCores);
+    const growthPercentForLogging = growth !== 0 ? growth - 1 : 0;
     const newSec = server.hackDifficulty;
 
     Player.gainHackingExp(expGain);
     this.print(
-      `Available money on '${server.hostname}' grown by ${formatPercent(growth, 6)}. Gained ${formatExp(
-        expGain,
-      )} hacking exp.`,
+      `Available money on '${server.hostname}' grown by ${formatPercent(
+        growthPercentForLogging,
+        6,
+      )}. Gained ${formatExp(expGain)} hacking exp.`,
     );
     this.print(
       `Security increased on '${server.hostname}' from ${formatSecurity(oldSec)} to ${formatSecurity(newSec)}`,

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -307,15 +307,13 @@ export class Terminal {
     const expGain = calculateHackingExpGain(server, Player);
     const oldSec = server.hackDifficulty;
     const growth = processSingleServerGrowth(server, 25, server.cpuCores);
-    const growthPercentForLogging = growth !== 0 ? growth - 1 : 0;
     const newSec = server.hackDifficulty;
 
     Player.gainHackingExp(expGain);
     this.print(
-      `Available money on '${server.hostname}' grown by ${formatPercent(
-        growthPercentForLogging,
-        6,
-      )}. Gained ${formatExp(expGain)} hacking exp.`,
+      `Available money on '${server.hostname}' grown by ${formatPercent(growth - 1, 6)}. Gained ${formatExp(
+        expGain,
+      )} hacking exp.`,
     );
     this.print(
       `Security increased on '${server.hostname}' from ${formatSecurity(oldSec)} to ${formatSecurity(newSec)}`,


### PR DESCRIPTION
In 23c862b72710bd38327fa7449dbcacb90629ffd6, we fixed the case in which `ns.grow` returns Infinity. On Discord, we received a report that terminal grow shows NaN%. When I checked the implementation of `processSingleServerGrowth` and its callers, I found more bugs:
- On servers with maxMoney = 0:
  - Terminal grow shows NaN.
  - `ns.grow` shows "-100%".
- On "grow-able" servers: Terminal grow shows Infinity if server's money before growing is 0.

I carefully refactored code of `processSingleServerGrowth` and its callers so that there is no behavior change in `ns.grow`.

Before:
![before1](https://github.com/user-attachments/assets/824c9991-d891-4b65-8948-9db28ee04a74)
![before2](https://github.com/user-attachments/assets/29200a31-394a-4688-9a67-c77b10e70079)
![before3](https://github.com/user-attachments/assets/3f5d71a6-e03e-495f-b28a-98e9c43da7c0)

After:
![after1](https://github.com/user-attachments/assets/b677a9b0-4237-4db6-a760-a23aebc534f3)
![after2](https://github.com/user-attachments/assets/389933f7-eb8b-443d-9615-0b9eb4f24e6f)
![after3](https://github.com/user-attachments/assets/5d48d0a3-fc0c-441e-96ab-e753fdf3e8f6)
