### PR TITLE
DOCS: Fixed linking between markdown docs

### DIFF
--- a/src/Documentation/doc/advanced/intelligence.md
+++ b/src/Documentation/doc/advanced/intelligence.md
@@ -13,5 +13,5 @@ Intelligence will boost your production for many actions in the game, including:
 - [Infiltration](../basic/infiltration.md)
 - [Crime](../basic/crimes.md) success rate
 - [Bladeburner](bladeburners.md) actions
-- [Reputation](../basic/reputation.md) gain for [Companies](../basic//companies.md) & [Factions](../basic/factions.md)
+- [Reputation](../basic/reputation.md) gain for [Companies](../basic/companies.md) & [Factions](../basic/factions.md)
 - [Augmentation](../basic/augmentations.md) [Grafting](grafting.md) speed

--- a/src/Documentation/doc/basic/scripts.md
+++ b/src/Documentation/doc/basic/scripts.md
@@ -10,7 +10,7 @@ Scripts you write in Bitburner are real, working JavaScript and can be used to a
 
 Running any script requires in-game [RAM](ram.md), with a minimum cost of 1.6 GB per script.
 More complex scripts and API functions generally require more [RAM](ram.md), which you will gain in many ways.
-Scripts can be run on any [server](server.md) you have root access to, but not all servers you find will have useable RAM.
+Scripts can be run on any [server](servers.md) you have root access to, but not all servers you find will have useable RAM.
 
 ## How Scripts work offline
 


### PR DESCRIPTION
1. _**intelligence.md**_ did not properly link to _**companies.md**_.
2. _**scripts.md**_ did not properly link to _**servers.md**_.

*Append:
changelog-v0.md has a link at line 2092 to a no longer existing file. It can be removed, unless it should be kept for posterity.