### PR TITLE
MISC: Standardize behavior of connect CLI and Singularity API

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -24,7 +24,7 @@ import { Companies } from "../Company/Companies";
 import { Factions } from "../Faction/Factions";
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { convertTimeMsToTimeElapsedString } from "../utils/StringHelperFunctions";
-import { connectServer, getServerOnNetwork } from "../Server/ServerHelpers";
+import { getServerOnNetwork } from "../Server/ServerHelpers";
 import { Terminal } from "../Terminal";
 import { calculateHackingTime } from "../Hacking";
 import { Server } from "../Server/Server";
@@ -492,7 +492,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           return false;
         }
         if (other.hostname === hostname) {
-          connectServer(other);
+          Terminal.connectToServer(hostname);
           return true;
         }
       }
@@ -502,7 +502,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
        * is true.
        */
       if (target.backdoorInstalled || target.purchasedByPlayer) {
-        connectServer(target);
+        Terminal.connectToServer(hostname);
         return true;
       }
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -492,7 +492,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           return false;
         }
         if (other.hostname === hostname) {
-          Terminal.connectToServer(hostname);
+          Terminal.connectToServer(hostname, true);
           return true;
         }
       }
@@ -502,7 +502,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
        * is true.
        */
       if (target.backdoorInstalled || target.purchasedByPlayer) {
-        Terminal.connectToServer(hostname);
+        Terminal.connectToServer(hostname, true);
         return true;
       }
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -24,7 +24,7 @@ import { Companies } from "../Company/Companies";
 import { Factions } from "../Faction/Factions";
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { convertTimeMsToTimeElapsedString } from "../utils/StringHelperFunctions";
-import { getServerOnNetwork } from "../Server/ServerHelpers";
+import { connectServer, getServerOnNetwork } from "../Server/ServerHelpers";
 import { Terminal } from "../Terminal";
 import { calculateHackingTime } from "../Hacking";
 import { Server } from "../Server/Server";
@@ -52,6 +52,7 @@ import { blackOpsArray } from "../Bladeburner/data/BlackOperations";
 import { calculateEffectiveRequiredReputation } from "../Company/utils";
 import { calculateFavorAfterResetting } from "../Faction/formulas/favor";
 import { validBitNodes } from "../BitNode/BitNodeUtils";
+import { exceptionAlert } from "../utils/helpers/exceptionAlert";
 
 export function NetscriptSingularity(): InternalAPI<ISingularity> {
   const runAfterReset = function (cbScript: ScriptFilePath) {
@@ -479,40 +480,34 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         throw helpers.errorMessage(ctx, `Invalid hostname: '${hostname}'`);
       }
 
-      //Home case
-      if (hostname === "home") {
-        Player.getCurrentServer().isConnectedTo = false;
-        Player.currentServer = Player.getHomeComputer().hostname;
-        Player.getCurrentServer().isConnectedTo = true;
-        Terminal.setcwd(root);
-        return true;
-      }
-
-      //Adjacent server case
+      // Adjacent servers
       const server = Player.getCurrentServer();
       for (let i = 0; i < server.serversOnNetwork.length; i++) {
         const other = getServerOnNetwork(server, i);
-        if (other === null) continue;
-        if (other.hostname == hostname) {
-          Player.getCurrentServer().isConnectedTo = false;
-          Player.currentServer = target.hostname;
-          Player.getCurrentServer().isConnectedTo = true;
-          Terminal.setcwd(root);
+        if (other === null) {
+          exceptionAlert(
+            new Error(
+              `${server.serversOnNetwork[i]} is on the network of ${server.hostname}, but we cannot find its data.`,
+            ),
+          );
+          return false;
+        }
+        if (other.hostname === hostname) {
+          connectServer(other);
           return true;
         }
       }
 
-      //Backdoor case
-      const other = GetServer(hostname);
-      if (other !== null && other instanceof Server && other.backdoorInstalled) {
-        Player.getCurrentServer().isConnectedTo = false;
-        Player.currentServer = target.hostname;
-        Player.getCurrentServer().isConnectedTo = true;
-        Terminal.setcwd(root);
+      /**
+       * Backdoored + owned servers (home, private servers, or hacknet servers). With home computer, purchasedByPlayer
+       * is true.
+       */
+      if (target.backdoorInstalled || target.purchasedByPlayer) {
+        connectServer(target);
         return true;
       }
 
-      //Failure case
+      // Failure case
       return false;
     },
     manualHack: (ctx) => () => {

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -44,7 +44,6 @@ import { findEnumMember } from "../utils/helpers/enum";
 import { Engine } from "../engine";
 import { getEnumHelper } from "../utils/EnumHelper";
 import { ScriptFilePath, resolveScriptFilePath } from "../Paths/ScriptFilePath";
-import { root } from "../Paths/Directory";
 import { getRecordEntries } from "../Types/Record";
 import { JobTracks } from "../Company/data/JobTracks";
 import { ServerConstants } from "../Server/data/Constants";

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -12,8 +12,6 @@ import { workerScripts } from "../Netscript/WorkerScripts";
 import { killWorkerScriptByPid } from "../Netscript/killWorkerScript";
 import { serverMetadata } from "./data/servers";
 import { exceptionAlert } from "../utils/helpers/exceptionAlert";
-import { Terminal } from "../Terminal";
-import { root } from "../Paths/Directory";
 
 /**
  * Constructs a new server, while also ensuring that the new server
@@ -272,11 +270,4 @@ export function getCoreBonus(cores = 1): number {
 export function getWeakenEffect(threads: number, cores: number): number {
   const coreBonus = getCoreBonus(cores);
   return ServerConstants.ServerWeakenAmount * threads * coreBonus * currentNodeMults.ServerWeakenRate;
-}
-
-export function connectServer(server: BaseServer): void {
-  Player.getCurrentServer().isConnectedTo = false;
-  Player.currentServer = server.hostname;
-  Player.getCurrentServer().isConnectedTo = true;
-  Terminal.setcwd(root);
 }

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -12,6 +12,8 @@ import { workerScripts } from "../Netscript/WorkerScripts";
 import { killWorkerScriptByPid } from "../Netscript/killWorkerScript";
 import { serverMetadata } from "./data/servers";
 import { exceptionAlert } from "../utils/helpers/exceptionAlert";
+import { Terminal } from "../Terminal";
+import { root } from "../Paths/Directory";
 
 /**
  * Constructs a new server, while also ensuring that the new server
@@ -270,4 +272,11 @@ export function getCoreBonus(cores = 1): number {
 export function getWeakenEffect(threads: number, cores: number): number {
   const coreBonus = getCoreBonus(cores);
   return ServerConstants.ServerWeakenAmount * threads * coreBonus * currentNodeMults.ServerWeakenRate;
+}
+
+export function connectServer(server: BaseServer): void {
+  Player.getCurrentServer().isConnectedTo = false;
+  Player.currentServer = server.hostname;
+  Player.getCurrentServer().isConnectedTo = true;
+  Terminal.setcwd(root);
 }

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -17,7 +17,7 @@ import { GetServer } from "../Server/AllServers";
 
 import { checkIfConnectedToDarkweb } from "../DarkWeb/DarkWeb";
 import { iTutorialNextStep, iTutorialSteps, ITutorial } from "../InteractiveTutorial";
-import { processSingleServerGrowth, getWeakenEffect } from "../Server/ServerHelpers";
+import { processSingleServerGrowth, getWeakenEffect, connectServer } from "../Server/ServerHelpers";
 import { parseCommand, parseCommands } from "./Parser";
 import { SpecialServers } from "../Server/data/SpecialServers";
 import { Settings } from "../Settings/Settings";
@@ -79,7 +79,7 @@ import { changelog } from "./commands/changelog";
 import { clear } from "./commands/clear";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { Engine } from "../engine";
-import { Directory, resolveDirectory, root } from "../Paths/Directory";
+import { Directory, resolveDirectory } from "../Paths/Directory";
 import { FilePath, isFilePath, resolveFilePath } from "../Paths/FilePath";
 import { hasTextExtension } from "../Paths/TextFilePath";
 import { ContractFilePath } from "../Paths/ContractFilePath";
@@ -586,17 +586,14 @@ export class Terminal {
     printOutput(root);
   }
 
-  connectToServer(server: string): void {
-    const serv = GetServer(server);
-    if (serv == null) {
+  connectToServer(hostname: string): void {
+    const server = GetServer(hostname);
+    if (server == null) {
       this.error("Invalid server. Connection failed.");
       return;
     }
-    Player.getCurrentServer().isConnectedTo = false;
-    Player.currentServer = serv.hostname;
-    Player.getCurrentServer().isConnectedTo = true;
-    this.print("Connected to " + serv.hostname);
-    this.setcwd(root);
+    connectServer(server);
+    this.print("Connected to " + server.hostname);
     if (Player.getCurrentServer().hostname == "darkweb") {
       checkIfConnectedToDarkweb(); // Posts a 'help' message if connecting to dark web
     }

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -594,7 +594,7 @@ export class Terminal {
     }
     Player.getCurrentServer().isConnectedTo = false;
     Player.currentServer = hostname;
-    Player.getCurrentServer().isConnectedTo = true;
+    server.isConnectedTo = true;
     this.setcwd(root);
     if (!singularity) {
       this.print("Connected to " + server.hostname);

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -17,7 +17,7 @@ import { GetServer } from "../Server/AllServers";
 
 import { checkIfConnectedToDarkweb } from "../DarkWeb/DarkWeb";
 import { iTutorialNextStep, iTutorialSteps, ITutorial } from "../InteractiveTutorial";
-import { processSingleServerGrowth, getWeakenEffect, connectServer } from "../Server/ServerHelpers";
+import { processSingleServerGrowth, getWeakenEffect } from "../Server/ServerHelpers";
 import { parseCommand, parseCommands } from "./Parser";
 import { SpecialServers } from "../Server/data/SpecialServers";
 import { Settings } from "../Settings/Settings";
@@ -79,7 +79,7 @@ import { changelog } from "./commands/changelog";
 import { clear } from "./commands/clear";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { Engine } from "../engine";
-import { Directory, resolveDirectory } from "../Paths/Directory";
+import { Directory, resolveDirectory, root } from "../Paths/Directory";
 import { FilePath, isFilePath, resolveFilePath } from "../Paths/FilePath";
 import { hasTextExtension } from "../Paths/TextFilePath";
 import { ContractFilePath } from "../Paths/ContractFilePath";
@@ -586,16 +586,21 @@ export class Terminal {
     printOutput(root);
   }
 
-  connectToServer(hostname: string): void {
+  connectToServer(hostname: string, singularity = false): void {
     const server = GetServer(hostname);
-    if (server == null) {
+    if (server === null) {
       this.error("Invalid server. Connection failed.");
       return;
     }
-    connectServer(server);
-    this.print("Connected to " + server.hostname);
-    if (Player.getCurrentServer().hostname == "darkweb") {
-      checkIfConnectedToDarkweb(); // Posts a 'help' message if connecting to dark web
+    Player.getCurrentServer().isConnectedTo = false;
+    Player.currentServer = hostname;
+    Player.getCurrentServer().isConnectedTo = true;
+    this.setcwd(root);
+    if (!singularity) {
+      this.print("Connected to " + server.hostname);
+      if (Player.getCurrentServer().hostname == "darkweb") {
+        checkIfConnectedToDarkweb(); // Posts a 'help' message if connecting to dark web
+      }
     }
   }
 

--- a/src/Terminal/commands/home.ts
+++ b/src/Terminal/commands/home.ts
@@ -1,12 +1,9 @@
-import { connectServer } from "../../Server/ServerHelpers";
 import { Terminal } from "../../Terminal";
-import { Player } from "@player";
 
 export function home(args: (string | number | boolean)[]): void {
   if (args.length !== 0) {
     Terminal.error("Incorrect usage of home command. Usage: home");
     return;
   }
-  connectServer(Player.getHomeComputer());
-  Terminal.print("Connected to home");
+  Terminal.connectToServer("home");
 }

--- a/src/Terminal/commands/home.ts
+++ b/src/Terminal/commands/home.ts
@@ -1,4 +1,4 @@
-import { root } from "../../Paths/Directory";
+import { connectServer } from "../../Server/ServerHelpers";
 import { Terminal } from "../../Terminal";
 import { Player } from "@player";
 
@@ -7,9 +7,6 @@ export function home(args: (string | number | boolean)[]): void {
     Terminal.error("Incorrect usage of home command. Usage: home");
     return;
   }
-  Player.getCurrentServer().isConnectedTo = false;
-  Player.currentServer = Player.getHomeComputer().hostname;
-  Player.getCurrentServer().isConnectedTo = true;
+  connectServer(Player.getHomeComputer());
   Terminal.print("Connected to home");
-  Terminal.setcwd(root);
 }

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -8,12 +8,18 @@ import { SpecialServers } from "../../../src/Server/data/SpecialServers";
 import { Factions } from "../../../src/Faction/Factions";
 import { PlayerOwnedAugmentation } from "../../../src/Augmentation/PlayerOwnedAugmentation";
 import { getNS, initGameEnvironment, setupBasicTestingEnvironment } from "./Utilities";
+import { connectServer } from "../../../src/Server/ServerHelpers";
+import type { NSFull } from "../../../src/NetscriptFunctions";
 
 function setNumBlackOpsComplete(value: number): void {
   if (!Player.bladeburner) {
     throw new Error("Invalid Bladeburner data");
   }
   Player.bladeburner.numBlackOpsComplete = value;
+}
+
+function connectServerWithHostname(hostname: string) {
+  connectServer(GetServerOrThrow(hostname));
 }
 
 const nextBN = 3;
@@ -294,6 +300,60 @@ describe("purchaseAugmentation", () => {
       const ns = getNS();
       expect(ns.singularity.purchaseAugmentation(FactionName.Illuminati, AugmentationName.QLink)).toStrictEqual(false);
       expectNoQueuedAugmentation(AugmentationName.QLink);
+    });
+  });
+});
+
+describe("connect", () => {
+  beforeEach(() => {
+    setupBasicTestingEnvironment();
+    Player.sourceFiles.set(9, 3);
+    prestigeSourceFile(true);
+    Player.money = 1e100;
+  });
+
+  describe("Success", () => {
+    const expectConnectSuccessfully = (ns: NSFull, targetHostname: string) => {
+      expect(ns.singularity.connect(targetHostname)).toStrictEqual(true);
+      expect(Player.getCurrentServer().hostname).toStrictEqual(targetHostname);
+    };
+    test("Built-in adjacent server", () => {
+      expectConnectSuccessfully(getNS(), "n00dles");
+    });
+    test("Home", () => {
+      connectServerWithHostname(SpecialServers.DaedalusServer);
+      expectConnectSuccessfully(getNS(), "home");
+    });
+    test("Private server", () => {
+      const ns = getNS();
+      ns.purchaseServer("pserver-0", 8);
+      connectServerWithHostname(SpecialServers.DaedalusServer);
+      expectConnectSuccessfully(ns, "pserver-0");
+    });
+    test("Hacknet server", () => {
+      const ns = getNS();
+      ns.hacknet.purchaseNode();
+      connectServerWithHostname(SpecialServers.DaedalusServer);
+      expectConnectSuccessfully(ns, "hacknet-server-0");
+    });
+    test("Backdoored server", () => {
+      const ns = getNS();
+      connectServerWithHostname(SpecialServers.DaedalusServer);
+      GetServerOrThrow("n00dles").backdoorInstalled = true;
+      expectConnectSuccessfully(ns, "n00dles");
+    });
+  });
+
+  describe("Failure", () => {
+    test("Non-existent server", () => {
+      const ns = getNS();
+      expect(() => ns.singularity.connect("abc")).toThrow();
+      expect(Player.getCurrentServer().hostname).not.toStrictEqual("abc");
+    });
+    test("Non-adjacent server", () => {
+      const ns = getNS();
+      expect(ns.singularity.connect(SpecialServers.DaedalusServer)).toStrictEqual(false);
+      expect(Player.getCurrentServer().hostname).not.toStrictEqual(SpecialServers.DaedalusServer);
     });
   });
 });

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -310,10 +310,13 @@ describe("connect", () => {
 
   describe("Success", () => {
     const expectConnectSuccessfully = (ns: NSFull, targetHostname: string) => {
+      const currentServerBeforeConnecting = Player.getCurrentServer();
       expect(ns.singularity.connect(targetHostname)).toStrictEqual(true);
-      const currentServer = Player.getCurrentServer();
-      expect(currentServer.hostname).toStrictEqual(targetHostname);
-      expect(currentServer.isConnectedTo).toStrictEqual(true);
+      expect(currentServerBeforeConnecting.isConnectedTo).toStrictEqual(false);
+
+      const currentServerAfterConnecting = Player.getCurrentServer();
+      expect(currentServerAfterConnecting.hostname).toStrictEqual(targetHostname);
+      expect(currentServerAfterConnecting.isConnectedTo).toStrictEqual(true);
     };
     test("Built-in adjacent server", () => {
       expectConnectSuccessfully(getNS(), "n00dles");

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -8,7 +8,7 @@ import { SpecialServers } from "../../../src/Server/data/SpecialServers";
 import { Factions } from "../../../src/Faction/Factions";
 import { PlayerOwnedAugmentation } from "../../../src/Augmentation/PlayerOwnedAugmentation";
 import { getNS, initGameEnvironment, setupBasicTestingEnvironment } from "./Utilities";
-import { connectServer } from "../../../src/Server/ServerHelpers";
+import { Terminal } from "../../../src/Terminal";
 import type { NSFull } from "../../../src/NetscriptFunctions";
 
 function setNumBlackOpsComplete(value: number): void {
@@ -16,10 +16,6 @@ function setNumBlackOpsComplete(value: number): void {
     throw new Error("Invalid Bladeburner data");
   }
   Player.bladeburner.numBlackOpsComplete = value;
-}
-
-function connectServerWithHostname(hostname: string) {
-  connectServer(GetServerOrThrow(hostname));
 }
 
 const nextBN = 3;
@@ -321,24 +317,24 @@ describe("connect", () => {
       expectConnectSuccessfully(getNS(), "n00dles");
     });
     test("Home", () => {
-      connectServerWithHostname(SpecialServers.DaedalusServer);
+      Terminal.connectToServer(SpecialServers.DaedalusServer);
       expectConnectSuccessfully(getNS(), "home");
     });
     test("Private server", () => {
       const ns = getNS();
       ns.purchaseServer("pserver-0", 8);
-      connectServerWithHostname(SpecialServers.DaedalusServer);
+      Terminal.connectToServer(SpecialServers.DaedalusServer);
       expectConnectSuccessfully(ns, "pserver-0");
     });
     test("Hacknet server", () => {
       const ns = getNS();
       ns.hacknet.purchaseNode();
-      connectServerWithHostname(SpecialServers.DaedalusServer);
+      Terminal.connectToServer(SpecialServers.DaedalusServer);
       expectConnectSuccessfully(ns, "hacknet-server-0");
     });
     test("Backdoored server", () => {
       const ns = getNS();
-      connectServerWithHostname(SpecialServers.DaedalusServer);
+      Terminal.connectToServer(SpecialServers.DaedalusServer);
       GetServerOrThrow("n00dles").backdoorInstalled = true;
       expectConnectSuccessfully(ns, "n00dles");
     });

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -311,7 +311,9 @@ describe("connect", () => {
   describe("Success", () => {
     const expectConnectSuccessfully = (ns: NSFull, targetHostname: string) => {
       expect(ns.singularity.connect(targetHostname)).toStrictEqual(true);
-      expect(Player.getCurrentServer().hostname).toStrictEqual(targetHostname);
+      const currentServer = Player.getCurrentServer();
+      expect(currentServer.hostname).toStrictEqual(targetHostname);
+      expect(currentServer.isConnectedTo).toStrictEqual(true);
     };
     test("Built-in adjacent server", () => {
       expectConnectSuccessfully(getNS(), "n00dles");


### PR DESCRIPTION
`connect` CLI and the equivalent Singularity API are inconsistent in their behaviors.

`ns.singularity.connect` only supports:
- Go to home, regardless of the currently connected server.
- Go to backdoored servers, regardless of the currently connected server.
- Go to adjacent servers.

`connect` CLI also supports `server.purchasedByPlayer`.

This PR standardizes their behaviors.