### PR TITLE
BUGFIX: Electron app cannot sync new save file to Steam Cloud

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -128,7 +128,7 @@ function setStopProcessHandler(window) {
       if (playtime > minimumPlaytime) {
         saveToCloud(save);
       } else {
-        log.debug(`Auto-save to cloud disabled for save game under ${minimumPlaytime}ms (${playtime}ms)`);
+        log.info(`Auto-save to cloud disabled for save game under ${minimumPlaytime}ms (${playtime}ms)`);
       }
     }
   };

--- a/electron/storage.js
+++ b/electron/storage.js
@@ -119,6 +119,23 @@ function isCloudEnabled() {
 }
 
 function saveCloudFile(name, content) {
+  /**
+   * Bitburner's Steam Cloud allows only 1 file, so if the player has a save file stored in Steam Cloud, they cannot
+   * save another file. For example, let's say they start playing with SaveID s123. After a few months, they want to
+   * start another run with a clean save file; the new SaveId is s456. In this case, the new s456.json.gz cannot be
+   * saved to Steam Cloud because s123.json.gz exists. In this case, we need to delete the current cloud file before
+   * writing the new file.
+   */
+  const files = steamworksClient.cloud.listFiles();
+  if (files.length !== 0) {
+    const currentCloudFile = getFilenameOfFirstCloudFile();
+    if (currentCloudFile !== name) {
+      log.info(
+        `Found a different cloud file. The current file will be deleted. Current file: ${currentCloudFile}. New file: ${name}.`,
+      );
+      deleteCloudFile();
+    }
+  }
   steamworksClient.cloud.writeFile(name, content);
 }
 
@@ -189,7 +206,7 @@ async function pushSaveDataToSteamCloud(saveData, currentPlayerId) {
   const content = Buffer.from(saveData).toString("base64");
   log.debug(`saveData: ${saveData.length} bytes`);
   log.debug(`Base64 string of saveData: ${content.length} bytes`);
-  log.debug(`Saving to Steam Cloud as ${steamSaveName}`);
+  log.info(`Saving to Steam Cloud as ${steamSaveName}`);
 
   try {
     saveCloudFile(steamSaveName, content);


### PR DESCRIPTION
Some players reported that Steam Cloud did not sync their save file, especially after they imported another save file or create a new one by using "Delete Save". Please check my comment in `saveCloudFile` for more information.

There is another way to fix this problem, but it's fairly complicated. At first, we need to ask hydroflame to set the max number of files to a higher value. After that, we need to refactor the way we manage the Steam Cloud files and save slots. IMO, we don't have a useful save slot system, so this change does not bring much benefit.

How to test:
- Open the Electron app.
- Options -> Delete Save.
- Wait at least 15 minutes or use dev menu to add play time.
- Save game and quit app.
- Check:
  - Log
  - https://store.steampowered.com/account/remotestorageapp/?appid=1812820
  - path\bitburner\saves\_backups

Sample log:
```
[2025-04-21 xx:xx:59.046] [info]  Started app: ["path\\.build\\bitburner-win32-x64\\bitburner.exe"]
[2025-04-21 xx:xx:59.161] [info]  Application is ready!
[2025-04-21 xx:xx:09.236] [warn]  'path\bitburner\saves\a64d9f2b7b6c9' not found, creating it...
[2025-04-21 xx:xx:20.621] [info]  Saving to Steam Cloud as a64d9f2b7b6c9.json.gz
[2025-04-21 xx:xx:20.622] [info]  Found a different cloud file. The current file will be deleted. Current file: da3a9406f047b.json.gz. New file: a64d9f2b7b6c9.json.gz.
[2025-04-21 xx:xx:22.262] [info]  Quitting the app...
```
