### PR TITLE
BUGFIX: Wrong plural form in modal of coding contract

### DIFF
--- a/src/Achievements/AchievementList.tsx
+++ b/src/Achievements/AchievementList.tsx
@@ -7,6 +7,7 @@ import { Achievement, PlayerAchievement } from "./Achievements";
 import { Settings } from "../Settings/Settings";
 import { getFiltersFromHex } from "../ThirdParty/colorUtils";
 import { CorruptableText } from "../ui/React/CorruptableText";
+import { pluralize } from "../utils/I18nUtils";
 
 interface IProps {
   achievements: Achievement[];
@@ -101,7 +102,8 @@ export function AchievementList({ achievements, playerAchievements }: IProps): J
             </AccordionSummary>
             <AccordionDetails>
               <Typography sx={{ mt: 1 }}>
-                {unavailable.length} additional achievements hidden behind content you don't have access to.
+                {pluralize(unavailable.length, "additional achievement")} hidden behind content you don't have access
+                to.
               </Typography>
             </AccordionDetails>
           </Accordion>

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -54,6 +54,7 @@ import { shuffleArray } from "../Infiltration/ui/BribeGame";
 import { assertObject } from "../utils/TypeAssertion";
 import { throwIfReachable } from "../utils/helpers/throwIfReachable";
 import { loadActionIdentifier } from "./utils/loadActionIdentifier";
+import { pluralize } from "../utils/I18nUtils";
 
 export const BladeburnerPromise: PromisePair<number> = { promise: null, resolve: null };
 
@@ -166,9 +167,7 @@ export class Bladeburner implements OperationTeam {
     this.setSkillLevel(skillName, currentSkillLevel + availability.actualCount);
     return {
       success: true,
-      message: `Upgraded skill ${skillName} by ${availability.actualCount} level${
-        availability.actualCount > 1 ? "s" : ""
-      }`,
+      message: `Upgraded skill ${skillName} by ${pluralize(availability.actualCount, "level")}`,
     };
   }
 

--- a/src/Gang/ui/RecruitButton.tsx
+++ b/src/Gang/ui/RecruitButton.tsx
@@ -6,6 +6,7 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import { RecruitmentResult } from "../Gang";
+import { pluralize } from "../../utils/I18nUtils";
 
 interface IProps {
   onRecruit: () => void;
@@ -35,9 +36,7 @@ export function RecruitButton(props: IProps): React.ReactElement {
     <>
       <Box display="flex" alignItems="center" sx={{ mx: 1 }}>
         <Button onClick={() => setOpen(true)}>Recruit Gang Member</Button>
-        <Typography sx={{ ml: 1 }}>
-          Can recruit {recruitsAvailable} more gang member{recruitsAvailable === 1 ? "" : "s"}
-        </Typography>
+        <Typography sx={{ ml: 1 }}>Can recruit {pluralize(recruitsAvailable, "more gang member")}</Typography>
       </Box>
       <RecruitModal open={open} onClose={() => setOpen(false)} onRecruit={props.onRecruit} />
     </>

--- a/src/Terminal/commands/grep.ts
+++ b/src/Terminal/commands/grep.ts
@@ -5,6 +5,7 @@ import { ContentFile, ContentFilePath, allContentFiles } from "../../Paths/Conte
 import { Settings } from "../../Settings/Settings";
 import { help } from "../commands/help";
 import { Output } from "../OutputTypes";
+import { pluralize } from "../../utils/I18nUtils";
 
 type LineParser = (options: Options, filename: string, line: string, i: number) => ParsedLine;
 
@@ -290,12 +291,9 @@ class Results {
 
   getVerboseInfo(files: ContentFile[], pattern: string | RegExp, options: Options): string {
     if (!options.isVerbose) return "";
-    const suffix = (pre: string, num: number) => pre + (num === 1 ? "" : "s");
     const totalLines = this.results.length;
     const matchCount = Math.abs((options.isInvertMatch ? totalLines : 0) - this.numMatches);
-    const inputStr = options.isPipeIn
-      ? "piped from terminal "
-      : `in ${files.length} ${suffix("file", files.length)}:\n`;
+    const inputStr = options.isPipeIn ? "piped from terminal " : `in ${pluralize(files.length, "file")}:\n`;
     const filesStr = files
       .map((file, i) => `${i % 2 ? WHITE : ""}${file.filename}(${file.content.split("\n").length}loc)${DEFAULT}`)
       .join(", ");
@@ -304,9 +302,9 @@ class Results {
       `\n${
         (this.params.maxMatches ? this.params.maxMatches : matchCount) + (options.isInvertMatch ? " INVERTED" : "")
       } `,
-      suffix("line", matchCount) + " matched ",
+      pluralize(matchCount, "line", undefined, true) + " matched ",
       `against PATTERN "${pattern.toString()}" `,
-      `in ${totalLines} ${suffix("line", totalLines)}, `,
+      `in ${pluralize(totalLines, "line")}, `,
       inputStr,
       `${filesStr}`,
     ].join("");

--- a/src/Terminal/commands/runScript.ts
+++ b/src/Terminal/commands/runScript.ts
@@ -11,6 +11,7 @@ import { ScriptFilePath, isLegacyScript } from "../../Paths/ScriptFilePath";
 import { sendDeprecationNotice } from "./common/deprecation";
 import { roundToTwo } from "../../utils/helpers/roundToTwo";
 import { RamCostConstants } from "../../Netscript/RamCostGenerator";
+import { pluralize } from "../../utils/I18nUtils";
 
 export function runScript(path: ScriptFilePath, commandArgs: (string | number | boolean)[], server: BaseServer): void {
   // This takes in the absolute filepath, see "run.ts"
@@ -77,7 +78,9 @@ export function runScript(path: ScriptFilePath, commandArgs: (string | number | 
     sendDeprecationNotice();
   }
   Terminal.print(
-    `Running script with ${numThreads} thread(s), pid ${runningScript.pid} and args: ${JSON.stringify(args)}.`,
+    `Running script with ${pluralize(numThreads, "thread")}, pid ${runningScript.pid} and args: ${JSON.stringify(
+      args,
+    )}.`,
   );
   if (tailFlag) {
     LogBoxEvents.emit(runningScript);

--- a/src/ui/React/CodingContractModal.tsx
+++ b/src/ui/React/CodingContractModal.tsx
@@ -9,6 +9,7 @@ import { EventEmitter } from "../../utils/EventEmitter";
 import Typography from "@mui/material/Typography";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
+import { pluralize } from "../../utils/I18nUtils";
 
 interface CodingContractProps {
   c: CodingContract;
@@ -63,8 +64,9 @@ export function CodingContractModal(): React.ReactElement {
     <Modal open={contract !== null} onClose={close}>
       <CopyableText variant="h4" value={contract.c.type} />
       <Typography>
-        You are attempting to solve a Coding Contract. You have {contract.c.getMaxNumTries() - contract.c.tries} tries
-        remaining, after which the contract will self-destruct.
+        You are attempting to solve a Coding Contract. You have{" "}
+        {pluralize(contract.c.getMaxNumTries() - contract.c.tries, "try", "tries")} remaining, after which the contract
+        will self-destruct.
       </Typography>
       <br />
       <Typography>{description}</Typography>

--- a/src/utils/APIBreaks/APIBreak.ts
+++ b/src/utils/APIBreaks/APIBreak.ts
@@ -7,6 +7,7 @@ import { GetAllServers } from "../../Server/AllServers";
 import { resolveTextFilePath } from "../../Paths/TextFilePath";
 import { dialogBoxCreate as dialogBoxCreateOriginal } from "../../ui/React/DialogBox";
 import { Terminal } from "../../Terminal";
+import { pluralize } from "../I18nUtils";
 
 // Temporary until fixing alerts manager to store alerts outside of react scope
 const dialogBoxCreate = (text: string) => setTimeout(() => dialogBoxCreateOriginal(text), 2000);
@@ -64,7 +65,9 @@ export function showAPIBreaks(version: string, ...breakInfos: APIBreakInfo[]) {
               [...scriptImpactMap]
                 .map(
                   ([filename, lineNumbers]) =>
-                    `${filename}: (Line number${lineNumbers.length > 1 ? "s" : ""}: ${lineNumbers.join(", ")})`,
+                    `${filename}: (${pluralize(lineNumbers.length, "Line number", undefined, true)}: ${lineNumbers.join(
+                      ", ",
+                    )})`,
                 )
                 .join("\n"),
           )

--- a/src/utils/I18nUtils.ts
+++ b/src/utils/I18nUtils.ts
@@ -1,0 +1,9 @@
+const pluralRules = new Intl.PluralRules("en-US");
+
+export function pluralize(count: number, singular: string, plural?: string, skipCountInReturnedValue = false): string {
+  const pluralRule = pluralRules.select(count);
+  if (pluralRule === "one") {
+    return `${!skipCountInReturnedValue ? `${count} ` : ""}${singular}`;
+  }
+  return `${!skipCountInReturnedValue ? `${count} ` : ""}${plural !== undefined ? plural : `${singular}s`}`;
+}

--- a/src/utils/I18nUtils.ts
+++ b/src/utils/I18nUtils.ts
@@ -1,9 +1,10 @@
 const pluralRules = new Intl.PluralRules("en-US");
 
 export function pluralize(count: number, singular: string, plural?: string, skipCountInReturnedValue = false): string {
+  const countText = !skipCountInReturnedValue ? `${count} ` : "";
   const pluralRule = pluralRules.select(count);
   if (pluralRule === "one") {
-    return `${!skipCountInReturnedValue ? `${count} ` : ""}${singular}`;
+    return countText + singular;
   }
-  return `${!skipCountInReturnedValue ? `${count} ` : ""}${plural !== undefined ? plural : `${singular}s`}`;
+  return countText + (plural !== undefined ? plural : `${singular}s`);
 }

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -1,5 +1,6 @@
 import { Settings } from "../Settings/Settings";
 import { CONSTANTS } from "../Constants";
+import { pluralize } from "./I18nUtils";
 
 /*
 Converts a date representing time in milliseconds to a string with the format H hours M minutes and S seconds
@@ -38,13 +39,13 @@ export function convertTimeMsToTimeElapsedString(time: number, showMilli = false
 
   let res = "";
   if (days > 0) {
-    res += `${days} day${days === 1 ? "" : "s"} `;
+    res += `${pluralize(days, "day")} `;
   }
   if (hours > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
-    res += `${hours} hour${hours === 1 ? "" : "s"} `;
+    res += `${pluralize(hours, "hour")} `;
   }
   if (minutes > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
-    res += `${minutes} minute${minutes === 1 ? "" : "s"} `;
+    res += `${pluralize(minutes, "minute")} `;
   }
   res += `${seconds} second${!showMilli && secTruncMinutes === 1 ? "" : "s"}`;
 


### PR DESCRIPTION
A player reported this bug on Discord. In that modal, we show `1 tries` instead of `1 try`. While fixing the bug, I see that we rewrite this snippet everywhere:
```js
count + ` line${count !== 1 ? "s" : ""}`
```
Therefore, I created a utility function for it. We don't have any plans to support more languages in the near future, so using `Intl.PluralRules` is a bit unnecessary, but it's still harmless.

I also intentionally skip rewriting some code that I don't think they need to use `pluralize`. For example:
https://github.com/bitburner-official/bitburner-src/blob/f337de47dff7063b080403ab8b223dd9f1b08e85/src/utils/StringHelperFunctions.ts#L49
https://github.com/bitburner-official/bitburner-src/blob/f337de47dff7063b080403ab8b223dd9f1b08e85/src/Terminal/commands/runScript.ts#L64

Screenshots:

![1](https://github.com/user-attachments/assets/324d415d-82ac-4a25-aba3-e80151fc7ae1)
![2](https://github.com/user-attachments/assets/bf511076-d08a-4464-97d3-d8278e83b6ba)
![3](https://github.com/user-attachments/assets/27128963-c10b-482b-a231-9f1f18e3caaf)
![4](https://github.com/user-attachments/assets/36d41afc-e71a-4dec-85d8-77609f7cf6aa)
![5](https://github.com/user-attachments/assets/a514f3cf-3ef8-4df9-9e40-9258c3206309)
![6](https://github.com/user-attachments/assets/576f7028-e0dd-47f8-860e-1fa330f67414)
![7](https://github.com/user-attachments/assets/16029b40-ccc4-40d2-9695-ac7b26f7891c)
![8](https://github.com/user-attachments/assets/7718d28e-13bf-4b33-930c-5815fb740eb2)
![9](https://github.com/user-attachments/assets/f0dffc2a-47f0-4302-b93a-f2a9d5ed05e8)
