### PR TITLE
BUGFIX: "Import Save Comparison" popup is shown after reloading

### DIFF
--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -182,7 +182,7 @@ function initElectronBridge(): void {
   });
   bridge.receive("push-save-request", (params: unknown) => {
     if (typeof params !== "object") throw new Error("Error trying to push save request");
-    const { save, automatic = false } = params as { save: string; automatic: boolean };
+    const { save, automatic = false } = params as { save: SaveData; automatic: boolean };
     window.appSaveFns.pushSaveData(save, automatic);
   });
   bridge.receive("trigger-save", () => {

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -19,7 +19,7 @@ import { dialogBoxCreate } from "./ui/React/DialogBox";
 import { constructorsForReviver, Generic_toJSON, Generic_fromJSON, type IReviverValue } from "./utils/JSONReviver";
 import { save } from "./db";
 import { ToastVariant } from "@enums";
-import { pushGameSaved } from "./Electron";
+import { pushGameSaved, pushImportResult } from "./Electron";
 import { getGoSave, loadGo } from "./Go/SaveLoad";
 import { SaveData } from "./types";
 import { SaveDataError, canUseBinaryFormat, decodeSaveData, encodeJsonSaveString } from "./utils/SaveDataUtils";
@@ -236,6 +236,11 @@ class BitburnerSaveObject implements BitburnerSaveObjectType {
     }
     try {
       await save(saveData);
+      /**
+       * Notify Electron code that the player imported a save file. "restoreIfNewerExists" will be disabled for a brief
+       * period of time.
+       */
+      pushImportResult(true);
     } catch (error) {
       console.error(error);
       dialogBoxCreate(`Cannot import save data: ${error}`);

--- a/src/ui/React/ImportSave/ImportSave.tsx
+++ b/src/ui/React/ImportSave/ImportSave.tsx
@@ -110,7 +110,6 @@ export const ImportSave = (props: { saveData: SaveData; automatic: boolean }): J
 
   const handleImport = async (): Promise<void> => {
     await saveObject.importGame(props.saveData, true);
-    pushImportResult(true);
   };
 
   useEffect(() => {
@@ -389,12 +388,16 @@ export const ImportSave = (props: { saveData: SaveData; automatic: boolean }): J
 
       <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
         <ButtonGroup>
-          <Button onClick={handleGoBack} sx={{ my: 2 }} startIcon={<ArrowBackIcon />} color="secondary">
-            Take me back!
-          </Button>
-          <Button onClick={openImportModal} sx={{ my: 2 }} startIcon={<DirectionsRunIcon />} color="warning">
-            Proceed with import
-          </Button>
+          <Tooltip title="Continue with current save">
+            <Button onClick={handleGoBack} sx={{ my: 2 }} startIcon={<ArrowBackIcon />} color="secondary">
+              Take me back!
+            </Button>
+          </Tooltip>
+          <Tooltip title="Import newer save and reload">
+            <Button onClick={openImportModal} sx={{ my: 2 }} startIcon={<DirectionsRunIcon />} color="warning">
+              Proceed with import
+            </Button>
+          </Tooltip>
         </ButtonGroup>
         <ConfirmationModal
           open={isImportModalOpen}


### PR DESCRIPTION
How to reproduce this bug:
- Create a "clean" state:
  - Open the Electron app. Open the save folder (Files -> Open Directory -> Open Saves Directory).
  - Delete the current save (Options -> Delete Save). Save game. Close the Electron app.
  - Open the Electron app again. Delete old saves in the saves folder.
- Import BIG (1q-edited.json.gz). Save game. Close the Electron app.[1]
- You will see a folder named "1ce7b2f80ebfd3" with a save file.
- Open the Electron app.
- Import SMALL (1k-edited.json.gz). [2]
- After the game reloads, the "Import Save Comparison" is shown. In the save folder, there is folder name "dc70827649567", but it's empty.

After [1], BIG is saved on disk in "1ce7b2f80ebfd3". This is the "newest save file". After [2], SMALL has not been saved on disk ("dc70827649567" is empty), so when the game reloads, it sees BIG (in "1ce7b2f80ebfd3") as the newest save file.

We have a built-in mechanic to mitigate the problem of "comparison popup should not be shown after importing". For details, please check:
- `pushImportResult` and `pushDisableRestore` in `src\Electron.tsx`
- `setStopProcessHandler` in `electron\main.js`

The gist is that we disable that popup for a brief period of time after importing. We need to notify the Electron code by calling `pushImportResult` after calling `saveObject.importGame`. We need to do that in:
- `confirmedImportGame` in `src\GameOptions\ui\GameOptionsSidebar.tsx` -> We forgot to do that here.
- `handleImport` in `src\ui\React\ImportSave\ImportSave.tsx`

This PR fixes this bug by calling `pushImportResult` in `saveObject.importGame`. With this change, we never have to worry about forgetting to call `pushImportResult`.

@d0sboots I think our mitigation is not really good. The root cause of the problem is that we don't save the new save data to disk (and cloud) after importing. If the player closes the game after importing SMALL without pressing the "save button" (and before the autosave triggged), the game won't "flush" the new save data to disk. When they open the game again, the popup is still shown. Reproducible steps:
- Do the steps above.
- After importing SMALL and the popup is shown, just close the game.
- Open the game again. The popup is shown again.

I did not implement a proper fix in this PR to keep the change as small as possible (reduce the risk of a regression bug). If you want, I'll fix the root cause properly in another PR.

I also add some tooltips to clarify the meaning of 2 buttons mentioned in #1890.

Save files:
BIG: [1q-edited.json.gz](https://github.com/user-attachments/files/18327570/1q-edited.json.gz)
SMALL: [1k-edited.json.gz](https://github.com/user-attachments/files/18327571/1k-edited.json.gz)

Before:
![before](https://github.com/user-attachments/assets/7616e282-f847-436a-a2dc-61099df7eeba)

After:
![after1](https://github.com/user-attachments/assets/1fbef142-44d8-4f9d-83fe-0f8577ccea7a)
![after2](https://github.com/user-attachments/assets/4f76d0dc-78da-4f89-bee0-551be8a56734)

Fixes #1890.