### PR TITLE
MISC: Clarify description of BN2 about gang and The Red Pill

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -70,7 +70,7 @@ export function initBitNodes() {
         {FactionName.TheDarkArmy}, {FactionName.SpeakersForTheDead}, {FactionName.NiteSec}, and{" "}
         {FactionName.TheBlackHand}) give the player the ability to form and manage their own gang, which can earn the
         player money and reputation with the corresponding faction. The gang faction offers more augmentations than
-        other factions, and in BitNode-2, it offers a way to destroy the BitNode.
+        other factions, and in BitNode-2, it offers The Red Pill.
         <br />
         <br />
         Destroying this BitNode will give you Source-File 2, or if you already have this Source-File, it will upgrade

--- a/src/Documentation/doc/advanced/bitnodes.md
+++ b/src/Documentation/doc/advanced/bitnodes.md
@@ -64,7 +64,7 @@ Destroying this BitNode will give you Source-File 1, or if you already have this
 
 Organized crime groups quickly filled the void of power left behind from the collapse of Western government in the 2050s. As society and civilization broke down, people quickly succumbed to the innate human impulse of evil and savagery. The organized crime factions quickly rose to the top of the modern world.
 
-Certain factions (Slum Snakes, Tetrads, The Syndicate, The Dark Army, Speakers for the Dead, NiteSec, and The Black Hand) give the player the ability to form and manage their own gang, which can earn the player money and reputation with the corresponding faction. The gang faction offers more augmentations than other factions, and in BitNode-2, it offers a way to destroy the BitNode.
+Certain factions (Slum Snakes, Tetrads, The Syndicate, The Dark Army, Speakers for the Dead, NiteSec, and The Black Hand) give the player the ability to form and manage their own gang, which can earn the player money and reputation with the corresponding faction. The gang faction offers more augmentations than other factions, and in BitNode-2, it offers The Red Pill.
 
 Destroying this BitNode will give you Source-File 2, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File allows you to form gangs in other BitNodes once your karma decreases to a certain value. It also increases your crime success rate, crime money, and charisma multipliers by:
 


### PR DESCRIPTION
In BN2's description, we say that the gang "offers a way to destroy the BitNode". Many players ask us what that means. That phrase makes them think that there is a special way to destroy the BN (like Bladeburner). However, that phrase is just a roundabout way to say that the gang offers The Red Pill.

This PR removes that confusing phrase and clearly tells the player that the gang offers The Red Pill.