### PR TITLE
MISC: Do not round return value of getBonusTime APIs

### DIFF
--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -334,7 +334,7 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     },
     getBonusTime: (ctx) => () => {
       const bladeburner = getBladeburner(ctx);
-      return Math.round(bladeburner.storedCycles / 5) * 1000;
+      return bladeburner.storedCycles * 200;
     },
     nextUpdate: (ctx) => () => {
       checkBladeburnerAccess(ctx);

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -785,7 +785,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
     },
     getBonusTime: (ctx) => () => {
       checkAccess(ctx);
-      return Math.round(getCorporation().storedCycles / 5) * 1000;
+      return getCorporation().storedCycles * 200;
     },
     nextUpdate: (ctx) => () => {
       checkAccess(ctx);

--- a/src/NetscriptFunctions/Gang.ts
+++ b/src/NetscriptFunctions/Gang.ts
@@ -331,7 +331,7 @@ export function NetscriptGang(): InternalAPI<IGang> {
     },
     getBonusTime: (ctx) => () => {
       const gang = getGang(ctx);
-      return Math.round(gang.storedCycles / 5) * 1000;
+      return gang.storedCycles * 200;
     },
     nextUpdate: (ctx) => () => {
       getGang(ctx);

--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -396,7 +396,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
     },
     getBonusTime: (ctx) => () => {
       checkTixApiAccess(ctx);
-      return Math.round(StockMarket.storedCycles / 5) * 1000;
+      return StockMarket.storedCycles * 200;
     },
     nextUpdate: (ctx) => () => {
       checkTixApiAccess(ctx);


### PR DESCRIPTION
This PR implements the change mentioned at https://github.com/bitburner-official/bitburner-src/issues/1924#issuecomment-2612964949.

For more information, please check that issue and https://discord.com/channels/415207508303544321/415213413745164318/1332268782735065171.

Test code:
```js
/** @param {NS} ns */
async function loopBBNextUpdate(ns) {
  while (true) {
    await ns.bladeburner.nextUpdate();
    console.log(new Date().toISOString(), "BB nextUpdate");
  }
}

/** @param {NS} ns */
export async function main(ns) {
  ns.clearLog();
  console.clear();
  await ns.bladeburner.nextUpdate();
  Player.bladeburner.storedCycles = 0; // debug code
  loopBBNextUpdate(ns);
  while (true) {
    console.log(new Date().toISOString(), ns.bladeburner.getBonusTime(), Player.bladeburner.storedCycles)
    await ns.asleep(100);
  }
}
```

Before:
![before](https://github.com/user-attachments/assets/e22870d0-393f-4152-bb4c-2b93dc30f9e0)


After:
![after](https://github.com/user-attachments/assets/f16cc9b4-19e3-4827-89cc-0fbf5540143b)

