### PR TITLE
MISC: Allow using wss for RFA

### DIFF
--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -4,6 +4,7 @@ import { GameOptionsPage } from "./GameOptionsPage";
 import { isValidConnectionHostname, isValidConnectionPort, Settings } from "../../Settings/Settings";
 import { ConnectionBauble } from "./ConnectionBauble";
 import { isRemoteFileApiConnectionLive, newRemoteFileApiConnection } from "../../RemoteFileAPI/RemoteFileAPI";
+import { OptionSwitch } from "../../ui/React/OptionSwitch";
 
 export const RemoteAPIPage = (): React.ReactElement => {
   const [remoteFileApiHostname, setRemoteFileApiHostname] = useState(Settings.RemoteFileApiAddress);
@@ -106,6 +107,12 @@ export const RemoteAPIPage = (): React.ReactElement => {
           {portError && <Typography color={Settings.theme.error}>{portError}</Typography>}
         </div>
       </Tooltip>
+      <OptionSwitch
+        checked={Settings.UseWssForRemoteFileApi}
+        onChange={(newValue) => (Settings.UseWssForRemoteFileApi = newValue)}
+        text="Use wss"
+        tooltip={<>Use wss instead of ws when connecting to RFA clients.</>}
+      />
       <Button disabled={!isValidHostname || !isValidPort} onClick={newRemoteFileApiConnection}>
         Connect
       </Button>

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -2,6 +2,7 @@ import { RFAMessage } from "./MessageDefinitions";
 import { RFARequestHandler } from "./MessageHandlers";
 import { SnackbarEvents } from "../ui/React/Snackbar";
 import { ToastVariant } from "@enums";
+import { Settings } from "../Settings/Settings";
 
 function showErrorMessage(address: string, detail: string) {
   SnackbarEvents.emit(`Error with websocket ${address}, details: ${detail}`, ToastVariant.ERROR, 5000);
@@ -9,7 +10,6 @@ function showErrorMessage(address: string, detail: string) {
 
 export class Remote {
   connection?: WebSocket;
-  static protocol = "ws";
   ipaddr: string;
   port: number;
 
@@ -23,7 +23,7 @@ export class Remote {
   }
 
   public startConnection(): void {
-    const address = Remote.protocol + "://" + this.ipaddr + ":" + this.port;
+    const address = (Settings.UseWssForRemoteFileApi ? "wss" : "ws") + "://" + this.ipaddr + ":" + this.port;
     try {
       this.connection = new WebSocket(address);
     } catch (error) {

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -113,6 +113,8 @@ export const Settings = {
   RemoteFileApiAddress: "localhost",
   /** Port the Remote File API client will try to connect to. 0 to disable. */
   RemoteFileApiPort: 0,
+  /** Use wss instead of ws when connecting to RFA clients */
+  UseWssForRemoteFileApi: false,
   /** Whether to save the game when the player saves any file. */
   SaveGameOnFileSave: true,
   /** Whether to hide the confirmation dialog for augmentation purchases. */
@@ -179,7 +181,7 @@ export const Settings = {
   hideTrailingDecimalZeros: false,
   /** Whether to hide thousands separators. */
   hideThousandsSeparator: false,
-  /** Whether to use engineering notation instead of scientific for exponentials. */
+  /** Whether to use engineering notation instead of scientific for exponential form. */
   useEngineeringNotation: false,
   /** Whether to disable suffixes and always use exponential form (scientific or engineering). */
   disableSuffixes: false,


### PR DESCRIPTION
This change was suggested on Discord: https://discord.com/channels/415207508303544321/415213435974975508/1333077887846191246.
```
We should add a toggle or smth to the RFA to switch between ws/wss. That way you can connect to the web version via RFA from different machines too.
```

Screenshots:

![ws](https://github.com/user-attachments/assets/a7d60f9e-1a01-4a33-8e48-9598963f7f66)
![wss](https://github.com/user-attachments/assets/c23bed03-bbe3-4ce3-9413-107063df3af7)
