### PR TITLE
IPVGO: Ensure there is always at least one offline node

### DIFF
--- a/src/Go/boardState/offlineNodes.ts
+++ b/src/Go/boardState/offlineNodes.ts
@@ -15,7 +15,7 @@ export function addObstacles(boardState: BoardState) {
   const shouldAddCenterBreak = !shouldRemoveCorner && !shouldRemoveRows && random(0, 3);
   const obstacleTypeCount = +shouldRemoveCorner + +shouldRemoveRows + +shouldAddCenterBreak;
 
-  const edgeDeadCount = random(0, (getScale(boardState.board) + 2 - obstacleTypeCount) * 1.5);
+  const edgeDeadCount = random(1, (getScale(boardState.board) + 2 - obstacleTypeCount) * 1.5);
 
   if (shouldRemoveCorner) {
     boardState.board = addDeadCorners(boardState.board, random);


### PR DESCRIPTION
We want to ensure that the optimal solution to IPvGO is not just "reset until you get a regular square board then use an existing go engine". We want to reward the player for good scripts, not just good network requests. There is an interesting puzzle to solve in modifying the requests to a go engine to support offline nodes/holes/odd board shapes, or re-training an existing AI using offline nodes, or building your own AI or script solution.

To that end, this PR tweaks the minimum number of offline nodes to make sure there is always at least one. In my testing, this only affects one out of every several thousand generated boards.