### PR TITLE
DOCUMENTATION: Clarify value of gang territory

### DIFF
--- a/markdown/bitburner.ganggeninfo.md
+++ b/markdown/bitburner.ganggeninfo.md
@@ -23,7 +23,7 @@ interface GangGenInfo
 |  [respect](./bitburner.ganggeninfo.respect.md) |  | number | Gang's respect |
 |  [respectForNextRecruit](./bitburner.ganggeninfo.respectfornextrecruit.md) |  | number | Amount of Respect needed for next gang recruit, if possible |
 |  [respectGainRate](./bitburner.ganggeninfo.respectgainrate.md) |  | number | Respect earned per game cycle |
-|  [territory](./bitburner.ganggeninfo.territory.md) |  | number | Amount of territory held |
+|  [territory](./bitburner.ganggeninfo.territory.md) |  | number | Amount of territory held, in decimal form |
 |  [territoryClashChance](./bitburner.ganggeninfo.territoryclashchance.md) |  | number | Clash chance |
 |  [territoryWarfareEngaged](./bitburner.ganggeninfo.territorywarfareengaged.md) |  | boolean | Indicating if territory clashes are enabled |
 |  [wantedLevel](./bitburner.ganggeninfo.wantedlevel.md) |  | number | Gang's wanted level |

--- a/markdown/bitburner.ganggeninfo.md
+++ b/markdown/bitburner.ganggeninfo.md
@@ -23,7 +23,7 @@ interface GangGenInfo
 |  [respect](./bitburner.ganggeninfo.respect.md) |  | number | Gang's respect |
 |  [respectForNextRecruit](./bitburner.ganggeninfo.respectfornextrecruit.md) |  | number | Amount of Respect needed for next gang recruit, if possible |
 |  [respectGainRate](./bitburner.ganggeninfo.respectgainrate.md) |  | number | Respect earned per game cycle |
-|  [territory](./bitburner.ganggeninfo.territory.md) |  | number | Amount of territory held, in decimal form |
+|  [territory](./bitburner.ganggeninfo.territory.md) |  | number | Amount of territory held, in the range 0-1 |
 |  [territoryClashChance](./bitburner.ganggeninfo.territoryclashchance.md) |  | number | Clash chance |
 |  [territoryWarfareEngaged](./bitburner.ganggeninfo.territorywarfareengaged.md) |  | boolean | Indicating if territory clashes are enabled |
 |  [wantedLevel](./bitburner.ganggeninfo.wantedlevel.md) |  | number | Gang's wanted level |

--- a/markdown/bitburner.ganggeninfo.territory.md
+++ b/markdown/bitburner.ganggeninfo.territory.md
@@ -4,7 +4,7 @@
 
 ## GangGenInfo.territory property
 
-Amount of territory held
+Amount of territory held, in decimal form
 
 **Signature:**
 

--- a/markdown/bitburner.ganggeninfo.territory.md
+++ b/markdown/bitburner.ganggeninfo.territory.md
@@ -4,7 +4,7 @@
 
 ## GangGenInfo.territory property
 
-Amount of territory held, in decimal form
+Amount of territory held, in the range 0-1
 
 **Signature:**
 

--- a/markdown/bitburner.gangotherinfoobject.md
+++ b/markdown/bitburner.gangotherinfoobject.md
@@ -16,5 +16,5 @@ interface GangOtherInfoObject
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
 |  [power](./bitburner.gangotherinfoobject.power.md) |  | number | Gang power |
-|  [territory](./bitburner.gangotherinfoobject.territory.md) |  | number | Gang territory, in decimal form |
+|  [territory](./bitburner.gangotherinfoobject.territory.md) |  | number | Gang territory, in the range 0-1 |
 

--- a/markdown/bitburner.gangotherinfoobject.territory.md
+++ b/markdown/bitburner.gangotherinfoobject.territory.md
@@ -4,7 +4,7 @@
 
 ## GangOtherInfoObject.territory property
 
-Gang territory, in decimal form
+Gang territory, in the range 0-1
 
 **Signature:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -831,7 +831,7 @@ interface GangGenInfo {
   respectGainRate: number;
   /** Amount of Respect needed for next gang recruit, if possible */
   respectForNextRecruit: number;
-  /** Amount of territory held */
+  /** Amount of territory held, in decimal form */
   territory: number;
   /** Clash chance */
   territoryClashChance: number;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -831,7 +831,7 @@ interface GangGenInfo {
   respectGainRate: number;
   /** Amount of Respect needed for next gang recruit, if possible */
   respectForNextRecruit: number;
-  /** Amount of territory held, in decimal form */
+  /** Amount of territory held, in the range 0-1 */
   territory: number;
   /** Clash chance */
   territoryClashChance: number;
@@ -849,7 +849,7 @@ interface GangGenInfo {
 interface GangOtherInfoObject {
   /** Gang power */
   power: number;
-  /** Gang territory, in decimal form */
+  /** Gang territory, in the range 0-1 */
   territory: number;
 }
 


### PR DESCRIPTION
Context: https://discord.com/channels/415207508303544321/415207923506216971/1341396121578111088
```
for ns.gang.getGangInfo().territory, does it go from 0 to 1 or 0 to 100?
```
We already said that `GangOtherInfoObject.territory` is in decimal form. This PR clarifies `GangGenInfo.territory`.