### PR TITLE
CHORE: Add mathjax-full and csstype as direct dependencies, since we depend on them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "babel-plugin-transform-barrels": "^1.0.17",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
+        "csstype": "^3.1.3",
         "electron": "^29.4.5",
         "electron-packager": "^17.1.2",
         "eslint": "^8.52.0",
@@ -7724,9 +7725,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/data-urls": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "babel-plugin-transform-barrels": "^1.0.17",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
-        "csstype": "^3.1.3",
+        "csstype": "3.1.2",
         "electron": "^29.4.5",
         "electron-packager": "^17.1.2",
         "eslint": "^8.52.0",
@@ -7725,9 +7725,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/data-urls": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jsdom": "^20.0.3",
         "lodash": "^4.17.21",
+        "mathjax-full": "^3.2.2",
         "monaco-editor": "^0.52.0",
         "monaco-editor-webpack-plugin": "^7.1.0",
         "prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "babel-plugin-transform-barrels": "^1.0.17",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
+    "csstype": "^3.1.3",
     "electron": "^29.4.5",
     "electron-packager": "^17.1.2",
     "eslint": "^8.52.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^20.0.3",
     "lodash": "^4.17.21",
+    "mathjax-full": "^3.2.2",
     "monaco-editor": "^0.52.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "babel-plugin-transform-barrels": "^1.0.17",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
-    "csstype": "^3.1.3",
+    "csstype": "3.1.2",
     "electron": "^29.4.5",
     "electron-packager": "^17.1.2",
     "eslint": "^8.52.0",

--- a/src/ui/MD/components.tsx
+++ b/src/ui/MD/components.tsx
@@ -70,7 +70,7 @@ const fixAlign = (align: React.CSSProperties["textAlign"]): TableCellProps["alig
   if (align === "end") return "inherit";
   if (align === "start") return "inherit";
   if (align === "match-parent") return "inherit";
-  return align as TableCellProps["align"];
+  return align;
 };
 
 export const Td = (props: React.PropsWithChildren<TableDataCellProps>): React.ReactElement => {

--- a/src/ui/MD/components.tsx
+++ b/src/ui/MD/components.tsx
@@ -70,7 +70,7 @@ const fixAlign = (align: React.CSSProperties["textAlign"]): TableCellProps["alig
   if (align === "end") return "inherit";
   if (align === "start") return "inherit";
   if (align === "match-parent") return "inherit";
-  return align;
+  return align as TableCellProps["align"];
 };
 
 export const Td = (props: React.PropsWithChildren<TableDataCellProps>): React.ReactElement => {


### PR DESCRIPTION
Currently the dependency mathjax-full is required in our webpack config, but is not in our package.json. It happens to work as-is because other dependencies require it, 
https://github.com/bitburner-official/bitburner-src/blob/stable/webpack.config.js#L132

similarly src/ui/React/StatsTable.tsx uses csstype but it is only included since some other dependencies use it.

This could cause issues in the future if any of these happen to be swapped out by a dependency, or if a dev needs to build without the lockfile as happened here https://discord.com/channels/415207508303544321/459097632896188436/1351902615247785994