### PR TITLE
BUGFIX: Changed no such file run command error to include all executable types

### DIFF
--- a/src/Terminal/commands/runProgram.ts
+++ b/src/Terminal/commands/runProgram.ts
@@ -14,7 +14,7 @@ export function runProgram(path: ProgramFilePath, args: (string | number | boole
   const realProgramName = getRecordKeys(Programs).find((name) => name.toLowerCase() === programLowered);
   if (!realProgramName || !Player.hasProgram(realProgramName)) {
     Terminal.error(
-      `No such (exe, script, js, or cct) file! (Only finished programs that exist on your home computer or scripts on ${server.hostname} can be run)`,
+      `No such (js, jsx, ts, tsx, script, cct, or exe) file! (Only finished programs that exist on your home computer or scripts on ${server.hostname} can be run)`,
     );
     return;
   }


### PR DESCRIPTION
Very simple fix, just changed the string that is printed to the terminal when attempting to run a file that doesn't exist to include all the executable types, rather than just exe, script, js, or cct.

Also reordered them to match the invalid file extension error in run.ts as run.ts was far more up-to-date

Tested by making a build with this change and attempting to run fl1ght.exe before it was acquired, and it worked as expected.
