### PR TITLE
MISC: Decrease factionInviteCheckInterval and check for Invites on faction page load

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -160,7 +160,7 @@ const Engine: {
     updateActiveScriptsDisplay: 5,
     createProgramNotifications: 10,
     augmentationsNotifications: 10,
-    checkFactionInvitations: 25,
+    checkFactionInvitations: 10
     passiveFactionGrowth: 5,
     messages: 150,
     mechanicProcess: 5, // Process Bladeburner
@@ -188,7 +188,7 @@ const Engine: {
       for (const invitedFaction of invitedFactions) {
         inviteToFaction(invitedFaction);
       }
-      Engine.Counters.checkFactionInvitations = 25;
+      Engine.Counters.checkFactionInvitations = 10;
     }
 
     if (Engine.Counters.passiveFactionGrowth <= 0) {

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -160,7 +160,7 @@ const Engine: {
     updateActiveScriptsDisplay: 5,
     createProgramNotifications: 10,
     augmentationsNotifications: 10,
-    checkFactionInvitations: 10
+    checkFactionInvitations: 10,
     passiveFactionGrowth: 5,
     messages: 150,
     mechanicProcess: 5, // Process Bladeburner

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -160,7 +160,7 @@ const Engine: {
     updateActiveScriptsDisplay: 5,
     createProgramNotifications: 10,
     augmentationsNotifications: 10,
-    checkFactionInvitations: 100,
+    checkFactionInvitations: 25,
     passiveFactionGrowth: 5,
     messages: 150,
     mechanicProcess: 5, // Process Bladeburner
@@ -188,7 +188,7 @@ const Engine: {
       for (const invitedFaction of invitedFactions) {
         inviteToFaction(invitedFaction);
       }
-      Engine.Counters.checkFactionInvitations = 100;
+      Engine.Counters.checkFactionInvitations = 25;
     }
 
     if (Engine.Counters.passiveFactionGrowth <= 0) {

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -59,7 +59,7 @@ import { AlertManager } from "./React/AlertManager";
 import { PromptManager } from "./React/PromptManager";
 import { FactionInvitationManager } from "../Faction/ui/FactionInvitationManager";
 import { calculateAchievements } from "../Achievements/Achievements";
-import { inviteToFaction } from "../Faction/FactionHelpers";
+import { Engine } from "../engine";
 import { RecoveryMode, RecoveryRoot } from "./React/RecoveryRoot";
 import { AchievementsRoot } from "../Achievements/AchievementsRoot";
 import { ErrorBoundary } from "./ErrorBoundary";
@@ -281,10 +281,8 @@ export function GameRoot(): React.ReactElement {
       break;
     }
     case Page.Factions: {
-      const invitedFactions = Player.checkForFactionInvitations();
-      for (const invitedFaction of invitedFactions) {
-        inviteToFaction(invitedFaction);
-      }
+      Engine.Counters.checkFactionInvitations = 0;
+      Engine.checkCounters();
       mainPage = <FactionsRoot />;
       break;
     }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -59,7 +59,7 @@ import { AlertManager } from "./React/AlertManager";
 import { PromptManager } from "./React/PromptManager";
 import { FactionInvitationManager } from "../Faction/ui/FactionInvitationManager";
 import { calculateAchievements } from "../Achievements/Achievements";
-
+import { inviteToFaction } from "../Faction/FactionHelpers";
 import { RecoveryMode, RecoveryRoot } from "./React/RecoveryRoot";
 import { AchievementsRoot } from "../Achievements/AchievementsRoot";
 import { ErrorBoundary } from "./ErrorBoundary";
@@ -281,6 +281,10 @@ export function GameRoot(): React.ReactElement {
       break;
     }
     case Page.Factions: {
+      const invitedFactions = Player.checkForFactionInvitations();
+      for (const invitedFaction of invitedFactions) {
+        inviteToFaction(invitedFaction);
+      }
       mainPage = <FactionsRoot />;
       break;
     }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -59,7 +59,6 @@ import { AlertManager } from "./React/AlertManager";
 import { PromptManager } from "./React/PromptManager";
 import { FactionInvitationManager } from "../Faction/ui/FactionInvitationManager";
 import { calculateAchievements } from "../Achievements/Achievements";
-import { Engine } from "../engine";
 import { RecoveryMode, RecoveryRoot } from "./React/RecoveryRoot";
 import { AchievementsRoot } from "../Achievements/AchievementsRoot";
 import { ErrorBoundary } from "./ErrorBoundary";
@@ -281,8 +280,6 @@ export function GameRoot(): React.ReactElement {
       break;
     }
     case Page.Factions: {
-      Engine.Counters.checkFactionInvitations = 0;
-      Engine.checkCounters();
       mainPage = <FactionsRoot />;
       break;
     }


### PR DESCRIPTION
Current faction check interval is every 20 seconds.  This can cause confusion when you're watching your stats/requirements to be invited to a faction and no invite comes.

This change will hopefully address that by decreasing the check time from every 20 seconds to every 5 seconds, as well as checking any time you load the faction page, so you don't need to wait for the 5 second interval.