### PR TITLE
UI: Improve performance of April Fools Easter egg

### DIFF
--- a/src/ui/Apr1.tsx
+++ b/src/ui/Apr1.tsx
@@ -45,9 +45,12 @@ export function Apr1(): React.ReactElement {
   const [n, setN] = useState(0);
 
   useEffect(() => {
+    if (!open) {
+      return;
+    }
     const id = setInterval(() => setN((n) => (n + 1) % frames.length), 100);
     return () => clearInterval(id);
-  }, []);
+  }, [open]);
 
   useEffect(
     () =>


### PR DESCRIPTION
While profiling unrelated things, I found out `src\ui\Apr1.tsx` is rerendered constantly, despite of not being activated (on April First or the `apr1` command).

How to reproduce it: 
https://github.com/bitburner-official/bitburner-src/blob/a25ab3dd39819168d34dab97fff6db2f1a9559c8/src/ui/Apr1.tsx#L47-L50
Change it to:
```js
useEffect(() => {
  const id = setInterval(() => {
    console.log(new Date());
    setN((n) => (n + 1) % frames.length);
  }, 100);
  return () => clearInterval(id);
}, []);
```
Your console will be spammed immediately after the game is loaded.

I tested this change. It still works when `isApr1` returns true or the player runs the `apr1` command.