### PR TITLE
IPVGO: do not count go favor as part of the favor gained from reputation, to avoid punishing players for getting go favor at the 'wrong time'

### DIFF
--- a/src/Faction/Faction.ts
+++ b/src/Faction/Faction.ts
@@ -76,7 +76,7 @@ export class Faction {
 
   prestigeAugmentation(): void {
     // Gain favor
-    this.setFavor(calculateFavorAfterResetting(this.favor, this.playerReputation, this.name)); // TODO: update this
+    this.setFavor(calculateFavorAfterResetting(this.favor, this.playerReputation, this.name));
     // Reset reputation and flags
     this.playerReputation = 0;
     this.alreadyInvited = false;

--- a/src/Faction/Faction.ts
+++ b/src/Faction/Faction.ts
@@ -76,7 +76,7 @@ export class Faction {
 
   prestigeAugmentation(): void {
     // Gain favor
-    this.setFavor(calculateFavorAfterResetting(this.favor, this.playerReputation));
+    this.setFavor(calculateFavorAfterResetting(this.favor, this.playerReputation, this.name)); // TODO: update this
     // Reset reputation and flags
     this.playerReputation = 0;
     this.alreadyInvited = false;

--- a/src/Faction/formulas/favor.ts
+++ b/src/Faction/formulas/favor.ts
@@ -3,15 +3,17 @@
 // for information on how to calculate this
 
 import { clampNumber } from "../../utils/helpers/clampNumber";
+import { getGoFavorForFaction } from "../../Go/effects/effect";
 
 export const MaxFavor = 35331;
 // This is the nearest representable value of log(1.02), which is the base of our power.
 // It is *not* the same as Math.log(1.02), since "1.02" lacks sufficient precision.
 const log1point02 = 0.019802627296179712;
 
-export function favorToRep(f: number): number {
+export function favorToRep(f: number, factionName = ""): number {
+  const favorFromRep = f - getGoFavorForFaction(factionName);
   // expm1 is e^x - 1, which is more accurate for small x than doing it the obvious way.
-  return clampNumber(25000 * Math.expm1(log1point02 * f), 0);
+  return clampNumber(25000 * Math.expm1(log1point02 * favorFromRep), 0);
 }
 
 export function repToFavor(r: number): number {
@@ -19,6 +21,7 @@ export function repToFavor(r: number): number {
   return clampNumber(Math.log1p(r / 25000) / log1point02, 0, MaxFavor);
 }
 
-export function calculateFavorAfterResetting(favor: number, playerReputation: number) {
-  return repToFavor(favorToRep(favor) + playerReputation);
+export function calculateFavorAfterResetting(favor: number, playerReputation: number, factionName = "") {
+  const favorFromGo = getGoFavorForFaction(factionName);
+  return repToFavor(favorToRep(favor, factionName) + playerReputation) + favorFromGo;
 }

--- a/src/Faction/formulas/favor.ts
+++ b/src/Faction/formulas/favor.ts
@@ -3,7 +3,7 @@
 // for information on how to calculate this
 
 import { clampNumber } from "../../utils/helpers/clampNumber";
-import { getGoFavorForFaction } from "../../Go/effects/effect";
+import { getGoFavorForFaction } from "../../Go/effects/favor";
 
 export const MaxFavor = 35331;
 // This is the nearest representable value of log(1.02), which is the base of our power.

--- a/src/Faction/ui/Info.tsx
+++ b/src/Faction/ui/Info.tsx
@@ -75,7 +75,13 @@ export function Info(props: IProps): React.ReactElement {
             <>
               <Typography>
                 You will have{" "}
-                <Favor favor={calculateFavorAfterResetting(props.faction.favor, props.faction.playerReputation)} />{" "}
+                <Favor
+                  favor={calculateFavorAfterResetting(
+                    props.faction.favor,
+                    props.faction.playerReputation,
+                    props.faction.name,
+                  )}
+                />{" "}
                 faction favor after installing an Augmentation.
               </Typography>
               <MathJax>{"\\(\\huge{r = \\text{total faction reputation}}\\)"}</MathJax>

--- a/src/Go/Go.ts
+++ b/src/Go/Go.ts
@@ -1,9 +1,7 @@
 import type { BoardState, OpponentStats } from "./Types";
 
-import type { GoOpponent } from "@enums";
-import { getRecordKeys, PartialRecord } from "../Types/Record";
-import { resetGoPromises } from "./boardAnalysis/goAI";
-import { getNewBoardState } from "./boardState/boardState";
+import { GoColor, GoOpponent } from "@enums";
+import { PartialRecord } from "../Types/Record";
 import { EventEmitter } from "../utils/EventEmitter";
 
 export const getEmptyHighlightedPoints = (size: number = 7) => {
@@ -11,33 +9,10 @@ export const getEmptyHighlightedPoints = (size: number = 7) => {
 };
 
 export class GoObject {
-  // Todo: Make previous game a slimmer interface
   previousGame: BoardState | null = null;
-  currentGame: BoardState = getNewBoardState(7);
+  currentGame: BoardState = getEmptyBoardState();
   stats: PartialRecord<GoOpponent, OpponentStats> = {};
   storedCycles: number = 0;
-
-  prestigeAugmentation() {
-    for (const opponent of getRecordKeys(Go.stats)) {
-      const stats = Go.stats[opponent];
-      if (!stats) {
-        continue;
-      }
-      stats.wins = 0;
-      stats.losses = 0;
-      stats.nodes = 0;
-      stats.nodePower = 0;
-      stats.winStreak = 0;
-      stats.oldWinStreak = 0;
-      stats.highestWinStreak = 0;
-    }
-  }
-  prestigeSourceFile() {
-    this.previousGame = null;
-    this.currentGame = getNewBoardState(7);
-    this.stats = {};
-    resetGoPromises();
-  }
 
   /**
    * Stores offline time that is consumed to speed up the AI.
@@ -48,6 +23,28 @@ export class GoObject {
       this.storedCycles += offlineCycles ?? 0;
     }
   }
+}
+
+function getEmptyBoardState() {
+  return {
+    previousBoards: [],
+    previousPlayer: GoColor.white,
+    ai: GoOpponent.Netburners,
+    passCount: 0,
+    cheatCount: 0,
+    cheatCountForWhite: 0,
+    komiOverride: null,
+    highlightedPoints: Array.from({ length: 7 }, () => Array.from({ length: 7 }, () => null)),
+    board: Array.from({ length: 7 }, (_, x) =>
+      Array.from({ length: 7 }, (_, y) => ({
+        color: GoColor.empty,
+        chain: "",
+        liberties: null,
+        x,
+        y,
+      })),
+    ),
+  };
 }
 
 export const Go = new GoObject();

--- a/src/Go/effects/effect.ts
+++ b/src/Go/effects/effect.ts
@@ -8,7 +8,6 @@ import { defaultMultipliers, mergeMultipliers, Multipliers } from "../../PersonO
 import { formatPercent } from "../../ui/formatNumber";
 import { getOpponentStats } from "../boardAnalysis/scoring";
 import { getRecordEntries, getRecordValues } from "../../Types/Record";
-import { getEnumHelper } from "../../utils/EnumHelper";
 
 /**
  * Calculates the effect size of the given player boost, based on the node power (points based on number of subnet
@@ -131,13 +130,4 @@ export function getWinstreakMultiplier(winStreak: number, previousWinStreak: num
 export function getDifficultyMultiplier(komi: number, boardSize: number) {
   const isTinyBoardVsIlluminati = boardSize === 5 && komi === opponentDetails[GoOpponent.Illuminati].komi;
   return isTinyBoardVsIlluminati ? 8 : (komi + 0.5) * 0.25;
-}
-
-export function getGoFavorForFaction(factionName: string) {
-  const faction = getEnumHelper("FactionName").getMember(factionName);
-  if (!faction) {
-    return 0;
-  }
-  const factionDetails = getOpponentStats(faction as unknown as GoOpponent);
-  return factionDetails?.favor ?? 0;
 }

--- a/src/Go/effects/effect.ts
+++ b/src/Go/effects/effect.ts
@@ -8,6 +8,7 @@ import { defaultMultipliers, mergeMultipliers, Multipliers } from "../../PersonO
 import { formatPercent } from "../../ui/formatNumber";
 import { getOpponentStats } from "../boardAnalysis/scoring";
 import { getRecordEntries, getRecordValues } from "../../Types/Record";
+import { getEnumHelper } from "../../utils/EnumHelper";
 
 /**
  * Calculates the effect size of the given player boost, based on the node power (points based on number of subnet
@@ -107,7 +108,7 @@ export function playerHasDiscoveredGo() {
 }
 
 function getEffectPowerForFaction(opponent: GoOpponent) {
-  return opponentDetails[opponent].bonusPower;
+  return opponentDetails[opponent]?.bonusPower ?? 0;
 }
 
 export function getEffectTypeForFaction(opponent: GoOpponent) {
@@ -130,4 +131,13 @@ export function getWinstreakMultiplier(winStreak: number, previousWinStreak: num
 export function getDifficultyMultiplier(komi: number, boardSize: number) {
   const isTinyBoardVsIlluminati = boardSize === 5 && komi === opponentDetails[GoOpponent.Illuminati].komi;
   return isTinyBoardVsIlluminati ? 8 : (komi + 0.5) * 0.25;
+}
+
+export function getGoFavorForFaction(factionName: string) {
+  const faction = getEnumHelper("FactionName").getMember(factionName);
+  if (!faction) {
+    return 0;
+  }
+  const factionDetails = getOpponentStats(faction as unknown as GoOpponent);
+  return factionDetails?.favor ?? 0;
 }

--- a/src/Go/effects/favor.ts
+++ b/src/Go/effects/favor.ts
@@ -1,0 +1,12 @@
+import { GoOpponent } from "@enums";
+import { Go } from "../Go";
+import { newOpponentStats } from "../Constants";
+
+export function getGoFavorForFaction(factionName: string) {
+  const factionDetails = getOpponentStats(factionName as unknown as GoOpponent);
+  return factionDetails?.favor ?? 0;
+}
+
+export function getOpponentStats(opponent: GoOpponent) {
+  return Go.stats[opponent] ?? (Go.stats[opponent] = newOpponentStats());
+}

--- a/src/Go/effects/prestige.ts
+++ b/src/Go/effects/prestige.ts
@@ -1,0 +1,27 @@
+import { getRecordKeys } from "../../Types/Record";
+import { getNewBoardState } from "../boardState/boardState";
+import { resetGoPromises } from "../boardAnalysis/goAI";
+import { Go } from "../Go";
+
+export function prestigeGoAugmentation() {
+  for (const opponent of getRecordKeys(Go.stats)) {
+    const stats = Go.stats[opponent];
+    if (!stats) {
+      continue;
+    }
+    stats.wins = 0;
+    stats.losses = 0;
+    stats.nodes = 0;
+    stats.nodePower = 0;
+    stats.winStreak = 0;
+    stats.oldWinStreak = 0;
+    stats.highestWinStreak = 0;
+  }
+}
+
+export function prestigeGoSourceFile() {
+  Go.previousGame = null;
+  Go.currentGame = getNewBoardState(7);
+  Go.stats = {};
+  resetGoPromises();
+}

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -924,7 +924,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       helpers.checkSingularityAccess(ctx);
       const facName = getEnumHelper("FactionName").nsGetMember(ctx, _facName);
       const faction = Factions[facName];
-      return calculateFavorAfterResetting(faction.favor, faction.playerReputation) - faction.favor;
+      return calculateFavorAfterResetting(faction.favor, faction.playerReputation, facName) - faction.favor;
     },
     donateToFaction: (ctx) => (_facName, _amt) => {
       helpers.checkSingularityAccess(ctx);

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -25,11 +25,11 @@ import { InvitationsSeen } from "./Faction/ui/FactionsRoot";
 import { CONSTANTS } from "./Constants";
 import { LogBoxClearEvents } from "./ui/React/LogBoxManager";
 import { initCircadianModulator } from "./Augmentation/Augmentations";
-import { Go } from "./Go/Go";
 import { calculateExp } from "./PersonObjects/formulas/skill";
 import { currentNodeMults } from "./BitNode/BitNodeMultipliers";
 import { canAccessBitNodeFeature } from "./BitNode/BitNodeUtils";
 import { pendingUIShareJobIds } from "./NetworkShare/Share";
+import { prestigeGoAugmentation, prestigeGoSourceFile } from "./Go/effects/prestige";
 
 const BitNode8StartingMoney = 250e6;
 function delayedDialog(message: string, canBeDismissedEasily = true) {
@@ -66,7 +66,7 @@ export function prestigeAugmentation(): void {
   }
 
   Player.prestigeAugmentation();
-  Go.prestigeAugmentation();
+  prestigeGoAugmentation();
 
   const homeComp = Player.getHomeComputer();
   // Delete all servers except home computer
@@ -198,7 +198,7 @@ export function prestigeSourceFile(isFlume: boolean): void {
   initBitNodeMultipliers();
 
   Player.prestigeSourceFile();
-  Go.prestigeSourceFile();
+  prestigeGoSourceFile();
 
   const homeComp = Player.getHomeComputer();
 

--- a/src/ui/React/CompanyDropdown.tsx
+++ b/src/ui/React/CompanyDropdown.tsx
@@ -1,6 +1,6 @@
 import type { CompanyName } from "../../Enums";
 
-import React from "react";
+import React, { useMemo } from "react";
 
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
@@ -15,9 +15,8 @@ interface IProps {
   value: CompanyName;
 }
 
-const sortedCompanies = getRecordKeys(Companies).sort((a, b) => a.localeCompare(b));
-
 export function CompanyDropdown(props: IProps): React.ReactElement {
+  const sortedCompanies = useMemo(() => getRecordKeys(Companies ?? {}).sort((a, b) => a.localeCompare(b)), []);
   const companies = [];
   for (const company of sortedCompanies) {
     companies.push(


### PR DESCRIPTION
Currently, all favor is assumed to come from reputation grinding, and it takes much more rep to gain each favor when you already have 100 compared to having 0 favor. Thus, it ended up being pretty punishing in terms of rep needed to hit 150 favor if a player got their favor gains from IPvGO early in that process (even including the boosts that favor gives to rep gain!) A number of players have requested this be changed to avoid a "noob trap" feelsbad scenario.

player request 1: 
https://discord.com/channels/415207508303544321/923445914461413376/1361035760643473509

player request 2:
https://discord.com/channels/415207508303544321/459097632896188436/1353769464839016542

This PR also has some refactoring to split out some parts of Go's code. 

Previously there was an issue where the Company class needed to use the rep & favor gain tools, which needed to look at the Go tools to account for Go favor. One of the Go imports looked at at Factions to be able to add favor. Factions imports the router from game root for some reason, which then imports a bunch of react components. One of which is the hashnet UI, which needs companies to populate a dropdown, thus going in a circle. 

The changes here split out the parts of Go that need to see Factions from the other parts, to break this chain.