### PR TITLE
UI: Warn player if they are editing and saving files on non-home servers

### DIFF
--- a/src/ScriptEditor/ui/Tab.tsx
+++ b/src/ScriptEditor/ui/Tab.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from "react";
 import { DraggableProvided } from "react-beautiful-dnd";
-import { makeStyles } from "tss-react/mui";
 
 import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
@@ -23,32 +22,11 @@ interface IProps {
   onUpdate: () => void;
 }
 
-const useStyles = makeStyles()(() => ({
-  blink: {
-    "@keyframes blinker": {
-      "0%": {
-        opacity: 1,
-      },
-      "50%": {
-        opacity: 0.4,
-      },
-      "100%": {
-        opacity: 1,
-      },
-    },
-    animationName: "blinker",
-    animationDuration: "2s",
-    animationTimingFunction: "ease",
-    animationIterationCount: "infinite",
-  },
-}));
-
 const tabMargin = 5;
 const tabIconWidth = 25;
 const tabIconHeight = 38.5;
 
 export function Tab({ provided, fullPath, isActive, isExternal, isUnsaved, onClick, onClose, onUpdate }: IProps) {
-  const { classes } = useStyles();
   const colorProps = isActive
     ? {
         background: Settings.theme.button,
@@ -67,7 +45,7 @@ export function Tab({ provided, fullPath, isActive, isExternal, isUnsaved, onCli
     // Show a blinking "*" character to notify the player that this file is dirtied.
     tabTitle = (
       <>
-        <Typography component="span" className={classes.blink} color={Settings.theme.warning}>
+        <Typography component="span" color={Settings.theme.warning}>
           *{" "}
         </Typography>
         {fullPath}
@@ -131,7 +109,6 @@ export function Tab({ provided, fullPath, isActive, isExternal, isUnsaved, onCli
               onClose();
             }
           }}
-          className={isExternal ? classes.blink : ""}
           style={{
             minHeight: tabIconHeight,
             overflow: "hidden",

--- a/src/ScriptEditor/ui/Tab.tsx
+++ b/src/ScriptEditor/ui/Tab.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from "react";
 import { DraggableProvided } from "react-beautiful-dnd";
+import { makeStyles } from "tss-react/mui";
 
 import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 
 import SyncIcon from "@mui/icons-material/Sync";
 import CloseIcon from "@mui/icons-material/Close";
@@ -11,20 +13,42 @@ import { Settings } from "../../Settings/Settings";
 
 interface IProps {
   provided: DraggableProvided;
-  title: string;
+  fullPath: string;
   isActive: boolean;
   isExternal: boolean;
+  isUnsaved: boolean;
 
   onClick: () => void;
   onClose: () => void;
   onUpdate: () => void;
 }
 
+const useStyles = makeStyles()(() => ({
+  blink: {
+    "@keyframes blinker": {
+      "0%": {
+        opacity: 1,
+      },
+      "50%": {
+        opacity: 0.4,
+      },
+      "100%": {
+        opacity: 1,
+      },
+    },
+    animationName: "blinker",
+    animationDuration: "2s",
+    animationTimingFunction: "ease",
+    animationIterationCount: "infinite",
+  },
+}));
+
 const tabMargin = 5;
 const tabIconWidth = 25;
 const tabIconHeight = 38.5;
 
-export function Tab({ provided, title, isActive, isExternal, onClick, onClose, onUpdate }: IProps) {
+export function Tab({ provided, fullPath, isActive, isExternal, isUnsaved, onClick, onClose, onUpdate }: IProps) {
+  const { classes } = useStyles();
   const colorProps = isActive
     ? {
         background: Settings.theme.button,
@@ -37,8 +61,35 @@ export function Tab({ provided, title, isActive, isExternal, onClick, onClose, o
         color: Settings.theme.secondary,
       };
 
+  let tabTitle;
+  let tooltipTitle;
+  if (isUnsaved) {
+    // Show a blinking "*" character to notify the player that this file is dirtied.
+    tabTitle = (
+      <>
+        <Typography component="span" className={classes.blink} color={Settings.theme.warning}>
+          *{" "}
+        </Typography>
+        {fullPath}
+      </>
+    );
+  } else {
+    tabTitle = fullPath;
+  }
+
   if (isExternal) {
-    colorProps.color = Settings.theme.info;
+    colorProps.color = Settings.theme.warning;
+    // Show a warning message if this file is on a non-home server.
+    tooltipTitle = (
+      <Typography component="span" color={Settings.theme.warning}>
+        {tabTitle}
+        <br />
+        This file is on a non-home server. You will lose all files on non-home servers when they are deleted or
+        recreated (install augmentations, soft reset, deleted by NS APIs, etc.).
+      </Typography>
+    );
+  } else {
+    tooltipTitle = tabTitle;
   }
   const iconButtonStyle = {
     maxWidth: tabIconWidth,
@@ -71,20 +122,23 @@ export function Tab({ provided, title, isActive, isExternal, onClick, onClose, o
         border: "1px solid " + Settings.theme.well,
       }}
     >
-      <Tooltip title={title}>
+      <Tooltip title={tooltipTitle}>
         <Button
           onClick={onClick}
           onMouseDown={(e) => {
             e.preventDefault();
-            if (e.button === 1) onClose();
+            if (e.button === 1) {
+              onClose();
+            }
           }}
+          className={isExternal ? classes.blink : ""}
           style={{
             minHeight: tabIconHeight,
             overflow: "hidden",
             ...colorProps,
           }}
         >
-          <span style={{ overflow: "hidden", direction: "rtl", textOverflow: "ellipsis" }}>{title}</span>
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{tabTitle}</span>
         </Button>
       </Tooltip>
       <Tooltip title="Overwrite editor content with saved file content">

--- a/src/ScriptEditor/ui/Tabs.tsx
+++ b/src/ScriptEditor/ui/Tabs.tsx
@@ -13,9 +13,10 @@ import SearchIcon from "@mui/icons-material/Search";
 import { useBoolean, useRerender } from "../../ui/React/hooks";
 import { Settings } from "../../Settings/Settings";
 
-import { dirty, reorder } from "./utils";
+import { isUnsavedFile, reorder } from "./utils";
 import { OpenScript } from "./OpenScript";
 import { Tab } from "./Tab";
+import { SpecialServers } from "../../Server/data/SpecialServers";
 
 const tabsMaxWidth = 1640;
 const searchWidth = 180;
@@ -119,22 +120,16 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
               {filteredScripts.map(({ script, originalIndex }, index) => {
                 const { path: fileName, hostname } = script;
                 const isActive = currentScript?.path === script.path && currentScript.hostname === script.hostname;
-
-                const title = `${hostname}:~${fileName.startsWith("/") ? "" : "/"}${fileName} ${dirty(scripts, index)}`;
-
+                const fullPath = `${hostname}:/${fileName}`;
                 return (
-                  <Draggable
-                    key={fileName + hostname}
-                    draggableId={fileName + hostname}
-                    index={index}
-                    disableInteractiveElementBlocking
-                  >
+                  <Draggable key={fullPath} draggableId={fullPath} index={index} disableInteractiveElementBlocking>
                     {(provided) => (
                       <Tab
                         provided={provided}
-                        title={title}
+                        fullPath={fullPath}
                         isActive={isActive}
-                        isExternal={hostname !== "home"}
+                        isExternal={hostname !== SpecialServers.Home}
+                        isUnsaved={isUnsavedFile(scripts, index)}
                         onClick={() => onTabClick(originalIndex)}
                         onClose={() => onTabClose(originalIndex)}
                         onUpdate={() => onTabUpdate(originalIndex)}

--- a/src/ScriptEditor/ui/utils.ts
+++ b/src/ScriptEditor/ui/utils.ts
@@ -12,11 +12,13 @@ function getServerCode(scripts: OpenScript[], index: number): string | null {
   return data;
 }
 
-function dirty(scripts: OpenScript[], index: number): string {
+function isUnsavedFile(scripts: OpenScript[], index: number): boolean {
   const openScript = scripts[index];
   const serverData = getServerCode(scripts, index);
-  if (serverData === null) return " *";
-  return serverData !== openScript.code ? " *" : "";
+  if (serverData === null) {
+    return true;
+  }
+  return serverData !== openScript.code;
 }
 
 function reorder(list: unknown[], startIndex: number, endIndex: number): void {
@@ -60,4 +62,4 @@ function makeModel(hostname: string, filename: string, code: string): editor.ITe
   return editor.createModel(code, language, uri);
 }
 
-export { getServerCode, dirty, reorder, makeModel };
+export { getServerCode, isUnsavedFile, reorder, makeModel };


### PR DESCRIPTION
Saving files on non-home servers is a common newbie mistake. This PR adds many UI hints to warn them if they are doing that.
- Blink animation.
- Change color (info -> warning).
- Warning toast message.

![Capture](https://github.com/user-attachments/assets/bccfbb50-dd0b-40e1-9dbb-0bbb066eef1b)

https://github.com/user-attachments/assets/2a08d286-ce5f-457c-919e-f353d04185c1

