### PR TITLE
IPVGO: correctly initialize board from save when there are no prior moves

### DIFF
--- a/src/Go/SaveLoad.ts
+++ b/src/Go/SaveLoad.ts
@@ -111,7 +111,7 @@ function loadCurrentGame(currentGame: unknown): BoardState | string {
     ? Math.max(0, currentGame.cheatCountForWhite || 0)
     : 0;
   if (!isInteger(currentGame.passCount) || currentGame.passCount < 0) return "invalid number for currentGame.passCount";
-  const previousBoards = typeof currentGame.previousBoard === "string" ? [currentGame.previousBoard] : [];
+  const previousBoards = currentGame.previousBoard && typeof currentGame.previousBoard === "string" ? [currentGame.previousBoard] : [];
 
   const boardState = boardStateFromSimpleBoard(board, ai);
   boardState.previousPlayer = previousPlayer;

--- a/src/Go/SaveLoad.ts
+++ b/src/Go/SaveLoad.ts
@@ -111,7 +111,8 @@ function loadCurrentGame(currentGame: unknown): BoardState | string {
     ? Math.max(0, currentGame.cheatCountForWhite || 0)
     : 0;
   if (!isInteger(currentGame.passCount) || currentGame.passCount < 0) return "invalid number for currentGame.passCount";
-  const previousBoards = currentGame.previousBoard && typeof currentGame.previousBoard === "string" ? [currentGame.previousBoard] : [];
+  const previousBoards =
+    currentGame.previousBoard && typeof currentGame.previousBoard === "string" ? [currentGame.previousBoard] : [];
 
   const boardState = boardStateFromSimpleBoard(board, ai);
   boardState.previousPlayer = previousPlayer;

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -403,7 +403,9 @@ async function getIlluminatiPriorityMove(moves: MoveOptions, rng: number): Promi
     return moves.corner()?.point ?? null;
   }
 
-  const hasMoves = [moves.eyeMove(), moves.eyeBlock(), moves.growth(), moves.defend(), surround].filter((m) => m).length;
+  const hasMoves = [moves.eyeMove(), moves.eyeBlock(), moves.growth(), moves.defend(), surround].filter(
+    (m) => m,
+  ).length;
   const usePattern = rng > 0.25 || !hasMoves;
 
   if ((await moves.pattern()) && usePattern) {

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -403,7 +403,7 @@ async function getIlluminatiPriorityMove(moves: MoveOptions, rng: number): Promi
     return moves.corner()?.point ?? null;
   }
 
-  const hasMoves = [moves.eyeMove(), moves.eyeBlock(), moves.growth(), moves.defend, surround].filter((m) => m).length;
+  const hasMoves = [moves.eyeMove(), moves.eyeBlock(), moves.growth(), moves.defend(), surround].filter((m) => m).length;
   const usePattern = rng > 0.25 || !hasMoves;
 
   if ((await moves.pattern()) && usePattern) {


### PR DESCRIPTION
The prior move is saved as an empty string if it does not exist, to save on filespace and avoid null serializing. This PR ensures that it is not treated as a valid previous move, in that scenario, when loaded.

This PR also fixes a minor bug where defending moves were not properly checked for the purposes of knowing when to try to pattern match.