### PR TITLE
DOCUMENTATION: Clarify the return descriptions of pserv cost methods

### DIFF
--- a/markdown/bitburner.ns.getpurchasedservercost.md
+++ b/markdown/bitburner.ns.getpurchasedservercost.md
@@ -22,7 +22,7 @@ getPurchasedServerCost(ram: number): number;
 
 number
 
-The cost to purchase a server with the specified amount of ram.
+The cost to purchase a server with the specified amount of ram, or returns Infinity if ram is not a valid amount.
 
 ## Remarks
 

--- a/markdown/bitburner.ns.getpurchasedserverupgradecost.md
+++ b/markdown/bitburner.ns.getpurchasedserverupgradecost.md
@@ -23,7 +23,7 @@ getPurchasedServerUpgradeCost(hostname: string, ram: number): number;
 
 number
 
-The price to upgrade.
+The price to upgrade or -1 if either input is not valid, i.e. hostname is not the name of a purchased server or ram is not a valid amount.
 
 ## Remarks
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7164,7 +7164,7 @@ export interface NS {
    * ns.tprint(`A purchased server with ${ns.formatRam(ram)} costs $${ns.formatNumber(cost)}`);
    * ```
    * @param ram - Amount of RAM of a potential purchased server, in GB. Must be a power of 2 (2, 4, 8, 16, etc.). Maximum value of 1048576 (2^20).
-   * @returns The cost to purchase a server with the specified amount of ram.
+   * @returns The cost to purchase a server with the specified amount of ram, or returns Infinity if ram is not a valid amount.
    */
   getPurchasedServerCost(ram: number): number;
 
@@ -7214,7 +7214,7 @@ export interface NS {
    *
    * @param hostname - Hostname of the server to upgrade.
    * @param ram - Amount of RAM of the purchased server, in GB. Must be a power of 2 (2, 4, 8, 16, etc.). Maximum value of 1048576 (2^20).
-   * @returns The price to upgrade.
+   * @returns The price to upgrade or -1 if either input is not valid, i.e. hostname is not the name of a purchased server or ram is not a valid amount.
    */
   getPurchasedServerUpgradeCost(hostname: string, ram: number): number;
 


### PR DESCRIPTION
Both "getPurchasedServerCost" and "getPurchasedServerUpgradeCost" were missing descriptions of what gets returned if their arguments are present but not valid.  I simply added the respective annotations to their return documentation.