### PR TITLE
DOCUMENTATION: Make nuke and port opening functions return boolean

### DIFF
--- a/markdown/bitburner.ns.brutessh.md
+++ b/markdown/bitburner.ns.brutessh.md
@@ -9,7 +9,7 @@ Runs BruteSSH.exe on a server.
 **Signature:**
 
 ```typescript
-brutessh(host: string): void;
+brutessh(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ brutessh(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+True if the player runs the program successfully, and false otherwise.
 
 ## Remarks
 

--- a/markdown/bitburner.ns.ftpcrack.md
+++ b/markdown/bitburner.ns.ftpcrack.md
@@ -9,7 +9,7 @@ Runs FTPCrack.exe on a server.
 **Signature:**
 
 ```typescript
-ftpcrack(host: string): void;
+ftpcrack(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ ftpcrack(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+True if the player runs the program successfully, and false otherwise.
 
 ## Remarks
 

--- a/markdown/bitburner.ns.httpworm.md
+++ b/markdown/bitburner.ns.httpworm.md
@@ -9,7 +9,7 @@ Runs HTTPWorm.exe on a server.
 **Signature:**
 
 ```typescript
-httpworm(host: string): void;
+httpworm(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ httpworm(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+True if the player runs the program successfully, and false otherwise.
 
 ## Remarks
 

--- a/markdown/bitburner.ns.nuke.md
+++ b/markdown/bitburner.ns.nuke.md
@@ -9,7 +9,7 @@ Runs NUKE.exe on a server.
 **Signature:**
 
 ```typescript
-nuke(host: string): void;
+nuke(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ nuke(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+True if the player runs the program successfully, and false otherwise.
 
 ## Remarks
 

--- a/markdown/bitburner.ns.relaysmtp.md
+++ b/markdown/bitburner.ns.relaysmtp.md
@@ -9,7 +9,7 @@ Runs relaySMTP.exe on a server.
 **Signature:**
 
 ```typescript
-relaysmtp(host: string): void;
+relaysmtp(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ relaysmtp(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+True if the player runs the program successfully, and false otherwise.
 
 ## Remarks
 

--- a/markdown/bitburner.ns.sqlinject.md
+++ b/markdown/bitburner.ns.sqlinject.md
@@ -9,7 +9,7 @@ Runs SQLInject.exe on a server.
 **Signature:**
 
 ```typescript
-sqlinject(host: string): void;
+sqlinject(host: string): boolean;
 ```
 
 ## Parameters
@@ -20,7 +20,9 @@ sqlinject(host: string): void;
 
 **Returns:**
 
-void
+boolean
+
+True if the player runs the program successfully, and false otherwise.
 
 ## Remarks
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6543,8 +6543,9 @@ export interface NS {
    * ns.nuke("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns True if the player runs the program successfully, and false otherwise.
    */
-  nuke(host: string): void;
+  nuke(host: string): boolean;
 
   /**
    * Runs BruteSSH.exe on a server.
@@ -6558,8 +6559,9 @@ export interface NS {
    * ns.brutessh("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns True if the player runs the program successfully, and false otherwise.
    */
-  brutessh(host: string): void;
+  brutessh(host: string): boolean;
 
   /**
    * Runs FTPCrack.exe on a server.
@@ -6573,8 +6575,9 @@ export interface NS {
    * ns.ftpcrack("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns True if the player runs the program successfully, and false otherwise.
    */
-  ftpcrack(host: string): void;
+  ftpcrack(host: string): boolean;
 
   /**
    * Runs relaySMTP.exe on a server.
@@ -6588,8 +6591,9 @@ export interface NS {
    * ns.relaysmtp("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns True if the player runs the program successfully, and false otherwise.
    */
-  relaysmtp(host: string): void;
+  relaysmtp(host: string): boolean;
 
   /**
    * Runs HTTPWorm.exe on a server.
@@ -6603,8 +6607,9 @@ export interface NS {
    * ns.httpworm("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns True if the player runs the program successfully, and false otherwise.
    */
-  httpworm(host: string): void;
+  httpworm(host: string): boolean;
 
   /**
    * Runs SQLInject.exe on a server.
@@ -6618,8 +6623,9 @@ export interface NS {
    * ns.sqlinject("foodnstuff");
    * ```
    * @param host - Hostname of the target server.
+   * @returns True if the player runs the program successfully, and false otherwise.
    */
-  sqlinject(host: string): void;
+  sqlinject(host: string): boolean;
 
   /**
    * Start another script on the current server.


### PR DESCRIPTION
I noticed this problem when looking at https://github.com/bitburner-official/bitburner-src/pull/1023#issuecomment-1892544463. With these APIs, we return a boolean value, but the API documentation uses the `void` type. Technically, this is a breaking change for TS players, but I don't think it'll affect many players.