### PR TITLE
API: syntax errors in NetscriptDefinitions.d.ts

### DIFF
--- a/markdown/bitburner.go.makemove.md
+++ b/markdown/bitburner.go.makemove.md
@@ -14,7 +14,7 @@ playAsWhite is optional, and attempts to make a move as the white player. Only c
 makeMove(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -28,7 +28,7 @@ makeMove(
 |  --- | --- | --- |
 |  x | number |  |
 |  y | number |  |
-|  playAsWhite | (not declared) | _(Optional)_ |
+|  playAsWhite | boolean | _(Optional)_ |
 
 **Returns:**
 

--- a/markdown/bitburner.go.opponentnextturn.md
+++ b/markdown/bitburner.go.opponentnextturn.md
@@ -11,7 +11,7 @@ Returns a promise that resolves with the success or failure state of your last m
 ```typescript
 opponentNextTurn(
     logOpponentMove?: boolean,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -24,7 +24,7 @@ opponentNextTurn(
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  logOpponentMove | boolean | _(Optional)_ optional, defaults to true. if false prevents logging opponent move |
-|  playAsWhite | (not declared) | _(Optional)_ optional. If true, waits to get the next move the black player makes. Intended to be used when playing as white when the opponent is set to "No AI" |
+|  playAsWhite | boolean | _(Optional)_ optional. If true, waits to get the next move the black player makes. Intended to be used when playing as white when the opponent is set to "No AI" |
 
 **Returns:**
 

--- a/markdown/bitburner.go.passturn.md
+++ b/markdown/bitburner.go.passturn.md
@@ -13,7 +13,7 @@ passAsWhite is optional, and attempts to pass while playing as the white player.
 **Signature:**
 
 ```typescript
-passTurn(passAsWhite = false): Promise<{
+passTurn(passAsWhite?: boolean): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
     y: number | null;
@@ -24,7 +24,7 @@ passTurn(passAsWhite = false): Promise<{
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  passAsWhite | (not declared) | _(Optional)_ |
+|  passAsWhite | boolean | _(Optional)_ |
 
 **Returns:**
 

--- a/markdown/bitburner.goanalysis.getvalidmoves.md
+++ b/markdown/bitburner.goanalysis.getvalidmoves.md
@@ -19,7 +19,7 @@ playAsWhite is optional, and gets the current valid moves for the white player. 
 **Signature:**
 
 ```typescript
-getValidMoves(boardState?: string[], priorBoardState?: string[], playAsWhite = false): boolean[][];
+getValidMoves(boardState?: string[], priorBoardState?: string[], playAsWhite?: boolean): boolean[][];
 ```
 
 ## Parameters
@@ -28,7 +28,7 @@ getValidMoves(boardState?: string[], priorBoardState?: string[], playAsWhite = f
 |  --- | --- | --- |
 |  boardState | string\[\] | _(Optional)_ |
 |  priorBoardState | string\[\] | _(Optional)_ |
-|  playAsWhite | (not declared) | _(Optional)_ |
+|  playAsWhite | boolean | _(Optional)_ |
 
 **Returns:**
 

--- a/markdown/bitburner.goanalysis.resetstats.md
+++ b/markdown/bitburner.goanalysis.resetstats.md
@@ -9,14 +9,14 @@ Reset all win/loss and winstreak records for the No AI opponent.
 **Signature:**
 
 ```typescript
-resetStats(resetAll = false): void;
+resetStats(resetAll?: boolean): void;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  resetAll | (not declared) | _(Optional)_ if true, reset win/loss records for all opponents. Leaves node power and bonuses unchanged. |
+|  resetAll | boolean | _(Optional)_ if true, reset win/loss records for all opponents. Leaves node power and bonuses unchanged. |
 
 **Returns:**
 

--- a/markdown/bitburner.gocheat.destroynode.md
+++ b/markdown/bitburner.gocheat.destroynode.md
@@ -16,7 +16,7 @@ Warning: if you fail to play a cheat move, your turn will be skipped. After your
 destroyNode(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -30,7 +30,7 @@ destroyNode(
 |  --- | --- | --- |
 |  x | number | x coordinate of empty node to destroy |
 |  y | number | y coordinate of empty node to destroy |
-|  playAsWhite | (not declared) | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
+|  playAsWhite | boolean | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
 
 **Returns:**
 

--- a/markdown/bitburner.gocheat.getcheatcount.md
+++ b/markdown/bitburner.gocheat.getcheatcount.md
@@ -9,14 +9,14 @@ Returns the number of times you've attempted to cheat in the current game.
 **Signature:**
 
 ```typescript
-getCheatCount(playAsWhite = false): number;
+getCheatCount(playAsWhite?: boolean): number;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  playAsWhite | (not declared) | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
+|  playAsWhite | boolean | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
 
 **Returns:**
 

--- a/markdown/bitburner.gocheat.getcheatsuccesschance.md
+++ b/markdown/bitburner.gocheat.getcheatsuccesschance.md
@@ -11,7 +11,7 @@ Warning: if you fail to play a cheat move, your turn will be skipped. After your
 **Signature:**
 
 ```typescript
-getCheatSuccessChance(cheatCount?: number, playAsWhite = false): number;
+getCheatSuccessChance(cheatCount?: number, playAsWhite?: boolean): number;
 ```
 
 ## Parameters
@@ -19,7 +19,7 @@ getCheatSuccessChance(cheatCount?: number, playAsWhite = false): number;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  cheatCount | number | _(Optional)_ Optional override for the number of cheats already attempted. Defaults to the number of cheats attempted in the current game. |
-|  playAsWhite | (not declared) | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
+|  playAsWhite | boolean | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
 
 **Returns:**
 

--- a/markdown/bitburner.gocheat.playtwomoves.md
+++ b/markdown/bitburner.gocheat.playtwomoves.md
@@ -18,7 +18,7 @@ playTwoMoves(
     y1: number,
     x2: number,
     y2: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -34,7 +34,7 @@ playTwoMoves(
 |  y1 | number | y coordinate of first move to make |
 |  x2 | number | x coordinate of second move to make |
 |  y2 | number | y coordinate of second move to make |
-|  playAsWhite | (not declared) | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
+|  playAsWhite | boolean | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
 
 **Returns:**
 

--- a/markdown/bitburner.gocheat.removerouter.md
+++ b/markdown/bitburner.gocheat.removerouter.md
@@ -16,7 +16,7 @@ Warning: if you fail to play a cheat move, your turn will be skipped. After your
 removeRouter(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -30,7 +30,7 @@ removeRouter(
 |  --- | --- | --- |
 |  x | number | x coordinate of router to remove |
 |  y | number | y coordinate of router to remove |
-|  playAsWhite | (not declared) | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
+|  playAsWhite | boolean | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
 
 **Returns:**
 

--- a/markdown/bitburner.gocheat.repairofflinenode.md
+++ b/markdown/bitburner.gocheat.repairofflinenode.md
@@ -16,7 +16,7 @@ Warning: if you fail to play a cheat move, your turn will be skipped. After your
 repairOfflineNode(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -30,7 +30,7 @@ repairOfflineNode(
 |  --- | --- | --- |
 |  x | number | x coordinate of offline node to repair |
 |  y | number | y coordinate of offline node to repair |
-|  playAsWhite | (not declared) | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
+|  playAsWhite | boolean | _(Optional)_ Optional override for playing as white. Can only be used when playing on a 'No AI' board. |
 
 **Returns:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4390,7 +4390,7 @@ export interface GoAnalysis {
    * RAM cost: 8 GB
    * (This is intentionally expensive; you can derive this info from just getBoardState() )
    */
-  getValidMoves(boardState?: string[], priorBoardState?: string[], playAsWhite = false): boolean[][];
+  getValidMoves(boardState?: string[], priorBoardState?: string[], playAsWhite?: boolean): boolean[][];
 
   /**
    * Returns an ID for each point. All points that share an ID are part of the same network (or "chain"). Empty points
@@ -4494,7 +4494,7 @@ export interface GoAnalysis {
    * Reset all win/loss and winstreak records for the No AI opponent.
    * @param resetAll if true, reset win/loss records for all opponents. Leaves node power and bonuses unchanged.
    */
-  resetStats(resetAll = false): void;
+  resetStats(resetAll?: boolean): void;
 }
 
 /**
@@ -4518,7 +4518,7 @@ export interface GoCheat {
    * RAM cost: 1 GB
    * Requires BitNode 14.2 to use
    */
-  getCheatSuccessChance(cheatCount?: number, playAsWhite = false): number;
+  getCheatSuccessChance(cheatCount?: number, playAsWhite?: boolean): number;
   /**
    * Returns the number of times you've attempted to cheat in the current game.
    * @param playAsWhite - Optional override for playing as white. Can only be used when playing on a 'No AI' board.
@@ -4527,7 +4527,7 @@ export interface GoCheat {
    * RAM cost: 1 GB
    * Requires BitNode 14.2 to use
    */
-  getCheatCount(playAsWhite = false): number;
+  getCheatCount(playAsWhite?: boolean): number;
   /**
    * Attempts to remove an existing router, leaving an empty node behind.
    *
@@ -4550,7 +4550,7 @@ export interface GoCheat {
   removeRouter(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -4583,7 +4583,7 @@ export interface GoCheat {
     y1: number,
     x2: number,
     y2: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -4611,7 +4611,7 @@ export interface GoCheat {
   repairOfflineNode(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -4640,7 +4640,7 @@ export interface GoCheat {
   destroyNode(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -4667,7 +4667,7 @@ export interface Go {
   makeMove(
     x: number,
     y: number,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
@@ -4689,7 +4689,7 @@ export interface Go {
    * RAM cost: 0 GB
    *
    */
-  passTurn(passAsWhite = false): Promise<{
+  passTurn(passAsWhite?: boolean): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;
     y: number | null;
@@ -4709,7 +4709,7 @@ export interface Go {
    */
   opponentNextTurn(
     logOpponentMove?: boolean,
-    playAsWhite = false,
+    playAsWhite?: boolean,
   ): Promise<{
     type: "move" | "pass" | "gameOver";
     x: number | null;


### PR DESCRIPTION
The go API declares function parameters with default values. That's not valid syntax in a declaration file since default values are an implementation detail. I replaced the default values with optional booleans to fix that.

Example
```ts
repairOfflineNode(
    x: number,
    y: number,
    playAsWhite = false,
  ): Promise<{
    type: "move" | "pass" | "gameOver";
    x: number | null;
    y: number | null;
  }>;
  
  //replaced with 
  
  repairOfflineNode(
    x: number,
    y: number,
    playAsWhite?: boolean,
  ): Promise<{
    type: "move" | "pass" | "gameOver";
    x: number | null;
    y: number | null;
  }>;
  ```