### PR TITLE
BUGFIX: fix faction enum key of Bachman & Associates

### DIFF
--- a/markdown/bitburner.factionname.md
+++ b/markdown/bitburner.factionname.md
@@ -11,7 +11,7 @@ Warning: Spoiler ahead. This enum contains names of \*\*all\*\* factions. If you
 **Signature:**
 
 ```typescript
-declare enum FactionName 
+declare enum FactionName
 ```
 
 ## Enumeration Members
@@ -19,7 +19,7 @@ declare enum FactionName
 |  Member | Value | Description |
 |  --- | --- | --- |
 |  Aevum | <code>&quot;Aevum&quot;</code> |  |
-|  BachmanAssociates | <code>&quot;Bachman &amp; Associates&quot;</code> |  |
+|  BachmanAndAssociates | <code>&quot;Bachman &amp; Associates&quot;</code> |  |
 |  BitRunners | <code>&quot;BitRunners&quot;</code> |  |
 |  Bladeburners | <code>&quot;Bladeburners&quot;</code> |  |
 |  BladeIndustries | <code>&quot;Blade Industries&quot;</code> |  |
@@ -52,4 +52,3 @@ declare enum FactionName
 |  TheSyndicate | <code>&quot;The Syndicate&quot;</code> |  |
 |  TianDiHui | <code>&quot;Tian Di Hui&quot;</code> |  |
 |  Volhaven | <code>&quot;Volhaven&quot;</code> |  |
-

--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -673,7 +673,7 @@ export const achievements: Record<string, Achievement> = {
 // Steam has a limit of 100 achievement. So these were planned but commented for now.
 // { ID: FactionNames.ECorp.toUpperCase(), Condition: () => Player.factions.includes(FactionNames.ECorp) },
 // { ID: FactionNames.MegaCorp.toUpperCase(), Condition: () => Player.factions.includes(FactionNames.MegaCorp) },
-// { ID: "BACHMAN_&_ASSOCIATES", Condition: () => Player.factions.includes(FactionNames.BachmanAssociates) },
+// { ID: "BACHMAN_&_ASSOCIATES", Condition: () => Player.factions.includes(FactionNames.BachmanAndAssociates) },
 // { ID: "BLADE_INDUSTRIES", Condition: () => Player.factions.includes(FactionNames.BladeIndustries) },
 // { ID: FactionNames.NWO.toUpperCase(), Condition: () => Player.factions.includes(FactionNames.NWO) },
 // { ID: "CLARKE_INCORPORATED", Condition: () => Player.factions.includes(FactionNames.ClarkeIncorporated) },

--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -39,7 +39,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       factions: [
         FactionName.Silhouette,
         FactionName.FourSigma,
-        FactionName.BachmanAssociates,
+        FactionName.BachmanAndAssociates,
         FactionName.ClarkeIncorporated,
       ],
     },
@@ -685,7 +685,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       charisma: 1.6,
       charisma_exp: 1.6,
       factions: [
-        FactionName.BachmanAssociates,
+        FactionName.BachmanAndAssociates,
         FactionName.NWO,
         FactionName.ClarkeIncorporated,
         FactionName.OmniTekIncorporated,
@@ -731,7 +731,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       company_rep: 1.1,
       work_money: 1.2,
       factions: [
-        FactionName.BachmanAssociates,
+        FactionName.BachmanAndAssociates,
         FactionName.ClarkeIncorporated,
         FactionName.FourSigma,
         FactionName.KuaiGongInternational,
@@ -1089,7 +1089,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
         FactionName.Aevum,
         FactionName.Ishima,
         FactionName.Volhaven,
-        FactionName.BachmanAssociates,
+        FactionName.BachmanAndAssociates,
         FactionName.ClarkeIncorporated,
         FactionName.FourSigma,
       ],
@@ -1247,7 +1247,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
         FactionName.Chongqing,
         FactionName.ClarkeIncorporated,
         FactionName.FourSigma,
-        FactionName.BachmanAssociates,
+        FactionName.BachmanAndAssociates,
       ],
     },
     [AugmentationName.NutriGen]: {
@@ -1466,7 +1466,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       charisma_exp: 1.5,
       company_rep: 1.25,
       faction_rep: 1.25,
-      factions: [FactionName.BachmanAssociates],
+      factions: [FactionName.BachmanAndAssociates],
     },
     [AugmentationName.SmartSonar]: {
       repCost: 2.25e4,
@@ -1492,7 +1492,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
         FactionName.FourSigma,
         FactionName.KuaiGongInternational,
         FactionName.ClarkeIncorporated,
-        FactionName.BachmanAssociates,
+        FactionName.BachmanAndAssociates,
       ],
     },
     [AugmentationName.SpeechProcessor]: {

--- a/src/Company/data/CompaniesMetadata.ts
+++ b/src/Company/data/CompaniesMetadata.ts
@@ -41,7 +41,7 @@ export function getCompaniesMetadata(): Record<CompanyName, CompanyCtorParams> {
       expMultiplier: 2.6,
       salaryMultiplier: 2.6,
       jobStatReqOffset: 224,
-      relatedFaction: FactionName.BachmanAssociates,
+      relatedFaction: FactionName.BachmanAndAssociates,
     },
     [CompanyName.BladeIndustries]: {
       name: CompanyName.BladeIndustries,

--- a/src/Faction/Enums.ts
+++ b/src/Faction/Enums.ts
@@ -4,7 +4,7 @@ export enum FactionName {
   TheCovenant = "The Covenant",
   ECorp = "ECorp",
   MegaCorp = "MegaCorp",
-  BachmanAssociates = "Bachman & Associates",
+  BachmanAndAssociates = "Bachman & Associates",
   BladeIndustries = "Blade Industries",
   NWO = "NWO",
   ClarkeIncorporated = "Clarke Incorporated",

--- a/src/Faction/FactionInfo.tsx
+++ b/src/Faction/FactionInfo.tsx
@@ -211,7 +211,7 @@ export const FactionInfos: Record<FactionName, FactionInfo> = {
     keepOnInstall: true,
   }),
 
-  [FactionName.BachmanAssociates]: new FactionInfo({
+  [FactionName.BachmanAndAssociates]: new FactionInfo({
     infoText: (
       <>
         Where Law and Business meet - that's where we are.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4755,12 +4755,12 @@ export interface Go {
    *
    * For example, a 5x5 board might look like this:
    *
-   [<br/>  
-      "XX.O.",<br/>  
-      "X..OO",<br/>  
-      ".XO..",<br/>  
-      "XXO.#",<br/>  
-      ".XO.#",<br/>  
+   [<br/>
+      "XX.O.",<br/>
+      "X..OO",<br/>
+      ".XO..",<br/>
+      "XXO.#",<br/>
+      ".XO.#",<br/>
    ]
    *
    * Each string represents a vertical column on the board, and each character in the string represents a point.
@@ -4781,12 +4781,12 @@ export interface Go {
    *
    * For example, a single 5x5 prior move board might look like this:
    *
-   [<br/>  
-      "XX.O.",<br/>  
-      "X..OO",<br/>  
-      ".XO..",<br/>  
-      "XXO.#",<br/>  
-      ".XO.#",<br/>  
+   [<br/>
+      "XX.O.",<br/>
+      "X..OO",<br/>
+      ".XO..",<br/>
+      "XXO.#",<br/>
+      ".XO.#",<br/>
    ]
    */
   getMoveHistory(): string[][];
@@ -8631,7 +8631,7 @@ declare enum FactionName {
   TheCovenant = "The Covenant",
   ECorp = "ECorp",
   MegaCorp = "MegaCorp",
-  BachmanAssociates = "Bachman & Associates",
+  BachmanAndAssociates = "Bachman & Associates",
   BladeIndustries = "Blade Industries",
   NWO = "NWO",
   ClarkeIncorporated = "Clarke Incorporated",


### PR DESCRIPTION
it's not match `enums.CompanyName` key of `Backman & Associates`

