### PR TITLE
MISC: Add support for getting the save file through the RFA

### DIFF
--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -26,6 +26,7 @@ type ResultType =
   | RFAServerData[]
   | {
       identifier: string;
+      binary: boolean;
       save: SaveData;
     };
 type FileMetadata = FileData | FileContent | FileLocation | FileServer;

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -1,3 +1,4 @@
+import { SaveData } from "../types";
 import type { BaseServer } from "../Server/BaseServer";
 
 export class RFAMessage {
@@ -17,7 +18,16 @@ export class RFAMessage {
   }
 }
 
-type ResultType = string | number | string[] | FileContent[] | RFAServerData[];
+type ResultType =
+  | string
+  | number
+  | string[]
+  | FileContent[]
+  | RFAServerData[]
+  | {
+      identifier: string;
+      save: SaveData;
+    };
 type FileMetadata = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -13,12 +13,14 @@ import {
 } from "./MessageDefinitions";
 
 import libSource from "../ScriptEditor/NetscriptDefinitions.d.ts?raw";
+import { saveObject } from "../SaveObject";
+import { Player } from "@player";
 
 function error(errorMsg: string, { id }: RFAMessage): RFAMessage {
   return new RFAMessage({ error: errorMsg, id: id });
 }
 
-export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessage> = {
+export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessage | Promise<RFAMessage>> = {
   pushFile: function (msg: RFAMessage): RFAMessage {
     if (!isFileData(msg.params)) return error("Misses parameters", msg);
 
@@ -110,6 +112,22 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
 
   getDefinitionFile: function (msg: RFAMessage): RFAMessage {
     return new RFAMessage({ result: libSource, id: msg.id });
+  },
+
+  getSaveFile: async function (msg: RFAMessage): Promise<RFAMessage> {
+    const saveData = await saveObject.getSaveData();
+    // We can't serialize the Uint8Array directly, so we convert every integer to a character and make a string out of the array
+    // The external editor can simply recreate the save by converting each char back to their char code
+    const converted =
+      typeof saveData === "string" ? saveData : saveData.reduce((acc, cur) => acc + String.fromCharCode(cur), "");
+
+    return new RFAMessage({
+      result: {
+        identifier: Player.identifier,
+        save: converted,
+      },
+      id: msg.id,
+    });
   },
 
   getAllServers: function (msg: RFAMessage): RFAMessage {

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -116,14 +116,29 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
 
   getSaveFile: async function (msg: RFAMessage): Promise<RFAMessage> {
     const saveData = await saveObject.getSaveData();
+
+    if (typeof saveData === "string") {
+      return new RFAMessage({
+        result: {
+          identifier: Player.identifier,
+          binary: false,
+          save: saveData,
+        },
+        id: msg.id,
+      });
+    }
+
     // We can't serialize the Uint8Array directly, so we convert every integer to a character and make a string out of the array
     // The external editor can simply recreate the save by converting each char back to their char code
-    const converted =
-      typeof saveData === "string" ? saveData : saveData.reduce((acc, cur) => acc + String.fromCharCode(cur), "");
+    let converted = "";
+    for (let i = 0; i < saveData.length; i++) {
+      converted += String.fromCharCode(saveData[i]);
+    }
 
     return new RFAMessage({
       result: {
         identifier: Player.identifier,
+        binary: true,
         save: converted,
       },
       id: msg.id,

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -60,5 +60,10 @@ function handleMessageEvent(this: WebSocket, e: MessageEvent): void {
   }
   const response = RFARequestHandler[msg.method](msg);
   if (!response) return;
+
+  if (response instanceof Promise) {
+    void response.then((data) => this.send(JSON.stringify(data)));
+    return;
+  }
   this.send(JSON.stringify(response));
 }


### PR DESCRIPTION
Currently, you can only programmatically get the save file through the NS API. While this does allow for automatic backups, getting those backups into your external editor can be quite cumbersome. Now, the current save file is exposed to the RFA via a new request.

I'm not quite sure if it should also be possible to import a save file via the RFA. It would be quite frustrating to have your save file be lost because your external editor overwrites it. Maybe a middle ground would be a confirmation popup? This feature seems quite niche IMO, so maybe it is not needed?