### PR TITLE
BUGFIX: Ensure that IPvGO promises are initialized correctly on a new save and on fluming

### DIFF
--- a/src/Go/Go.ts
+++ b/src/Go/Go.ts
@@ -2,11 +2,10 @@ import type { BoardState, OpponentStats } from "./Types";
 
 import type { GoOpponent } from "@enums";
 import { getRecordKeys, PartialRecord } from "../Types/Record";
-import { handleNextTurn, resetAI } from "./boardAnalysis/goAI";
+import { resetGoPromises } from "./boardAnalysis/goAI";
 import { getNewBoardState } from "./boardState/boardState";
 import { EventEmitter } from "../utils/EventEmitter";
 import { newOpponentStats } from "./Constants";
-import { exceptionAlert } from "../utils/helpers/exceptionAlert";
 
 export class GoObject {
   // Todo: Make previous game a slimmer interface
@@ -21,12 +20,10 @@ export class GoObject {
     }
   }
   prestigeSourceFile() {
-    resetAI();
     this.previousGame = null;
     this.currentGame = getNewBoardState(7);
     this.stats = {};
-    resetAI();
-    handleNextTurn().catch((error) => exceptionAlert(error, true));
+    resetGoPromises();
   }
 
   /**

--- a/src/Go/Go.ts
+++ b/src/Go/Go.ts
@@ -2,10 +2,11 @@ import type { BoardState, OpponentStats } from "./Types";
 
 import type { GoOpponent } from "@enums";
 import { getRecordKeys, PartialRecord } from "../Types/Record";
-import { resetAI } from "./boardAnalysis/goAI";
+import { handleNextTurn, resetAI } from "./boardAnalysis/goAI";
 import { getNewBoardState } from "./boardState/boardState";
 import { EventEmitter } from "../utils/EventEmitter";
 import { newOpponentStats } from "./Constants";
+import { exceptionAlert } from "../utils/helpers/exceptionAlert";
 
 export class GoObject {
   // Todo: Make previous game a slimmer interface
@@ -24,6 +25,8 @@ export class GoObject {
     this.previousGame = null;
     this.currentGame = getNewBoardState(7);
     this.stats = {};
+    resetAI();
+    handleNextTurn().catch((error) => exceptionAlert(error, true));
   }
 
   /**

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -27,7 +27,7 @@ type PlayerPromise = {
   resolver: ((play?: Play) => void) | null;
 };
 
-const gameOver = { type: GoPlayType.gameOver, x: null, y: null } as const;
+const gameOver: Play = { type: GoPlayType.gameOver, x: null, y: null } as const;
 const playerPromises: Record<GoColor.black | GoColor.white, PlayerPromise> = {
   [GoColor.black]: { nextTurn: Promise.resolve(gameOver), resolver: null },
   [GoColor.white]: { nextTurn: Promise.resolve(gameOver), resolver: null },
@@ -51,7 +51,7 @@ export function getNextTurn(color: GoColor.black | GoColor.white): Promise<Play>
  * handling and dispatches common events.
  * @returns the nextTurn promise for the player who just moved
  */
-export function handleNextTurn(boardState: BoardState, useOfflineCycles = true): Promise<Play> {
+export function handleNextTurn(boardState: BoardState = Go.currentGame, useOfflineCycles = true): Promise<Play> {
   const previousColor = boardState.previousPlayer;
   if (previousColor === null) {
     // The game is over. We shouldn't get here in most circumstances,

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -40,6 +40,11 @@ export function getNextTurn(color: GoColor.black | GoColor.white): Promise<Play>
   return playerPromises[color].nextTurn;
 }
 
+export function resetGoPromises(): void {
+  resetAI();
+  handleNextTurn().catch((error) => exceptionAlert(error, true));
+}
+
 /**
  * Does common processing in response to a move being made.
  *

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -10,7 +10,7 @@ import {
   passTurn,
   updateCaptures,
 } from "../boardState/boardState";
-import { getNextTurn, handleNextTurn, resetAI } from "../boardAnalysis/goAI";
+import { getNextTurn, handleNextTurn, resetGoPromises } from "../boardAnalysis/goAI";
 import {
   evaluateIfMoveIsValid,
   getControlledSpace,
@@ -22,7 +22,6 @@ import { endGoGame, getOpponentStats, getScore, resetWinstreak } from "../boardA
 import { WHRNG } from "../../Casino/RNG";
 import { getRecordKeys } from "../../Types/Record";
 import { CalculateEffect, getEffectTypeForFaction } from "./effect";
-import { exceptionAlert } from "../../utils/helpers/exceptionAlert";
 import { newOpponentStats } from "../Constants";
 
 /**
@@ -342,9 +341,8 @@ export function resetBoardState(
     resetWinstreak(oldBoardState.ai, false);
   }
 
-  resetAI();
   Go.currentGame = getNewBoardState(boardSize, opponent, true);
-  handleNextTurn(Go.currentGame).catch((error) => exceptionAlert(error));
+  resetGoPromises();
   logger(`New game started: ${opponent}, ${boardSize}x${boardSize}`);
   return simpleBoardFromBoard(Go.currentGame.board);
 }

--- a/src/Go/ui/GoGameboardWrapper.tsx
+++ b/src/Go/ui/GoGameboardWrapper.tsx
@@ -18,7 +18,7 @@ import { GoScoreModal } from "./GoScoreModal";
 import { GoGameboard } from "./GoGameboard";
 import { GoSubnetSearch } from "./GoSubnetSearch";
 import { CorruptableText } from "../../ui/React/CorruptableText";
-import { handleNextTurn, resetAI } from "../boardAnalysis/goAI";
+import { handleNextTurn, resetGoPromises } from "../boardAnalysis/goAI";
 import { GoScoreExplanation } from "./GoScoreExplanation";
 import { exceptionAlert } from "../../utils/helpers/exceptionAlert";
 
@@ -133,9 +133,8 @@ export function GoGameboardWrapper({ showInstructions }: GoGameboardWrapperProps
       resetWinstreak(boardState.ai, false);
     }
 
-    resetAI();
     Go.currentGame = getNewBoardState(newBoardSize, newOpponent, true);
-    handleNextTurn(Go.currentGame).catch((error) => exceptionAlert(error));
+    resetGoPromises();
   }
 
   function getPriorMove() {

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -47,7 +47,7 @@ import { SaveData } from "./types";
 import { Go } from "./Go/Go";
 import { EventEmitter } from "./utils/EventEmitter";
 import { Companies } from "./Company/Companies";
-import { handleNextTurn, resetAI } from "./Go/boardAnalysis/goAI";
+import { resetGoPromises } from "./Go/boardAnalysis/goAI";
 
 declare global {
   // This property is only available in the dev build
@@ -392,8 +392,7 @@ const Engine: {
       Player.init();
       initForeignServers(Player.getHomeComputer());
       Player.reapplyAllAugmentations();
-      resetAI();
-      handleNextTurn().catch((error) => exceptionAlert(error, true));
+      resetGoPromises();
 
       // Start interactive tutorial
       iTutorialStart();

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -47,6 +47,7 @@ import { SaveData } from "./types";
 import { Go } from "./Go/Go";
 import { EventEmitter } from "./utils/EventEmitter";
 import { Companies } from "./Company/Companies";
+import { handleNextTurn, resetAI } from "./Go/boardAnalysis/goAI";
 
 declare global {
   // This property is only available in the dev build
@@ -391,6 +392,8 @@ const Engine: {
       Player.init();
       initForeignServers(Player.getHomeComputer());
       Player.reapplyAllAugmentations();
+      resetAI();
+      handleNextTurn().catch((error) => exceptionAlert(error, true));
 
       // Start interactive tutorial
       iTutorialStart();


### PR DESCRIPTION
Previously resetAI() and handleNextTurn() (which set up promises in an appropriate state for the first move in IPvGO) were not being called on the very first game of a new save, or after a new bitnode was chosen. This caused certain next move promises to never resolve, even when it was that player's turn.