### PR TITLE
BUGFIX: Cannot buy augmentations via UI when money is equal to cost

### DIFF
--- a/src/Augmentation/ui/PurchasableAugmentations.tsx
+++ b/src/Augmentation/ui/PurchasableAugmentations.tsx
@@ -240,7 +240,7 @@ export function PurchasableAugmentation(props: IPurchasableAugProps): React.Reac
         {props.owned || (
           <Box sx={{ display: "grid", alignItems: "center", gridTemplateColumns: "1fr 1fr" }}>
             <Requirement
-              fulfilled={cost === 0 || Player.money > cost}
+              fulfilled={cost === 0 || Player.money >= cost}
               value={formatMoney(cost)}
               color={Settings.theme.money}
               incompleteColor={Settings.theme.error}

--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -80,7 +80,7 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
       const repCost = augCosts.repCost;
       const hasReq = faction.playerReputation >= repCost;
       const hasRep = hasAugmentationPrereqs(aug);
-      const hasCost = augCosts.moneyCost !== 0 && Player.money > augCosts.moneyCost;
+      const hasCost = augCosts.moneyCost !== 0 && Player.money >= augCosts.moneyCost;
       return hasCost && hasReq && hasRep;
     }
     const buy = augs.filter(canBuy).sort((augName1, augName2) => {
@@ -243,7 +243,7 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
           return (
             hasAugmentationPrereqs(aug) &&
             faction.playerReputation >= costs.repCost &&
-            (costs.moneyCost === 0 || Player.money > costs.moneyCost)
+            (costs.moneyCost === 0 || Player.money >= costs.moneyCost)
           );
         }}
         purchaseAugmentation={(aug, showModal) => {

--- a/src/PersonObjects/Sleeve/ui/SleeveAugmentationsModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveAugmentationsModal.tsx
@@ -43,7 +43,7 @@ export function SleeveAugmentationsModal(props: IProps): React.ReactElement {
         augNames={availableAugs.map((aug) => aug.name)}
         ownedAugNames={ownedAugNames}
         canPurchase={(aug) => {
-          return Player.money > aug.baseCost;
+          return Player.money >= aug.baseCost;
         }}
         purchaseAugmentation={(aug) => {
           props.sleeve.tryBuyAugmentation(aug);


### PR DESCRIPTION
We use `Player.money >` instead of `Player.money >=`, so the check fails when the player's money is equal to the cost.

Save file: 
[bug buy augmentation.gz](https://github.com/user-attachments/files/19362872/bug.buy.augmentation.gz)

Before:

![before](https://github.com/user-attachments/assets/498f6e3a-f540-4618-888f-515d42622729)

After:

![after](https://github.com/user-attachments/assets/a7968822-b143-4c71-ac00-d06921801d2d)

Fixes #2038.