### PR TITLE
BUGFIX: Game crashes when loading new save in edge cases

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -388,13 +388,14 @@ const Engine: {
       // No save found, start new game
       FormatsNeedToChange.emit();
       initBitNodeMultipliers();
-      Engine.start(); // Run main game loop and Scripts loop
       Player.init();
       initForeignServers(Player.getHomeComputer());
       Player.reapplyAllAugmentations();
 
       // Start interactive tutorial
       iTutorialStart();
+
+      Engine.start(); // Run main game loop and Scripts loop
     }
 
     // Expose internal objects/functions in the dev build


### PR DESCRIPTION
How to reproduce:
- Simulate a slow network (Use the built-in network throttling debug tool of browsers or edit `src\ui\LoadingScreen.tsx`: `Promise.all([initSwc(), load(), new Promise((resolve) => setTimeout(resolve, 3000))])`).
- Load the game. If you already have save data, use "Delete Save".

Stack trace:
```
Error: home computer was not a normal server
    at PlayerObject.getHomeComputer (webpack://bitburner/./src/PersonObjects/Player/PlayerObjectServerMethods.ts?:35:9)
    at Object.isSatisfied (webpack://bitburner/./src/Faction/FactionJoinCondition.ts?:361:28)
    at eval (webpack://bitburner/./src/Faction/FactionJoinCondition.ts?:433:36)
    at Array.every (<anonymous>)
    at Object.isSatisfied (webpack://bitburner/./src/Faction/FactionJoinCondition.ts?:433:23)
    at PlayerObject.checkForFactionInvitations (webpack://bitburner/./src/PersonObjects/Player/PlayerObjectGeneralMethods.ts?:458:19)
    at Object.checkCounters (webpack://bitburner/./src/engine.tsx?:182:76)
    at Object.updateGame (webpack://bitburner/./src/engine.tsx?:142:12)
    at Object.start (webpack://bitburner/./src/engine.tsx?:396:14)
    at Object.load (webpack://bitburner/./src/engine.tsx?:352:14)
```

When `src\engine.tsx` is loaded, `Engine._lastUpdate` is initialized immediately [1]. After loading required data (SWC wasm file and save data from IndexedDB), if there is no save data, we start a new save [2]:
https://github.com/bitburner-official/bitburner-src/blob/ae99055d5a703f16d7ffb1bfd8d7489325bd496c/src/engine.tsx#L389-L397
`Engine.start()` is called before we initialize Player data, including the home server. If the time gap between [1] and [2] is large enough, the engine will call `checkForFactionInvitations` and crash.

This PR moved `Engine.start()` to the end of that block of code. There is no reason to start the engine before initializing everything else.

Fixes: #2025.