### PR TITLE
UI: Fix migration doc typo

### DIFF
--- a/src/Documentation/doc/migrations/v2.md
+++ b/src/Documentation/doc/migrations/v2.md
@@ -80,7 +80,7 @@ If you want to get the total income/exp for all scripts, use the new getTotalScr
 
 ## scp
 
-The last two arguments of spc have been reversed. The signature is now scp(files, destination, optional_source)
+The last two arguments of scp have been reversed. The signature is now scp(files, destination, optional_source)
 
 ## Singularity
 


### PR DESCRIPTION
`spc` becomes `scp`.
