### PR TITLE
CI: Pin commit id of tj-actions/changed-files

### DIFF
--- a/.github/workflows/title-and-dist-checks.yml
+++ b/.github/workflows/title-and-dist-checks.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Check bundle files
         id: changed-bundle-files
-        uses: tj-actions/changed-files@v44
+        uses: catloversg/tj-actions-changed-files@c65cd883420fd2eb864698a825fc4162dd94482c
         with:
           files: |
             dist/**

--- a/.github/workflows/title-and-dist-checks.yml
+++ b/.github/workflows/title-and-dist-checks.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Check bundle files
         id: changed-bundle-files
-        uses: catloversg/tj-actions-changed-files@c65cd883420fd2eb864698a825fc4162dd94482c
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c
         with:
           files: |
             dist/**


### PR DESCRIPTION
`tj-actions/changed-files` was compromised and taken down, so the `Validate Title and Check for Dist Changes` action failed in recent PRs. We are not in danger now, but we need to find or write an alternative solution soon. Ideally, we should write that kind of logic instead of relying on a third-party action. Our usage is very simple and can be implemented fairly easily. It still takes a while, though. In the meantime, we can switch the compromised action to a fork and pin the commit id to avoid this kind of supply chain attack.

The source code was pulled from https://code.forgejo.org/tj-actions/changed-files. I pushed everything to my fork, except the malicious commit.

Fork: https://github.com/catloversg/tj-actions-changed-files
Test the fork: https://github.com/catloversg/test-tj-actions-changed-files

I pinned it at c65cd883420fd2eb864698a825fc4162dd94482c, which is the last known-good commit of v44. You can verify this claim by checking the log of old action runs. For example: https://github.com/bitburner-official/bitburner-src/actions/runs/13858868484/job/38782020497.