### PR TITLE
UI: Add disambiguation to the confusing "1s / ls" tutorial step

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -656,6 +656,9 @@ export class Terminal {
         case iTutorialSteps.TerminalLs:
           if (commandArray.length === 1 && commandArray[0] == "ls") {
             iTutorialNextStep();
+          } else if (commandArray[0] == "1s") {
+            this.error("Command '1s' not found. Did you mean 'ls' with a lowercase L?");
+            return;
           } else {
             this.error(errorMessageForBadCommand);
             return;
@@ -800,7 +803,11 @@ export class Terminal {
     commandArray.shift();
 
     const f = TerminalCommands[commandName.toLowerCase()];
-    if (!f) return this.error(`Command ${commandName} not found`);
+    if (!f) {
+      const similarCommands = findSimilarCommands(commandName);
+      const didYouMeanString = similarCommands.length ? `Did you mean: ${similarCommands.join(" or ")}?` : "";
+      return this.error(`Command ${commandName} not found. ${didYouMeanString}`);
+    }
 
     f(commandArray, currentServer);
   }
@@ -812,4 +819,17 @@ export class Terminal {
       totalTicks: 50,
     });
   }
+}
+
+function findSimilarCommands(command: string): string[] {
+  const commands = Object.keys(TerminalCommands);
+  const offByOneLetter = commands.filter((c) => {
+    let diff = 0;
+    for (let i = 0; i < c.length; i++) {
+      if (c[i] !== command[i]) diff++;
+    }
+    return diff === 1;
+  });
+  const subset = commands.filter((c) => c.includes(command)).sort((a, b) => a.length - b.length);
+  return [...offByOneLetter, ...subset].slice(0, 3);
 }

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -805,8 +805,8 @@ export class Terminal {
     const f = TerminalCommands[commandName.toLowerCase()];
     if (!f) {
       const similarCommands = findSimilarCommands(commandName);
-      const didYouMeanString = similarCommands.length ? `Did you mean: ${similarCommands.join(" or ")}?` : "";
-      return this.error(`Command ${commandName} not found. ${didYouMeanString}`);
+      const didYouMeanString = similarCommands.length ? ` Did you mean: ${similarCommands.join(" or ")}?` : "";
+      return this.error(`Command ${commandName} not found.${didYouMeanString}`);
     }
 
     f(commandArray, currentServer);

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -831,5 +831,5 @@ function findSimilarCommands(command: string): string[] {
     return diff === 1;
   });
   const subset = commands.filter((c) => c.includes(command)).sort((a, b) => a.length - b.length);
-  return [...offByOneLetter, ...subset].slice(0, 3);
+  return Array.from(new Set([...offByOneLetter, ...subset])).slice(0, 3);
 }

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -824,6 +824,7 @@ export class Terminal {
 function findSimilarCommands(command: string): string[] {
   const commands = Object.keys(TerminalCommands);
   const offByOneLetter = commands.filter((c) => {
+    if (c.length !== command.length) return false;
     let diff = 0;
     for (let i = 0; i < c.length; i++) {
       if (c[i] !== command[i]) diff++;

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -146,7 +146,9 @@ export function InteractiveTutorialRoot(): React.ReactElement {
           </Typography>
 
           <Typography classes={{ root: classes.textfield }}>{"[home /]> ls"}</Typography>
-          <Typography> ( "ls" is short for "list" )</Typography>
+          <Typography>
+            <br />( "ls" is short for "list" )
+          </Typography>
         </>
       ),
       canNext: false,

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -146,6 +146,7 @@ export function InteractiveTutorialRoot(): React.ReactElement {
           </Typography>
 
           <Typography classes={{ root: classes.textfield }}>{"[home /]> ls"}</Typography>
+          <Typography> ( "ls" is short for "list" )</Typography>
         </>
       ),
       canNext: false,
@@ -156,7 +157,7 @@ export function InteractiveTutorialRoot(): React.ReactElement {
           <Typography classes={{ root: classes.textfield }}>{"[home /]> ls"}</Typography>
           <Typography>
             {" "}
-            is a basic command that shows files on the computer. Right now, it shows that you have a program called{" "}
+            is a basic command that lists the files on the computer. Right now, it shows that you have a program called{" "}
             NUKE.exe on your computer. We'll get to what this does later. <br />
             <br />
             Using your home computer's terminal, you can connect to other machines throughout the world. Let's do that


### PR DESCRIPTION
There are a significant number of confused new players getting caught in the tutorial confusing "ls" as "1s":
https://discord.com/channels/415207508303544321/415213435974975508/1342166697716613200

This PR adds some context to the prompt in the tutorial that "ls" is short for "list", and an explicit error message for the "1s" case explaining it is spelled with an L :

![image](https://github.com/user-attachments/assets/9e5fc409-6685-4ca4-9ac6-fb145a5c3bcc)

When the user is not in the tutorial: if an invalid command is entered, and it is very similar, or a subset, of a real command, some real commands are listed as a "did you mean?" (maximum 3 suggestions)

![image](https://github.com/user-attachments/assets/1c768945-9f41-4390-96a6-ae23bb870b8b)
