### PR TITLE
UI: Warn player if they enable territory clash when their gang is too weak

### DIFF
--- a/src/Gang/Gang.ts
+++ b/src/Gang/Gang.ts
@@ -26,6 +26,7 @@ import { Player } from "@player";
 import { PowerMultiplier } from "./data/power";
 import { FactionName } from "@enums";
 import { CONSTANTS } from "../Constants";
+import { Result } from "../types";
 
 export enum RecruitmentResult {
   Success = "Success",
@@ -431,6 +432,41 @@ export class Gang {
       return Infinity;
     }
     return upg.cost / this.getDiscount();
+  }
+
+  isTooWeak(): Result {
+    let canWinAtLeastOneGang = false;
+    for (const gangName of Object.keys(AllGangs)) {
+      if (this.facName === gangName) {
+        continue;
+      }
+      if (getClashWinChance(this.facName, gangName) >= 0.5) {
+        canWinAtLeastOneGang = true;
+        break;
+      }
+    }
+    /**
+     * tooLowGangPower is a special check. Before the first tick of territory clash, the power of all gangs
+     * is 1, so the win chance of the player's gang against all gangs is 50%. If the player tries to enable
+     * the clash in this short time frame, canWinAtLeastOneGang is true, but their gang will still be
+     * crushed after the first clash tick.
+     */
+    const tooLowGangPower = this.getPower() < 2;
+    const needToBeWarned = !canWinAtLeastOneGang || tooLowGangPower;
+    if (needToBeWarned) {
+      let message = "Your gang is too weak.";
+      if (!canWinAtLeastOneGang) {
+        message += " Its win chances against all other gangs are below 50%.";
+      }
+      return {
+        success: true,
+        message,
+      };
+    }
+    return {
+      success: false,
+      message: "",
+    };
   }
 
   /** Serialize the current object to a JSON save state. */

--- a/src/Gang/ui/ManagementSubpage.tsx
+++ b/src/Gang/ui/ManagementSubpage.tsx
@@ -7,11 +7,20 @@ import { Typography } from "@mui/material";
 /** React Component for the subpage that manages gang members, the main page. */
 export function ManagementSubpage(): React.ReactElement {
   const gang = useGang();
+  const checkResult = gang.isTooWeak();
   return (
     <>
       <Typography variant="h4" color="primary">
         {gang.facName} (your Gang)
       </Typography>
+      {gang.territoryWarfareEngaged && checkResult.success && (
+        <Typography variant="h5" color="error">
+          {checkResult.message}
+          <br />
+          You should disable "Engage in Territory Clashes" in the Territory tab and improve your gang power before
+          enabling it again.
+        </Typography>
+      )}
       <Typography>
         <br />
         If a gang member is not earning much money or respect, the task you assigned might be too difficult. Consider

--- a/src/Gang/ui/TerritorySubpage.tsx
+++ b/src/Gang/ui/TerritorySubpage.tsx
@@ -39,36 +39,15 @@ export function TerritorySubpage(): React.ReactElement {
             <Switch
               checked={gang.territoryWarfareEngaged}
               onChange={(event) => {
-                let canWinAtLeastOneGang = false;
-                for (const gangName of Object.keys(AllGangs)) {
-                  if (gang.facName === gangName) {
-                    continue;
-                  }
-                  if (getClashWinChance(gang.facName, gangName) >= 0.5) {
-                    canWinAtLeastOneGang = true;
-                    break;
-                  }
-                }
-                /**
-                 * tooLowGangPower is a special check. Before the first tick of territory clash, the power of all gangs
-                 * is 1, so the win chance of the player's gang against all gangs is 50%. If the player tries to enable
-                 * the clash in this short time frame, canWinAtLeastOneGang is true, but their gang will still be
-                 * crushed after the first clash tick.
-                 */
-                const tooLowGangPower = gang.getPower() < 2;
-                const needToBeWarned = !canWinAtLeastOneGang || tooLowGangPower;
                 /**
                  * Show a confirmation popup if the player tries to enable the territory clash when their gang is too
                  * weak and cannot win any other gangs.
                  */
-                if (event.target.checked && needToBeWarned) {
-                  let message = "Your gang is too weak.";
-                  if (!canWinAtLeastOneGang) {
-                    message += " Its win chances against all other gangs are below 50%.";
-                  }
+                const checkResult = gang.isTooWeak();
+                if (event.target.checked && checkResult.success) {
                   PromptEvent.emit({
                     txt:
-                      message +
+                      checkResult.message +
                       "\nOn average, you will always lose territory when being engaged in clashes.\n\nDo you really want to engage in territory clashes?",
                     resolve: (value: string | boolean) => {
                       if (value === true) {


### PR DESCRIPTION
With #1760 and #2061, we warn the player if they try to enable the territory clash when their gang is too weak. However, if they already did that, there is no warning/reminder that they made a bad choice. I think we should put a big warning on the main tab as another reminder.

With this amount of warnings, if they still lose all territory, well, that's on them.

![Capture](https://github.com/user-attachments/assets/4484ec44-af94-4a61-9220-d2a5fd68f396)
