### PR TITLE
CODEBASE: Update webpack and katex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "rehype-mathjax": "^4.0.3",
         "remark-math": "^5.1.1",
         "style-loader": "^3.3.3",
-        "typescript": "^5.2.2",
+        "typescript": "^5.7.3",
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.1.0"
@@ -3836,6 +3836,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
@@ -13447,9 +13461,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.10.tgz",
-      "integrity": "sha512-ZiqaC04tp2O5utMsl2TEZTXxa6WSC4yo0fv5ML++D3QZv/vx2Mct0mTlRx3O+uUkjfuAgOkzsCmq5MiUEsDDdA==",
+      "version": "0.16.21",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
+      "integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -18110,10 +18124,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rehype-mathjax": "^4.0.3",
     "remark-math": "^5.1.1",
     "style-loader": "^3.3.3",
-    "typescript": "^5.2.2",
+    "typescript": "^5.7.3",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.1.0"

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -234,7 +234,7 @@ export class Division {
       //If this industry has a warehouse in this city, process the market
       //for every material this industry requires or produces
       if (this.warehouses[city]) {
-        const wh = this.warehouses[city] as Warehouse; // Warehouse type is known due to if check above
+        const wh = this.warehouses[city];
         for (const name of Object.keys(reqMats) as CorpMaterialName[]) {
           if (Object.hasOwn(reqMats, name)) {
             wh.materials[name].processMarket();

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -61,7 +61,9 @@ function getFormatter(
   formatList = digitFormats,
   options: Intl.NumberFormatOptions = {},
 ): Intl.NumberFormat {
-  if (formatList[fractionalDigits]) return formatList[fractionalDigits] as Intl.NumberFormat;
+  if (formatList[fractionalDigits]) {
+    return formatList[fractionalDigits];
+  }
   return (formatList[fractionalDigits] = makeFormatter(fractionalDigits, options));
 }
 


### PR DESCRIPTION
This PR fixes 2 problems with our dependencies:
- We are using a very old version of TypeScript. TSC reports wrong errors at https://github.com/bitburner-official/bitburner-src/actions/runs/13545961255/job/37857521062.
- npm reports a vulnerability in `katex`. I fixed it by running `npm audit fix`.