### PR TITLE
CODEBASE: Version 2.8 stuff

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -4,7 +4,7 @@
  * Constants for specific mechanics or features will NOT be here.
  */
 export const CONSTANTS = {
-  VersionString: "2.7.1dev",
+  VersionString: "2.8.0dev",
   isDevBranch: true,
   VersionNumber: 41,
 
@@ -109,7 +109,7 @@ export const CONSTANTS = {
 
   // Also update Documentation/doc/changelog.md when appropriate (when doing a release)
   LatestUpdate: `
-## v2.7.1 dev branch: Last updated 28 February 2025
+## v2.8.0 dev branch: Last updated 01 March 2025
 
 ### MAJOR CHANGES
 

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -528,7 +528,7 @@ Error: ${e}`,
   if (ver < 39) {
     showAPIBreaks("2.6.1", ...breakInfos261);
   }
-  if (ver <= 41) {
+  if (ver < 42) {
     // All whitespace except for spaces was allowed in filenames
     let found = false;
     for (const server of GetAllServers()) {


### PR DESCRIPTION
Change dev version from 2.7.1 to 2.8.0

Also adjust the save data migration code for the latest check to use "<" instead of "<=" to agree with the style of everything else. (I noticed this due to investistigating bumping the version, but that happens as part of the release commit so it shouldn't be done yet.)