### PR TITLE
BUGFIX: Sleeve takes on contracts without checking availability

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -136,9 +136,10 @@ export class Bladeburner implements OperationTeam {
       this.resetAction();
       return { success: true, message: "Stopped current Bladeburner action" };
     }
-    if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true)) Player.finishWork(true);
+    if (!Player.hasAugmentation(AugmentationName.BladesSimulacrum, true)) {
+      Player.finishWork(true);
+    }
     const action = this.getActionObject(actionId);
-    // This switch statement is just for handling error cases, it does not have to be exhaustive
     const availability = action.getAvailability(this);
     if (!availability.available) {
       return { message: `Could not start action ${action.name}: ${availability.error}` };


### PR DESCRIPTION
Sleeve code does not check the availability of contracts before starting the action.

Note: The removal of this line is intentional:
https://github.com/bitburner-official/bitburner-src/blob/381310946af7ce4dc91a66fa78090feea9a2a0f0/src/NetscriptFunctions/Sleeve.ts#L276
We already do that in `Player.sleeves[sleeveNumber].bladeburner(action, contract)`:
https://github.com/bitburner-official/bitburner-src/blob/381310946af7ce4dc91a66fa78090feea9a2a0f0/src/PersonObjects/Sleeve/Sleeve.ts#L525-L530

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.tail();
  ns.clearLog();
  Player.bladeburner.contracts.Tracking.count = 0;
  ns.sleeve.setToIdle(0);
  ns.print(ns.sleeve.setToBladeburnerAction(0, "Take on contracts", "Tracking"));
  ns.print(ns.sleeve.getTask(0));
}
```
Before:
```
true
{"type":"BLADEBURNER","actionType":"Contracts","actionName":"Tracking","tasksCompleted":0,"cyclesWorked":0,"cyclesNeeded":60,"nextCompletion":"[object Promise]"}
```
After:
```
sleeve.setToBladeburnerAction: Could not start action Tracking: Insufficient action count
false
null
```