### PR TITLE
UI: Change "overclock" to another phrase in Sleeves tab

### DIFF
--- a/src/PersonObjects/Sleeve/ui/FAQModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/FAQModal.tsx
@@ -110,6 +110,14 @@ export function FAQModal({ open, onClose }: IProps): React.ReactElement {
           Memory can only be increased by purchasing upgrades from {FactionName.TheCovenant}. It is a persistent stat,
           meaning it never gets resets back to 1. The maximum possible value for a sleeve's memory is 100.
         </Typography>
+        <br />
+        <br />
+        <Typography variant="h4">What is bonus time?</Typography>
+        <br />
+        <Typography>
+          Sleeves accumulate bonus time when they idle or when you open the game after being offline. They use bonus
+          time to reduce the time requirement of their tasks so that they can complete their tasks faster.
+        </Typography>
       </>
     </Modal>
   );

--- a/src/PersonObjects/Sleeve/ui/StatsElement.tsx
+++ b/src/PersonObjects/Sleeve/ui/StatsElement.tsx
@@ -174,7 +174,9 @@ export function EarningsElement(props: IProps): React.ReactElement {
       <TableBody>
         <TableRow>
           <TableCell classes={{ root: classes.cellNone }}>
-            <Typography variant="h6">Earnings {props.sleeve.storedCycles > 50 ? "(overclock)" : ""}</Typography>
+            <Typography variant="h6">
+              Earnings {props.sleeve.storedCycles > 50 ? "(Boosted by bonus time)" : ""}
+            </Typography>
           </TableCell>
         </TableRow>
         {data.map(([a, b]) => (


### PR DESCRIPTION
Bladeburner has a skill named "Overclock", so using that word in Sleeves UI is confusing. We often receive questions from players asking what "overclock" means. "overclock" in that UI is just a fancy way to say that sleeves are using bonus time. This PR changes the wording and clarifies the FAQ.

Before:
![before](https://github.com/user-attachments/assets/9beb7c5e-91a5-49b0-b022-ab7f997537a4)

After:
![after1](https://github.com/user-attachments/assets/a913c93c-8e98-4ba4-9e5c-deab7538bd21)
![after2](https://github.com/user-attachments/assets/4165496b-cf6a-433b-b3bd-b0b4d5ee699b)
