### PR TITLE
BB: Allow API Usage in BN 6 without 7 - Grants Augment for BN 7 completion

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -201,8 +201,8 @@ export function initBitNodes() {
         <br />
         Destroying this BitNode will give you Source-File 6, or if you already have this Source-File, it will upgrade
         its level up to a maximum of 3. This Source-File allows you to access the NSA's {FactionName.Bladeburners}{" "}
-        division in other BitNodes. In addition, this Source-File will raise both the level and experience gain rate of
-        all your combat stats by:
+        division and Netscript API in other BitNodes. In addition, this Source-File will raise both the level and
+        experience gain rate of all your combat stats by:
         <ul>
           <li>Level 1: 8%</li>
           <li>Level 2: 12%</li>
@@ -236,7 +236,7 @@ export function initBitNodes() {
         <ul>
           <li>Level 1: 8%</li>
           <li>Level 2: 12%</li>
-          <li>Level 3: 14%</li>
+          <li>Level 3: 14% and begin with The Blade's Simulacrum</li>
         </ul>
       </>
     ),

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -26,7 +26,7 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     return;
   };
   const getBladeburner = function (ctx: NetscriptContext): Bladeburner {
-    const apiAccess = canAccessBitNodeFeature(7);
+    const apiAccess = canAccessBitNodeFeature(7) || canAccessBitNodeFeature(6);
     if (!apiAccess) {
       throw helpers.errorMessage(ctx, "You have not unlocked the Bladeburner API.", "API ACCESS");
     }
@@ -307,7 +307,7 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
       return !!attempt.success;
     },
     joinBladeburnerDivision: (ctx) => () => {
-      if (!canAccessBitNodeFeature(7) || Player.bitNodeOptions.disableBladeburner) {
+      if ((!canAccessBitNodeFeature(7) && !canAccessBitNodeFeature(6)) || Player.bitNodeOptions.disableBladeburner) {
         return false;
       }
       if (currentNodeMults.BladeburnerRank === 0) {

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -307,7 +307,9 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
       return !!attempt.success;
     },
     joinBladeburnerDivision: (ctx) => () => {
-      if ((!canAccessBitNodeFeature(7) && !canAccessBitNodeFeature(6)) || Player.bitNodeOptions.disableBladeburner) {
+      if (!canAccessBitNodeFeature(7) && !canAccessBitNodeFeature(6)) {
+        return false; //Does not have bitnode 6 or 7
+      } else if (Player.bitNodeOptions.disableBladeburner) {
         return false;
       }
       if (currentNodeMults.BladeburnerRank === 0) {

--- a/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
@@ -1,6 +1,6 @@
 import { canAccessBitNodeFeature } from "../../BitNode/BitNodeUtils";
 import { Bladeburner } from "../../Bladeburner/Bladeburner";
-
+import { AugmentationName } from "@enums";
 import type { PlayerObject } from "./PlayerObject";
 
 export function canAccessBladeburner(this: PlayerObject): boolean {
@@ -10,4 +10,11 @@ export function canAccessBladeburner(this: PlayerObject): boolean {
 export function startBladeburner(this: PlayerObject): void {
   this.bladeburner = new Bladeburner();
   this.bladeburner.init();
+  // Give Blades Simulacrum if you have unlocked it
+  if (this.sourceFileLvl(7) >= 3) {
+    this.augmentations.push({
+      name: AugmentationName.BladesSimulacrum,
+      level: 1,
+    });
+  }
 }


### PR DESCRIPTION
This allows the user to use the Netscript API in BN 6 without having completed BN7 first.  Also grants The Blade's Simulacrum augment when starting BladeBurner if you have completed BN 7.

