### PR TITLE
MISC: Warn player that they cannot accept Stanek's Gift after joining Bladeburner with SF7.3

### DIFF
--- a/markdown/bitburner.bladeburner.joinbladeburnerdivision.md
+++ b/markdown/bitburner.bladeburner.joinbladeburnerdivision.md
@@ -23,6 +23,8 @@ RAM cost: 4 GB
 
 Attempts to join the Bladeburner division.
 
+If you have SF 7.3, you will immediately receive "The Blade's Simulacrum" augmentation and won't be able to accept Stanek's Gift after joining. If you want to accept Stanek's Gift, you must do that before calling this API.
+
 Returns true if you successfully join the Bladeburner division, or if you are already a member.
 
 Returns false otherwise.

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -419,6 +419,7 @@ export function initBitNodes() {
         <br />
         Each level of this Source-File increases the size of Stanek's Gift.
         <br />
+        <br />
         Due to the effect of Source-File 7.3, you must accept Stanek's Gift before joining the Bladeburner division if
         you have that Source-File.
       </>

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Player } from "@player";
-import { CityName, FactionName } from "@enums";
+import { AugmentationName, CityName, FactionName } from "@enums";
 import { BitNodeMultipliers, replaceCurrentNodeMults } from "./BitNodeMultipliers";
 
 class BitNode {
@@ -236,7 +236,10 @@ export function initBitNodes() {
         <ul>
           <li>Level 1: 8%</li>
           <li>Level 2: 12%</li>
-          <li>Level 3: 14% and begin with The Blade's Simulacrum</li>
+          <li>
+            Level 3: 14% and immediately receive "{AugmentationName.BladesSimulacrum}" augmentation after joining the
+            Bladeburner division
+          </li>
         </ul>
       </>
     ),
@@ -415,6 +418,9 @@ export function initBitNodes() {
         <br />
         <br />
         Each level of this Source-File increases the size of Stanek's Gift.
+        <br />
+        Due to the effect of Source-File 7.3, you must accept Stanek's Gift before joining the Bladeburner division if
+        you have that Source-File.
       </>
     ),
   );

--- a/src/CotMG/Helper.tsx
+++ b/src/CotMG/Helper.tsx
@@ -1,3 +1,5 @@
+import { Player } from "@player";
+import { AugmentationName } from "@enums";
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { Reviver } from "../utils/GenericReviver";
 import { BaseGift } from "./BaseGift";
@@ -48,4 +50,13 @@ export function calculateGrid(gift: BaseGift): number[][] {
   }
 
   return newGrid;
+}
+
+export function canAcceptStaneksGift(): boolean {
+  return (
+    Player.canAccessCotMG() &&
+    [...Player.augmentations, ...Player.queuedAugmentations].filter(
+      (a) => a.name !== AugmentationName.NeuroFluxGovernor,
+    ).length === 0
+  );
 }

--- a/src/Documentation/doc/advanced/bitnodes.md
+++ b/src/Documentation/doc/advanced/bitnodes.md
@@ -138,7 +138,7 @@ Destroying this BitNode will give you Source-File 7, or if you already have this
 
 - Level 1: 8%
 - Level 2: 12%
-- Level 3: 14%
+- Level 3: Level 3: 14% and immediately receive "The Blade's Simulacrum" augmentation after joining the Bladeburner division
 
 ### BitNode 8: Ghost of Wall Street
 
@@ -227,6 +227,8 @@ Their leader, Allison "Mother" Stanek is said to have created her own augmentati
 Destroying this BitNode will give you Source-File 13, or if you already have this Source-File, it will upgrade its level up to a maximum of 3. This Source-File lets the Church of the Machine God appear in other BitNodes.
 
 Each level of this Source-File increases the size of Stanek's Gift.
+
+Due to the effect of Source-File 7.3, you must accept Stanek's Gift before joining the Bladeburner division if you have that Source-File.
 
 ### BitNode 14: IPvGO Subnet Takeover
 

--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -1,7 +1,7 @@
 import { Player } from "@player";
 import { AugmentationName, FactionName } from "@enums";
 
-import { staneksGift } from "../CotMG/Helper";
+import { canAcceptStaneksGift, staneksGift } from "../CotMG/Helper";
 import { Fragments, FragmentById } from "../CotMG/Fragment";
 import { FragmentType } from "../CotMG/FragmentType";
 
@@ -110,22 +110,17 @@ export function NetscriptStanek(): InternalAPI<IStanek> {
     acceptGift: (ctx) => () => {
       const cotmgFaction = Factions[FactionName.ChurchOfTheMachineGod];
       // Check if the player is eligible to join the church
-      if (Player.canAccessCotMG()) {
-        const augs = [...Player.augmentations, ...Player.queuedAugmentations].filter(
-          (a) => a.name !== AugmentationName.NeuroFluxGovernor,
+      if (canAcceptStaneksGift()) {
+        // Join the CotMG factionn
+        joinFaction(cotmgFaction);
+        // Install the first Stanek aug
+        applyAugmentation({ name: AugmentationName.StaneksGift1, level: 1 });
+        helpers.log(
+          ctx,
+          () => `'${FactionName.ChurchOfTheMachineGod}' joined and '${AugmentationName.StaneksGift1}' installed.`,
         );
-        if (augs.length == 0) {
-          // Join the CotMG factionn
-          joinFaction(cotmgFaction);
-          // Install the first Stanek aug
-          applyAugmentation({ name: AugmentationName.StaneksGift1, level: 1 });
-          helpers.log(
-            ctx,
-            () => `'${FactionName.ChurchOfTheMachineGod}' joined and '${AugmentationName.StaneksGift1}' installed.`,
-          );
-        }
       }
-      // Return true iff the player is in CotMG and has the first Stanek aug installed
+      // Return true if the player is in CotMG and has the first Stanek aug installed
       return cotmgFaction.isMember && Player.hasAugmentation(AugmentationName.StaneksGift1, true);
     },
   };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3816,6 +3816,9 @@ export interface Bladeburner {
    *
    * Attempts to join the Bladeburner division.
    *
+   * If you have SF 7.3, you will immediately receive "The Blade's Simulacrum" augmentation and won't be able to accept
+   * Stanek's Gift after joining. If you want to accept Stanek's Gift, you must do that before calling this API.
+   *
    * Returns true if you successfully join the Bladeburner division, or if you are already a member.
    *
    * Returns false otherwise.


### PR DESCRIPTION
A player reported a "bug" at https://steamcommunity.com/app/1812820/discussions/0/599646376816548634/. It's not a bug at all. `The Blade's Simulacrum` is shown in the "Augmentations" tab as normal. Having this free augmentation does not mean they can bypass the requirement of Stanek's Gift. Nonetheless, it's best if we warn the player about this behavior in both UI and TSDoc.

![Capture](https://github.com/user-attachments/assets/351e59ba-b361-479d-8846-25a105af3515)

Note: This code block is obsolete now:
```js
const worldHeader = document.getElementById("world-menu-header");
if (worldHeader instanceof HTMLElement) {
  worldHeader.click();
  worldHeader.click();
}
```
I'm too lazy to search the git history for the specific commit, but I'm sure that we don't use "world-menu-header" anywhere in our current codebase. All code that calls `document.getElementById` is from the days in which we directly manipulated DOM instead of using React.

Edit: The simpler way to deal with this issue is to whitelist "The Blade's Simulacrum" when checking the condition of accepting Stanek's Gift. However, there is no reason to make that augmentation an exception.