### PR TITLE
UI: Show Save ID in Options tab

### DIFF
--- a/src/GameOptions/ui/GameOptionsSidebar.tsx
+++ b/src/GameOptions/ui/GameOptionsSidebar.tsx
@@ -290,8 +290,8 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
             Reddit
           </Button>
         </Box>
-        <Typography>Save ID: {Player.identifier}</Typography>
       </Box>
+      <Typography>Save ID: {Player.identifier}</Typography>
       <FileDiagnosticModal open={diagnosticOpen} onClose={() => setDiagnosticOpen(false)} />
 
       <ConfirmationModal

--- a/src/GameOptions/ui/GameOptionsSidebar.tsx
+++ b/src/GameOptions/ui/GameOptionsSidebar.tsx
@@ -25,6 +25,7 @@ import { Router } from "../../ui/GameRoot";
 import { Page } from "../../ui/Router";
 import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFunctions";
 import { OptionsTabName } from "./GameOptionsRoot";
+import { Player } from "@player";
 
 interface IProps {
   tab: OptionsTabName;
@@ -255,8 +256,7 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
             gridTemplateAreas: `"credits credits"
             "bug bug"
         "discord reddit"
-        "tut tut"
-        "plaza plaza"`,
+        "tut tut"`,
             gridTemplateColumns: "1fr 1fr",
             my: 1,
           }}
@@ -290,6 +290,7 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
             Reddit
           </Button>
         </Box>
+        <Typography>Save ID: {Player.identifier}</Typography>
       </Box>
       <FileDiagnosticModal open={diagnosticOpen} onClose={() => setDiagnosticOpen(false)} />
 


### PR DESCRIPTION
With the Steam app, the save folder may have many subfolders pointing to different saves. When troubleshooting Steam-related problems, it may be confusing if there are multiple save files. It's useful if we have an easy way to get the current save ID. This PR shows it in the Options tab.

Note: "plaza" in the gridTemplateAreas is useless now. We used it for an old link, but we removed that link a long time ago.

![Capture](https://github.com/user-attachments/assets/1a09ace6-5b84-47ee-aa0a-4e99ee0cbe5d)
