### PR TITLE
MISC: Clarify effect of Bladeburner augmentation and Stanek's Gift fragment

### DIFF
--- a/src/Augmentation/Augmentation.ts
+++ b/src/Augmentation/Augmentation.ts
@@ -162,7 +162,7 @@ function generateStatsDescription(mults: Multipliers, programs?: string[], start
     desc += `\n+${f(mults.bladeburner_analysis - 1)} Bladeburner Field Analysis effectiveness`;
   }
   if (mults.bladeburner_success_chance !== 1) {
-    desc += `\n+${f(mults.bladeburner_success_chance - 1)} Bladeburner Contracts and Operations success chance`;
+    desc += `\n+${f(mults.bladeburner_success_chance - 1)} Bladeburner action success chance`;
   }
   if (startingMoney) desc += `\nStart with ${startingMoney} after installing Augmentations.`;
   if (programs) desc += `\nStart with ${programs.join(" and ")} after installing Augmentations.`;

--- a/src/Bladeburner/ui/Stats.tsx
+++ b/src/Bladeburner/ui/Stats.tsx
@@ -220,7 +220,7 @@ export function Stats({ bladeburner }: StatsProps): React.ReactElement {
           <br />
           Aug. Stamina Gain mult: {formatNumberNoSuffix(Player.mults.bladeburner_stamina_gain * 100, 1)}%
           <br />
-          Aug. Field Analysis mult: {formatNumberNoSuffix(Player.mults.bladeburner_analysis * 100, 1)}%
+          Aug. Field Analysis effectiveness mult: {formatNumberNoSuffix(Player.mults.bladeburner_analysis * 100, 1)}%
         </Typography>
       </Box>
     </Paper>

--- a/src/CotMG/FragmentType.ts
+++ b/src/CotMG/FragmentType.ts
@@ -74,7 +74,7 @@ export function Effect(tpe: FragmentType): string {
       return "+x% crime money and success chance";
     }
     case FragmentType.Bladeburner: {
-      return "+x% all bladeburner stats";
+      return "+x% bladeburner stats (max stamina, stamina gain, Field Analysis effectiveness, action success chance)";
     }
     case FragmentType.Booster: {
       return "1.1x adjacent fragment power";


### PR DESCRIPTION
Some players asked us:
- What are "bladeburner stats"? https://discord.com/channels/415207508303544321/923445914461413376/1347081526914846842
- Does "Bladeburner Contracts and Operations success chance" include BlackOps? https://discord.com/channels/415207508303544321/923445914461413376/1342510814375968811 and 
https://discord.com/channels/415207508303544321/923445914461413376/1355804937119993856

This PR clarifies the description of Bladeburner augmentation and Stanek's Gift fragment.