### PR TITLE
MISC: Add "--tail" to default autocomplete options

### DIFF
--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -273,7 +273,13 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
       //fail silently if the script fails to compile (e.g. syntax error)
       return;
     }
-    if (!loadedModule || !loadedModule.autocomplete) return; // Doesn't have an autocomplete function.
+    if (!loadedModule) {
+      return;
+    }
+    // Return "--tail" if the player does not define the autocomplete function.
+    if (!loadedModule.autocomplete) {
+      return ["--tail"];
+    }
 
     const runArgs = { "--tail": Boolean, "-t": Number, "--ram-override": Number };
     let flags = {


### PR DESCRIPTION
Opening the tail log is a common action. Many players usually use the "--tail" option or call `ns.ui.openTail()` at the start of the main function. This PR adds the "--tail" option to default autocomplete options.

https://github.com/user-attachments/assets/430d5a67-cebc-42ce-b8f8-1d040d629d59

