### PR TITLE
DOCUMENTATION: Add starter react documentation

### DIFF
--- a/src/Documentation/doc/index.md
+++ b/src/Documentation/doc/index.md
@@ -47,6 +47,7 @@
 - [Learn to program](programming/learn.md)
 - [Remote API](programming/remote_api.md)
 - [Game frozen or stuck?](programming/game_frozen.md)
+- [React](programming/react.md)
 - [Tools & Resources](help/tools_and_resources.md)
 - [Changelog](changelog.md)
 - [Changelog - Legacy v1](changelog-v1.md)

--- a/src/Documentation/doc/programming/react.md
+++ b/src/Documentation/doc/programming/react.md
@@ -1,0 +1,29 @@
+# How to use React in game
+
+Since v2.7.0, Bitburner supports React and TypeScript out of the box. You can use the jsx syntax inside `.jsx` and `.tsx` files.
+
+## Example
+
+Use `ns.printRaw` and `ns.tprintRaw` to render React elements in the logs and terminal.
+
+```tsx
+// timer.tsx
+function Timer() {
+  const [seconds, setSeconds] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setSeconds((seconds) => seconds + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return <div>Seconds: {seconds}</div>;
+}
+
+export async function main(ns: NS) {
+  ns.tail();
+  ns.printRaw(<Timer />);
+  await ns.asleep(10000);
+}
+```

--- a/src/Documentation/pages.ts
+++ b/src/Documentation/pages.ts
@@ -59,7 +59,8 @@ import file56 from "./doc/programming/game_frozen.md?raw";
 import file57 from "./doc/programming/go_algorithms.md?raw";
 import file58 from "./doc/programming/hackingalgorithms.md?raw";
 import file59 from "./doc/programming/learn.md?raw";
-import file60 from "./doc/programming/remote_api.md?raw";
+import file60 from "./doc/programming/react.md?raw";
+import file61 from "./doc/programming/remote_api.md?raw";
 
 import type { Document } from "./root.ts";
 
@@ -124,4 +125,5 @@ AllPages["programming/game_frozen.md"] = file56;
 AllPages["programming/go_algorithms.md"] = file57;
 AllPages["programming/hackingalgorithms.md"] = file58;
 AllPages["programming/learn.md"] = file59;
-AllPages["programming/remote_api.md"] = file60;
+AllPages["programming/react.md"] = file60;
+AllPages["programming/remote_api.md"] = file61;


### PR DESCRIPTION
React (and TypeScript) support was added in v2.7.0 but there seems to be little documentation aside from the Changelog.

Added some rudimentary documentation for getting started with React in Bitburner to increase discoverability. Feel free to expand or make any suggestions.

![image](https://github.com/user-attachments/assets/4c73296d-1447-45e1-82c3-f1100b3bf635)


 