### PR TITLE
BUGFIX: Electron app does not run on Linux due to incompatible glibc version and wrong usage of net.fetch

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -28,7 +28,7 @@ const debounce = require("lodash/debounce");
 const Store = require("electron-store");
 const store = new Store();
 const path = require("path");
-const { realpathSync } = require("fs");
+const { realpathSync, readFileSync } = require("fs");
 const { fileURLToPath } = require("url");
 
 log.transports.file.level = store.get("file-log-level", "info");
@@ -188,8 +188,8 @@ app.on("ready", async () => {
     let relativePath;
     /**
      * "realpathSync" will throw an error if "filePath" points to a non-existent file. If an error is thrown here, the
-     * electron app will crash immediately. We can use fs.existsSync to check "filePath" before using it, but it's best
-     * to try-catch the entire code block and avoid unexpected issues.
+     * Electron app will not write any error logs, and the request will fail silently. We can use fs.existsSync to check
+     * "filePath" before using it, but it's best to try-catch the entire code block.
      */
     try {
       filePath = fileURLToPath(url);
@@ -197,13 +197,7 @@ app.on("ready", async () => {
       relativePath = path.relative(__dirname, realPath);
       // Only allow access to files in "dist" folder or html files in the same directory
       if (method === "GET" && (relativePath.startsWith("dist") || relativePath.match(/^[a-zA-Z-_]*\.html/))) {
-        /**
-         * By default, requests made by net.fetch go through custom protocol handlers, so we have to explicitly tell it
-         * to bypass those handles; otherwise, it creates an infinite loop.
-         *
-         * Ref: https://github.com/electron/electron/issues/39402
-         */
-        return net.fetch(realPath, { bypassCustomProtocolHandlers: true });
+        return new Response(readFileSync(realPath));
       }
     } catch (error) {
       log.error(error);

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -8,16 +8,16 @@
       "name": "bitburner",
       "version": "3.0.0",
       "dependencies": {
-        "@catloversg/steamworks.js": "0.0.1",
+        "@catloversg/steamworks.js": "0.0.2",
         "electron-log": "^4.4.8",
         "electron-store": "^8.1.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@catloversg/steamworks.js": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@catloversg/steamworks.js/-/steamworks.js-0.0.1.tgz",
-      "integrity": "sha512-Kj3JZUVqYuLsF34g/N/Ap/aWsJHJoWKbvn/R19fzlZTJY+XMv5myRcngUuydwzvJzHR+BhVk7FzQVV8D8w5x1Q==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@catloversg/steamworks.js/-/steamworks.js-0.0.2.tgz",
+      "integrity": "sha512-EPB7vQFZa0zGw+Ft4SHiHIDZ7UcuM/XUiyzPo5a9Pf+g5XmcvjIEjo8wKwk7Ox0DOjmSJ+s8GmOD/TDDQW5jgg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/electron/package.json
+++ b/electron/package.json
@@ -24,7 +24,7 @@
     "buildResources": "public"
   },
   "dependencies": {
-    "@catloversg/steamworks.js": "0.0.1",
+    "@catloversg/steamworks.js": "0.0.2",
     "electron-log": "^4.4.8",
     "electron-store": "^8.1.0",
     "lodash": "^4.17.21"


### PR DESCRIPTION
This PR fixes 2 regression bugs.

In https://github.com/ceifa/steamworks.js/pull/182, the maintainer of `steamworks.js` informed me that running CI actions on Ubuntu 24.04 may cause problems with glibc version. For more information, please check that PR. I ported the fix to my custom build at https://github.com/catloversg/steamworks.js.

The usage of `net.fetch` in #2100 is wrong. It works on Windows, but not on Linux. `realPath` is the absolute path, and `net.fetch` cannot fetch it on Linux. This is the error log when I run it in a Linux VM (Debian 12):
```
[2025-04-28 20:44:31.892] [error] Unhandled Exception UnhandledRejection TypeError: Failed to parse URL from /home/debian/Downloads/bitburner-linux-x64/resources/app/index.html
    at new Request (node:internal/deps/undici/undici:9580:19)
    at fetchWithSession (node:electron/js2c/browser_init:2:47422)
    at c.fetch (node:electron/js2c/browser_init:2:58416)
    at Object.fetch (node:electron/js2c/browser_init:2:49730)
    at /home/debian/Downloads/bitburner-linux-x64/resources/app/main.js:200:13
    at AsyncFunction.<anonymous> (node:electron/js2c/browser_init:2:53125)
```
In order to use `net.fetch`, we need to convert the path to URL with `url.format`. For example: `return net.fetch(url.format({pathname:realPath, protocol: "file"}), { bypassCustomProtocolHandlers: true });`. Using `net.fetch` is too troublesome at this point. That API is not really a problem, but its documentation of special usages is sparse. The need of `bypassCustomProtocolHandlers` is only mentioned in an issue, and I don't see this issue with absolute path mentioned anywhere, so I decided to use `readFileSync` directly.

I tested these changes on Windows 10, Debian 11, and Debian 12.

Closes #380.