### PR TITLE
UI: Do not close scripts in editor when their servers do not exist

### DIFF
--- a/src/Script/RamCalculationErrorCodes.ts
+++ b/src/Script/RamCalculationErrorCodes.ts
@@ -2,4 +2,5 @@
 export enum RamCalculationErrorCode {
   SyntaxError = -1,
   ImportError = -2,
+  InvalidServer = -3,
 }

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -45,6 +45,9 @@ export function ScriptEditorContextProvider({ children }: { children: React.Reac
       case RamCalculationErrorCode.ImportError:
         errorType = "Import Error";
         break;
+      case RamCalculationErrorCode.InvalidServer:
+        errorType = "Invalid server";
+        break;
       default:
         errorType = "Unknown Error";
         break;

--- a/src/ScriptEditor/ui/utils.ts
+++ b/src/ScriptEditor/ui/utils.ts
@@ -7,7 +7,9 @@ import { throwIfReachable } from "../../utils/helpers/throwIfReachable";
 function getServerCode(scripts: OpenScript[], index: number): string | null {
   const openScript = scripts[index];
   const server = GetServer(openScript.hostname);
-  if (server === null) throw new Error(`Server '${openScript.hostname}' should not be null, but it is.`);
+  if (server === null) {
+    return null;
+  }
   const data = server.getContentFile(openScript.path)?.content ?? null;
   return data;
 }


### PR DESCRIPTION
At first, let's take a look at a UI bug:
- `nano buy.js sell.js`. Paste code.
- Run them to get 2 log windows.
- Connect p0. Run `nano a.js` to create a.js on p0.
- Don't switch tabs, just run `sell.js` via the log window.
- Type anything on the current tab of a.js.
- The tab is closed. The content of the next tab (buy.js or sell.js) is replaced by the content of a.js.

This bug happens because we auto-close scripts when we detect that their servers do not exist, but the implementation is buggy.

Now let's check #1050 again. After the discussion there and ones on Discord, we have 2 approaches:
- Auto-close scripts on installing. ElJay tried to implement it at #1113.
- Do not auto-close scripts.

The "auto-close" approach has 2 downsides:
- IMO, auto-closing scripts without the player's consent is bad behavior. In real life, if your text editor opens a file on a remote server and the connection drops, does it discard your in-memory file and just close the tab? AFAIK, no text editor behaves like that. I'll be pissed if the editor discards my file content just because of a flaky Internet connection.
- Bugs
  - The bug that I described above.
  - The problem that I pointed out at https://discord.com/channels/415207508303544321/459097632896188436/1339560100842442833.

I created a poll at https://discord.com/channels/415207508303544321/459097632896188436/1339657772207308820. The result favors the "Do not auto-close scripts" approach.

This PR implements that approach.

```js
// buy.js on home
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  Player.money = 1e100;
  if (!ns.getPurchasedServers().includes("p0")) {
    ns.purchaseServer("p0", 8);
  }
  ns.singularity.connect("p0");
}
```

```js
// sell.js on home
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  ns.singularity.connect("home");
  ns.deleteServer("p0");
}
```

Screenshot:

![1](https://github.com/user-attachments/assets/2db66d86-f6db-4fc3-8dc7-c860837e5249)

![2](https://github.com/user-attachments/assets/0736f36e-ea16-483b-bbcd-70a8865c1766)

Closes #1050.
Closes #1113.