### PR TITLE
BUGFIX: Hacknet's RAM upgrade button is off-by-one

### DIFF
--- a/src/Hacknet/HacknetHelpers.tsx
+++ b/src/Hacknet/HacknetHelpers.tsx
@@ -103,7 +103,7 @@ export function getMaxNumberLevelUpgrades(nodeObj: HacknetNode | HacknetServer, 
   let min = 1;
   let max = maxLevel - 1;
   const levelsToMax = maxLevel - nodeObj.level;
-  if (Player.money > nodeObj.calculateLevelUpgradeCost(levelsToMax, Player.mults.hacknet_node_level_cost)) {
+  if (Player.money >= nodeObj.calculateLevelUpgradeCost(levelsToMax, Player.mults.hacknet_node_level_cost)) {
     return levelsToMax;
   }
 
@@ -142,13 +142,13 @@ export function getMaxNumberRamUpgrades(nodeObj: HacknetNode | HacknetServer, ma
   } else {
     levelsToMax = Math.round(Math.log2(maxLevel / nodeObj.ram));
   }
-  if (Player.money > nodeObj.calculateRamUpgradeCost(levelsToMax, Player.mults.hacknet_node_ram_cost)) {
+  if (Player.money >= nodeObj.calculateRamUpgradeCost(levelsToMax, Player.mults.hacknet_node_ram_cost)) {
     return levelsToMax;
   }
 
   //We'll just loop until we find the max
   for (let i = levelsToMax - 1; i >= 0; --i) {
-    if (Player.money > nodeObj.calculateRamUpgradeCost(i, Player.mults.hacknet_node_ram_cost)) {
+    if (Player.money >= nodeObj.calculateRamUpgradeCost(i, Player.mults.hacknet_node_ram_cost)) {
       return i;
     }
   }
@@ -168,7 +168,7 @@ export function getMaxNumberCoreUpgrades(nodeObj: HacknetNode | HacknetServer, m
   let min = 1;
   let max = maxLevel - 1;
   const levelsToMax = maxLevel - nodeObj.cores;
-  if (Player.money > nodeObj.calculateCoreUpgradeCost(levelsToMax, Player.mults.hacknet_node_core_cost)) {
+  if (Player.money >= nodeObj.calculateCoreUpgradeCost(levelsToMax, Player.mults.hacknet_node_core_cost)) {
     return levelsToMax;
   }
 


### PR DESCRIPTION
How to reproduce this bug:
- Load the attached save file.
- Run `run a.js`.
- Open Hacknet tab. Choose "MAX". Check the RAM upgrade button.

This bug is mitigated with "Level" and "Cores" upgrade buttons because they use a binary search after the wrong check.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  Player.hashManager.hashes = 0;
  Player.money = ns.hacknet.getRamUpgradeCost(0, 10);
}
```

Test save file: 
[bug hacknet.gz](https://github.com/user-attachments/files/19808278/bug.hacknet.gz)

Before:
![before](https://github.com/user-attachments/assets/806dd84e-a5db-4eac-8d76-0bac741d0526)

After:
![after](https://github.com/user-attachments/assets/a4a5c189-312c-426a-bb28-0716124e0549)
