### PR TITLE
CODEBASE: Remove wrong and irrelevant comments/code

### DIFF
--- a/src/Casino/CoinFlip.tsx
+++ b/src/Casino/CoinFlip.tsx
@@ -1,8 +1,3 @@
-/**
- * React Subcomponent for displaying a location's UI, when that location is a gym
- *
- * This subcomponent renders all of the buttons for training at the gym
- */
 import React, { useState } from "react";
 
 import { BadRNG } from "./RNG";

--- a/src/DevMenu/ui/EntropyDev.tsx
+++ b/src/DevMenu/ui/EntropyDev.tsx
@@ -9,8 +9,6 @@ import Typography from "@mui/material/Typography";
 import { Player } from "@player";
 import { Adjuster } from "./Adjuster";
 
-// TODO: Update as additional BitNodes get implemented
-
 export function EntropyDev(): React.ReactElement {
   return (
     <Accordion TransitionProps={{ unmountOnExit: true }}>

--- a/src/Locations/ui/CasinoLocation.tsx
+++ b/src/Locations/ui/CasinoLocation.tsx
@@ -1,8 +1,3 @@
-/**
- * React Subcomponent for displaying a location's UI, when that location is a gym
- *
- * This subcomponent renders all of the buttons for training at the gym
- */
 import React, { useState } from "react";
 import Button from "@mui/material/Button";
 import { Blackjack, DECK_COUNT } from "../../Casino/Blackjack";

--- a/src/Terminal/commands/common/editor.ts
+++ b/src/Terminal/commands/common/editor.ts
@@ -8,8 +8,6 @@ import { getGlobbedFileMap } from "../../../Paths/GlobbedFiles";
 import { sendDeprecationNotice } from "./deprecation";
 import { getFileType, getFileTypeFeature } from "../../../utils/ScriptTransformer";
 
-// 2.3: Globbing implementation was removed from this file. Globbing will be reintroduced as broader functionality and integrated here.
-
 interface EditorParameters {
   args: (string | number | boolean)[];
   server: BaseServer;

--- a/src/ui/Components/Requirement.tsx
+++ b/src/ui/Components/Requirement.tsx
@@ -3,8 +3,6 @@ import { Typography } from "@mui/material";
 import React from "react";
 import { Settings } from "../../Settings/Settings";
 
-Settings.theme.primary;
-
 export interface IReqProps {
   value: string;
   color?: string;


### PR DESCRIPTION
This PR removes:
- Wrong copy-paste comments: `React Subcomponent for displaying ...`
- Irrelevant comment in `src\DevMenu\ui\EntropyDev.tsx`
- The comment about globbing in `src\Terminal\commands\common\editor.ts`. I'm not sure what this comment means. It was added in #479. It looks like the globbing feature was rewritten to be simpler, not removed.
- Unused code in `src\ui\Components\Requirement.tsx`