### PR TITLE
BUGFIX: Game crashes when generating CCT in weird case

### DIFF
--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -78,6 +78,9 @@ export function generateRandomContract(): void {
 
   // Choose random server
   const randServer = getRandomServer();
+  if (randServer === null) {
+    return;
+  }
 
   const contractFn = getRandomFilename(randServer, reward);
   const contract = new CodingContract(contractFn, problemType, reward);
@@ -140,6 +143,9 @@ export function generateContract(params: IGenerateContractParams): void {
     }
   } else {
     server = getRandomServer();
+  }
+  if (server === null) {
+    return;
   }
 
   const filename = params.fn ? params.fn : getRandomFilename(server, reward);
@@ -218,8 +224,11 @@ function getRandomReward(): ICodingContractReward {
   }
 }
 
-function getRandomServer(): BaseServer {
+function getRandomServer(): BaseServer | null {
   const servers = GetAllServers().filter((server: BaseServer) => server.serversOnNetwork.length !== 0);
+  if (servers.length === 0) {
+    return null;
+  }
   let randIndex = getRandomIntInclusive(0, servers.length - 1);
   let randServer = servers[randIndex];
 


### PR DESCRIPTION
In #2074, a player reported a weird crash with this stack trace:
```
Error: Min is greater than max. Min: 0. Max: -1.
    at a (webpack:///src/utils/helpers/getRandomIntInclusive.ts:18:10)
    at M (webpack:///src/CodingContract/ContractGenerator.ts:223:40)
    at getRandomServer (webpack:///src/CodingContract/ContractGenerator.ts:80:21)
    at generateRandomContract (webpack:///src/CodingContract/ContractGenerator.ts:67:4)
    at timeOffline (webpack:///src/engine.tsx:277:34)
```
I don't get how `GetAllServers().filter((server: BaseServer) => server.serversOnNetwork.length !== 0)` can be an empty array. We need more information to find out why it happens. In the meantime, this PR adds a new check to make sure the game does not crash in this part.

Fixes #2074.