### PR TITLE
UI: Add button for exporting save file in recovery screen

### DIFF
--- a/src/ui/React/RecoveryRoot.tsx
+++ b/src/ui/React/RecoveryRoot.tsx
@@ -29,6 +29,19 @@ interface IProps {
   resetError?: () => void;
 }
 
+function exportSaveFile(): void {
+  load()
+    .then((content) => {
+      const epochTime = Math.round(Date.now() / 1000);
+      const extension = isBinaryFormat(content) ? "json.gz" : "json";
+      const filename = `RECOVERY_BITBURNER_${epochTime}.${extension}`;
+      downloadContentAsFile(content, filename);
+    })
+    .catch((err) => {
+      console.error(err);
+    });
+}
+
 export function RecoveryRoot({ softReset, errorData, resetError }: IProps): React.ReactElement {
   function recover(): void {
     if (resetError) resetError();
@@ -46,14 +59,7 @@ export function RecoveryRoot({ softReset, errorData, resetError }: IProps): Reac
   }
 
   useEffect(() => {
-    load()
-      .then((content) => {
-        const epochTime = Math.round(Date.now() / 1000);
-        const extension = isBinaryFormat(content) ? "json.gz" : "json";
-        const filename = `RECOVERY_BITBURNER_${epochTime}.${extension}`;
-        downloadContentAsFile(content, filename);
-      })
-      .catch((err) => console.error(err));
+    exportSaveFile();
   }, []);
 
   let instructions;
@@ -104,6 +110,9 @@ export function RecoveryRoot({ softReset, errorData, resetError }: IProps): Reac
         </Box>
       )}
       {instructions}
+      <br />
+      <Button onClick={exportSaveFile}>Export save file</Button>
+      <br />
       <br />
       <Typography>You can disable the recovery mode, but the game may not work correctly.</Typography>
       <ButtonGroup sx={{ my: 2 }}>


### PR DESCRIPTION
We already automatically export save file when the recovery screen is activated, but the player may accidentally cancel it if they play the Steam version. It's good to have an export button here instead of having to disable the recovery mode and go to the settings page.

![Capture](https://github.com/user-attachments/assets/8bd15b67-a9bb-4aae-9085-2c9d42072a58)
