### PR TITLE
BIGFIX: IPvGO tutorial was getting stuck if you left the tab and returned

### DIFF
--- a/src/Go/ui/GoTutorialChallenge.tsx
+++ b/src/Go/ui/GoTutorialChallenge.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect, useCallback } from "react";
 import { Typography, Button } from "@mui/material";
 
 import { GoColor, GoValidity, ToastVariant } from "@enums";
@@ -65,12 +65,17 @@ export function GoTutorialChallenge({
     }
   };
 
-  const reset = () => {
+  const reset = useCallback(() => {
     stateRef.current = getStateCopy(state);
     stateRef.current.previousBoards = [];
     setDisplayText(description);
     setShowReset(false);
-  };
+  }, [state, description]);
+
+  // Ensure that the challenge is reset on unmount / mount
+  useEffect(() => {
+    reset();
+  }, [reset]);
 
   return (
     <div>


### PR DESCRIPTION
context:
https://discord.com/channels/415207508303544321/1221920484111814828/1358399812164390932

Previously, if you placed a move on an interactive Go tutorial, left the instructions tab, and returned, the interactive tutorial would appear to reset. However, you could not make any moves or interact with it because the old move was still in the move history, making the tutorial think it needed to wait for the user to hit the reset button to do the puzzle and not just keep playing.

This fix ensures that the component is reset on unmount, to prevent this bug.