### PR TITLE
UI: Clarify availability of "buy" CLI

### DIFF
--- a/src/DarkWeb/DarkWeb.tsx
+++ b/src/DarkWeb/DarkWeb.tsx
@@ -15,7 +15,8 @@ export function checkIfConnectedToDarkweb(): void {
     Terminal.print(
       "You are now connected to the dark web. From the dark web you can purchase illegal items. " +
         "Use the 'buy -l' command to display a list of all the items you can buy. Use 'buy [item-name]' " +
-        "to purchase an item. Use 'buy -a' to purchase all unowned items.",
+        "to purchase an item. Use 'buy -a' to purchase all unowned items. You can use the 'buy' command anywhere, " +
+        "not only when connecting to the 'darkweb' server.",
     );
   }
 }


### PR DESCRIPTION
Some players think that they can use the "buy" command only when connecting to the dark web. This PR clarifies that they don't need to connect to the 'darkweb' server to use it.

Before:

![before](https://github.com/user-attachments/assets/95810cc1-d780-4dce-ac1f-befe2f36eacf)

After:

![after](https://github.com/user-attachments/assets/66159af2-18bb-43bc-8349-4531a2a7a241)
