### PR TITLE
IPVGO: "getCornerMove" coordinates corrected

### DIFF
--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -438,7 +438,7 @@ function getCornerMove(board: Board) {
   if (isCornerAvailableForMove(board, cornerMax, cornerMax, boardEdge, boardEdge)) {
     return board[cornerMax][cornerMax];
   }
-  if (isCornerAvailableForMove(board, 0, cornerMax, cornerMax, boardEdge)) {
+  if (isCornerAvailableForMove(board, 0, cornerMax, 2, boardEdge)) {
     return board[2][cornerMax];
   }
   if (isCornerAvailableForMove(board, 0, 0, 2, 2)) {


### PR DESCRIPTION
The X coordinates for the left corner move should be 0 and 2, to check for X being between 0 and 2; instead, they were from 0 to boardedge (far right edge). Updated so that it now bounds this corner move logic to just that top left corner.