### PR TITLE
BUGFIX: Fix terminal auto complete not properly handling folder casing

### DIFF
--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -51,8 +51,8 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
     baseDir = path;
     pathingRequiredMatch = currentText.replace(/^.*\//, path);
   } else if (baseDir !== root) {
-    pathingRequiredMatch = (baseDir + currentText);
-  } else{
+    pathingRequiredMatch = baseDir + currentText;
+  } else {
     pathingRequiredMatch = currentText.toLowerCase();
   }
 

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -52,6 +52,8 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
     pathingRequiredMatch = currentText.replace(/^.*\//, path);
   } else if (baseDir !== root) {
     pathingRequiredMatch = (baseDir + currentText);
+  } else{
+    pathingRequiredMatch = currentText.toLowerCase();
   }
 
   const possibilities: string[] = [];

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -37,7 +37,7 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
   const requiredMatch = currentText.toLowerCase();
 
   // If a relative directory is included in the path, this will store what the absolute path needs to start with to be valid
-  let pathingRequiredMatch = currentText.toLowerCase();
+  let pathingRequiredMatch = currentText;
 
   /** The directory portion of the current input */
   let relativeDir = "";
@@ -49,9 +49,9 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
     // No valid terminal inputs contain a / that does not indicate a path
     if (path === null) return [];
     baseDir = path;
-    pathingRequiredMatch = currentText.replace(/^.*\//, path).toLowerCase();
+    pathingRequiredMatch = currentText.replace(/^.*\//, path);
   } else if (baseDir !== root) {
-    pathingRequiredMatch = (baseDir + currentText).toLowerCase();
+    pathingRequiredMatch = (baseDir + currentText);
   }
 
   const possibilities: string[] = [];

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -53,7 +53,7 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
   } else if (baseDir !== root) {
     pathingRequiredMatch = baseDir + currentText;
   } else {
-    pathingRequiredMatch = currentText.toLowerCase();
+    pathingRequiredMatch = currentText;
   }
 
   const possibilities: string[] = [];
@@ -73,10 +73,23 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
   function addGeneric({ iterable, usePathing, ignoreCurrent }: AddAllGenericOptions) {
     const requiredStart = usePathing ? pathingRequiredMatch : requiredMatch;
     for (const member of iterable) {
+      // const name = usePathing ? member.substring(0, member.lastIndexOf("/")) + member.substring(member.lastIndexOf("/")).toLowerCase() : member.toLowerCase();
+      // if (ignoreCurrent && member.length <= requiredStart.length) continue;
+      // if (name.startsWith(requiredStart)) { // removed member.lower()
+      //   possibilities.push(usePathing ? relativeDir + member.substring(baseDir.length) : member);
+      // }
       if (ignoreCurrent && member.length <= requiredStart.length) continue;
-      if (member.toLowerCase().startsWith(requiredStart)) {
-        possibilities.push(usePathing ? relativeDir + member.substring(baseDir.length) : member);
-      }
+      if(usePathing){
+        if(member.startsWith(requiredStart)){
+          possibilities.push(usePathing ? relativeDir + member.substring(baseDir.length) : member);
+        }
+        else{
+          const name = member.substring(0, member.lastIndexOf("/")) + member.substring(member.lastIndexOf("/")).toLowerCase()
+          const start_lowered = pathingRequiredMatch.substring(0, slashIndex) + pathingRequiredMatch.substring(slashIndex).toLocaleLowerCase();
+          if (name.startsWith(start_lowered)) { // removed member.lower()
+            possibilities.push(usePathing ? relativeDir + member.substring(baseDir.length) : member);
+          }
+        }
     }
   }
 


### PR DESCRIPTION
closes #1708 

Removed the conversion of paths to lowercase for the terminal auto completion. Previously, this would allow similarly named folders (scripts vs. Scripts) to share tab auto completion options.

<img width="659" alt="Bug" src="https://github.com/user-attachments/assets/137eec79-3002-4a22-be0b-24e45903301b" />

Image showing improper casing, the "Scripts" folder does not exist but the terminal suggests files within the similar "scripts" folder.

<img width="532" alt="fixed" src="https://github.com/user-attachments/assets/3147e6cb-e395-4db2-af3e-0ecccb363117" />

Image showing proper casing, the "Scripts" folder does not exist, and no recommendations are given.

Tested with nested folders and ensured that auto completion still occurs on partial folder names (ex: typing "Scr" + TAB will autocomplete to "scripts")