### PR TITLE
DOCUMENTATION: Clarify returned value of ns.bladeburner.getActionCountRemaining

### DIFF
--- a/markdown/bitburner.bladeburner.getactioncountremaining.md
+++ b/markdown/bitburner.bladeburner.getactioncountremaining.md
@@ -34,5 +34,9 @@ RAM cost: 4 GB
 
 Returns the remaining count of the specified action.
 
-Note that this is meant to be used for Contracts and Operations. This function will return ‘Infinity’ for actions such as Training and Field Analysis. This function will return 1 for BlackOps not yet completed regardless of whether the player has the required rank to attempt the mission or not.
+Note:
+
+- This function is meant to be used for Contracts and Operations. It returns Infinity for General actions (Training, Field Analysis, etc.). It returns 1 for BlackOps not yet completed, regardless of whether the player has the required rank to attempt the mission.
+
+- With Contracts and Operations, the returned value is a floating-point number. The UI shows the rounded-down value.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3446,10 +3446,14 @@ export interface Bladeburner {
    *
    * Returns the remaining count of the specified action.
    *
-   * Note that this is meant to be used for Contracts and Operations.
-   * This function will return ‘Infinity’ for actions such as Training and Field Analysis.
-   * This function will return 1 for BlackOps not yet completed regardless of whether
-   * the player has the required rank to attempt the mission or not.
+   * Note:
+   *
+   * - This function is meant to be used for Contracts and Operations. It returns Infinity for General actions
+   * (Training, Field Analysis, etc.). It returns 1 for BlackOps not yet completed, regardless of whether the player has
+   * the required rank to attempt the mission.
+   *
+   * - With Contracts and Operations, the returned value is a floating-point number. The UI shows the rounded-down
+   * value.
    *
    * @param type - Type of action.
    * @param name - Name of action. Must be an exact match.


### PR DESCRIPTION
Context: https://discord.com/channels/415207508303544321/415213435974975508/1294022926923858031
```
Regarding Bladeburner: the "Contracts remaining" number is showed as integers even if it's actually not. You can for example check it with ns.bladeburner.getActionCountRemaining. This may be confusing
```