### PR TITLE
DOCUMENTATION: Add getContractTypes to Coding Contracts documentation page

### DIFF
--- a/src/Documentation/doc/basic/codingcontracts.md
+++ b/src/Documentation/doc/basic/codingcontracts.md
@@ -29,7 +29,7 @@ For example, some contracts have long solutions while others have even longer so
 You might want to use the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) to automate the process of submitting your solution rather than copy and paste a long solution into an answer box.
 
 However, using the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) comes at a cost.
-Like most functions in other APIs, almost all of the functions in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) have a RAM cost. 
+Like most functions in other APIs, almost all of the functions in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) have a RAM cost.
 
 Depending on which function you use, the initial [RAM](ram.md) on your home server might not be enough to allow you to use various [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) functions.
 Plan on upgrading the [RAM](ram.md) on your home server if you want to use the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).

--- a/src/Documentation/doc/basic/codingcontracts.md
+++ b/src/Documentation/doc/basic/codingcontracts.md
@@ -29,9 +29,12 @@ For example, some contracts have long solutions while others have even longer so
 You might want to use the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) to automate the process of submitting your solution rather than copy and paste a long solution into an answer box.
 
 However, using the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) comes at a cost.
-Like most functions in other APIs, each function in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) has a RAM cost.
+Like most functions in other APIs, almost all of the functions in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) have a RAM cost. 
+
 Depending on which function you use, the initial [RAM](ram.md) on your home server might not be enough to allow you to use various [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) functions.
 Plan on upgrading the [RAM](ram.md) on your home server if you want to use the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).
+
+The [`getContractTypes`](https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.codingcontract.getcontracttypes.md) function is free, and returns a list of all of the contract types currently in the game.
 
 ## Submitting Solutions
 


### PR DESCRIPTION
closes #2034 

The change adds reference/link to the in-game function `ns.codingcontract.getContractTypes()`.

This is used instead of adding a table similarly to the one in the readthedocs page for two reasons:
 - Duplicating the return data from `getContractTypes` requires updating this documentation page for any new contracts added, removed or reworked.
 - Most namespaces have "information" functions that are free; encouraging further exploration of the `codingcontract` namespace and use of available in-game functions for information should familiarise the player with similar structures used for other game mechanics.

If the full table is preferred I'll come back and update this PR.