### PR TITLE
MISC: Tweak "The Covenant" faction's rumor condition

### DIFF
--- a/src/Faction/FactionInfo.tsx
+++ b/src/Faction/FactionInfo.tsx
@@ -162,7 +162,12 @@ export const FactionInfos: Record<FactionName, FactionInfo> = {
       </>
     ),
     inviteReqs: [haveAugmentations(20), haveMoney(75e9), haveSkill("hacking", 850), haveCombatSkills(850)],
-    rumorReqs: [haveSourceFile(10)],
+    rumorReqs: [
+      someCondition([
+        inBitNode(10),
+        everyCondition([haveAugmentations(10), haveMoney(35e9), haveSkill("hacking", 425), haveCombatSkills(425)]),
+      ]),
+    ],
     offerHackingWork: true,
     offerFieldWork: true,
   }),

--- a/src/Faction/FactionJoinCondition.ts
+++ b/src/Faction/FactionJoinCondition.ts
@@ -121,11 +121,11 @@ export const haveAugmentations = (n: number): PlayerCondition => ({
     return { type: "numAugmentations", numAugmentations: n };
   },
   isSatisfied(p: PlayerObject): boolean {
-    if (n == 0) {
+    if (n === 0) {
       const augs = [...p.augmentations, ...p.queuedAugmentations].filter(
         (a) => a.name !== AugmentationName.NeuroFluxGovernor,
       );
-      return augs.length == 0;
+      return augs.length === 0;
     }
     return p.augmentations.length >= n;
   },
@@ -201,7 +201,7 @@ export const locatedInCity = (city: CityName): PlayerCondition => ({
     return { type: "city", city: city };
   },
   isSatisfied(p: PlayerObject): boolean {
-    return p.city == city;
+    return p.city === city;
   },
 });
 
@@ -284,7 +284,7 @@ export const inBitNode = (n: number): PlayerCondition => ({
     return { type: "bitNodeN", bitNodeN: n };
   },
   isSatisfied(p: PlayerObject): boolean {
-    return p.bitNodeN == n;
+    return p.bitNodeN === n;
   },
 });
 
@@ -302,7 +302,7 @@ export const haveSourceFile = (n: number): PlayerCondition => ({
     };
   },
   isSatisfied(p: PlayerObject): boolean {
-    return p.bitNodeN == n || p.activeSourceFileLvl(n) > 0;
+    return p.bitNodeN === n || p.activeSourceFileLvl(n) > 0;
   },
 });
 
@@ -370,7 +370,7 @@ export const someCondition = (conditions: PlayerCondition[]): CompoundPlayerCond
   },
   *[Symbol.iterator](): IterableIterator<PlayerCondition> {
     for (const cond of conditions) {
-      if ("type" in cond && cond.type == "someCondition") {
+      if ("type" in cond && cond.type === "someCondition") {
         // automatically flatten nested OR lists
         yield* cond as CompoundPlayerCondition;
       } else {
@@ -396,7 +396,7 @@ export const everyCondition = (conditions: PlayerCondition[]): CompoundPlayerCon
   },
   *[Symbol.iterator](): IterableIterator<PlayerCondition> {
     for (const cond of conditions) {
-      if ("type" in cond && cond.type == "everyCondition") {
+      if ("type" in cond && cond.type === "everyCondition") {
         // automatically flatten nested AND lists
         yield* cond as CompoundPlayerCondition;
       } else {


### PR DESCRIPTION
A player reported that they always received the rumor of this faction after they entered BN10, even after they went to other BNs. It happens because they have SF10 after completing BN10, and we use `haveSourceFile(10)` condition. This PR changes the condition to:
```js
[
  someCondition([
    inBitNode(10),
    everyCondition([haveAugmentations(10), haveMoney(35e9), haveSkill("hacking", 425), haveCombatSkills(425)]),
  ]),
]
```
In BN10, the player gets the rumor immediately. In other BNs, they get the rumor when they satisfy half of the invitation requirements.

At the start of BN1:

![bn1](https://github.com/user-attachments/assets/93d015d8-fef6-487f-9d25-1a154b88f795)

When they satisfy the condition:

![bn1-with-rumor](https://github.com/user-attachments/assets/861b7db8-d8b4-4cf4-a358-8ae2cddbf943)

At the start of BN10:

![bn10](https://github.com/user-attachments/assets/123237c5-8d02-4004-979a-33a773bc0585)
