### PR TITLE
UI: Clarify messages related to "buy" command

### DIFF
--- a/src/Locations/ui/TorButton.tsx
+++ b/src/Locations/ui/TorButton.tsx
@@ -32,7 +32,7 @@ export function purchaseTorRouter(): void {
   dialogBoxCreate(
     "You have purchased a TOR router!\n" +
       "You now have access to the dark web from your home computer.\n" +
-      "Use the buy command in the terminal to purchase programs.",
+      `Use the "buy" command in the terminal to purchase programs.`,
   );
 }
 

--- a/src/Terminal/commands/buy.ts
+++ b/src/Terminal/commands/buy.ts
@@ -5,7 +5,7 @@ import { listAllDarkwebItems, buyAllDarkwebItems, buyDarkwebItem } from "../../D
 export function buy(args: (string | number | boolean)[]): void {
   if (!Player.hasTorRouter()) {
     Terminal.error(
-      "You need to be able to connect to the Dark Web to use the buy command. (Maybe there's a TOR router you can buy somewhere)",
+      `You need to be able to connect to the Dark Web to use the "buy" command. (Maybe there's a TOR router you can buy somewhere)`,
     );
     return;
   }


### PR DESCRIPTION
Context: https://discord.com/channels/415207508303544321/415213435974975508/1324719713476939797

Adding double quotation marks around the word may be a bit clearer that we are talking about the `buy` command.