### PR TITLE
BUGFIX: Some calculations return NaN due to Player.playtimeSinceLastAug being 0 in edge cases

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1564,7 +1564,11 @@ export const ns: InternalAPI<NSFull> = {
       total += script.scriptRef.onlineMoneyMade / script.scriptRef.onlineRunningTime;
     }
 
-    return [total, Player.scriptProdSinceLastAug / (Player.playtimeSinceLastAug / 1000)];
+    let incomeFromScriptsSinceLastAug = Player.scriptProdSinceLastAug / (Player.playtimeSinceLastAug / 1000);
+    if (Number.isFinite(incomeFromScriptsSinceLastAug)) {
+      incomeFromScriptsSinceLastAug = 0;
+    }
+    return [total, incomeFromScriptsSinceLastAug];
   },
   getScriptIncome:
     (ctx) =>

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1565,7 +1565,7 @@ export const ns: InternalAPI<NSFull> = {
     }
 
     let incomeFromScriptsSinceLastAug = Player.scriptProdSinceLastAug / (Player.playtimeSinceLastAug / 1000);
-    if (Number.isFinite(incomeFromScriptsSinceLastAug)) {
+    if (!Number.isFinite(incomeFromScriptsSinceLastAug)) {
       incomeFromScriptsSinceLastAug = 0;
     }
     return [total, incomeFromScriptsSinceLastAug];

--- a/src/Script/ScriptHelpers.ts
+++ b/src/Script/ScriptHelpers.ts
@@ -58,8 +58,11 @@ export function scriptCalculateOfflineProduction(runningScript: RunningScript): 
   const expGain = confidence * (runningScript.onlineExpGained / runningScript.onlineRunningTime) * timePassed;
   Player.gainHackingExp(expGain);
 
-  const moneyGain =
+  let moneyGain =
     (runningScript.onlineMoneyMade / Player.playtimeSinceLastAug) * timePassed * CONSTANTS.OfflineHackingIncome;
+  if (!Number.isFinite(moneyGain)) {
+    moneyGain = 0;
+  }
   // money is given to player during engine load
   Player.scriptProdSinceLastAug += moneyGain;
 

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -278,7 +278,9 @@ const Engine: {
       let offlineReputation = 0;
       const offlineHackingIncome =
         (Player.moneySourceA.hacking / Player.playtimeSinceLastAug) * timeOffline * CONSTANTS.OfflineHackingIncome;
-      Player.gainMoney(offlineHackingIncome, "hacking");
+      if (Number.isFinite(offlineHackingIncome)) {
+        Player.gainMoney(offlineHackingIncome, "hacking");
+      }
       // Process offline progress
 
       loadAllRunningScripts(); // This also takes care of offline production for those scripts

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -276,11 +276,12 @@ const Engine: {
       tryGeneratingRandomContract(timeOffline / CONSTANTS.MillisecondsPerTenMinutes);
 
       let offlineReputation = 0;
-      const offlineHackingIncome =
+      let offlineHackingIncome =
         (Player.moneySourceA.hacking / Player.playtimeSinceLastAug) * timeOffline * CONSTANTS.OfflineHackingIncome;
-      if (Number.isFinite(offlineHackingIncome)) {
-        Player.gainMoney(offlineHackingIncome, "hacking");
+      if (!Number.isFinite(offlineHackingIncome)) {
+        offlineHackingIncome = 0;
       }
+      Player.gainMoney(offlineHackingIncome, "hacking");
       // Process offline progress
 
       loadAllRunningScripts(); // This also takes care of offline production for those scripts

--- a/src/ui/ActiveScripts/ScriptProduction.tsx
+++ b/src/ui/ActiveScripts/ScriptProduction.tsx
@@ -30,7 +30,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
 }));
 export function ScriptProduction(): React.ReactElement {
   const { classes } = useStyles();
-  const prodRateSinceLastAug = Player.scriptProdSinceLastAug / (Player.playtimeSinceLastAug / 1000);
+  let prodRateSinceLastAug = Player.scriptProdSinceLastAug / (Player.playtimeSinceLastAug / 1000);
+  if (!Number.isFinite(prodRateSinceLastAug)) {
+    prodRateSinceLastAug = 0;
+  }
 
   return (
     <Table size="small" classes={{ root: classes.size }}>


### PR DESCRIPTION
How to reproduce this bug:
- Expose `saveObject` in `src\SaveObject.ts`.
- Load the attached save file.
- Run `run a.js 10000`.
- Check console after the game is reloaded. You will see `NaN passed into Player.gainMoney()`.

Note: You may need to tweak `ns.asleep(100)` in `b.js` or run the test a few times.

This bug happens when the player resets (soft reset or install augmentations), saves game, and reloads *before* the next engine tick. It's almost impossible to happen in normal situations, but it still happens if the player rapidly spawns scripts that call the softReset API.

Note that I only expose `saveObject` for easy testing. It's possible to reproduce this bug even without doing that; it's harder and more inconsistent, though.

Save file: [NaN bug.gz](https://github.com/user-attachments/files/19029997/NaN.bug.gz)
