### PR TITLE
UI: Increase width of each job in "Job" tab

### DIFF
--- a/src/Locations/ui/JobRoot.tsx
+++ b/src/Locations/ui/JobRoot.tsx
@@ -32,5 +32,5 @@ export function JobRoot(): React.ReactElement {
     );
   }
 
-  return <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, 28em)" }}>{jobs}</Box>;
+  return <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, 30em)" }}>{jobs}</Box>;
 }


### PR DESCRIPTION
The text effect (`CorruptableText`) may make the company name jump between 1 line and 2 lines, depending on the current value. It happens with "KuaiGong International" and "Global Pharmaceuticals". This PR increases the width so that there is enough space for them to keep being on 1 line.

Save file: 
[test job tab.gz](https://github.com/user-attachments/files/19166660/test.job.tab.gz)

Before:

![before](https://github.com/user-attachments/assets/20358670-0b84-442e-ba18-e420167c290a)

After:

![after](https://github.com/user-attachments/assets/a3774f11-c7eb-4ea3-be87-ed150bfa2d26)

Closes #2015.