### PR TITLE
MISC: Show user-friendly error message when there is syntax error in scripts

### DIFF
--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -146,7 +146,7 @@ function parseOnlyRamCalculate(
     const scriptFileType = getFileType(script.filename);
     let moduleAST;
     try {
-      moduleAST = parseAST(script.code, scriptFileType);
+      moduleAST = parseAST(script.filename, script.server, script.code, scriptFileType);
     } catch (error) {
       return {
         errorCode: RamCalculationErrorCode.ImportError,
@@ -552,7 +552,7 @@ export function calculateRamUsage(
 ): RamCalculation {
   try {
     const fileType = getFileType(scriptName);
-    const ast = typeof input === "string" ? parseAST(input, fileType) : input;
+    const ast = typeof input === "string" ? parseAST(scriptName, server, input, fileType) : input;
     return parseOnlyRamCalculate(ast, scriptName, server, getFileTypeFeature(fileType), otherScripts);
   } catch (error) {
     return {

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -276,7 +276,7 @@ function Root(props: IProps): React.ReactElement {
     }
     let ast;
     try {
-      ast = parseAST(newCode, getFileType(currentScript.path));
+      ast = parseAST(currentScript.path, currentScript.hostname, newCode, getFileType(currentScript.path));
       makeModelsForImports(ast, server);
     } catch (error) {
       showRAMError({


### PR DESCRIPTION
The message of syntax errors may be cryptic for players without programming experience. For example, some players asked us what "Unexpected token" means.

Save file:
[test syntax error message.gz](https://github.com/user-attachments/files/18802415/test.syntax.error.message.gz)

Before:

![before1](https://github.com/user-attachments/assets/3c6f8105-65a2-4ef0-815a-e7c5a9c8c125)
![before2](https://github.com/user-attachments/assets/cbca644a-81a4-4b4c-b0bc-ac268a59f457)
![before3](https://github.com/user-attachments/assets/cb89a146-9260-4e34-8406-7df511063fd7)

After:

![after1](https://github.com/user-attachments/assets/a475c53a-8a33-4a4a-ac7c-e92130bb9679)
![after2](https://github.com/user-attachments/assets/697ae8e3-48f3-467a-8644-b720e2ddd6ea)
![after3](https://github.com/user-attachments/assets/ed486150-1f24-484d-bc93-96d944b3eea8)


