### PR TITLE
CORPORATION: Show production multiplier of product in research popup

### DIFF
--- a/src/Corporation/ui/modals/ResearchModal.tsx
+++ b/src/Corporation/ui/modals/ResearchModal.tsx
@@ -143,7 +143,7 @@ export function ResearchModal(props: IProps): React.ReactElement {
   return (
     <Modal open={props.open} onClose={props.onClose}>
       <Upgrade division={props.industry} n={researchTree.root} />
-      <Typography sx={{ mt: 1 }}>
+      <Typography component="div" sx={{ mt: 1 }}>
         Research points: {props.industry.researchPoints.toFixed(3)}
         <br />
         Multipliers from research:
@@ -155,6 +155,7 @@ export function ResearchModal(props: IProps): React.ReactElement {
             ["Employee Efficiency Multiplier:", formatCorpMultiplier(researchTree.getEmployeeEffMultiplier())],
             ["Employee Intelligence Multiplier:", formatCorpMultiplier(researchTree.getEmployeeIntMultiplier())],
             ["Production Multiplier:", formatCorpMultiplier(researchTree.getProductionMultiplier())],
+            ["Product Production Multiplier:", formatCorpMultiplier(researchTree.getProductProductionMultiplier())],
             ["Sales Multiplier:", formatCorpMultiplier(researchTree.getSalesMultiplier())],
             ["Scientific Research Multiplier:", formatCorpMultiplier(researchTree.getScientificResearchMultiplier())],
             ["Storage Multiplier:", formatCorpMultiplier(researchTree.getStorageMultiplier())],


### PR DESCRIPTION
Context: https://discord.com/channels/415207508303544321/415213413745164318/1330965093269114910

This multiplier is applied, but it's not shown on the UI.

Note: The usage of `component="div"` was added to fix a React warning:
```
Warning: validateDOMNesting(...): <table> cannot appear as a descendant of <p>.
    at table
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Table (webpack://bitburner/./node_modules/@mui/material/Table/Table.js?:68:82)
    at Table (webpack://bitburner/./src/ui/React/Table.tsx?:32:13)
    at StatsTable (webpack://bitburner/./src/ui/React/StatsTable.tsx?:25:3)
    at p
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Typography (webpack://bitburner/./node_modules/@mui/material/Typography/Typography.js?:101:87)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at div
    at Transition (webpack://bitburner/./node_modules/react-transition-group/esm/Transition.js?:127:30)
    at Fade (webpack://bitburner/./node_modules/@mui/material/Fade/Fade.js?:42:77)
    at FocusTrap (webpack://bitburner/./node_modules/@mui/base/FocusTrap/FocusTrap.js?:98:5)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Portal (webpack://bitburner/./node_modules/@mui/base/Portal/Portal.js?:39:5)
    at Modal (webpack://bitburner/./node_modules/@mui/material/Modal/Modal.js?:101:82)
    at Modal (webpack://bitburner/./src/ui/React/Modal.tsx?:49:3)
    at ResearchModal (webpack://bitburner/./src/Corporation/ui/modals/ResearchModal.tsx?:132:100)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Paper (webpack://bitburner/./node_modules/@mui/material/Paper/Paper.js?:80:82)
    at DivisionOverview (webpack://bitburner/./src/Corporation/ui/DivisionOverview.tsx?:105:73)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at Division (webpack://bitburner/./src/Corporation/ui/Division.tsx?:19:72)
    at CityTabs (webpack://bitburner/./src/Corporation/ui/CityTabs.tsx?:23:73)
    at MainPanel (webpack://bitburner/./src/Corporation/ui/MainPanel.tsx?:16:72)
    at CorporationRoot (webpack://bitburner/./src/Corporation/ui/CorporationRoot.tsx?:26:85)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at div
    at eval (webpack://bitburner/./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js?:56:66)
    at Box (webpack://bitburner/./node_modules/@mui/system/esm/createBox.js?:35:72)
    at SnackbarProvider (webpack://bitburner/./node_modules/notistack/dist/notistack.esm.js?:736:24)
    at SnackbarProvider (webpack://bitburner/./src/ui/React/Snackbar.tsx?:32:7)
    at HistoryProvider (webpack://bitburner/./src/ui/React/Documentation.tsx?:50:80)
    at BypassWrapper (webpack://bitburner/./src/ui/React/BypassWrapper.tsx?:7:14)
    at ErrorBoundary (webpack://bitburner/./src/ui/ErrorBoundary.tsx?:14:5)
    at MathJaxContext (webpack://bitburner/./node_modules/better-react-mathjax/esm/MathJaxContext/MathJaxContext.js?:6:592)
    at GameRoot (webpack://bitburner/./src/ui/GameRoot.tsx?:203:7)
    at LoadingScreen (webpack://bitburner/./src/ui/LoadingScreen.tsx?:29:74)
    at ThemeProvider (webpack://bitburner/./node_modules/@mui/private-theming/ThemeProvider/ThemeProvider.js?:43:5)
    at ThemeProvider (webpack://bitburner/./node_modules/@mui/system/esm/ThemeProvider/ThemeProvider.js?:55:5)
    at ThemeProvider (webpack://bitburner/./node_modules/@mui/material/styles/ThemeProvider.js?:24:14)
    at StyledEngineProvider (webpack://bitburner/./node_modules/@mui/styled-engine/StyledEngineProvider/StyledEngineProvider.js?:29:5)
    at TTheme (webpack://bitburner/./src/Themes/ui/Theme.tsx?:374:3)
```

Before:
![before](https://github.com/user-attachments/assets/42353a96-68c9-4816-97fe-308bdc96f1c9)

After:
![after](https://github.com/user-attachments/assets/8b1e1a5c-23cf-4a10-89b7-541c3bb76dd6)
