### PR TITLE
DOCUMENTATION: Fix incorrectly documented BusinessFactor

### DIFF
--- a/src/Documentation/doc/advanced/corporation/optimal-selling-price-market-ta2.md
+++ b/src/Documentation/doc/advanced/corporation/optimal-selling-price-market-ta2.md
@@ -43,7 +43,7 @@ Calculation of material and product is pretty similar, so I'll call them "item" 
 - Business factor:
   - `BusinessProduction = 1 + office.employeeProductionByJob["Business"]`
 
-$${BusinessFactor = (BusinessProduction)}^{0.26} + \left({BusinessProduction}\ast{0.001}\right)$$
+$${BusinessFactor = (BusinessProduction)}^{0.26} + \left({BusinessProduction}\ast{0.0001}\right)$$
 
 - Advert factor:
 


### PR DESCRIPTION
The advanced documentation incorrectly claims that the multiplier is 0.001. The actual code divides by 10000 (10e3), effectively multiplying by 0.0001:

https://github.com/bitburner-official/bitburner-src/blob/dev/src/Corporation/Division.ts#L1085

Perhaps the author confused 10e3 and 1e3, or the code changed since the guide was written?

---

Tested in trial by fire while developing my (incomplete) corporation management script, and wondering why the heck the numbers weren't lining up.

esainane/bitburner-scripts@22712cd39e5a:[src/corp.ts#L111](https://github.com/esainane/bitburner-scripts/blob/22712cd39e5a8c5a0b13597f32b689eac80e804c/src/corp.ts#L111)
