### PR TITLE
BUGFIX: Player can manipulate internal state of coding contract

### DIFF
--- a/src/NetscriptFunctions/CodingContract.ts
+++ b/src/NetscriptFunctions/CodingContract.ts
@@ -84,7 +84,7 @@ export function NetscriptCodingContract(): InternalAPI<ICodingContract> {
       // asserting type here is required, since it is not feasible to properly type getData
       return {
         type: contract.type,
-        data: contract.getData(),
+        data: structuredClone(contract.getData()),
         submit: (answer: unknown) => {
           helpers.checkEnvFlags(ctx);
           return attemptContract(ctx, server, contract, answer);


### PR DESCRIPTION
`ns.codingcontract.getContract().data` may be manipulated by the player because we forgot using `structuredClone`.

```js
/** @param {NS} ns */
export async function main(ns) {
  ns.clearLog();
  ns.ui.openTail();
  const filename = ns.codingcontract.createDummyContract("Subarray with Maximum Sum");
  const contractData = ns.codingcontract.getContract(filename);
  ns.print(`before: ${contractData.data}`);
  contractData.data[0] = -1111111111;
  ns.print(`after: ${ns.codingcontract.getContract(filename).data}`);
}
```

Before:

![before](https://github.com/user-attachments/assets/d57642c5-cd8d-4e84-86db-5ac49e53fc43)

After:

![after](https://github.com/user-attachments/assets/f287dcf3-670a-4d9b-b1f5-152a4a7c3801)
