### PR TITLE
IPVGO: ensure def is treated the same as the other stats boosted by playing against tetrads

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -931,6 +931,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): BitNodeMultiplier
         StrengthLevelMultiplier: 0.5,
         DexterityLevelMultiplier: 0.5,
         AgilityLevelMultiplier: 0.5,
+        DefenseLevelMultiplier: 0.5,
 
         AugmentationMoneyCost: 1.5,
 


### PR DESCRIPTION
When defense was added to tetrads' bonus in #1284 , the bitnode multipliers for BN 14 were not updated. This fixes defense to be more consistent