### PR TITLE
CODEBASE: Suppress false-positive console errors caused by RamCalculation.test.ts

### DIFF
--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -26,6 +26,7 @@ function grabCost<API>(ramEntry: RamCostTree<API>[keyof API]) {
 
 describe("Netscript RAM Calculation/Generation Tests", function () {
   jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
   Player.sourceFiles.set(4, 3);
   // For simulating costs of singularity functions.
   const baseCost = RamCostConstants.Base;


### PR DESCRIPTION
While running Jest tests, I see these console errors:
```
  console.error
    validate.errors: [
      {
        instancePath: '',
        schemaPath: '#/type',
        keyword: 'type',
        params: { type: 'object' },
        message: 'must be object'
      }
    ]

       8 | function assertAndSanitize(data: unknown, validate: ValidateFunction<unknown>): void {
       9 |   if (!validate(data)) {
    > 10 |     console.error("validate.errors:", validate.errors);
         |             ^
      11 |     // validate.errors is an array of objects, so we need to use JSON.stringify.
      12 |     throw new Error(JSON.stringify(validate.errors));
      13 |   }

      at error (src/JsonSchema/JSONSchemaAssertion.ts:10:13)
      at assertAndSanitize (src/JsonSchema/JSONSchemaAssertion.ts:20:3)
      at src/NetscriptFunctions/UserInterface.ts:122:35
      at func (src/Netscript/APIWrapper.ts:82:16)
      at fn (test/jest/Netscript/RamCalculation.test.ts:49:7)
      at tryFunction (test/jest/Netscript/RamCalculation.test.ts:100:7)
      at Object.combinedRamCheck (test/jest/Netscript/RamCalculation.test.ts:132:37)

  console.error
    validate.errors: [
      {
        instancePath: '',
        schemaPath: '#/type',
        keyword: 'type',
        params: { type: 'object' },
        message: 'must be object'
      }
    ]

       8 | function assertAndSanitize(data: unknown, validate: ValidateFunction<unknown>): void {
       9 |   if (!validate(data)) {
    > 10 |     console.error("validate.errors:", validate.errors);
         |             ^
      11 |     // validate.errors is an array of objects, so we need to use JSON.stringify.
      12 |     throw new Error(JSON.stringify(validate.errors));
      13 |   }

      at error (src/JsonSchema/JSONSchemaAssertion.ts:10:13)
      at assertAndSanitize (src/JsonSchema/JSONSchemaAssertion.ts:20:3)
      at src/NetscriptFunctions/UserInterface.ts:122:35
      at func (src/Netscript/APIWrapper.ts:82:16)
      at fn (test/jest/Netscript/RamCalculation.test.ts:49:7)
      at tryFunction (test/jest/Netscript/RamCalculation.test.ts:101:7)
      at Object.combinedRamCheck (test/jest/Netscript/RamCalculation.test.ts:132:37)

  console.error
    validate.errors: [
      {
        instancePath: '',
        schemaPath: '#/type',
        keyword: 'type',
        params: { type: 'object' },
        message: 'must be object'
      }
    ]

       8 | function assertAndSanitize(data: unknown, validate: ValidateFunction<unknown>): void {
       9 |   if (!validate(data)) {
    > 10 |     console.error("validate.errors:", validate.errors);
         |             ^
      11 |     // validate.errors is an array of objects, so we need to use JSON.stringify.
      12 |     throw new Error(JSON.stringify(validate.errors));
      13 |   }

      at error (src/JsonSchema/JSONSchemaAssertion.ts:10:13)
      at assertAndSanitize (src/JsonSchema/JSONSchemaAssertion.ts:20:3)
      at src/NetscriptFunctions/UserInterface.ts:122:35
      at func (src/Netscript/APIWrapper.ts:82:16)
      at fn (test/jest/Netscript/RamCalculation.test.ts:49:7)
      at tryFunction (test/jest/Netscript/RamCalculation.test.ts:102:7)
      at Object.combinedRamCheck (test/jest/Netscript/RamCalculation.test.ts:132:37)

  console.error
    validate.errors: [
      {
        instancePath: '',
        schemaPath: '#/type',
        keyword: 'type',
        params: { type: 'object' },
        message: 'must be object'
      }
    ]

       8 | function assertAndSanitize(data: unknown, validate: ValidateFunction<unknown>): void {
       9 |   if (!validate(data)) {
    > 10 |     console.error("validate.errors:", validate.errors);
         |             ^
      11 |     // validate.errors is an array of objects, so we need to use JSON.stringify.
      12 |     throw new Error(JSON.stringify(validate.errors));
      13 |   }

      at error (src/JsonSchema/JSONSchemaAssertion.ts:10:13)
      at assertAndSanitize (src/JsonSchema/JSONSchemaAssertion.ts:34:3)
      at src/NetscriptFunctions/UserInterface.ts:139:32
      at func (src/Netscript/APIWrapper.ts:82:16)
      at fn (test/jest/Netscript/RamCalculation.test.ts:49:7)
      at tryFunction (test/jest/Netscript/RamCalculation.test.ts:100:7)
      at Object.combinedRamCheck (test/jest/Netscript/RamCalculation.test.ts:132:37)

  console.error
    validate.errors: [
      {
        instancePath: '',
        schemaPath: '#/type',
        keyword: 'type',
        params: { type: 'object' },
        message: 'must be object'
      }
    ]

       8 | function assertAndSanitize(data: unknown, validate: ValidateFunction<unknown>): void {
       9 |   if (!validate(data)) {
    > 10 |     console.error("validate.errors:", validate.errors);
         |             ^
      11 |     // validate.errors is an array of objects, so we need to use JSON.stringify.
      12 |     throw new Error(JSON.stringify(validate.errors));
      13 |   }

      at error (src/JsonSchema/JSONSchemaAssertion.ts:10:13)
      at assertAndSanitize (src/JsonSchema/JSONSchemaAssertion.ts:34:3)
      at src/NetscriptFunctions/UserInterface.ts:139:32
      at func (src/Netscript/APIWrapper.ts:82:16)
      at fn (test/jest/Netscript/RamCalculation.test.ts:49:7)
      at tryFunction (test/jest/Netscript/RamCalculation.test.ts:101:7)
      at Object.combinedRamCheck (test/jest/Netscript/RamCalculation.test.ts:132:37)

  console.error
    validate.errors: [
      {
        instancePath: '',
        schemaPath: '#/type',
        keyword: 'type',
        params: { type: 'object' },
        message: 'must be object'
      }
    ]

       8 | function assertAndSanitize(data: unknown, validate: ValidateFunction<unknown>): void {
       9 |   if (!validate(data)) {
    > 10 |     console.error("validate.errors:", validate.errors);
         |             ^
      11 |     // validate.errors is an array of objects, so we need to use JSON.stringify.
      12 |     throw new Error(JSON.stringify(validate.errors));
      13 |   }

      at error (src/JsonSchema/JSONSchemaAssertion.ts:10:13)
      at assertAndSanitize (src/JsonSchema/JSONSchemaAssertion.ts:34:3)
      at src/NetscriptFunctions/UserInterface.ts:139:32
      at func (src/Netscript/APIWrapper.ts:82:16)
      at fn (test/jest/Netscript/RamCalculation.test.ts:49:7)
      at tryFunction (test/jest/Netscript/RamCalculation.test.ts:102:7)
      at Object.combinedRamCheck (test/jest/Netscript/RamCalculation.test.ts:132:37)
```

In `test\jest\Netscript\RamCalculation.test.ts`, we try to run all NS APIs and check bugs of RAM cost. We intentionally ignore all errors when running those APIs (we call them without any input data). This is fine for most APIs, but with some APIs that involve checking JSON Schema, it prints many errors in the console. This PR suppresses those false-positive errors.