### PR TITLE
CODEBASE: Fix React warning when using StatsTable

### DIFF
--- a/src/ui/React/StatsTable.tsx
+++ b/src/ui/React/StatsTable.tsx
@@ -31,7 +31,9 @@ export function StatsTable({ rows, title, wide, textAlign, paddingLeft }: StatsT
             <TableRow key={rowIndex}>
               {row.map((cell, cellIndex) => (
                 <TableCell key={cellIndex} className={cellIndex === 0 ? classes.firstCell : classes.nonFirstCell}>
-                  <Typography component="div" noWrap>{cell}</Typography>
+                  <Typography component="div" noWrap>
+                    {cell}
+                  </Typography>
                 </TableCell>
               ))}
             </TableRow>

--- a/src/ui/React/StatsTable.tsx
+++ b/src/ui/React/StatsTable.tsx
@@ -31,7 +31,7 @@ export function StatsTable({ rows, title, wide, textAlign, paddingLeft }: StatsT
             <TableRow key={rowIndex}>
               {row.map((cell, cellIndex) => (
                 <TableCell key={cellIndex} className={cellIndex === 0 ? classes.firstCell : classes.nonFirstCell}>
-                  <Typography noWrap>{cell}</Typography>
+                  <Typography component="div" noWrap>{cell}</Typography>
                 </TableCell>
               ))}
             </TableRow>


### PR DESCRIPTION
How to reproduce this issue: Take a job and go to the Job tab.

Warning:
```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
    at p
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Typography (webpack://bitburner/./node_modules/@mui/material/Typography/Typography.js?:101:87)
    at Tooltip (webpack://bitburner/./node_modules/@mui/material/Tooltip/Tooltip.js?:245:82)
    at p
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Typography (webpack://bitburner/./node_modules/@mui/material/Typography/Typography.js?:101:87)
    at td
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at TableCell (webpack://bitburner/./node_modules/@mui/material/TableCell/TableCell.js?:118:82)
    at TableCell (webpack://bitburner/./src/ui/React/Table.tsx?:24:13)
    at tr
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at TableRow (webpack://bitburner/./node_modules/@mui/material/TableRow/TableRow.js?:78:82)
    at tbody
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at TableBody (webpack://bitburner/./node_modules/@mui/material/TableBody/TableBody.js?:51:82)
    at table
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Table (webpack://bitburner/./node_modules/@mui/material/Table/Table.js?:68:82)
    at StatsTable (webpack://bitburner/./src/ui/React/StatsTable.tsx?:25:3)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Paper (webpack://bitburner/./node_modules/@mui/material/Paper/Paper.js?:80:82)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at CompanyLocation (webpack://bitburner/./src/Locations/ui/CompanyLocation.tsx?:50:82)
    at GenericLocation (webpack://bitburner/./src/Locations/ui/GenericLocation.tsx?:53:3)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at SnackbarProvider (webpack://bitburner/./node_modules/notistack/dist/notistack.esm.js?:736:24)
    at SnackbarProvider (webpack://bitburner/./src/ui/React/Snackbar.tsx?:32:7)
    at HistoryProvider (webpack://bitburner/./src/ui/React/Documentation.tsx?:50:80)
    at BypassWrapper (webpack://bitburner/./src/ui/React/BypassWrapper.tsx?:7:14)
    at ErrorBoundary (webpack://bitburner/./src/ui/ErrorBoundary.tsx?:14:5)
    at MathJaxContext (webpack://bitburner/./node_modules/better-react-mathjax/esm/MathJaxContext/MathJaxContext.js?:6:592)
    at GameRoot (webpack://bitburner/./src/ui/GameRoot.tsx?:203:7)
    at LoadingScreen (webpack://bitburner/./src/ui/LoadingScreen.tsx?:29:74)
    at ThemeProvider (webpack://bitburner/./node_modules/@mui/private-theming/ThemeProvider/ThemeProvider.js?:43:5)
    at ThemeProvider (webpack://bitburner/./node_modules/@mui/system/esm/ThemeProvider/ThemeProvider.js?:55:5)
    at ThemeProvider (webpack://bitburner/./node_modules/@mui/material/styles/ThemeProvider.js?:24:14)
    at StyledEngineProvider (webpack://bitburner/./node_modules/@mui/styled-engine/StyledEngineProvider/StyledEngineProvider.js?:29:5)
    at TTheme (webpack://bitburner/./src/Themes/ui/Theme.tsx?:374:3)
```