### PR TITLE
CODEBASE: Refactor Player.applyForJob

### DIFF
--- a/src/Company/ui/ApplyToJobButton.tsx
+++ b/src/Company/ui/ApplyToJobButton.tsx
@@ -9,6 +9,7 @@ import { ButtonWithTooltip } from "../../ui/Components/ButtonWithTooltip";
 import { JobSummary } from "./JobSummary";
 import { Requirement } from "../../ui/Components/Requirement";
 import { getJobRequirements } from "../GetJobRequirements";
+import { dialogBoxCreate } from "../../ui/React/DialogBox";
 
 interface ApplyToJobProps {
   company: Company;
@@ -47,7 +48,10 @@ export function ApplyToJobButton({ company, position, qualified }: ApplyToJobPro
   );
 
   function applyForJob(): void {
-    Player.applyForJob(company, position);
+    const result = Player.applyForJob(company, position);
+    if (result.message) {
+      dialogBoxCreate(result.message);
+    }
   }
 
   return (

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -714,13 +714,17 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       const company = Companies[companyName];
       const entryPos = CompanyPositions[JobTracks[field][0]];
 
-      const jobName = Player.applyForJob(company, entryPos, true);
-      if (jobName) {
-        helpers.log(ctx, () => `You were offered a new job at '${companyName}' with position '${jobName}'`);
-      } else {
-        helpers.log(ctx, () => `You failed to get a new job/promotion at '${companyName}' in the '${field}' field.`);
+      const result = Player.applyForJob(company, entryPos);
+      if (!result.success) {
+        helpers.log(
+          ctx,
+          () =>
+            `You failed to get a new job/promotion at '${companyName}' in the '${field}' field. Reason: ${result.message}`,
+        );
+        return null;
       }
-      return jobName;
+      helpers.log(ctx, () => `You were offered a new job at '${companyName}' with position '${result.jobName}'.`);
+      return result.jobName;
     },
     quitJob: (ctx) => (_companyName) => {
       helpers.checkSingularityAccess(ctx);


### PR DESCRIPTION
`Player.applyForJob` and `ns.singularity.applyToCompany` (a caller of `Player.applyForJob`) have 2 problems:
- Inconsistent error reports: Most errors are reported via `dialogBoxCreate` (non-singularity cases) except when the company does not offer the specified position. When it happens, the error is only printed to the console.
- The singularity API does not state the reason why the player cannot apply.

This PR fixes these problems.