### PR TITLE
NETSCRIPT:  Store the value of `Player.money` in the returned object's `moneyAvailable` property when `ns.getServer` is called with `"home"`

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1007,7 +1007,7 @@ export const ns: InternalAPI<NSFull> = {
       baseDifficulty: server.baseDifficulty,
       hackDifficulty: server.hackDifficulty,
       minDifficulty: server.minDifficulty,
-      moneyAvailable: server.moneyAvailable,
+      moneyAvailable: server.hostname === "home" ? Player.money : server.moneyAvailable,
       moneyMax: server.moneyMax,
       numOpenPortsRequired: server.numOpenPortsRequired,
       openPortCount: server.openPortCount,


### PR DESCRIPTION
## Motivation
As pointed out [here on the Discord](https://discord.com/channels/415207508303544321/415213413745164318/1349519270849155192), currently `ns.getServerMoneyAvailable("home")` and `ns.getServer("home").moneyAvailable` do not return the same value.  This PR brings both into parity.

## Scope
Rather than change the underlying object used for the player's home computer on the back end, this conditionally inserts the value of `Player.money` into the returned object created by `ns.getServer`, similar to how it is handled in `ns.getServerMoneyAvailable`.

## Considerations
- While this may break scripts that rely on `ns.getServer("home").moneyAvailable` being `0`, most community filter implementations use a server's maximum money as the discriminator, not its current money.
- This change will also save a redundant 0.1 - 0.5 GB of RAM in situations where `getServer` is being used already and the player's money is also a desired value, allowing for a small RAM cost optimization in these cases.
- This PR does not require any documentation change, as no documented behaviors are altered.

Tested on latest version of 3.0.0dev