### PR TITLE
NETSCRIPT: Log script kill immediately and identify the killing script.

### DIFF
--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -23,9 +23,10 @@ export function killWorkerScript(ws: WorkerScript): boolean {
   return true;
 }
 
-export function killWorkerScriptByPid(pid: number): boolean {
+export function killWorkerScriptByPid(pid: number, killer?: WorkerScript): boolean {
   const ws = workerScripts.get(pid);
   if (ws instanceof WorkerScript) {
+    ws.log("", () => (killer ? `Script killed by script ${killer.name} with PID ${killer.pid}` : "Script killed."));
     stopAndCleanUpWorkerScript(ws);
     return true;
   }

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -811,7 +811,7 @@ export const ns: InternalAPI<NSFull> = {
       const killByPid = typeof ident === "number";
       if (killByPid) {
         // Kill by pid
-        res = killWorkerScriptByPid(ident);
+        res = killWorkerScriptByPid(ident, ctx.workerScript);
       } else {
         // Kill by filename/hostname
         if (scriptID === undefined) {
@@ -826,7 +826,7 @@ export const ns: InternalAPI<NSFull> = {
 
         res = true;
         for (const pid of byPid.keys()) {
-          res &&= killWorkerScriptByPid(pid);
+          res &&= killWorkerScriptByPid(pid, ctx.workerScript);
         }
       }
 
@@ -861,7 +861,7 @@ export const ns: InternalAPI<NSFull> = {
       for (const byPid of server.runningScriptMap.values()) {
         for (const pid of byPid.keys()) {
           if (safetyGuard && pid == ctx.workerScript.pid) continue;
-          killWorkerScriptByPid(pid);
+          killWorkerScriptByPid(pid, ctx.workerScript);
           ++scriptsKilled;
         }
       }
@@ -1494,7 +1494,7 @@ export const ns: InternalAPI<NSFull> = {
       if (!pattern.test(key)) continue;
       suc = true;
       for (const pid of byPid.keys()) {
-        killWorkerScriptByPid(pid);
+        killWorkerScriptByPid(pid, ctx.workerScript);
       }
     }
     return suc;

--- a/src/NetscriptWorker.ts
+++ b/src/NetscriptWorker.ts
@@ -355,7 +355,7 @@ Otherwise, this can also occur if you have attempted to launch a script from a t
       killWorkerScript(workerScript);
       workerScript.log("", () =>
         error instanceof ScriptDeath
-          ? "Script killed."
+          ? "main() terminated."
           : getErrorMessageWithStackAndCause(error, "Script crashed due to an error: "),
       );
     })


### PR DESCRIPTION
Redo of #1818 because I can't be bothered to figure out how to rebase a PR.
I've incorporated the comments from that PR; demo at https://yichizhng.github.io/bitburner-src/

Sample kill message:
```
asleep: Sleeping for 1.000 seconds.
Script killed by script kill.js with PID 8
print: Failed to run due to script being killed.
main() terminated.
```