### PR TITLE
BLADEBURNER: Show operation description in tooltip of completed BlackOps

### DIFF
--- a/src/Bladeburner/ui/BlackOpElem.tsx
+++ b/src/Bladeburner/ui/BlackOpElem.tsx
@@ -2,7 +2,8 @@ import type { Bladeburner } from "../Bladeburner";
 import type { BlackOperation } from "../Actions/BlackOperation";
 
 import React from "react";
-import { Paper, Typography } from "@mui/material";
+import { Paper, Typography, Tooltip } from "@mui/material";
+import { Info } from "@mui/icons-material";
 
 import { Player } from "@player";
 import { formatNumberNoSuffix } from "../../ui/formatNumber";
@@ -22,7 +23,11 @@ export function BlackOpElem({ bladeburner, action }: BlackOpElemProps): React.Re
   if (isCompleted) {
     return (
       <Paper sx={{ my: 1, p: 1 }}>
-        <Typography>{action.name} (COMPLETED)</Typography>
+        <Tooltip title={action.desc}>
+          <Typography>
+            {action.name} (COMPLETED) <Info sx={{ fontSize: "1.1em" }} />
+          </Typography>
+        </Tooltip>
       </Paper>
     );
   }

--- a/src/Bladeburner/ui/SuccessChance.tsx
+++ b/src/Bladeburner/ui/SuccessChance.tsx
@@ -25,7 +25,7 @@ export function SuccessChance({ bladeburner, action }: SuccessChanceProps): Reac
       <Tooltip title={action.successScaling ? <Typography>{action.successScaling}</Typography> : ""}>
         <Typography component="span" sx={{ marginRight: "15px" }}>
           Estimated success chance: {chance}
-          {action.successScaling && <InfoIcon sx={{ fontSize: "1.1rem", marginLeft: "10px" }} />}
+          {action.successScaling && <InfoIcon sx={{ fontSize: "1.1em", marginLeft: "10px" }} />}
         </Typography>
       </Tooltip>
       {action.isStealth ? <StealthIcon /> : <></>}


### PR DESCRIPTION
This change was suggested on Discord: https://discord.com/channels/415207508303544321/415213435974975508/1333104156826669056
```
There should be an arrow here to be able to read more info (aka the mission description/lore) similar to the arrow button next to the Overview in the top right
```

Screenshot:

![Capture](https://github.com/user-attachments/assets/23853438-def9-44c0-97a6-243a010d72e7)
