### PR TITLE
UI: Show faction enemies even after joining

### DIFF
--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -154,7 +154,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
                 </Tooltip>
               )}
 
-              {!props.faction.isMember && facInfo.enemies.length > 0 && (
+              {facInfo.enemies.length > 0 && (
                 <Tooltip
                   title={
                     <Typography component="div">
@@ -164,7 +164,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
                           <li key={enemy}>{enemy}</li>
                         ))}
                       </ul>
-                      Joining this Faction will prevent you from joining its enemies
+                      {!props.faction.isMember && <>Joining this Faction will prevent you from joining its enemies</>}
                     </Typography>
                   }
                 >

--- a/src/Faction/ui/Info.tsx
+++ b/src/Faction/ui/Info.tsx
@@ -52,6 +52,12 @@ export function Info(props: IProps): React.ReactElement {
   return (
     <>
       <Typography classes={{ root: classes.noformat }}>{props.factionInfo.infoText}</Typography>
+      {props.factionInfo.enemies.length > 0 && (
+        <Typography component="div">
+          <br />
+          This faction is enemies with: {props.factionInfo.enemies.join(", ")}.
+        </Typography>
+      )}
       <Typography>-------------------------</Typography>
       <Box display="flex">
         <Tooltip


### PR DESCRIPTION
This PR implements the suggested change at #2043.

Closes #2043.

Screenshots:

![1](https://github.com/user-attachments/assets/1fd84144-6c9d-41bf-a250-34a726f65bd1)

![2](https://github.com/user-attachments/assets/202ace6a-8233-4852-b742-d2d040cf94ee)

![3](https://github.com/user-attachments/assets/c8a0d107-e6b3-40e6-b2da-c7d891f8c2e4)
