### PR TITLE
MISC: Remove useless iframe in April Fool's Day popup

### DIFF
--- a/src/ui/Apr1.tsx
+++ b/src/ui/Apr1.tsx
@@ -65,15 +65,6 @@ export function Apr1(): React.ReactElement {
   return (
     <Modal open={open} onClose={() => setOpen(false)}>
       <pre style={{ color: "#0f0" }}>{frames[n]}</pre>
-      <div style={{ display: "none" }}>
-        <iframe
-          width="560"
-          height="315"
-          src="https://www.youtube.com/embed/a3Z7zEc7AXQ?autoplay=1"
-          title="YouTube video player"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        ></iframe>
-      </div>
     </Modal>
   );
 }


### PR DESCRIPTION
A player notified us that the current YouTube URL died. After replacing and testing a new URL, I realize that this "feature" does not work nowadays. We use a hidden autoplay iframe to provide sound for the Rickroll joke, but modern browsers do not allow autoplaying a video unless it's muted. This means this hidden iframe is useless.