### PR TITLE
UI: Hide spoiler content in Soft Reset popup

### DIFF
--- a/src/ui/React/SoftResetButton.tsx
+++ b/src/ui/React/SoftResetButton.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { Button, Tooltip } from "@mui/material";
 import { ConfirmationModal } from "./ConfirmationModal";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import { knowAboutBitverse } from "../../BitNode/BitNodeUtils";
 
 interface IProps {
   color?: "primary" | "warning" | "error";
@@ -32,7 +33,7 @@ export function SoftResetButton({
   - Install Augmentations if you have any purchased
   - Reset servers, programs, recent scripts and terminal 
   - Scripts on your home server will stop, but aren't deleted
-  - Stop some special mechanics like Bladeburner tasks
+  - Stop some special mechanics (crime, study, ${knowAboutBitverse() ? `Bladeburner action, Grafting task, ` : ""}etc.)
   - You will not lose overall progress or access to special mechanics
 
 Are you sure? 


### PR DESCRIPTION
It's just as the title said.

Before:
![before](https://github.com/user-attachments/assets/e9741d04-32c1-4c73-87ec-22f4a8511a04)

After:
![after1](https://github.com/user-attachments/assets/07514117-bc58-40a7-8d27-232820290470)
![after2](https://github.com/user-attachments/assets/eeb9d196-d33a-46c3-8d8e-4533e76559d0)
