### PR TITLE
IPVGO: ensure offline nodes 2: electric boogaloo

### DIFF
--- a/src/Go/boardState/offlineNodes.ts
+++ b/src/Go/boardState/offlineNodes.ts
@@ -33,6 +33,8 @@ export function addObstacles(boardState: BoardState) {
 
   boardState.board = addDeadNodesToEdge(boardState.board, random, edgeDeadCount);
 
+  boardState.board = ensureOfflineNodes(boardState.board);
+
   boardState.board = resetCoordinates(boardState.board);
 }
 
@@ -110,6 +112,14 @@ function addCenterBreak(board: Board, random: rand) {
   board[xIndex] = board[xIndex].map((point, index) => (index < length ? null : point));
 
   return randomizeRotation(board, random);
+}
+
+function ensureOfflineNodes(board: Board) {
+  if (board.flat().some((point) => !point)) {
+    return board;
+  }
+  board[0][0] = null;
+  return board;
 }
 
 function randomizeRotation(board: Board, random: rand) {


### PR DESCRIPTION
The prior fix worked on size seven and above boards, but I did not specifically check 5x5, which still could sometimes not have offline nodes.

This PR ensures that the one in a few thousand boards that otherwise would have no offline nodes has at least one in a corner.