### PR TITLE
BUGFIX: Fix first-time Go initialization

### DIFF
--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -32,6 +32,9 @@ const playerPromises: Record<GoColor.black | GoColor.white, PlayerPromise> = {
   [GoColor.black]: { nextTurn: Promise.resolve(gameOver), resolver: null },
   [GoColor.white]: { nextTurn: Promise.resolve(gameOver), resolver: null },
 };
+// The promises aren't in a fully working state until we do this.
+// It is OK to reset the AI multiple times in a row.
+resetAI();
 
 export function getNextTurn(color: GoColor.black | GoColor.white): Promise<Play> {
   return playerPromises[color].nextTurn;


### PR DESCRIPTION
Fixes #2010
It was intended that all the various codepaths call `resetAI()` to initialize the promise handling. However, when there is no savegame at all, `loadGo()` is not even called, so this is skipped, and the promises remain not-fully-initialized. This puts the initialization as part of the static construction, guaranteeing a fix.

Tested all 3 scenarios in #2010, as well as two more:
* Delete save, immediately "Find new subnet".
* Play a move, save game, ensure IPvGO works on reload.
* Play a move, save game *before the AI moves*, ensure that the AI plays different random moves on reload.