### PR TITLE
MISC: Dynamically load imported scripts for editor

### DIFF
--- a/src/ScriptEditor/ui/utils.ts
+++ b/src/ScriptEditor/ui/utils.ts
@@ -23,11 +23,17 @@ function reorder(list: unknown[], startIndex: number, endIndex: number): void {
   const [removed] = list.splice(startIndex, 1);
   list.splice(endIndex, 0, removed);
 }
-function makeModel(hostname: string, filename: string, code: string) {
+
+function makeModel(hostname: string, filename: string, code: string): editor.ITextModel {
   const uri = Uri.from({
-    scheme: "file",
+    scheme: "memory",
     path: `${hostname}/${filename}`,
   });
+  // If there is a model with this URI and it's not disposed, return it.
+  const model = editor.getModel(uri);
+  if (model && !model.isDisposed()) {
+    return model;
+  }
   let language;
   const fileType = getFileType(filename);
   switch (fileType) {
@@ -51,8 +57,7 @@ function makeModel(hostname: string, filename: string, code: string) {
     default:
       throwIfReachable(fileType);
   }
-  //if somehow a model already exist return it
-  return editor.getModel(uri) ?? editor.createModel(code, language, uri);
+  return editor.createModel(code, language, uri);
 }
 
 export { getServerCode, dirty, reorder, makeModel };


### PR DESCRIPTION
For context, please check my comment at https://github.com/bitburner-official/bitburner-src/issues/1747#issuecomment-2558912702.

This PR fixes that problem by dynamically loading only imported scripts instead of loading all scripts.

Note: This PR conflicts with #1865 and #1866, so I ported those fixes to this PR.

How to test:
Test 1:
- Load this save file: [test suite for editor.gz](https://github.com/user-attachments/files/18310863/test.suite.for.editor.gz)
- Open all scripts, especially `ts.ts` and `tsx.tsx`. False-positive error markers should disappear after 2 seconds.

Test 2:
- Load the save file in #1877.
- Make sure that autocomplete works normally.

Closes #1877.