### PR TITLE
BUGFIX: Passive faction reputation gain applies Player.mults.faction_rep twice

### DIFF
--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -132,16 +132,27 @@ export function purchaseAugmentation(faction: Faction, augmentation: Augmentatio
 }
 
 export function processPassiveFactionRepGain(numCycles: number): void {
-  if (Player.bitNodeN === 2) return;
+  // Passive gain is disabled in BN2.
+  if (Player.bitNodeN === 2) {
+    return;
+  }
   for (const name of getRecordKeys(Factions)) {
-    if (isFactionWork(Player.currentWork) && name === Player.currentWork.factionName) continue;
+    if (isFactionWork(Player.currentWork) && name === Player.currentWork.factionName) {
+      continue;
+    }
     const faction = Factions[name];
-    if (!faction.isMember) continue;
-    // No passive rep for special factions
+    if (!faction.isMember) {
+      continue;
+    }
+    // No passive rep for special factions.
     const info = faction.getInfo();
-    if (!info.offersWork()) continue;
+    if (info.special) {
+      continue;
+    }
     // No passive rep for gangs.
-    if (Player.getGangName() === name) continue;
+    if (Player.getGangName() === name) {
+      continue;
+    }
     // 0 favor = 1%/s
     // 50 favor = 6%/s
     // 100 favor = 11%/s
@@ -152,7 +163,11 @@ export function processPassiveFactionRepGain(numCycles: number): void {
     const fRep = getFactionFieldWorkRepGain(Player, faction.favor);
     const rate = Math.max(hRep * favorMult, sRep * favorMult, fRep * favorMult, 1 / 120);
 
-    faction.playerReputation += rate * numCycles * Player.mults.faction_rep * currentNodeMults.FactionPassiveRepGain;
+    /**
+     * Do not apply Player.mults.faction_rep here. That multiplier was applied in getHackingWorkRepGain and similar
+     * functions.
+     */
+    faction.playerReputation += rate * numCycles * currentNodeMults.FactionPassiveRepGain;
   }
 }
 

--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -132,8 +132,8 @@ export function purchaseAugmentation(faction: Faction, augmentation: Augmentatio
 }
 
 export function processPassiveFactionRepGain(numCycles: number): void {
-  // Passive gain is disabled in BN2.
-  if (Player.bitNodeN === 2) {
+  // Passive gain is disabled in some BitNodes (e.g., BN2).
+  if (currentNodeMults.FactionPassiveRepGain === 0) {
     return;
   }
   for (const name of getRecordKeys(Factions)) {

--- a/src/Faction/ui/Info.tsx
+++ b/src/Faction/ui/Info.tsx
@@ -46,7 +46,7 @@ function DefaultAssignment(): React.ReactElement {
       Perform work/carry out assignments for your faction to help further its cause! By doing so, you will earn
       reputation for your faction. You will also gain reputation passively over time, although at a very slow
       rate.&nbsp;
-      {knowAboutBitverse() && <>Note that the passive reputation gain is disabled in BitNode 2. </>}
+      {knowAboutBitverse() && <>Note that the passive reputation gain is disabled in some BitNodes. </>}
       Earning reputation will allow you to purchase augmentations through this faction, which are powerful upgrades that
       enhance your abilities.
     </Typography>


### PR DESCRIPTION
When calculating passive faction rep, `Player.mults.faction_rep` is applied twice (`getHackingWorkRepGain` and `processPassiveFactionRepGain`). This PR makes sure that we only apply that mult once. This change was discussed on Discord, but we did not make any decision. As hydroflame said, we should either "fix" it or add comments to point out that this is intentional. I decided to "fix" it. Technically, this is a nerf to passive rep, but it should not affect the normal gameplay.

Tested in BN1.1:
- No augmentations:
  - Hacking level 60: 0.041666666666666664 -> 0.041708333333333326
  - Hacking level 550: 0.041666666666666664 -> 0.041708333333333326 (It does not change because `hRep * favorMult` is smaller than `1 / 120`).
  - Hacking level 2500: 0.12833333333333333 -> 0.12846166666666664
- Rep augmentations (PCMatrix, ADR-V1, ADR-V2, The Shadow's Simulacrum, SmartJaw, S.N.A):
  - Hacking level 60: 0.041666666666666664 -> 0.09808449119218748
  - Hacking level 550: 0.06639565557624999 -> 0.15629721826963694
  - Hacking level 2500: 0.3017984344375 -> 0.7104419012256226
- Rep augmentations + 100 NFG:
  - Hacking level 60: 0.041666666666666664 -> 0.26534731091940716
  - Hacking level 550: 0.17961971816082947 -> 1.1438786208498697
  - Hacking level 2500: 0.816453264367407 -> 5.199448276590319
- Rep augmentations + 200 NFG + Hacking level 2500:
  - Passive: 2.2087454964390827 -> 38.05274201071145
  - Active (Daedalus): ~220
- Rep augmentations + 300 NFG + Hacking level 2500:
  - Passive: 5.975304259233831 -> 278.4932357252601
  - Active (Daedalus): ~600
- Rep augmentations + 400 NFG + Hacking level 2500:
  - Passive: 16.164950216301527 -> 2038.1838008649524
  - Active (Daedalus): ~1600

As you can see, passive gain only surpasses active gain when `Player.mults.faction_rep` becomes unusually high. It usually only happens with a massive amount of NFG (corp money, deep BN12, etc.).

Note: `!info.offersWork()` is changed to `info.special`. Checking the `special` flag is the intended way to check if a faction is "special". It does not change the behavior because all 3 special factions do not offer work.