### PR TITLE
MISC: Disable effect of SF7.3 and SF10 if player disables them with advanced options

### DIFF
--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -71,7 +71,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
       return;
     }
     if (
-      Player.sourceFileLvl(7) >= 3 &&
+      Player.activeSourceFileLvl(7) >= 3 &&
       canAcceptStaneksGift() &&
       !Player.hasAugmentation(AugmentationName.StaneksGift1)
     ) {

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -17,7 +17,7 @@ import { SleeveWorkType } from "../PersonObjects/Sleeve/Work/Work";
 import { canAccessBitNodeFeature } from "../BitNode/BitNodeUtils";
 
 export const checkSleeveAPIAccess = function (ctx: NetscriptContext) {
-  if (Player.bitNodeN !== 10 && !Player.sourceFileLvl(10)) {
+  if (Player.bitNodeN !== 10 && Player.activeSourceFileLvl(10) <= 0) {
     throw helpers.errorMessage(
       ctx,
       "You do not currently have access to the Sleeve API. This is either because you are not in BitNode-10 or because you do not have Source-File 10",

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -17,7 +17,11 @@ import { SleeveWorkType } from "../PersonObjects/Sleeve/Work/Work";
 import { canAccessBitNodeFeature } from "../BitNode/BitNodeUtils";
 
 export const checkSleeveAPIAccess = function (ctx: NetscriptContext) {
-  if (Player.bitNodeN !== 10 && Player.activeSourceFileLvl(10) <= 0) {
+  /**
+   * Don't change sourceFileLvl to activeSourceFileLvl. The ability to control Sleeves (via both UI and APIs) is a
+   * permanent benefit.
+   */
+  if (Player.bitNodeN !== 10 && Player.sourceFileLvl(10) <= 0) {
     throw helpers.errorMessage(
       ctx,
       "You do not currently have access to the Sleeve API. This is either because you are not in BitNode-10 or because you do not have Source-File 10",

--- a/src/PersonObjects/Person.ts
+++ b/src/PersonObjects/Person.ts
@@ -147,6 +147,10 @@ export abstract class Person implements IPerson {
       console.error("ERROR: NaN passed into Player.gainIntelligenceExp()");
       return;
     }
+    /**
+     * Don't change sourceFileLvl to activeSourceFileLvl. When the player has int level, the ability to gain more int is
+     * a permanent benefit.
+     */
     if (Player.sourceFileLvl(5) > 0 || this.skills.intelligence > 0 || Player.bitNodeN === 5) {
       this.exp.intelligence += exp;
       this.skills.intelligence = Math.floor(this.calculateSkill(this.exp.intelligence, 1));

--- a/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectBladeburnerMethods.ts
@@ -11,7 +11,7 @@ export function startBladeburner(this: PlayerObject): void {
   this.bladeburner = new Bladeburner();
   this.bladeburner.init();
   // Give Blades Simulacrum if you have unlocked it
-  if (this.sourceFileLvl(7) >= 3) {
+  if (this.activeSourceFileLvl(7) >= 3) {
     this.augmentations.push({
       name: AugmentationName.BladesSimulacrum,
       level: 1,

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -558,6 +558,11 @@ export class Sleeve extends Person implements SleevePerson {
   }
 
   static recalculateNumOwned() {
+    /**
+     * Don't change sourceFileLvl to activeSourceFileLvl. The number of sleeves is a permanent effect. It's too
+     * troublesome for the player if they lose Sleeves and have to go BN10 to buy them again when they override the
+     * level of SF 10.
+     */
     const numSleeves =
       Math.min(3, Player.sourceFileLvl(10) + (Player.bitNodeN === 10 ? 1 : 0)) + Player.sleevesFromCovenant;
     while (Player.sleeves.length > numSleeves) {


### PR DESCRIPTION
We always use `Player.activeSourceFileLvl` instead of `Player.sourceFileLvl` to check if we should apply the SF effect. I checked the codebase and found some places that still use `Player.sourceFileLvl`. This PR made changes for SF7.3 and SF10. There are 2 other places that I don't touch in this PR:

https://github.com/bitburner-official/bitburner-src/blob/6666a176eebb9cdc56cb620a130424f7dea51491/src/PersonObjects/Person.ts#L150
Technically, we should change this one as well, but I'm a bit hesitant. @d0sboots What do you think about this?

https://github.com/bitburner-official/bitburner-src/blob/6666a176eebb9cdc56cb620a130424f7dea51491/src/PersonObjects/Sleeve/Sleeve.ts#L562
The number of sleeves should be a permanent effect. It's really troublesome for the player if they lose Sleeves and have to go BN10 to buy them again.