### PR TITLE
MISC: Enforce stricter param check on ns.getBitNodeMultipliers and ns.hacknet.spendHashes

### DIFF
--- a/markdown/bitburner.hacknet.spendhashes.md
+++ b/markdown/bitburner.hacknet.spendhashes.md
@@ -18,7 +18,7 @@ spendHashes(upgName: string, upgTarget?: string, count?: number): boolean;
 |  --- | --- | --- |
 |  upgName | string | Name of the upgrade of Hacknet Node. |
 |  upgTarget | string | _(Optional)_ Object to which upgrade applies. Required for certain upgrades. |
-|  count | number | _(Optional)_ Number of upgrades to buy at once. Must be a positive integer. Defaults to 1 if not specified. For compatibility reasons, upgTarget must be specified, even if it is not used, in order to specify count. |
+|  count | number | _(Optional)_ Number of upgrades to buy at once. Must be a non-negative integer. Defaults to 1 if not specified. For compatibility reasons, upgTarget must be specified, even if it is not used, in order to specify count. |
 
 **Returns:**
 

--- a/markdown/bitburner.hacknet.spendhashes.md
+++ b/markdown/bitburner.hacknet.spendhashes.md
@@ -18,7 +18,7 @@ spendHashes(upgName: string, upgTarget?: string, count?: number): boolean;
 |  --- | --- | --- |
 |  upgName | string | Name of the upgrade of Hacknet Node. |
 |  upgTarget | string | _(Optional)_ Object to which upgrade applies. Required for certain upgrades. |
-|  count | number | _(Optional)_ Number of upgrades to buy at once. Defaults to 1 if not specified. For compatibility reasons, upgTarget must be specified, even if it is not used, in order to specify count. |
+|  count | number | _(Optional)_ Number of upgrades to buy at once. Must be a positive integer. Defaults to 1 if not specified. For compatibility reasons, upgTarget must be specified, even if it is not used, in order to specify count. |
 
 **Returns:**
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -322,7 +322,7 @@ export const ns: InternalAPI<NSFull> = {
     (_host, _multiplier, _cores = 1) => {
       const host = helpers.string(ctx, "hostname", _host);
       const mult = helpers.number(ctx, "multiplier", _multiplier);
-      const cores = helpers.number(ctx, "cores", _cores);
+      const cores = helpers.positiveInteger(ctx, "cores", _cores);
 
       // Check argument validity
       const server = helpers.getServer(ctx, host);
@@ -331,12 +331,8 @@ export const ns: InternalAPI<NSFull> = {
         helpers.log(ctx, () => `${host} is not a hackable server. Returning 0.`);
         return 0;
       }
-      if (mult < 1 || !isFinite(mult)) {
+      if (!Number.isFinite(mult) || mult < 1) {
         throw helpers.errorMessage(ctx, `Invalid argument: multiplier must be finite and >= 1, is ${mult}.`);
-      }
-      // TODO 2.3: Add assertion function for positive integer, there are a lot of places everywhere that can use this
-      if (!Number.isInteger(cores) || cores < 1) {
-        throw helpers.errorMessage(ctx, `Cores should be a positive integer. Cores provided: ${cores}`);
       }
 
       return numCycleForGrowth(server, mult, cores);
@@ -973,14 +969,10 @@ export const ns: InternalAPI<NSFull> = {
       if (!canAccessBitNodeFeature(5)) {
         throw helpers.errorMessage(ctx, "Requires Source-File 5 to run.");
       }
-      // TODO v3.0: check n and lvl with helpers.number() and Number.isInteger().
-      const n = Math.round(helpers.number(ctx, "n", _n));
-      const lvl = Math.round(helpers.number(ctx, "lvl", _lvl));
+      const n = helpers.positiveInteger(ctx, "n", _n);
+      const lvl = helpers.positiveInteger(ctx, "lvl", _lvl);
       if (!validBitNodes.includes(n)) {
         throw new Error(`Invalid BitNode: ${n}.`);
-      }
-      if (lvl < 1) {
-        throw new Error("SF level must be greater than or equal to 1.");
       }
 
       return Object.assign({}, getBitNodeMultipliers(n, lvl));

--- a/src/NetscriptFunctions/Hacknet.ts
+++ b/src/NetscriptFunctions/Hacknet.ts
@@ -201,7 +201,10 @@ export function NetscriptHacknet(): InternalAPI<IHacknet> {
       (_upgName, _upgTarget = "", _count = 1) => {
         const upgName = helpers.string(ctx, "upgName", _upgName);
         const upgTarget = helpers.string(ctx, "upgTarget", _upgTarget);
-        const count = helpers.positiveInteger(ctx, "count", _count);
+        const count = helpers.integer(ctx, "count", _count);
+        if (count < 0) {
+          throw helpers.errorMessage(ctx, "Count must be a non-negative integer.");
+        }
         if (!hasHacknetServers()) {
           return false;
         }

--- a/src/NetscriptFunctions/Hacknet.ts
+++ b/src/NetscriptFunctions/Hacknet.ts
@@ -201,11 +201,7 @@ export function NetscriptHacknet(): InternalAPI<IHacknet> {
       (_upgName, _upgTarget = "", _count = 1) => {
         const upgName = helpers.string(ctx, "upgName", _upgName);
         const upgTarget = helpers.string(ctx, "upgTarget", _upgTarget);
-        const count = Math.floor(helpers.number(ctx, "count", _count));
-        // TODO (3.0.0): use helpers.positiveInteger
-        if (!(count >= 0)) {
-          throw helpers.errorMessage(ctx, "count may not be negative");
-        }
+        const count = helpers.positiveInteger(ctx, "count", _count);
         if (!hasHacknetServers()) {
           return false;
         }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3099,7 +3099,7 @@ export interface Hacknet {
    * ```
    * @param upgName - Name of the upgrade of Hacknet Node.
    * @param upgTarget - Object to which upgrade applies. Required for certain upgrades.
-   * @param count - Number of upgrades to buy at once. Defaults to 1 if not specified.
+   * @param count - Number of upgrades to buy at once. Must be a positive integer. Defaults to 1 if not specified.
    * For compatibility reasons, upgTarget must be specified, even if it is not used, in order to specify count.
    * @returns True if the upgrade is successfully purchased, and false otherwise.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3099,7 +3099,7 @@ export interface Hacknet {
    * ```
    * @param upgName - Name of the upgrade of Hacknet Node.
    * @param upgTarget - Object to which upgrade applies. Required for certain upgrades.
-   * @param count - Number of upgrades to buy at once. Must be a positive integer. Defaults to 1 if not specified.
+   * @param count - Number of upgrades to buy at once. Must be a non-negative integer. Defaults to 1 if not specified.
    * For compatibility reasons, upgTarget must be specified, even if it is not used, in order to specify count.
    * @returns True if the upgrade is successfully purchased, and false otherwise.
    */


### PR DESCRIPTION
This PR makes changes in 3 APIs:
- `ns.getBitNodeMultipliers`: Minor behavior change.
- `ns.hacknet.spendHashes`: <https://github.com/bitburner-official/bitburner-src/pull/1127#issuecomment-1966690212>
- `ns.growthAnalyze`: No behavior change.