### PR TITLE
DOCUMENTATION: improve documentation for `atExit()`

### DIFF
--- a/markdown/bitburner.ns.atexit.md
+++ b/markdown/bitburner.ns.atexit.md
@@ -4,7 +4,7 @@
 
 ## NS.atExit() method
 
-Add callback function when the script dies
+Add a callback to be executed when the script dies.
 
 **Signature:**
 
@@ -16,8 +16,8 @@ atExit(f: () => void, id?: string): void;
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  f | () =&gt; void |  |
-|  id | string | _(Optional)_ |
+|  f | () =&gt; void | A function to execute when the script dies. |
+|  id | string | _(Optional)_ Callback ID. Optional, defaults to <code>&quot;default&quot;</code>. |
 
 **Returns:**
 
@@ -29,5 +29,5 @@ RAM cost: 0 GB
 
 NS2 exclusive
 
-Add callback to be executed when the script dies.
+Each script can only register one callback per callback ID. If another callback is registered with the same callback ID the previous callback with that ID is forgotten and will not be executed when the script dies.
 

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -56,7 +56,7 @@ export async function main(ns) {
 |  --- | --- |
 |  [alert(msg)](./bitburner.ns.alert.md) | Open up a message box. |
 |  [asleep(millis)](./bitburner.ns.asleep.md) | Suspends the script for n milliseconds. Doesn't block with concurrent calls. |
-|  [atExit(f, id)](./bitburner.ns.atexit.md) | Add callback function when the script dies |
+|  [atExit(f, id)](./bitburner.ns.atexit.md) | Add a callback to be executed when the script dies. |
 |  [brutessh(host)](./bitburner.ns.brutessh.md) | Runs BruteSSH.exe on a server. |
 |  [clear(handle)](./bitburner.ns.clear.md) | Clear data from a file. |
 |  [clearLog()](./bitburner.ns.clearlog.md) | Clears the script’s logs. |

--- a/markdown/bitburner.ns.settailfontsize.md
+++ b/markdown/bitburner.ns.settailfontsize.md
@@ -31,8 +31,6 @@ RAM cost: 0 GB
 
 This overwrites the tail font size and forces an update of the tail window's contents.
 
-The font size is saved across restarts.
-
 If ran without a filename or pid, this will affect the current script's tail window.
 
 Otherwise, the PID or filename, hostname/ip, and args… arguments can be used to target the tail window from another script. Remember that scripts are uniquely identified by both their names and arguments.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7905,13 +7905,18 @@ export interface NS {
   getMoneySources(): MoneySources;
 
   /**
-   * Add callback function when the script dies
+   * Add a callback to be executed when the script dies.
    * @remarks
    * RAM cost: 0 GB
    *
    * NS2 exclusive
    *
-   * Add callback to be executed when the script dies.
+   * Each script can only register one callback per callback ID.
+   * If another callback is registered with the same callback ID
+   * the previous callback with that ID is forgotten and will not be executed when the script dies.
+   *
+   * @param f - A function to execute when the script dies.
+   * @param id - Callback ID. Optional, defaults to `"default"`.
    */
   atExit(f: () => void, id?: string): void;
 


### PR DESCRIPTION
• remove duplicate description from remarks
• add explaination of the significance of the callback IDs
• add parameter descriptions