### PR TITLE
BUGFIX: Mitigate crash in Terminal page in edge cases

### DIFF
--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -9,6 +9,7 @@ import { Player } from "@player";
 import { getTabCompletionPossibilities } from "../getTabCompletionPossibilities";
 import { Settings } from "../../Settings/Settings";
 import { longestCommonStart } from "../../utils/StringHelperFunctions";
+import { exceptionAlert } from "../../utils/helpers/exceptionAlert";
 
 const useStyles = makeStyles()((theme: Theme) => ({
   input: {
@@ -62,6 +63,23 @@ export function TerminalInput(): React.ReactElement {
   }, [postUpdateValue]);
 
   function saveValue(newValue: string, postUpdate?: () => void): void {
+    /**
+     * There are reports of a crash caused by "value" (the React state) being undefined. It means that a caller of this
+     * function passes undefined to the first parameter. Currently, we don't know which caller does that, so we put this
+     * safety check here to mitigate the crash and gather more debug information.
+     */
+    if (newValue == null) {
+      exceptionAlert(
+        new Error(
+          `saveValue was called with invalid value.\n` +
+            `command: ${command}\nterminalInput.current.value: ${terminalInput.current?.value}\nvalue: ${value}\n` +
+            `possibilities: ${possibilities}\nsearchResults: ${searchResults}\nsearchResultsIndex: ${searchResultsIndex}\n` +
+            `Terminal.commandHistory: ${Terminal.commandHistory}\nTerminal.commandHistoryIndex: ${Terminal.commandHistoryIndex}`,
+        ),
+        true,
+      );
+      return;
+    }
     command = newValue;
     setValue(newValue);
 


### PR DESCRIPTION
There are reports of a crash caused by "value" (the React state) being undefined. The stack trace:
```
TypeError: Cannot read properties of undefined (reading 'length')
    at length (webpack:///src/Terminal/ui/TerminalInput.tsx:454:67)
    at c (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:157:136)
    at Ch (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:180:153)
    at li (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:269:342)
    at ck (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:250:346)
    at bk (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:250:277)
    at ak (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:250:137)
    at Tj (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:243:162)
    at c (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:123:114)
    at b (webpack:///node_modules/scheduler/cjs/scheduler.production.min.js:18:342)
```

It means that a caller of `saveValue` passes undefined to the first parameter. Currently, we don't know which caller does that, so this PR adds a safety check to mitigate the crash and gather more debug information.

Example of the exception alert:

![Capture](https://github.com/user-attachments/assets/bb169197-0d17-4f68-91db-0817d14d8a12)

Ref #1482.
Ref #2096.