### PR TITLE
IPVGO: First ever game promise handling

### DIFF
--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -62,10 +62,10 @@ export function handleNextTurn(boardState: BoardState, useOfflineCycles = true):
   const previousPromise = playerPromises[currentColor];
   const currentPromise = playerPromises[currentColor === GoColor.black ? GoColor.white : GoColor.black];
   // If we've already handled this turn, return the existing promise.
-  if (previousPromise.resolver === null) {
+  if (previousPromise.resolver === null && currentPromise.resolver) {
     return currentPromise.nextTurn;
   }
-  previousPromise.resolver();
+  previousPromise?.resolver?.();
   previousPromise.resolver = null;
   GoEvents.emit();
 


### PR DESCRIPTION
There is currently code that handles when move processing is attempted when the AI is already thinking (or a player script is), which gives back the current move promise instead of making a new move.

This caused #2010 because the very first ever game was improperly identified as a scenario such as that.

This PR fixes it by ensuring we have a valid promise to hand to the user before attempting that shortcut.
