### PR TITLE
BUGFIX: fix exploit where favor limit from IPvGO was removed on augmentation

### DIFF
--- a/src/Go/Go.ts
+++ b/src/Go/Go.ts
@@ -5,7 +5,6 @@ import { getRecordKeys, PartialRecord } from "../Types/Record";
 import { resetGoPromises } from "./boardAnalysis/goAI";
 import { getNewBoardState } from "./boardState/boardState";
 import { EventEmitter } from "../utils/EventEmitter";
-import { newOpponentStats } from "./Constants";
 
 export class GoObject {
   // Todo: Make previous game a slimmer interface
@@ -16,7 +15,17 @@ export class GoObject {
 
   prestigeAugmentation() {
     for (const opponent of getRecordKeys(Go.stats)) {
-      Go.stats[opponent] = newOpponentStats();
+      const stats = Go.stats[opponent];
+      if (!stats) {
+        continue;
+      }
+      stats.wins = 0;
+      stats.losses = 0;
+      stats.nodes = 0;
+      stats.nodePower = 0;
+      stats.winStreak = 0;
+      stats.oldWinStreak = 0;
+      stats.highestWinStreak = 0;
     }
   }
   prestigeSourceFile() {

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -22,6 +22,7 @@ import { endGoGame, getOpponentStats, getScore, resetWinstreak } from "../boardA
 import { WHRNG } from "../../Casino/RNG";
 import { getRecordKeys } from "../../Types/Record";
 import { CalculateEffect, getEffectTypeForFaction } from "./effect";
+import { newOpponentStats } from "../Constants";
 
 /**
  * Check the move based on the current settings
@@ -401,7 +402,7 @@ export function resetStats(resetAll = false) {
       };
     }
   } else {
-    Go.prestigeAugmentation();
+    Go.stats[GoOpponent.none] = newOpponentStats();
   }
 }
 

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -22,7 +22,6 @@ import { endGoGame, getOpponentStats, getScore, resetWinstreak } from "../boardA
 import { WHRNG } from "../../Casino/RNG";
 import { getRecordKeys } from "../../Types/Record";
 import { CalculateEffect, getEffectTypeForFaction } from "./effect";
-import { newOpponentStats } from "../Constants";
 
 /**
  * Check the move based on the current settings

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -402,7 +402,7 @@ export function resetStats(resetAll = false) {
       };
     }
   } else {
-    Go.stats[GoOpponent.none] = newOpponentStats();
+    Go.prestigeAugmentation();
   }
 }
 


### PR DESCRIPTION
As a side effect of a recent change that resets the win/loss records of IPvGO on aug install, the favor cap per faction was also being reset (effectively allowing unlimited favor gain from IPvGO). The resetStats() go API method also had this same bug.

This PR changes both to not affect the favor gained status per faction, preventing the exploit for uncapped favor gain.

Resolves #2047 


There is ongoing discussion about further tuning favor gains from IPvGO in the discord, but I wanted to get out a fix for this exploit quickly.
