### PR TITLE
UI: Remove RAM usage percentage in "free" CLI if it's NaN

### DIFF
--- a/src/Terminal/commands/free.ts
+++ b/src/Terminal/commands/free.ts
@@ -14,6 +14,8 @@ export function free(args: (string | number | boolean)[], server: BaseServer): v
   const usedPercent = formatPercent(server.ramUsed / server.maxRam);
 
   Terminal.print(`Total:     ${" ".repeat(maxLength - ram.length)}${ram}`);
-  Terminal.print(`Used:      ${" ".repeat(maxLength - used.length)}${used} (${usedPercent})`);
+  Terminal.print(
+    `Used:      ${" ".repeat(maxLength - used.length)}${used}` + (server.maxRam > 0 ? ` (${usedPercent})` : ""),
+  );
   Terminal.print(`Available: ${" ".repeat(maxLength - avail.length)}${avail}`);
 }


### PR DESCRIPTION
It's just as the title said.

Before:
![before](https://github.com/user-attachments/assets/19a672a0-2499-48f9-ac6a-f0969f4848c0)

After:
![after](https://github.com/user-attachments/assets/e32563c5-9cfe-48ce-a117-553f646c47e1)
