### PR TITLE
UI: Realign and update text in achievement icons

### DIFF
--- a/assets/Steam/achievements/icons/$1Q.svg
+++ b/assets/Steam/achievements/icons/$1Q.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:23.0096px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.308159"
-       x="11.70841"
-       y="40.642994"
+       style="font-weight:bold;font-size:29.9861px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.308159"
+       x="33.551872"
+       y="43.962086"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.308159"
-         x="11.70841"
-         y="40.642994">$1Q</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.9861px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.308159"
+         x="33.551872"
+         y="43.962086">$1Q</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/$1Q.svg
+++ b/assets/Steam/achievements/icons/$1Q.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="$1Q.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:23.0096px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.308159"
-       x="8.2434549"
-       y="38.355984"
+       x="11.70841"
+       y="40.642994"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.308159"
-         x="8.2434549"
-         y="38.355984">$1Q</tspan></text>
+         x="11.70841"
+         y="40.642994">$1Q</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/-1b.svg
+++ b/assets/Steam/achievements/icons/-1b.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="-1b.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:23.4183px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.313633"
-       x="3.2184403"
-       y="41.740555"
+       x="9.6755438"
+       y="42.086491"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.313633"
-         x="3.2184403"
-         y="41.740555">-$1b</tspan></text>
+         x="9.6755438"
+         y="42.086491">-$1b</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/-1b.svg
+++ b/assets/Steam/achievements/icons/-1b.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:23.4183px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.313633"
-       x="9.6755438"
-       y="42.086491"
+       style="font-weight:bold;font-size:28.2222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.313633"
+       x="33.618622"
+       y="43.368233"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.313633"
-         x="9.6755438"
-         y="42.086491">-$1b</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:28.2222px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.313633"
+         x="33.618622"
+         y="43.368233">-$1b</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/1H.svg
+++ b/assets/Steam/achievements/icons/1H.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.918098"
-       y="37.947285"
+       style="font-weight:bold;font-size:38.8056px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="33.819298"
+       y="47.812428"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.918098"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.819298"
+         y="47.812428"
          id="tspan17808">1H</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/1H.svg
+++ b/assets/Steam/achievements/icons/1H.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="1H.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="34.034172"
-       y="37.49543"
+       x="33.918098"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="34.034172"
-         y="37.49543"
+         x="33.918098"
+         y="37.947285"
          id="tspan17808">1H</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/2DAYS.svg
+++ b/assets/Steam/achievements/icons/2DAYS.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.86095"
-       y="37.947285"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="34.056576"
+       y="39.544613"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.86095"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="34.056576"
+         y="39.544613"
          id="tspan17808">2 DAYS</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/2DAYS.svg
+++ b/assets/Steam/achievements/icons/2DAYS.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="2DAYS.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="34.034172"
-       y="37.49543"
+       x="33.86095"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="34.034172"
-         y="37.49543"
+         x="33.86095"
+         y="37.947285"
          id="tspan17808">2 DAYS</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/4S.svg
+++ b/assets/Steam/achievements/icons/4S.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.061558"
-       y="39.218739"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="34.454056"
+       y="47.746109"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.061558"
-         y="39.218739"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="34.454056"
+         y="47.746109"
          id="tspan16668">4S</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/4S.svg
+++ b/assets/Steam/achievements/icons/4S.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="4S.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="37.743938"
+       x="34.061558"
+       y="39.218739"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="37.743938"
+         x="34.061558"
+         y="39.218739"
          id="tspan16668">4S</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BLADE.svg
+++ b/assets/Steam/achievements/icons/BLADE.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BLADE.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.589317"
+       y="39.241226"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.589317"
+         y="39.241226"
          id="tspan16415">BLADE</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BLADE.svg
+++ b/assets/Steam/achievements/icons/BLADE.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.589317"
-       y="39.241226"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.68063"
+       y="39.548489"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.589317"
-         y="39.241226"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="39.548489"
          id="tspan16415">BLADE</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BLADE100K.svg
+++ b/assets/Steam/achievements/icons/BLADE100K.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BLADE100K.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.566833"
+       y="29.796392"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.566833"
+         y="29.796392"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.40966"
-         y="49.888741"
+         x="33.566833"
+         y="48.536144"
          id="tspan16668">100000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BLADE100K.svg
+++ b/assets/Steam/achievements/icons/BLADE100K.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.566833"
-       y="29.796392"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.68063"
+       y="29.457327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.566833"
-         y="29.796392"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="29.457327"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.566833"
-         y="48.536144"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="49.445869"
          id="tspan16668">100000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BLADEOVERCLOCK.svg
+++ b/assets/Steam/achievements/icons/BLADEOVERCLOCK.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BLADEOVERCLOCK.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.589317"
+       y="29.796392"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.589317"
+         y="29.796392"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.589317"
+         y="48.536144"
          id="tspan16668">OC</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BLADEOVERCLOCK.svg
+++ b/assets/Steam/achievements/icons/BLADEOVERCLOCK.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.589317"
-       y="29.796392"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.68063"
+       y="29.457327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.589317"
-         y="29.796392"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="29.457327"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.589317"
-         y="48.536144"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="49.445869"
          id="tspan16668">OC</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN1+.svg
+++ b/assets/Steam/achievements/icons/BN1+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN1+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN1+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN1+.svg
+++ b/assets/Steam/achievements/icons/BN1+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.47345"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.47345"
          id="tspan20241">BN1+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN10+.svg
+++ b/assets/Steam/achievements/icons/BN10+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.613014"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.591061"
+       y="40.097988"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.613014"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.591061"
+         y="40.097988"
          id="tspan20241">BN10+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN10+.svg
+++ b/assets/Steam/achievements/icons/BN10+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN10+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.613014"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.613014"
          id="tspan20241">BN10+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN12+.svg
+++ b/assets/Steam/achievements/icons/BN12+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN12+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.685345"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.685345"
          id="tspan20241">BN12+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN12+.svg
+++ b/assets/Steam/achievements/icons/BN12+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.685345"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.591061"
+       y="40.205647"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.685345"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.591061"
+         y="40.205647"
          id="tspan20241">BN12+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN13+.svg
+++ b/assets/Steam/achievements/icons/BN13+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.591061"
+       y="40.097988"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.591061"
+         y="40.097988"
          id="tspan20241">BN13+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN13+.svg
+++ b/assets/Steam/achievements/icons/BN13+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN13+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="29"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN13+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN2+.svg
+++ b/assets/Steam/achievements/icons/BN2+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN2+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.685345"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.685345"
          id="tspan20241">BN2+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN2+.svg
+++ b/assets/Steam/achievements/icons/BN2+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.685345"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.47345"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.685345"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.47345"
          id="tspan20241">BN2+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN3+.svg
+++ b/assets/Steam/achievements/icons/BN3+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN3+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN3+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN3+.svg
+++ b/assets/Steam/achievements/icons/BN3+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.344257"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.344257"
          id="tspan20241">BN3+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN6+.svg
+++ b/assets/Steam/achievements/icons/BN6+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.344257"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.344257"
          id="tspan20241">BN6+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN6+.svg
+++ b/assets/Steam/achievements/icons/BN6+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN6+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN6+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN7+.svg
+++ b/assets/Steam/achievements/icons/BN7+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN7+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN7+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN7+.svg
+++ b/assets/Steam/achievements/icons/BN7+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.442444"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.442444"
          id="tspan20241">BN7+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN8+.svg
+++ b/assets/Steam/achievements/icons/BN8+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN8+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN8+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN8+.svg
+++ b/assets/Steam/achievements/icons/BN8+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.339092"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.339092"
          id="tspan20241">BN8+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN9+.svg
+++ b/assets/Steam/achievements/icons/BN9+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.339092"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.339092"
          id="tspan20241">BN9+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/BN9+.svg
+++ b/assets/Steam/achievements/icons/BN9+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN9+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN9+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORP.svg
+++ b/assets/Steam/achievements/icons/CORP.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORP.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.791702"
+       y="39.226234"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.791702"
+         y="39.226234"
          id="tspan14497">CORP</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORP.svg
+++ b/assets/Steam/achievements/icons/CORP.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="39.226234"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="40.811127"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="39.226234"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="40.811127"
          id="tspan14497">CORP</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORP1000.svg
+++ b/assets/Steam/achievements/icons/CORP1000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="29.856359"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="28.595892"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="29.856359"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="28.595892"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="48.596111"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="53.02636"
          id="tspan15347">1000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORP1000.svg
+++ b/assets/Steam/achievements/icons/CORP1000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORP1000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.791702"
+       y="29.856359"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.791702"
+         y="29.856359"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.791702"
+         y="48.596111"
          id="tspan15347">1000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORPCITY.svg
+++ b/assets/Steam/achievements/icons/CORPCITY.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORPCITY.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.791702"
+       y="29.856359"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.791702"
+         y="29.856359"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.791702"
+         y="48.596111"
          id="tspan15347">3000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORPCITY.svg
+++ b/assets/Steam/achievements/icons/CORPCITY.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="29.856359"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="28.595892"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="29.856359"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="28.595892"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="48.596111"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="53.02636"
          id="tspan15347">3000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORPLOBBY.svg
+++ b/assets/Steam/achievements/icons/CORPLOBBY.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.139565"
-       y="29.856359"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.250423"
+       y="29.55422"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.139565"
-         y="29.856359"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.250423"
+         y="29.55422"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.139565"
-         y="48.596111"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.250423"
+         y="49.542763"
          id="tspan15347">LOBBY</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORPLOBBY.svg
+++ b/assets/Steam/achievements/icons/CORPLOBBY.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORPLOBBY.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.139565"
+       y="29.856359"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.139565"
+         y="29.856359"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.139565"
+         y="48.596111"
          id="tspan15347">LOBBY</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORPRE.svg
+++ b/assets/Steam/achievements/icons/CORPRE.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORPRE.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.791702"
+       y="29.931318"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.791702"
+         y="29.931318"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.791702"
+         y="48.67107"
          id="tspan15347">RE</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CORPRE.svg
+++ b/assets/Steam/achievements/icons/CORPRE.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="29.931318"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="28.714317"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="29.931318"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="28.714317"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="48.67107"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="53.144783"
          id="tspan15347">RE</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CSEC.svg
+++ b/assets/Steam/achievements/icons/CSEC.svg
@@ -64,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:18.9715px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="8.5974092"
-       y="43.353848"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+       x="31.388172"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="8.5974092"
-         y="43.353848">CSEC</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+         x="31.388172"
+         y="42.889858">CSEC</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/CSEC.svg
+++ b/assets/Steam/achievements/icons/CSEC.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CSEC.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,14 +65,14 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:18.9715px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="4.3416786"
-       y="43.981724"
+       x="8.5974092"
+       y="43.353848"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
          style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="4.3416786"
-         y="43.981724">CSEC</tspan></text>
+         x="8.5974092"
+         y="43.353848">CSEC</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANG.svg
+++ b/assets/Steam/achievements/icons/GANG.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANG.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.964119"
+       y="39.218739"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.964119"
+         y="39.218739"
          id="tspan11415">GANG</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANG.svg
+++ b/assets/Steam/achievements/icons/GANG.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.964119"
-       y="39.218739"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="40.17981"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="39.218739"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="40.17981"
          id="tspan11415">GANG</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANG100%.svg
+++ b/assets/Steam/achievements/icons/GANG100%.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANG100%.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.964119"
+       y="29.848864"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.964119"
+         y="29.848864"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="57.620747"
+         x="33.964119"
+         y="48.588615"
          id="tspan14185">100%</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANG100%.svg
+++ b/assets/Steam/achievements/icons/GANG100%.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.964119"
-       y="29.848864"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="28.928638"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="29.848864"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="28.928638"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="48.588615"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="51.138145"
          id="tspan14185">100%</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANG10000.svg
+++ b/assets/Steam/achievements/icons/GANG10000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.757977"
-       y="29.848864"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="29.075056"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.757977"
-         y="29.848864"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="29.075056"
          id="tspan14185">GANG</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.757977"
-         y="48.588615"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.978626"
+         y="51.284561"
          id="tspan14497">10000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANG10000.svg
+++ b/assets/Steam/achievements/icons/GANG10000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANG10000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.757977"
+       y="29.848864"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.757977"
+         y="29.848864"
          id="tspan14185">GANG</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="57.620747"
+         x="33.757977"
+         y="48.588615"
          id="tspan14497">10000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANGMAX.svg
+++ b/assets/Steam/achievements/icons/GANGMAX.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANGMAX.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.964119"
+       y="29.923822"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.964119"
+         y="29.923822"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="57.620747"
+         x="33.964119"
+         y="48.663574"
          id="tspan14185">MAX</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/GANGMAX.svg
+++ b/assets/Steam/achievements/icons/GANGMAX.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.964119"
-       y="29.923822"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="29.182714"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="29.923822"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="29.182714"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="48.663574"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="51.39222"
          id="tspan14185">MAX</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNET.svg
+++ b/assets/Steam/achievements/icons/HASHNET.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="37.947285"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="37.904324"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="37.904324"
          id="tspan16668">HASHNET</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNET.svg
+++ b/assets/Steam/achievements/icons/HASHNET.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNET.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="37.947285"
          id="tspan16668">HASHNET</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETALL.svg
+++ b/assets/Steam/achievements/icons/HASHNETALL.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.860498"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.860498"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.868937"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="45.148373"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="45.083027"
          id="tspan17808">ALL</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETALL.svg
+++ b/assets/Steam/achievements/icons/HASHNETALL.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETALL.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.860498"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.860498"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="45.148373"
          id="tspan17808">ALL</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETCAP.svg
+++ b/assets/Steam/achievements/icons/HASHNETCAP.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.803347"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.706327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.803347"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.706327"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="45.091221"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="44.920418"
          id="tspan17808">100%</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETCAP.svg
+++ b/assets/Steam/achievements/icons/HASHNETCAP.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETCAP.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.803347"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.803347"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="45.091221"
          id="tspan17808">100%</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETMAX.svg
+++ b/assets/Steam/achievements/icons/HASHNETMAX.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.860498"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.860498"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.868937"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="45.148373"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="45.083027"
          id="tspan17808">MAX</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETMAX.svg
+++ b/assets/Steam/achievements/icons/HASHNETMAX.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETMAX.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.860498"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.860498"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="45.148373"
          id="tspan17808">MAX</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETMONEY.svg
+++ b/assets/Steam/achievements/icons/HASHNETMONEY.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETMONEY.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.529018"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.529018"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="44.816895"
          id="tspan17808">$1B</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/HASHNETMONEY.svg
+++ b/assets/Steam/achievements/icons/HASHNETMONEY.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.529018"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.30394"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.529018"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.30394"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="44.816895"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="44.518028"
          id="tspan17808">$1B</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/INT255.svg
+++ b/assets/Steam/achievements/icons/INT255.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="INT255.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.817944"
+       y="29.773905"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.817944"
+         y="29.773905"
          id="tspan15347">INT</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.817944"
+         y="48.513657"
          id="tspan16415">255</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/INT255.svg
+++ b/assets/Steam/achievements/icons/INT255.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.817944"
-       y="29.773905"
+       style="font-weight:bold;font-size:24.6944px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.932983"
+       y="27.007704"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.817944"
-         y="29.773905"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.932983"
+         y="27.007704"
          id="tspan15347">INT</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.817944"
-         y="48.513657"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.932983"
+         y="58.100937"
          id="tspan16415">255</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/NiteSec.svg
+++ b/assets/Steam/achievements/icons/NiteSec.svg
@@ -64,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.3201px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-       x="8.801322"
-       y="39.833897"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+       x="32.432976"
+       y="40.039101"
        id="text2505"
        transform="scale(1.0332295,0.96783918)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="8.801322"
-         y="39.833897">NiteSec</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.432976"
+         y="40.039101">NiteSec</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/NiteSec.svg
+++ b/assets/Steam/achievements/icons/NiteSec.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="NiteSec.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,14 +65,14 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:13.3201px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-       x="4.4427061"
-       y="39.151321"
+       x="8.801322"
+       y="39.833897"
        id="text2505"
-       transform="scale(1.0332295,0.96783917)"><tspan
+       transform="scale(1.0332295,0.96783918)"><tspan
          sodipodi:role="line"
          id="tspan2503"
          style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="4.4427061"
-         y="39.151321">NiteSec</tspan></text>
+         x="8.801322"
+         y="39.833897">NiteSec</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/OUCH.svg
+++ b/assets/Steam/achievements/icons/OUCH.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.956612"
-       y="39.196251"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="34.273617"
+       y="39.548489"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.956612"
-         y="39.196251"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="34.273617"
+         y="39.548489"
          id="tspan11415">OUCH!</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/OUCH.svg
+++ b/assets/Steam/achievements/icons/OUCH.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="OUCH.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.956612"
+       y="39.196251"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.956612"
+         y="39.196251"
          id="tspan11415">OUCH!</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF-1.svg
+++ b/assets/Steam/achievements/icons/SF-1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF-1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:18.9715px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="4.3416786"
-       y="43.981724"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="4.3416786"
-         y="43.981724">SF -1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF -1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF-1.svg
+++ b/assets/Steam/achievements/icons/SF-1.svg
@@ -64,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="32.46907"
-       y="42.889858"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+       x="32.803677"
+       y="44.78252"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="32.46907"
-         y="42.889858">SF -1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+         x="32.803677"
+         y="44.78252">SF -1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF1.1.svg
+++ b/assets/Steam/achievements/icons/SF1.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF1.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="335"
      inkscape:window-y="29"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF1.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF1.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF1.1.svg
+++ b/assets/Steam/achievements/icons/SF1.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF1.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF1.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF10.1.svg
+++ b/assets/Steam/achievements/icons/SF10.1.svg
@@ -71,7 +71,7 @@
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
          x="32.46907"
          y="42.889858">SF10.1</tspan></text>
   </g>

--- a/assets/Steam/achievements/icons/SF10.1.svg
+++ b/assets/Steam/achievements/icons/SF10.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF10.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.2573px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-       x="2.3807058"
-       y="43.837727"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-         x="2.3807058"
-         y="43.837727">SF10.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF10.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF11.1.svg
+++ b/assets/Steam/achievements/icons/SF11.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF11.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.2573px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-       x="2.3807058"
-       y="43.837727"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-         x="2.3807058"
-         y="43.837727">SF11.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF11.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF12.1.svg
+++ b/assets/Steam/achievements/icons/SF12.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF12.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.2573px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-       x="2.3807058"
-       y="43.837727"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-         x="2.3807058"
-         y="43.837727">SF12.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF12.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF13.1.svg
+++ b/assets/Steam/achievements/icons/SF13.1.svg
@@ -56,14 +56,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-size:17.6389px;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#55d400;stroke-width:0.264583"
-       x="34.982018"
-       y="40.175503"
-       id="text1"><tspan
+       style="font-size:17.6389px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#55d400;stroke-width:0.24922"
+       x="33.015541"
+       y="42.263199"
+       id="text1"
+       transform="scale(1.0616446,0.94193481)"><tspan
          sodipodi:role="line"
          id="tspan1"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.264583"
-         x="34.982018"
-         y="40.175503">SF13.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.24922"
+         x="33.015541"
+         y="42.263199">SF13.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF2.1.svg
+++ b/assets/Steam/achievements/icons/SF2.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF2.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF2.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF2.1.svg
+++ b/assets/Steam/achievements/icons/SF2.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF2.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF2.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF2.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF3.1.svg
+++ b/assets/Steam/achievements/icons/SF3.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF3.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF3.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF3.1.svg
+++ b/assets/Steam/achievements/icons/SF3.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF3.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF3.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF3.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF4.1.svg
+++ b/assets/Steam/achievements/icons/SF4.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF4.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF4.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF4.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF4.1.svg
+++ b/assets/Steam/achievements/icons/SF4.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF4.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF4.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF5.1.svg
+++ b/assets/Steam/achievements/icons/SF5.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF5.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF5.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF5.1.svg
+++ b/assets/Steam/achievements/icons/SF5.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF5.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF5.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF5.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF6.1.svg
+++ b/assets/Steam/achievements/icons/SF6.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF6.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF6.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF6.1.svg
+++ b/assets/Steam/achievements/icons/SF6.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF6.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF6.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF6.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF7.1.svg
+++ b/assets/Steam/achievements/icons/SF7.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF7.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF7.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF7.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF7.1.svg
+++ b/assets/Steam/achievements/icons/SF7.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF7.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF7.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF8.1.svg
+++ b/assets/Steam/achievements/icons/SF8.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF8.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF8.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF8.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF8.1.svg
+++ b/assets/Steam/achievements/icons/SF8.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF8.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF8.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF9.1.svg
+++ b/assets/Steam/achievements/icons/SF9.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF9.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF9.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SF9.1.svg
+++ b/assets/Steam/achievements/icons/SF9.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF9.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF9.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF9.1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SLEEVE8.svg
+++ b/assets/Steam/achievements/icons/SLEEVE8.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SLEEVE8.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="34.034172"
-       y="37.49543"
+       x="33.855236"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="34.034172"
-         y="37.49543"
-         id="tspan17808">8 SLEEVE</tspan></text>
+         x="33.855236"
+         y="37.947285"
+         id="tspan17808">8 SLEEVES</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/SLEEVE8.svg
+++ b/assets/Steam/achievements/icons/SLEEVE8.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-       x="33.855236"
-       y="37.947285"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+       x="33.910591"
+       y="37.651955"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
-         x="33.855236"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.153084"
+         x="33.910591"
+         y="37.651955"
          id="tspan17808">8 SLEEVES</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/TBH.svg
+++ b/assets/Steam/achievements/icons/TBH.svg
@@ -32,7 +32,7 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer2"
+     inkscape:current-layer="layer1"
      inkscape:showpageshadow="2"
      inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
@@ -64,25 +64,25 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.3201px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-       x="32.751316"
-       y="22.204227"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+       x="32.273643"
+       y="20.592304"
        id="text2505"
        transform="scale(1.0332295,0.96783918)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="32.751316"
-         y="22.204227">The</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.273643"
+         y="20.592304">The</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="32.751316"
-         y="38.854351"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.273643"
+         y="40.580845"
          id="tspan5436">Black</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="32.751316"
-         y="55.504478"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.273643"
+         y="60.569389"
          id="tspan5438">Hand</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/TBH.svg
+++ b/assets/Steam/achievements/icons/TBH.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="TBH.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer2"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -48,8 +55,8 @@
        id="rect849"
        width="67.73333"
        height="67.73333"
-       x="0"
-       y="0" />
+       x="1.7801921e-06"
+       y="1.7801921e-06" />
   </g>
   <g
      inkscape:label="main"
@@ -71,11 +78,11 @@
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
          x="32.751316"
          y="38.854351"
-         id="tspan5436">black</tspan><tspan
+         id="tspan5436">Black</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
          x="32.751316"
-         y="55.504475"
-         id="tspan5438">hand</tspan></text>
+         y="55.504478"
+         id="tspan5438">Hand</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/TOR.svg
+++ b/assets/Steam/achievements/icons/TOR.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="33.904144"
-       y="39.226234"
+       style="font-weight:bold;font-size:24.6944px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+       x="33.667713"
+       y="42.705044"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="33.904144"
-         y="39.226234"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
+         x="33.667713"
+         y="42.705044"
          id="tspan11415">TOR</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/TOR.svg
+++ b/assets/Steam/achievements/icons/TOR.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="TOR.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.904144"
+       y="39.226234"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.904144"
+         y="39.226234"
          id="tspan11415">TOR</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/TRAVEL.svg
+++ b/assets/Steam/achievements/icons/TRAVEL.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="TRAVEL.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="34.110645"
+       y="37.426777"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="34.110645"
+         y="37.426777"
          id="tspan11415">WORLD</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/TRAVEL.svg
+++ b/assets/Steam/achievements/icons/TRAVEL.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="34.110645"
-       y="37.426777"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="34.193951"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="34.110645"
-         y="37.426777"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="34.193951"
+         y="38.917171"
          id="tspan11415">WORLD</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/WORKOUT.svg
+++ b/assets/Steam/achievements/icons/WORKOUT.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="WORKOUT.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="33.861687"
+       y="37.426777"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="33.861687"
+         y="37.426777"
          id="tspan11415">WORKOUT</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/WORKOUT.svg
+++ b/assets/Steam/achievements/icons/WORKOUT.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.861687"
-       y="37.426777"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="33.9571"
+       y="37.654537"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.861687"
-         y="37.426777"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.9571"
+         y="37.654537"
          id="tspan11415">WORKOUT</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/bigcost.svg
+++ b/assets/Steam/achievements/icons/bigcost.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="bigcost.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:13.3483px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.17877"
-       x="34.172409"
-       y="39.818333"
+       x="33.913391"
+       y="38.632011"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.17877"
-         x="34.172409"
-         y="39.818333"
+         x="33.913391"
+         y="38.632011"
          id="tspan5330">32GB+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/bigcost.svg
+++ b/assets/Steam/achievements/icons/bigcost.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.3483px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.17877"
-       x="33.913391"
-       y="38.632011"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.17877"
+       x="33.905426"
+       y="40.17981"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.17877"
-         x="33.913391"
-         y="38.632011"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.17877"
+         x="33.905426"
+         y="40.17981"
          id="tspan5330">32GB+</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/bitrunners.svg
+++ b/assets/Steam/achievements/icons/bitrunners.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.86318px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.132095"
-       x="7.9610338"
-       y="37.451931"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.132095"
+       x="33.734894"
+       y="37.592525"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.132095"
-         x="7.9610338"
-         y="37.451931">BitRunners</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.132095"
+         x="33.734894"
+         y="37.592525">BitRunners</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/bitrunners.svg
+++ b/assets/Steam/achievements/icons/bitrunners.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   sodipodi:docname="bitrunners.svg.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="bitrunners.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.86318px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.132095"
-       x="2.8813558"
-       y="37.776012"
+       x="7.9610338"
+       y="37.451931"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.132095"
-         x="2.8813558"
-         y="37.776012">BitRunners</tspan></text>
+         x="7.9610338"
+         y="37.451931">BitRunners</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/broker.svg
+++ b/assets/Steam/achievements/icons/broker.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:20.708px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.277337"
-       x="34.104805"
-       y="39.240395"
+       style="font-weight:bold;font-size:29.9861px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.277337"
+       x="34.298595"
+       y="42.505241"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.277337"
-         x="34.104805"
-         y="39.240395"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.9861px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.277337"
+         x="34.298595"
+         y="42.505241"
          id="tspan5330">$1q</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/broker.svg
+++ b/assets/Steam/achievements/icons/broker.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="broker.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:20.708px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.277337"
-       x="34.164398"
-       y="40.048054"
+       x="34.104805"
+       y="39.240395"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.277337"
-         x="34.164398"
-         y="40.048054"
+         x="34.104805"
+         y="39.240395"
          id="tspan5330">$1q</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/combat3000.svg
+++ b/assets/Steam/achievements/icons/combat3000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.580757"
-       y="30.201166"
+       style="font-weight:bold;font-size:14.8167px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+       x="33.606216"
+       y="29.841707"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.580757"
-         y="30.201166"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.8167px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+         x="33.606216"
+         y="29.841707"
          id="tspan2495">Combat</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.580757"
-         y="48.528667"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.8167px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+         x="33.606216"
+         y="48.497723"
          id="tspan3127">3000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/combat3000.svg
+++ b/assets/Steam/achievements/icons/combat3000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="combat3000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.197567"
-       y="30.194496"
+       x="33.580757"
+       y="30.201166"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="30.194496"
-         id="tspan2495">combat</tspan><tspan
+         x="33.580757"
+         y="30.201166"
+         id="tspan2495">Combat</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="48.521996"
+         x="33.580757"
+         y="48.528667"
          id="tspan3127">3000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/daedalus.svg
+++ b/assets/Steam/achievements/icons/daedalus.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.9663px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.160262"
-       x="7.3134484"
-       y="38.354031"
+       style="font-weight:bold;font-size:13.4056px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.160262"
+       x="33.706299"
+       y="38.586117"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.160262"
-         x="7.3134484"
-         y="38.354031">Daedalus</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.4056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.160262"
+         x="33.706299"
+         y="38.586117">Daedalus</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/daedalus.svg
+++ b/assets/Steam/achievements/icons/daedalus.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="daedalus.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.9663px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.160262"
-       x="2.6862416"
-       y="39.373894"
+       x="7.3134484"
+       y="38.354031"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.160262"
-         x="2.6862416"
-         y="39.373894">Daedalus</tspan></text>
+         x="7.3134484"
+         y="38.354031">Daedalus</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/discount.svg
+++ b/assets/Steam/achievements/icons/discount.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.3511px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.218986"
-       x="33.940243"
-       y="39.712185"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.218986"
+       x="33.7603"
+       y="41.883419"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.218986"
-         x="33.940243"
-         y="39.712185"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.218986"
+         x="33.7603"
+         y="41.883419"
          id="tspan5330">-10%</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/discount.svg
+++ b/assets/Steam/achievements/icons/discount.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="discount.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.3511px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.218986"
-       x="35.443775"
-       y="39.886589"
+       x="33.940243"
+       y="39.712185"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.218986"
-         x="35.443775"
-         y="39.886589"
+         x="33.940243"
+         y="39.712185"
          id="tspan5330">-10%</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/donation.svg
+++ b/assets/Steam/achievements/icons/donation.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.866669"
-       y="37.426777"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="33.908009"
+       y="37.654537"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.866669"
-         y="37.426777"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.908009"
+         y="37.654537"
          id="tspan11415">DONATION</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/donation.svg
+++ b/assets/Steam/achievements/icons/donation.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="donation.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="33.866669"
+       y="37.426777"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="33.866669"
+         y="37.426777"
          id="tspan11415">DONATION</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/drain.svg
+++ b/assets/Steam/achievements/icons/drain.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="drain.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:30.1035px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.403166"
-       x="34.864677"
-       y="41.09906"
+       x="33.671001"
+       y="44.417942"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.403166"
-         x="34.864677"
-         y="41.09906"
+         x="33.671001"
+         y="44.417942"
          id="tspan5330">$0</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/drain.svg
+++ b/assets/Steam/achievements/icons/drain.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:30.1035px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.403166"
-       x="33.671001"
-       y="44.417942"
+       style="font-weight:bold;font-size:38.8056px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.403166"
+       x="34.160362"
+       y="46.931343"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.403166"
-         x="33.671001"
-         y="44.417942"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.403166"
+         x="34.160362"
+         y="46.931343"
          id="tspan5330">$0</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/folders.svg
+++ b/assets/Steam/achievements/icons/folders.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="folders.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-       x="34.928535"
-       y="37.743538"
+       x="33.866665"
+       y="36.505936"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-         x="34.928535"
-         y="37.743538"
+         x="33.866665"
+         y="36.505936"
          id="tspan5330">/scripts/</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/folders.svg
+++ b/assets/Steam/achievements/icons/folders.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-       x="33.866665"
-       y="36.505936"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
+       x="33.87011"
+       y="37.611481"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-         x="33.866665"
-         y="36.505936"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
+         x="33.87011"
+         y="37.611481"
          id="tspan5330">/scripts/</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/formulas.svg
+++ b/assets/Steam/achievements/icons/formulas.svg
@@ -65,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:35.2778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
-       x="7.1413207"
+       x="34.57291"
        y="42.996178"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:35.2778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
-         x="7.1413207"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:35.2778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
+         x="34.57291"
          y="42.996178">f(x)</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/formulas.svg
+++ b/assets/Steam/achievements/icons/formulas.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="formulas.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:27.3155px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
-       x="5.2327757"
-       y="39.963947"
+       x="14.090266"
+       y="42.156921"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
-         x="5.2327757"
-         y="39.963947">f(x)</tspan></text>
+         x="14.090266"
+         y="42.156921">f(x)</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/formulas.svg
+++ b/assets/Steam/achievements/icons/formulas.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:27.3155px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
-       x="14.090266"
-       y="42.156921"
+       style="font-weight:bold;font-size:35.2778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
+       x="7.1413207"
+       y="42.996178"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
-         x="14.090266"
-         y="42.156921">f(x)</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:35.2778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.365827"
+         x="7.1413207"
+         y="42.996178">f(x)</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/frozen.svg
+++ b/assets/Steam/achievements/icons/frozen.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   sodipodi:docname="forze.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="frozen.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-       x="34.064476"
-       y="38.520031"
+       x="33.866669"
+       y="38.517883"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-         x="34.064476"
-         y="38.520031"
+         x="33.866669"
+         y="38.517883"
          id="tspan3127">FROZEN</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/frozen.svg
+++ b/assets/Steam/achievements/icons/frozen.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-       x="33.866669"
-       y="38.517883"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
+       x="33.911453"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-         x="33.866669"
-         y="38.517883"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
+         x="33.911453"
+         y="38.917171"
          id="tspan3127">FROZEN</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hack100000.svg
+++ b/assets/Steam/achievements/icons/hack100000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hack100000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.197567"
-       y="30.194496"
+       x="33.573429"
+       y="30.201166"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="30.194496"
-         id="tspan2003">hack</tspan><tspan
+         x="33.573429"
+         y="30.201166"
+         id="tspan2003">Hack</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="48.521996"
+         x="33.573429"
+         y="48.528667"
          id="tspan2495">100000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hack100000.svg
+++ b/assets/Steam/achievements/icons/hack100000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.573429"
-       y="30.201166"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+       x="33.630245"
+       y="29.457327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.573429"
-         y="30.201166"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+         x="33.630245"
+         y="29.457327"
          id="tspan2003">Hack</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.573429"
-         y="48.528667"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+         x="33.630245"
+         y="49.445869"
          id="tspan2495">100000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hacknet-10m.svg
+++ b/assets/Steam/achievements/icons/hacknet-10m.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="30.958828"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="30.30394"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="30.958828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="30.30394"
          id="tspan10677">HACKNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="43.406765"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="44.518028"
          id="tspan11099">$10m</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hacknet-10m.svg
+++ b/assets/Steam/achievements/icons/hacknet-10m.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hacknet-10m.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="34.445259"
-       y="33.325958"
+       x="33.438457"
+       y="30.958828"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="34.445259"
-         y="33.325958"
+         x="33.438457"
+         y="30.958828"
          id="tspan10677">HACKNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="34.445259"
-         y="45.773895"
+         x="33.438457"
+         y="43.406765"
          id="tspan11099">$10m</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hacknet-all.svg
+++ b/assets/Steam/achievements/icons/hacknet-all.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hacknet-all.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="34.217846"
-       y="34.463017"
+       x="33.438457"
+       y="31.24762"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="34.463017"
+         x="33.438457"
+         y="31.24762"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="46.910954"
+         x="33.438457"
+         y="43.695557"
          id="tspan10677">ALL</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hacknet-all.svg
+++ b/assets/Steam/achievements/icons/hacknet-all.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="31.24762"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="31.24762"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="30.868937"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="43.695557"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="45.083023"
          id="tspan10677">ALL</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hacknet-max.svg
+++ b/assets/Steam/achievements/icons/hacknet-max.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="31.24762"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="31.24762"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="30.868937"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="43.695557"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="45.083023"
          id="tspan10677">MAX</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/hacknet-max.svg
+++ b/assets/Steam/achievements/icons/hacknet-max.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hacknet-max.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="34.217846"
-       y="34.463017"
+       x="33.438457"
+       y="31.24762"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="34.463017"
+         x="33.438457"
+         y="31.24762"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="46.910954"
+         x="33.438457"
+         y="43.695557"
          id="tspan10677">MAX</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/illuminati.svg
+++ b/assets/Steam/achievements/icons/illuminati.svg
@@ -65,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.152171"
-       x="34.12772"
-       y="39.158329"
+       x="33.870113"
+       y="38.834492"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="font-size:14.1111px;text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.152171"
-         x="34.12772"
-         y="39.158329">Illuminati</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.152171"
+         x="33.870113"
+         y="38.834492">Illuminati</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/illuminati.svg
+++ b/assets/Steam/achievements/icons/illuminati.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="illuminati.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.3623px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.152171"
-       x="2.7185695"
-       y="38.914951"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.152171"
+       x="34.12772"
+       y="39.158329"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.152171"
-         x="2.7185695"
-         y="38.914951">Illuminati</tspan></text>
+         style="font-size:14.1111px;text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.152171"
+         x="34.12772"
+         y="39.158329">Illuminati</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/install.svg
+++ b/assets/Steam/achievements/icons/install.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="install.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-       x="6.1825614"
-       y="39.945213"
+       x="11.697483"
+       y="39.743965"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="6.1825614"
-         y="39.945213">Install</tspan></text>
+         x="11.697483"
+         y="39.743965">Install</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/install.svg
+++ b/assets/Steam/achievements/icons/install.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-       x="11.697483"
-       y="39.743965"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+       x="33.871403"
+       y="40.697437"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="11.697483"
-         y="39.743965">Install</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+         x="33.871403"
+         y="40.697437">Install</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/install_100.svg
+++ b/assets/Steam/achievements/icons/install_100.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-       x="34.219299"
-       y="29.948467"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+       x="33.871403"
+       y="28.477467"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="34.219299"
-         y="29.948467">Install</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+         x="33.871403"
+         y="28.477467">Install</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="34.219299"
-         y="49.539467"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+         x="33.871403"
+         y="52.907936"
          id="tspan1231">100</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/install_100.svg
+++ b/assets/Steam/achievements/icons/install_100.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="install_100.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-       x="34.312416"
-       y="31.189854"
+       x="34.219299"
+       y="29.948467"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="31.189854">Install</tspan><tspan
+         x="34.219299"
+         y="29.948467">Install</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="50.780853"
+         x="34.219299"
+         y="49.539467"
          id="tspan1231">100</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/karma.svg
+++ b/assets/Steam/achievements/icons/karma.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="karma.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-       x="34.928535"
-       y="37.743538"
+       x="33.356869"
+       y="37.674225"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-         x="34.928535"
-         y="37.743538"
+         x="33.356869"
+         y="37.674225"
          id="tspan5330">KARMA</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/karma.svg
+++ b/assets/Steam/achievements/icons/karma.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-       x="33.356869"
-       y="37.674225"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
+       x="33.36713"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
-         x="33.356869"
-         y="37.674225"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.142242"
+         x="33.36713"
+         y="38.917171"
          id="tspan5330">KARMA</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/maxcores.svg
+++ b/assets/Steam/achievements/icons/maxcores.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-       x="33.840996"
-       y="38.449512"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
+       x="33.921791"
+       y="38.913727"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-         x="33.840996"
-         y="38.449512"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
+         x="33.921791"
+         y="38.913727"
          id="tspan5330">8 Cores</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/maxcores.svg
+++ b/assets/Steam/achievements/icons/maxcores.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="maxcores.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-       x="34.01947"
-       y="38.517769"
+       x="33.840996"
+       y="38.449512"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-         x="34.01947"
-         y="38.517769"
+         x="33.840996"
+         y="38.449512"
          id="tspan5330">8 Cores</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/maxram.svg
+++ b/assets/Steam/achievements/icons/maxram.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="maxram.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-       x="32.996117"
-       y="37.60812"
+       x="33.905174"
+       y="38.455929"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-         x="32.996117"
-         y="37.60812"
+         x="33.905174"
+         y="38.455929"
          id="tspan5330">2^30GB</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/maxram.svg
+++ b/assets/Steam/achievements/icons/maxram.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-       x="33.905174"
-       y="38.455929"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
+       x="34.038921"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
-         x="33.905174"
-         y="38.455929"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.171924"
+         x="34.038921"
+         y="38.917171"
          id="tspan5330">2^30GB</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/nfg255.svg
+++ b/assets/Steam/achievements/icons/nfg255.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   sodipodi:docname="nf255.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="nfg255.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.538685"
-       y="39.290974"
+       x="33.573429"
+       y="39.101002"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.538685"
-         y="39.290974"
-         id="tspan3127">NF 255</tspan></text>
+         x="33.573429"
+         y="39.101002"
+         id="tspan3127">NFG 255</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/nfg255.svg
+++ b/assets/Steam/achievements/icons/nfg255.svg
@@ -64,14 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.573429"
-       y="39.101002"
+       style="font-weight:bold;font-size:24.6944px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+       x="33.697857"
+       y="27.158426"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.573429"
-         y="39.101002"
-         id="tspan3127">NFG 255</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+         x="33.697857"
+         y="27.158426"
+         id="tspan3127">NFG</tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+         x="33.697857"
+         y="58.251659"
+         id="tspan1">255</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/node.svg
+++ b/assets/Steam/achievements/icons/node.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="37.421799"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="37.907078"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="37.421799"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="37.907078"
          id="tspan5330">HACKNET</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/node.svg
+++ b/assets/Steam/achievements/icons/node.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="node.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.763023"
-       y="38.329018"
+       x="33.438457"
+       y="37.421799"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.763023"
-         y="38.329018"
+         x="33.438457"
+         y="37.421799"
          id="tspan5330">HACKNET</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/ns2.svg
+++ b/assets/Steam/achievements/icons/ns2.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="ns2.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.538685"
-       y="39.290974"
+       x="33.536774"
+       y="39.101002"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.538685"
-         y="39.290974"
+         x="33.536774"
+         y="39.101002"
          id="tspan3127">NS2</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/ns2.svg
+++ b/assets/Steam/achievements/icons/ns2.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-       x="33.536774"
-       y="39.101002"
+       style="font-weight:bold;font-size:29.9861px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+       x="33.507946"
+       y="44.591675"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
-         x="33.536774"
-         y="39.101002"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.9861px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.196363"
+         x="33.507946"
+         y="44.591675"
          id="tspan3127">NS2</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p0.svg
+++ b/assets/Steam/achievements/icons/p0.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="8.5273066"
-       y="48.656586"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+       x="33.370575"
+       y="48.821815"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="8.5273066"
-         y="48.656586">P0</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+         x="33.370575"
+         y="48.821815">P0</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p0.svg
+++ b/assets/Steam/achievements/icons/p0.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p0.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="8.5273066"
+       y="48.656586"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P0</tspan></text>
+         x="8.5273066"
+         y="48.656586">P0</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p1.svg
+++ b/assets/Steam/achievements/icons/p1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="12.00242"
-       y="48.635899"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+       x="35.768356"
+       y="49.080196"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="12.00242"
-         y="48.635899">P1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+         x="35.768356"
+         y="49.080196">P1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p1.svg
+++ b/assets/Steam/achievements/icons/p1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="12.00242"
+       y="48.635899"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P1</tspan></text>
+         x="12.00242"
+         y="48.635899">P1</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p2.svg
+++ b/assets/Steam/achievements/icons/p2.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p2.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="8.5893621"
+       y="48.842751"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P2</tspan></text>
+         x="8.5893621"
+         y="48.842751">P2</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p2.svg
+++ b/assets/Steam/achievements/icons/p2.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="8.5893621"
-       y="48.842751"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+       x="33.391243"
+       y="49.080196"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="8.5893621"
-         y="48.842751">P2</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+         x="33.391243"
+         y="49.080196">P2</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p3.svg
+++ b/assets/Steam/achievements/icons/p3.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="8.6927881"
-       y="48.635899"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+       x="33.236214"
+       y="48.821815"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="8.6927881"
-         y="48.635899">P3</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+         x="33.236214"
+         y="48.821815">P3</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p3.svg
+++ b/assets/Steam/achievements/icons/p3.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p3.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="8.6927881"
+       y="48.635899"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P3</tspan></text>
+         x="8.6927881"
+         y="48.635899">P3</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p4.svg
+++ b/assets/Steam/achievements/icons/p4.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="7.9274364"
-       y="48.718639"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+       x="32.812469"
+       y="49.080196"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="7.9274364"
-         y="48.718639">P4</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
+         x="32.812469"
+         y="49.080196">P4</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/p4.svg
+++ b/assets/Steam/achievements/icons/p4.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p4.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="7.9274364"
+       y="48.718639"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#00ff00;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P4</tspan></text>
+         x="7.9274364"
+         y="48.718639">P4</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/queue40.svg
+++ b/assets/Steam/achievements/icons/queue40.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-       x="33.788296"
-       y="29.674192"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+       x="33.835438"
+       y="29.075056"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="33.788296"
-         y="29.674192"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+         x="33.835438"
+         y="29.075056"
          id="tspan1231">Queue</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="33.788296"
-         y="49.265194"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
+         x="33.835438"
+         y="51.284561"
          id="tspan2003">40</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/queue40.svg
+++ b/assets/Steam/achievements/icons/queue40.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="queue40.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-       x="34.312416"
-       y="30.507618"
+       x="33.788296"
+       y="29.674192"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="30.507618"
-         id="tspan1231">queue</tspan><tspan
+         x="33.788296"
+         y="29.674192"
+         id="tspan1231">Queue</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="50.098618"
+         x="33.788296"
+         y="49.265194"
          id="tspan2003">40</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/reputation.svg
+++ b/assets/Steam/achievements/icons/reputation.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.786999"
-       y="31.262558"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+       x="33.835659"
+       y="30.927116"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.786999"
-         y="31.262558"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.835659"
+         y="30.927116"
          id="tspan11099">Reputation</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.786999"
-         y="43.710495"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
+         x="33.835659"
+         y="44.252769"
          id="tspan11415">10m</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/reputation.svg
+++ b/assets/Steam/achievements/icons/reputation.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="reputation.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="33.786999"
+       y="31.262558"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="33.786999"
+         y="31.262558"
          id="tspan11099">Reputation</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="45.773895"
+         x="33.786999"
+         y="43.710495"
          id="tspan11415">10m</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/run1000.svg
+++ b/assets/Steam/achievements/icons/run1000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="run1000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-       x="34.291889"
-       y="30.105789"
+       x="33.606461"
+       y="30.314827"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-         x="34.291889"
-         y="30.105789"
+         x="33.606461"
+         y="30.314827"
          id="tspan3127">RUN</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-         x="34.291889"
-         y="46.36879"
+         x="33.606461"
+         y="46.577827"
          id="tspan5330">1000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/run1000.svg
+++ b/assets/Steam/achievements/icons/run1000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-       x="33.606461"
-       y="30.314827"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
+       x="33.525169"
+       y="27.497606"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-         x="33.606461"
-         y="30.314827"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
+         x="33.525169"
+         y="27.497606"
          id="tspan3127">RUN</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
-         x="33.606461"
-         y="46.577827"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.174244"
+         x="33.525169"
+         y="56.370003"
          id="tspan5330">1000</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/thecovenant.svg
+++ b/assets/Steam/achievements/icons/thecovenant.svg
@@ -65,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.87778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.107759"
-       x="33.925934"
-       y="37.570835"
+       x="33.820847"
+       y="37.402023"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="font-size:9.87778px;text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.107759"
-         x="33.925934"
-         y="37.570835">The Covenant</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.87778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.107759"
+         x="33.820847"
+         y="37.402023">The Covenant</tspan></text>
   </g>
 </svg>

--- a/assets/Steam/achievements/icons/thecovenant.svg
+++ b/assets/Steam/achievements/icons/thecovenant.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="thecovenant.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:8.0461px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.107759"
-       x="2.917733"
-       y="36.395454"
+       style="font-weight:bold;font-size:9.87778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00ff00;fill-opacity:1;stroke-width:0.107759"
+       x="33.925934"
+       y="37.570835"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#00ff00;fill-opacity:1;stroke-width:0.107759"
-         x="2.917733"
-         y="36.395454">The Covenant</tspan></text>
+         style="font-size:9.87778px;text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke-width:0.107759"
+         x="33.925934"
+         y="37.570835">The Covenant</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/$1Q.svg
+++ b/dist/icons/achievements/$1Q.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="$1Q.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:23.0096px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.308159"
-       x="8.2434549"
-       y="38.355984"
+       x="11.70841"
+       y="40.642994"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.308159"
-         x="8.2434549"
-         y="38.355984">$1Q</tspan></text>
+         x="11.70841"
+         y="40.642994">$1Q</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/$1Q.svg
+++ b/dist/icons/achievements/$1Q.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:23.0096px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.308159"
-       x="11.70841"
-       y="40.642994"
+       style="font-weight:bold;font-size:29.9861px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.308159"
+       x="33.551872"
+       y="43.962086"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.308159"
-         x="11.70841"
-         y="40.642994">$1Q</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.9861px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.308159"
+         x="33.551872"
+         y="43.962086">$1Q</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/-1b.svg
+++ b/dist/icons/achievements/-1b.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="-1b.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:23.4183px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.313633"
-       x="3.2184403"
-       y="41.740555"
+       x="9.6755438"
+       y="42.086491"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.313633"
-         x="3.2184403"
-         y="41.740555">-$1b</tspan></text>
+         x="9.6755438"
+         y="42.086491">-$1b</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/-1b.svg
+++ b/dist/icons/achievements/-1b.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:23.4183px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.313633"
-       x="9.6755438"
-       y="42.086491"
+       style="font-weight:bold;font-size:28.2222px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.313633"
+       x="33.618622"
+       y="43.368233"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.313633"
-         x="9.6755438"
-         y="42.086491">-$1b</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:28.2222px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.313633"
+         x="33.618622"
+         y="43.368233">-$1b</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/1H.svg
+++ b/dist/icons/achievements/1H.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="1H.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="34.034172"
-       y="37.49543"
+       x="33.918098"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="34.034172"
-         y="37.49543"
+         x="33.918098"
+         y="37.947285"
          id="tspan17808">1H</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/1H.svg
+++ b/dist/icons/achievements/1H.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.918098"
-       y="37.947285"
+       style="font-weight:bold;font-size:38.8056px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="33.819298"
+       y="47.812428"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.918098"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.819298"
+         y="47.812428"
          id="tspan17808">1H</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/2DAYS.svg
+++ b/dist/icons/achievements/2DAYS.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.86095"
-       y="37.947285"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="34.056576"
+       y="39.544613"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.86095"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="34.056576"
+         y="39.544613"
          id="tspan17808">2 DAYS</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/2DAYS.svg
+++ b/dist/icons/achievements/2DAYS.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="2DAYS.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="34.034172"
-       y="37.49543"
+       x="33.86095"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="34.034172"
-         y="37.49543"
+         x="33.86095"
+         y="37.947285"
          id="tspan17808">2 DAYS</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/4S.svg
+++ b/dist/icons/achievements/4S.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="4S.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="37.743938"
+       x="34.061558"
+       y="39.218739"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="37.743938"
+         x="34.061558"
+         y="39.218739"
          id="tspan16668">4S</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/4S.svg
+++ b/dist/icons/achievements/4S.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.061558"
-       y="39.218739"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="34.454056"
+       y="47.746109"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.061558"
-         y="39.218739"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="34.454056"
+         y="47.746109"
          id="tspan16668">4S</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BLADE.svg
+++ b/dist/icons/achievements/BLADE.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.589317"
-       y="39.241226"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.68063"
+       y="39.548489"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.589317"
-         y="39.241226"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="39.548489"
          id="tspan16415">BLADE</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BLADE.svg
+++ b/dist/icons/achievements/BLADE.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BLADE.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.589317"
+       y="39.241226"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.589317"
+         y="39.241226"
          id="tspan16415">BLADE</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BLADE100K.svg
+++ b/dist/icons/achievements/BLADE100K.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.566833"
-       y="29.796392"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.68063"
+       y="29.457327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.566833"
-         y="29.796392"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="29.457327"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.566833"
-         y="48.536144"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="49.445869"
          id="tspan16668">100000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BLADE100K.svg
+++ b/dist/icons/achievements/BLADE100K.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BLADE100K.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.566833"
+       y="29.796392"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.566833"
+         y="29.796392"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.40966"
-         y="49.888741"
+         x="33.566833"
+         y="48.536144"
          id="tspan16668">100000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BLADEOVERCLOCK.svg
+++ b/dist/icons/achievements/BLADEOVERCLOCK.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.589317"
-       y="29.796392"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.68063"
+       y="29.457327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.589317"
-         y="29.796392"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="29.457327"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.589317"
-         y="48.536144"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.68063"
+         y="49.445869"
          id="tspan16668">OC</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BLADEOVERCLOCK.svg
+++ b/dist/icons/achievements/BLADEOVERCLOCK.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BLADEOVERCLOCK.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.589317"
+       y="29.796392"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.589317"
+         y="29.796392"
          id="tspan16415">BLADE</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.589317"
+         y="48.536144"
          id="tspan16668">OC</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN1+.svg
+++ b/dist/icons/achievements/BN1+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.47345"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.47345"
          id="tspan20241">BN1+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN1+.svg
+++ b/dist/icons/achievements/BN1+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN1+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN1+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN10+.svg
+++ b/dist/icons/achievements/BN10+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.613014"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.591061"
+       y="40.097988"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.613014"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.591061"
+         y="40.097988"
          id="tspan20241">BN10+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN10+.svg
+++ b/dist/icons/achievements/BN10+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN10+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.613014"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.613014"
          id="tspan20241">BN10+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN12+.svg
+++ b/dist/icons/achievements/BN12+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN12+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.685345"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.685345"
          id="tspan20241">BN12+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN12+.svg
+++ b/dist/icons/achievements/BN12+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.685345"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.591061"
+       y="40.205647"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.685345"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.591061"
+         y="40.205647"
          id="tspan20241">BN12+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN13+.svg
+++ b/dist/icons/achievements/BN13+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.591061"
+       y="40.097988"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.591061"
+         y="40.097988"
          id="tspan20241">BN13+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN13+.svg
+++ b/dist/icons/achievements/BN13+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN13+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="29"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN13+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN2+.svg
+++ b/dist/icons/achievements/BN2+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN2+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.685345"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.685345"
          id="tspan20241">BN2+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN2+.svg
+++ b/dist/icons/achievements/BN2+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.685345"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.47345"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.685345"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.47345"
          id="tspan20241">BN2+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN3+.svg
+++ b/dist/icons/achievements/BN3+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.344257"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.344257"
          id="tspan20241">BN3+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN3+.svg
+++ b/dist/icons/achievements/BN3+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN3+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN3+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN6+.svg
+++ b/dist/icons/achievements/BN6+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.344257"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.344257"
          id="tspan20241">BN6+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN6+.svg
+++ b/dist/icons/achievements/BN6+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN6+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN6+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN7+.svg
+++ b/dist/icons/achievements/BN7+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.442444"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.442444"
          id="tspan20241">BN7+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN7+.svg
+++ b/dist/icons/achievements/BN7+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN7+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN7+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN8+.svg
+++ b/dist/icons/achievements/BN8+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN8+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN8+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN8+.svg
+++ b/dist/icons/achievements/BN8+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.339092"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.339092"
          id="tspan20241">BN8+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN9+.svg
+++ b/dist/icons/achievements/BN9+.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="33.505013"
-       y="39.604977"
+       style="font-weight:bold;font-size:21.1667px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+       x="33.535938"
+       y="41.339092"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="33.505013"
-         y="39.604977"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.1667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
+         x="33.535938"
+         y="41.339092"
          id="tspan20241">BN9+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/BN9+.svg
+++ b/dist/icons/achievements/BN9+.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="BN9+.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.0737px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-       x="34.276661"
-       y="40.084541"
+       x="33.505013"
+       y="39.604977"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.215272"
-         x="34.276661"
-         y="40.084541"
+         x="33.505013"
+         y="39.604977"
          id="tspan20241">BN9+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORP.svg
+++ b/dist/icons/achievements/CORP.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="39.226234"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="40.811127"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="39.226234"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="40.811127"
          id="tspan14497">CORP</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORP.svg
+++ b/dist/icons/achievements/CORP.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORP.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.791702"
+       y="39.226234"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.791702"
+         y="39.226234"
          id="tspan14497">CORP</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORP1000.svg
+++ b/dist/icons/achievements/CORP1000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="29.856359"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="28.595892"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="29.856359"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="28.595892"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="48.596111"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="53.02636"
          id="tspan15347">1000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORP1000.svg
+++ b/dist/icons/achievements/CORP1000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORP1000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.791702"
+       y="29.856359"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.791702"
+         y="29.856359"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.791702"
+         y="48.596111"
          id="tspan15347">1000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORPCITY.svg
+++ b/dist/icons/achievements/CORPCITY.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORPCITY.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.791702"
+       y="29.856359"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.791702"
+         y="29.856359"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.791702"
+         y="48.596111"
          id="tspan15347">3000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORPCITY.svg
+++ b/dist/icons/achievements/CORPCITY.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="29.856359"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="28.595892"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="29.856359"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="28.595892"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="48.596111"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="53.02636"
          id="tspan15347">3000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORPLOBBY.svg
+++ b/dist/icons/achievements/CORPLOBBY.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.139565"
-       y="29.856359"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.250423"
+       y="29.55422"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.139565"
-         y="29.856359"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.250423"
+         y="29.55422"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.139565"
-         y="48.596111"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.250423"
+         y="49.542763"
          id="tspan15347">LOBBY</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORPLOBBY.svg
+++ b/dist/icons/achievements/CORPLOBBY.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORPLOBBY.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.139565"
+       y="29.856359"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.139565"
+         y="29.856359"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.139565"
+         y="48.596111"
          id="tspan15347">LOBBY</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORPRE.svg
+++ b/dist/icons/achievements/CORPRE.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.791702"
-       y="29.931318"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.852455"
+       y="28.714317"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="29.931318"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="28.714317"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.791702"
-         y="48.67107"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.852455"
+         y="53.144783"
          id="tspan15347">RE</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CORPRE.svg
+++ b/dist/icons/achievements/CORPRE.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CORPRE.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.791702"
+       y="29.931318"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.791702"
+         y="29.931318"
          id="tspan14497">CORP</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.791702"
+         y="48.67107"
          id="tspan15347">RE</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CSEC.svg
+++ b/dist/icons/achievements/CSEC.svg
@@ -64,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:18.9715px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="8.5974092"
-       y="43.353848"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+       x="31.388172"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="8.5974092"
-         y="43.353848">CSEC</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+         x="31.388172"
+         y="42.889858">CSEC</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/CSEC.svg
+++ b/dist/icons/achievements/CSEC.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="CSEC.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,14 +65,14 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:18.9715px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="4.3416786"
-       y="43.981724"
+       x="8.5974092"
+       y="43.353848"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
          style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="4.3416786"
-         y="43.981724">CSEC</tspan></text>
+         x="8.5974092"
+         y="43.353848">CSEC</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANG.svg
+++ b/dist/icons/achievements/GANG.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.964119"
-       y="39.218739"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="40.17981"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="39.218739"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="40.17981"
          id="tspan11415">GANG</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANG.svg
+++ b/dist/icons/achievements/GANG.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANG.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.964119"
+       y="39.218739"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.964119"
+         y="39.218739"
          id="tspan11415">GANG</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANG100%.svg
+++ b/dist/icons/achievements/GANG100%.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.964119"
-       y="29.848864"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="28.928638"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="29.848864"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="28.928638"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="48.588615"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="51.138145"
          id="tspan14185">100%</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANG100%.svg
+++ b/dist/icons/achievements/GANG100%.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANG100%.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.964119"
+       y="29.848864"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.964119"
+         y="29.848864"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="57.620747"
+         x="33.964119"
+         y="48.588615"
          id="tspan14185">100%</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANG10000.svg
+++ b/dist/icons/achievements/GANG10000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANG10000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.757977"
+       y="29.848864"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.757977"
+         y="29.848864"
          id="tspan14185">GANG</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="57.620747"
+         x="33.757977"
+         y="48.588615"
          id="tspan14497">10000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANG10000.svg
+++ b/dist/icons/achievements/GANG10000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.757977"
-       y="29.848864"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="29.075056"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.757977"
-         y="29.848864"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="29.075056"
          id="tspan14185">GANG</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.757977"
-         y="48.588615"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.978626"
+         y="51.284561"
          id="tspan14497">10000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANGMAX.svg
+++ b/dist/icons/achievements/GANGMAX.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.964119"
-       y="29.923822"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.97863"
+       y="29.182714"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="29.923822"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="29.182714"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.964119"
-         y="48.663574"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.97863"
+         y="51.39222"
          id="tspan14185">MAX</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/GANGMAX.svg
+++ b/dist/icons/achievements/GANGMAX.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="GANGMAX.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.964119"
+       y="29.923822"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.964119"
+         y="29.923822"
          id="tspan11415">GANG</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="57.620747"
+         x="33.964119"
+         y="48.663574"
          id="tspan14185">MAX</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNET.svg
+++ b/dist/icons/achievements/HASHNET.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNET.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="37.947285"
          id="tspan16668">HASHNET</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNET.svg
+++ b/dist/icons/achievements/HASHNET.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="37.947285"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="37.904324"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="37.904324"
          id="tspan16668">HASHNET</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETALL.svg
+++ b/dist/icons/achievements/HASHNETALL.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETALL.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.860498"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.860498"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="45.148373"
          id="tspan17808">ALL</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETALL.svg
+++ b/dist/icons/achievements/HASHNETALL.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.860498"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.860498"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.868937"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="45.148373"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="45.083027"
          id="tspan17808">ALL</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETCAP.svg
+++ b/dist/icons/achievements/HASHNETCAP.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.803347"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.706327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.803347"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.706327"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="45.091221"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="44.920418"
          id="tspan17808">100%</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETCAP.svg
+++ b/dist/icons/achievements/HASHNETCAP.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETCAP.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.803347"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.803347"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="45.091221"
          id="tspan17808">100%</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETMAX.svg
+++ b/dist/icons/achievements/HASHNETMAX.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETMAX.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.860498"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.860498"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="45.148373"
          id="tspan17808">MAX</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETMAX.svg
+++ b/dist/icons/achievements/HASHNETMAX.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.860498"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.860498"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.868937"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="45.148373"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="45.083027"
          id="tspan17808">MAX</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETMONEY.svg
+++ b/dist/icons/achievements/HASHNETMONEY.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="HASHNETMONEY.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.920467"
-       y="29.422306"
+       x="33.375164"
+       y="30.529018"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="29.422306"
+         x="33.375164"
+         y="30.529018"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.920467"
-         y="43.710182"
+         x="33.375164"
+         y="44.816895"
          id="tspan17808">$1B</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/HASHNETMONEY.svg
+++ b/dist/icons/achievements/HASHNETMONEY.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.375164"
-       y="30.529018"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="33.569012"
+       y="30.30394"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="30.529018"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="30.30394"
          id="tspan16668">HASHNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.375164"
-         y="44.816895"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.569012"
+         y="44.518028"
          id="tspan17808">$1B</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/INT255.svg
+++ b/dist/icons/achievements/INT255.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.817944"
-       y="29.773905"
+       style="font-weight:bold;font-size:24.6944px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.932983"
+       y="27.007704"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.817944"
-         y="29.773905"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.932983"
+         y="27.007704"
          id="tspan15347">INT</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.817944"
-         y="48.513657"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.932983"
+         y="58.100937"
          id="tspan16415">255</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/INT255.svg
+++ b/dist/icons/achievements/INT255.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="INT255.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.409664"
-       y="31.148991"
+       x="33.817944"
+       y="29.773905"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="31.148991"
+         x="33.817944"
+         y="29.773905"
          id="tspan15347">INT</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.409664"
-         y="49.888741"
+         x="33.817944"
+         y="48.513657"
          id="tspan16415">255</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/NiteSec.svg
+++ b/dist/icons/achievements/NiteSec.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="NiteSec.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,14 +65,14 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:13.3201px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-       x="4.4427061"
-       y="39.151321"
+       x="8.801322"
+       y="39.833897"
        id="text2505"
-       transform="scale(1.0332295,0.96783917)"><tspan
+       transform="scale(1.0332295,0.96783918)"><tspan
          sodipodi:role="line"
          id="tspan2503"
          style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="4.4427061"
-         y="39.151321">NiteSec</tspan></text>
+         x="8.801322"
+         y="39.833897">NiteSec</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/NiteSec.svg
+++ b/dist/icons/achievements/NiteSec.svg
@@ -64,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.3201px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-       x="8.801322"
-       y="39.833897"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+       x="32.432976"
+       y="40.039101"
        id="text2505"
        transform="scale(1.0332295,0.96783918)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="8.801322"
-         y="39.833897">NiteSec</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.432976"
+         y="40.039101">NiteSec</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/OUCH.svg
+++ b/dist/icons/achievements/OUCH.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.956612"
-       y="39.196251"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="34.273617"
+       y="39.548489"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.956612"
-         y="39.196251"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="34.273617"
+         y="39.548489"
          id="tspan11415">OUCH!</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/OUCH.svg
+++ b/dist/icons/achievements/OUCH.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="OUCH.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.956612"
+       y="39.196251"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.956612"
+         y="39.196251"
          id="tspan11415">OUCH!</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF-1.svg
+++ b/dist/icons/achievements/SF-1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF-1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:18.9715px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="4.3416786"
-       y="43.981724"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="4.3416786"
-         y="43.981724">SF -1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF -1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF-1.svg
+++ b/dist/icons/achievements/SF-1.svg
@@ -64,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-       x="32.46907"
-       y="42.889858"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+       x="32.803677"
+       y="44.78252"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
-         x="32.46907"
-         y="42.889858">SF -1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.254082;stroke-opacity:1"
+         x="32.803677"
+         y="44.78252">SF -1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF1.1.svg
+++ b/dist/icons/achievements/SF1.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF1.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF1.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF1.1.svg
+++ b/dist/icons/achievements/SF1.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF1.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="335"
      inkscape:window-y="29"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF1.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF1.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF10.1.svg
+++ b/dist/icons/achievements/SF10.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF10.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.2573px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-       x="2.3807058"
-       y="43.837727"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-         x="2.3807058"
-         y="43.837727">SF10.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF10.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF10.1.svg
+++ b/dist/icons/achievements/SF10.1.svg
@@ -71,7 +71,7 @@
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
          x="32.46907"
          y="42.889858">SF10.1</tspan></text>
   </g>

--- a/dist/icons/achievements/SF11.1.svg
+++ b/dist/icons/achievements/SF11.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF11.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.2573px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-       x="2.3807058"
-       y="43.837727"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-         x="2.3807058"
-         y="43.837727">SF11.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF11.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF12.1.svg
+++ b/dist/icons/achievements/SF12.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF12.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,15 +64,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.2573px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-       x="2.3807058"
-       y="43.837727"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+       x="32.46907"
+       y="42.889858"
        id="text2505"
        transform="scale(1.0801483,0.9257988)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
-         x="2.3807058"
-         y="43.837727">SF12.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.204338;stroke-opacity:1"
+         x="32.46907"
+         y="42.889858">SF12.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF13.1.svg
+++ b/dist/icons/achievements/SF13.1.svg
@@ -56,14 +56,15 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-size:17.6389px;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#55d400;stroke-width:0.264583"
-       x="34.982018"
-       y="40.175503"
-       id="text1"><tspan
+       style="font-size:17.6389px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#55d400;stroke-width:0.24922"
+       x="33.015541"
+       y="42.263199"
+       id="text1"
+       transform="scale(1.0616446,0.94193481)"><tspan
          sodipodi:role="line"
          id="tspan1"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.264583"
-         x="34.982018"
-         y="40.175503">SF13.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.24922"
+         x="33.015541"
+         y="42.263199">SF13.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF2.1.svg
+++ b/dist/icons/achievements/SF2.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF2.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF2.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF2.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF2.1.svg
+++ b/dist/icons/achievements/SF2.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF2.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF2.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF3.1.svg
+++ b/dist/icons/achievements/SF3.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF3.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF3.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF3.1.svg
+++ b/dist/icons/achievements/SF3.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF3.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF3.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF3.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF4.1.svg
+++ b/dist/icons/achievements/SF4.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF4.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF4.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF4.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF4.1.svg
+++ b/dist/icons/achievements/SF4.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF4.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF4.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF5.1.svg
+++ b/dist/icons/achievements/SF5.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF5.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF5.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF5.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF5.1.svg
+++ b/dist/icons/achievements/SF5.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF5.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF5.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF6.1.svg
+++ b/dist/icons/achievements/SF6.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF6.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF6.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF6.1.svg
+++ b/dist/icons/achievements/SF6.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF6.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF6.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF6.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF7.1.svg
+++ b/dist/icons/achievements/SF7.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF7.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="270"
      inkscape:window-y="58"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF7.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF7.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF7.1.svg
+++ b/dist/icons/achievements/SF7.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF7.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF7.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF8.1.svg
+++ b/dist/icons/achievements/SF8.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF8.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF8.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF8.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF8.1.svg
+++ b/dist/icons/achievements/SF8.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF8.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF8.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF9.1.svg
+++ b/dist/icons/achievements/SF9.1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SF9.1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:19.7556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="3.4424145"
-       y="42.027332"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="34.982018"
+       y="40.175503"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="3.4424145"
-         y="42.027332">SF9.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="34.982018"
+         y="40.175503">SF9.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SF9.1.svg
+++ b/dist/icons/achievements/SF9.1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-       x="34.982018"
-       y="40.175503"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+       x="35.316624"
+       y="42.068161"
        id="text2505"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
-         x="34.982018"
-         y="40.175503">SF9.1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         x="35.316624"
+         y="42.068161">SF9.1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SLEEVE8.svg
+++ b/dist/icons/achievements/SLEEVE8.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="33.855236"
-       y="37.947285"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+       x="33.910591"
+       y="37.651955"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="33.855236"
-         y="37.947285"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
+         x="33.910591"
+         y="37.651955"
          id="tspan17808">8 SLEEVES</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/SLEEVE8.svg
+++ b/dist/icons/achievements/SLEEVE8.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="SLEEVE8.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.4303px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-       x="34.034172"
-       y="37.49543"
+       x="33.855236"
+       y="37.947285"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.153084"
-         x="34.034172"
-         y="37.49543"
-         id="tspan17808">8 SLEEVE</tspan></text>
+         x="33.855236"
+         y="37.947285"
+         id="tspan17808">8 SLEEVES</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/TBH.svg
+++ b/dist/icons/achievements/TBH.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="TBH.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer2"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -48,8 +55,8 @@
        id="rect849"
        width="67.73333"
        height="67.73333"
-       x="0"
-       y="0" />
+       x="1.7801921e-06"
+       y="1.7801921e-06" />
   </g>
   <g
      inkscape:label="main"
@@ -71,11 +78,11 @@
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
          x="32.751316"
          y="38.854351"
-         id="tspan5436">black</tspan><tspan
+         id="tspan5436">Black</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
          x="32.751316"
-         y="55.504475"
-         id="tspan5438">hand</tspan></text>
+         y="55.504478"
+         id="tspan5438">Hand</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/TBH.svg
+++ b/dist/icons/achievements/TBH.svg
@@ -32,7 +32,7 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer2"
+     inkscape:current-layer="layer1"
      inkscape:showpageshadow="2"
      inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
@@ -64,25 +64,25 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.3201px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-       x="32.751316"
-       y="22.204227"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+       x="32.273643"
+       y="20.592304"
        id="text2505"
        transform="scale(1.0332295,0.96783918)"><tspan
          sodipodi:role="line"
          id="tspan2503"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="32.751316"
-         y="22.204227">The</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.273643"
+         y="20.592304">The</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="32.751316"
-         y="38.854351"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.273643"
+         y="40.580845"
          id="tspan5436">Black</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
-         x="32.751316"
-         y="55.504478"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.178394;stroke-opacity:1"
+         x="32.273643"
+         y="60.569389"
          id="tspan5438">Hand</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/TOR.svg
+++ b/dist/icons/achievements/TOR.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="33.904144"
-       y="39.226234"
+       style="font-weight:bold;font-size:24.6944px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+       x="33.667713"
+       y="42.705044"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="33.904144"
-         y="39.226234"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
+         x="33.667713"
+         y="42.705044"
          id="tspan11415">TOR</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/TOR.svg
+++ b/dist/icons/achievements/TOR.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="TOR.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.9918px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-       x="34.523369"
-       y="38.880997"
+       x="33.904144"
+       y="39.226234"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.200782"
-         x="34.523369"
-         y="38.880997"
+         x="33.904144"
+         y="39.226234"
          id="tspan11415">TOR</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/TRAVEL.svg
+++ b/dist/icons/achievements/TRAVEL.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="34.110645"
-       y="37.426777"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="34.193951"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="34.110645"
-         y="37.426777"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="34.193951"
+         y="38.917171"
          id="tspan11415">WORLD</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/TRAVEL.svg
+++ b/dist/icons/achievements/TRAVEL.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="TRAVEL.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="34.110645"
+       y="37.426777"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="34.110645"
+         y="37.426777"
          id="tspan11415">WORLD</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/WORKOUT.svg
+++ b/dist/icons/achievements/WORKOUT.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="WORKOUT.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="33.861687"
+       y="37.426777"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="33.861687"
+         y="37.426777"
          id="tspan11415">WORKOUT</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/WORKOUT.svg
+++ b/dist/icons/achievements/WORKOUT.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.861687"
-       y="37.426777"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="33.9571"
+       y="37.654537"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.861687"
-         y="37.426777"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.9571"
+         y="37.654537"
          id="tspan11415">WORKOUT</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/bigcost.svg
+++ b/dist/icons/achievements/bigcost.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="bigcost.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:13.3483px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.17877"
-       x="34.172409"
-       y="39.818333"
+       x="33.913391"
+       y="38.632011"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.17877"
-         x="34.172409"
-         y="39.818333"
+         x="33.913391"
+         y="38.632011"
          id="tspan5330">32GB+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/bigcost.svg
+++ b/dist/icons/achievements/bigcost.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.3483px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.17877"
-       x="33.913391"
-       y="38.632011"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.17877"
+       x="33.905426"
+       y="40.17981"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.17877"
-         x="33.913391"
-         y="38.632011"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.17877"
+         x="33.905426"
+         y="40.17981"
          id="tspan5330">32GB+</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/bitrunners.svg
+++ b/dist/icons/achievements/bitrunners.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.86318px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.132095"
-       x="7.9610338"
-       y="37.451931"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.132095"
+       x="33.734894"
+       y="37.592525"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.132095"
-         x="7.9610338"
-         y="37.451931">BitRunners</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.132095"
+         x="33.734894"
+         y="37.592525">BitRunners</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/bitrunners.svg
+++ b/dist/icons/achievements/bitrunners.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   sodipodi:docname="bitrunners.svg.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="bitrunners.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.86318px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.132095"
-       x="2.8813558"
-       y="37.776012"
+       x="7.9610338"
+       y="37.451931"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.132095"
-         x="2.8813558"
-         y="37.776012">BitRunners</tspan></text>
+         x="7.9610338"
+         y="37.451931">BitRunners</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/broker.svg
+++ b/dist/icons/achievements/broker.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:20.708px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.277337"
-       x="34.104805"
-       y="39.240395"
+       style="font-weight:bold;font-size:29.9861px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.277337"
+       x="34.298595"
+       y="42.505241"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.277337"
-         x="34.104805"
-         y="39.240395"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.9861px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.277337"
+         x="34.298595"
+         y="42.505241"
          id="tspan5330">$1q</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/broker.svg
+++ b/dist/icons/achievements/broker.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="broker.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:20.708px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.277337"
-       x="34.164398"
-       y="40.048054"
+       x="34.104805"
+       y="39.240395"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.277337"
-         x="34.164398"
-         y="40.048054"
+         x="34.104805"
+         y="39.240395"
          id="tspan5330">$1q</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/combat3000.svg
+++ b/dist/icons/achievements/combat3000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="combat3000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.197567"
-       y="30.194496"
+       x="33.580757"
+       y="30.201166"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="30.194496"
-         id="tspan2495">combat</tspan><tspan
+         x="33.580757"
+         y="30.201166"
+         id="tspan2495">Combat</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="48.521996"
+         x="33.580757"
+         y="48.528667"
          id="tspan3127">3000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/combat3000.svg
+++ b/dist/icons/achievements/combat3000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.580757"
-       y="30.201166"
+       style="font-weight:bold;font-size:14.8167px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+       x="33.606216"
+       y="29.841707"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.580757"
-         y="30.201166"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.8167px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.606216"
+         y="29.841707"
          id="tspan2495">Combat</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.580757"
-         y="48.528667"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.8167px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.606216"
+         y="48.497723"
          id="tspan3127">3000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/daedalus.svg
+++ b/dist/icons/achievements/daedalus.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="daedalus.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="101"
      inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:11.9663px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.160262"
-       x="2.6862416"
-       y="39.373894"
+       x="7.3134484"
+       y="38.354031"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.160262"
-         x="2.6862416"
-         y="39.373894">Daedalus</tspan></text>
+         x="7.3134484"
+         y="38.354031">Daedalus</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/daedalus.svg
+++ b/dist/icons/achievements/daedalus.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.9663px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.160262"
-       x="7.3134484"
-       y="38.354031"
+       style="font-weight:bold;font-size:13.4056px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.160262"
+       x="33.706299"
+       y="38.586117"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.160262"
-         x="7.3134484"
-         y="38.354031">Daedalus</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.4056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.160262"
+         x="33.706299"
+         y="38.586117">Daedalus</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/discount.svg
+++ b/dist/icons/achievements/discount.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:16.3511px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.218986"
-       x="33.940243"
-       y="39.712185"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.218986"
+       x="33.7603"
+       y="41.883419"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.218986"
-         x="33.940243"
-         y="39.712185"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.218986"
+         x="33.7603"
+         y="41.883419"
          id="tspan5330">-10%</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/discount.svg
+++ b/dist/icons/achievements/discount.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="discount.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:16.3511px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.218986"
-       x="35.443775"
-       y="39.886589"
+       x="33.940243"
+       y="39.712185"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.218986"
-         x="35.443775"
-         y="39.886589"
+         x="33.940243"
+         y="39.712185"
          id="tspan5330">-10%</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/donation.svg
+++ b/dist/icons/achievements/donation.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.866669"
-       y="37.426777"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="33.908009"
+       y="37.654537"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.866669"
-         y="37.426777"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.908009"
+         y="37.654537"
          id="tspan11415">DONATION</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/donation.svg
+++ b/dist/icons/achievements/donation.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="donation.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="33.866669"
+       y="37.426777"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="33.866669"
+         y="37.426777"
          id="tspan11415">DONATION</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/drain.svg
+++ b/dist/icons/achievements/drain.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="drain.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:30.1035px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.403166"
-       x="34.864677"
-       y="41.09906"
+       x="33.671001"
+       y="44.417942"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.403166"
-         x="34.864677"
-         y="41.09906"
+         x="33.671001"
+         y="44.417942"
          id="tspan5330">$0</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/drain.svg
+++ b/dist/icons/achievements/drain.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:30.1035px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.403166"
-       x="33.671001"
-       y="44.417942"
+       style="font-weight:bold;font-size:38.8056px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.403166"
+       x="34.160362"
+       y="46.931343"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.403166"
-         x="33.671001"
-         y="44.417942"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:38.8056px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.403166"
+         x="34.160362"
+         y="46.931343"
          id="tspan5330">$0</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/folders.svg
+++ b/dist/icons/achievements/folders.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-       x="33.866665"
-       y="36.505936"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
+       x="33.87011"
+       y="37.611481"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-         x="33.866665"
-         y="36.505936"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
+         x="33.87011"
+         y="37.611481"
          id="tspan5330">/scripts/</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/folders.svg
+++ b/dist/icons/achievements/folders.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="folders.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-       x="34.928535"
-       y="37.743538"
+       x="33.866665"
+       y="36.505936"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-         x="34.928535"
-         y="37.743538"
+         x="33.866665"
+         y="36.505936"
          id="tspan5330">/scripts/</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/formulas.svg
+++ b/dist/icons/achievements/formulas.svg
@@ -65,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:35.2778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.365827"
-       x="7.1413207"
+       x="34.57291"
        y="42.996178"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:35.2778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#000000;fill-opacity:1;stroke-width:0.365827"
-         x="7.1413207"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:35.2778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.365827"
+         x="34.57291"
          y="42.996178">f(x)</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/formulas.svg
+++ b/dist/icons/achievements/formulas.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:27.3155px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.365827"
-       x="14.090266"
-       y="42.156921"
+       style="font-weight:bold;font-size:35.2778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.365827"
+       x="7.1413207"
+       y="42.996178"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.365827"
-         x="14.090266"
-         y="42.156921">f(x)</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:35.2778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#000000;fill-opacity:1;stroke-width:0.365827"
+         x="7.1413207"
+         y="42.996178">f(x)</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/formulas.svg
+++ b/dist/icons/achievements/formulas.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="formulas.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:27.3155px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.365827"
-       x="5.2327757"
-       y="39.963947"
+       x="14.090266"
+       y="42.156921"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.365827"
-         x="5.2327757"
-         y="39.963947">f(x)</tspan></text>
+         x="14.090266"
+         y="42.156921">f(x)</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/frozen.svg
+++ b/dist/icons/achievements/frozen.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-       x="33.866669"
-       y="38.517883"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
+       x="33.911453"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-         x="33.866669"
-         y="38.517883"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
+         x="33.911453"
+         y="38.917171"
          id="tspan3127">FROZEN</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/frozen.svg
+++ b/dist/icons/achievements/frozen.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   sodipodi:docname="nf255.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="frozen.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.538685"
-       y="39.290974"
+       style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
+       x="33.866669"
+       y="38.517883"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.538685"
-         y="39.290974"
-         id="tspan3127">NF 255</tspan></text>
+         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
+         x="33.866669"
+         y="38.517883"
+         id="tspan3127">FROZEN</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hack100000.svg
+++ b/dist/icons/achievements/hack100000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.573429"
-       y="30.201166"
+       style="font-weight:bold;font-size:15.875px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+       x="33.630245"
+       y="29.457327"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.573429"
-         y="30.201166"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.630245"
+         y="29.457327"
          id="tspan2003">Hack</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.573429"
-         y="48.528667"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.875px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.630245"
+         y="49.445869"
          id="tspan2495">100000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hack100000.svg
+++ b/dist/icons/achievements/hack100000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hack100000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.197567"
-       y="30.194496"
+       x="33.573429"
+       y="30.201166"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="30.194496"
-         id="tspan2003">hack</tspan><tspan
+         x="33.573429"
+         y="30.201166"
+         id="tspan2003">Hack</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.197567"
-         y="48.521996"
+         x="33.573429"
+         y="48.528667"
          id="tspan2495">100000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hacknet-10m.svg
+++ b/dist/icons/achievements/hacknet-10m.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="30.958828"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="30.30394"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="30.958828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="30.30394"
          id="tspan10677">HACKNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="43.406765"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="44.518028"
          id="tspan11099">$10m</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hacknet-10m.svg
+++ b/dist/icons/achievements/hacknet-10m.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hacknet-10m.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="34.445259"
-       y="33.325958"
+       x="33.438457"
+       y="30.958828"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="34.445259"
-         y="33.325958"
+         x="33.438457"
+         y="30.958828"
          id="tspan10677">HACKNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="34.445259"
-         y="45.773895"
+         x="33.438457"
+         y="43.406765"
          id="tspan11099">$10m</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hacknet-all.svg
+++ b/dist/icons/achievements/hacknet-all.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="31.24762"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="31.24762"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="30.868937"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="43.695557"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="45.083023"
          id="tspan10677">ALL</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hacknet-all.svg
+++ b/dist/icons/achievements/hacknet-all.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hacknet-all.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="34.217846"
-       y="34.463017"
+       x="33.438457"
+       y="31.24762"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="34.463017"
+         x="33.438457"
+         y="31.24762"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="46.910954"
+         x="33.438457"
+         y="43.695557"
          id="tspan10677">ALL</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hacknet-max.svg
+++ b/dist/icons/achievements/hacknet-max.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="hacknet-max.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="34.217846"
-       y="34.463017"
+       x="33.438457"
+       y="31.24762"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="34.463017"
+         x="33.438457"
+         y="31.24762"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="34.217846"
-         y="46.910954"
+         x="33.438457"
+         y="43.695557"
          id="tspan10677">MAX</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/hacknet-max.svg
+++ b/dist/icons/achievements/hacknet-max.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="31.24762"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="30.868937"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="31.24762"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="30.868937"
          id="tspan5330">HACKNET</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="43.695557"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="45.083023"
          id="tspan10677">MAX</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/illuminati.svg
+++ b/dist/icons/achievements/illuminati.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="illuminati.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:11.3623px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.152171"
-       x="2.7185695"
-       y="38.914951"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.152171"
+       x="34.12772"
+       y="39.158329"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.152171"
-         x="2.7185695"
-         y="38.914951">Illuminati</tspan></text>
+         style="font-size:14.1111px;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.152171"
+         x="34.12772"
+         y="39.158329">Illuminati</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/illuminati.svg
+++ b/dist/icons/achievements/illuminati.svg
@@ -65,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.152171"
-       x="34.12772"
-       y="39.158329"
+       x="33.870113"
+       y="38.834492"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="font-size:14.1111px;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.152171"
-         x="34.12772"
-         y="39.158329">Illuminati</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.152171"
+         x="33.870113"
+         y="38.834492">Illuminati</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/install.svg
+++ b/dist/icons/achievements/install.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.2099"
-       x="11.697483"
-       y="39.743965"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.2099"
+       x="33.871403"
+       y="40.697437"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="11.697483"
-         y="39.743965">Install</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
+         x="33.871403"
+         y="40.697437">Install</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/install.svg
+++ b/dist/icons/achievements/install.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="install.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.2099"
-       x="6.1825614"
-       y="39.945213"
+       x="11.697483"
+       y="39.743965"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="6.1825614"
-         y="39.945213">Install</tspan></text>
+         x="11.697483"
+         y="39.743965">Install</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/install_100.svg
+++ b/dist/icons/achievements/install_100.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="install_100.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-       x="34.312416"
-       y="31.189854"
+       x="34.219299"
+       y="29.948467"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="31.189854">Install</tspan><tspan
+         x="34.219299"
+         y="29.948467">Install</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="50.780853"
+         x="34.219299"
+         y="49.539467"
          id="tspan1231">100</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/install_100.svg
+++ b/dist/icons/achievements/install_100.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-       x="34.219299"
-       y="29.948467"
+       style="font-weight:bold;font-size:19.4028px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
+       x="33.871403"
+       y="28.477467"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="34.219299"
-         y="29.948467">Install</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
+         x="33.871403"
+         y="28.477467">Install</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="34.219299"
-         y="49.539467"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.4028px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
+         x="33.871403"
+         y="52.907936"
          id="tspan1231">100</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/karma.svg
+++ b/dist/icons/achievements/karma.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-       x="33.356869"
-       y="37.674225"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
+       x="33.36713"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-         x="33.356869"
-         y="37.674225"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
+         x="33.36713"
+         y="38.917171"
          id="tspan5330">KARMA</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/karma.svg
+++ b/dist/icons/achievements/karma.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="karma.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:10.6208px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-       x="34.928535"
-       y="37.743538"
+       x="33.356869"
+       y="37.674225"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.142242"
-         x="34.928535"
-         y="37.743538"
+         x="33.356869"
+         y="37.674225"
          id="tspan5330">KARMA</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/maxcores.svg
+++ b/dist/icons/achievements/maxcores.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="maxcores.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-       x="34.01947"
-       y="38.517769"
+       x="33.840996"
+       y="38.449512"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-         x="34.01947"
-         y="38.517769"
+         x="33.840996"
+         y="38.449512"
          id="tspan5330">8 Cores</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/maxcores.svg
+++ b/dist/icons/achievements/maxcores.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-       x="33.840996"
-       y="38.449512"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
+       x="33.921791"
+       y="38.913727"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-         x="33.840996"
-         y="38.449512"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
+         x="33.921791"
+         y="38.913727"
          id="tspan5330">8 Cores</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/maxram.svg
+++ b/dist/icons/achievements/maxram.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="maxram.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-       x="32.996117"
-       y="37.60812"
+       x="33.905174"
+       y="38.455929"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-         x="32.996117"
-         y="37.60812"
+         x="33.905174"
+         y="38.455929"
          id="tspan5330">2^30GB</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/maxram.svg
+++ b/dist/icons/achievements/maxram.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:12.8371px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-       x="33.905174"
-       y="38.455929"
+       style="font-weight:bold;font-size:14.1111px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
+       x="34.038921"
+       y="38.917171"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
-         x="33.905174"
-         y="38.455929"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.1111px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.171924"
+         x="34.038921"
+         y="38.917171"
          id="tspan5330">2^30GB</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/nfg255.svg
+++ b/dist/icons/achievements/nfg255.svg
@@ -64,14 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.573429"
-       y="39.101002"
+       style="font-weight:bold;font-size:24.6944px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+       x="33.697857"
+       y="27.158426"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.573429"
-         y="39.101002"
-         id="tspan3127">NFG 255</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.697857"
+         y="27.158426"
+         id="tspan3127">NFG</tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6944px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.697857"
+         y="58.251659"
+         id="tspan1">255</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/nfg255.svg
+++ b/dist/icons/achievements/nfg255.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   sodipodi:docname="forze.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="nfg255.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-       x="34.064476"
-       y="38.520031"
+       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+       x="33.573429"
+       y="39.101002"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-         x="34.064476"
-         y="38.520031"
-         id="tspan3127">FROZEN</tspan></text>
+         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.573429"
+         y="39.101002"
+         id="tspan3127">NFG 255</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/node.svg
+++ b/dist/icons/achievements/node.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="node.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.763023"
-       y="38.329018"
+       x="33.438457"
+       y="37.421799"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.763023"
-         y="38.329018"
+         x="33.438457"
+         y="37.421799"
          id="tspan5330">HACKNET</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/node.svg
+++ b/dist/icons/achievements/node.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.438457"
-       y="37.421799"
+       style="font-weight:bold;font-size:11.2889px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="33.569012"
+       y="37.907078"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.438457"
-         y="37.421799"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.569012"
+         y="37.907078"
          id="tspan5330">HACKNET</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/ns2.svg
+++ b/dist/icons/achievements/ns2.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.536774"
-       y="39.101002"
+       style="font-weight:bold;font-size:29.9861px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+       x="33.507946"
+       y="44.591675"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.536774"
-         y="39.101002"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.9861px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
+         x="33.507946"
+         y="44.591675"
          id="tspan3127">NS2</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/ns2.svg
+++ b/dist/icons/achievements/ns2.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="ns2.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:14.662px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-       x="33.538685"
-       y="39.290974"
+       x="33.536774"
+       y="39.101002"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.196363"
-         x="33.538685"
-         y="39.290974"
+         x="33.536774"
+         y="39.101002"
          id="tspan3127">NS2</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p0.svg
+++ b/dist/icons/achievements/p0.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="8.5273066"
-       y="48.656586"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
+       x="33.370575"
+       y="48.821815"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="8.5273066"
-         y="48.656586">P0</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.554058"
+         x="33.370575"
+         y="48.821815">P0</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p0.svg
+++ b/dist/icons/achievements/p0.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p0.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="8.5273066"
+       y="48.656586"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P0</tspan></text>
+         x="8.5273066"
+         y="48.656586">P0</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p1.svg
+++ b/dist/icons/achievements/p1.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="12.00242"
-       y="48.635899"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
+       x="35.768356"
+       y="49.080196"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="12.00242"
-         y="48.635899">P1</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.554058"
+         x="35.768356"
+         y="49.080196">P1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p1.svg
+++ b/dist/icons/achievements/p1.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p1.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="12.00242"
+       y="48.635899"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P1</tspan></text>
+         x="12.00242"
+         y="48.635899">P1</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p2.svg
+++ b/dist/icons/achievements/p2.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p2.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="8.5893621"
+       y="48.842751"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P2</tspan></text>
+         x="8.5893621"
+         y="48.842751">P2</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p2.svg
+++ b/dist/icons/achievements/p2.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="8.5893621"
-       y="48.842751"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
+       x="33.391243"
+       y="49.080196"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="8.5893621"
-         y="48.842751">P2</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.554058"
+         x="33.391243"
+         y="49.080196">P2</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p3.svg
+++ b/dist/icons/achievements/p3.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="8.6927881"
-       y="48.635899"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
+       x="33.236214"
+       y="48.821815"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="8.6927881"
-         y="48.635899">P3</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.554058"
+         x="33.236214"
+         y="48.821815">P3</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p3.svg
+++ b/dist/icons/achievements/p3.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p3.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="8.6927881"
+       y="48.635899"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P3</tspan></text>
+         x="8.6927881"
+         y="48.635899">P3</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p4.svg
+++ b/dist/icons/achievements/p4.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="p4.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="4.0280304"
-       y="48.20945"
+       x="7.9274364"
+       y="48.718639"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
          style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="4.0280304"
-         y="48.20945">P4</tspan></text>
+         x="7.9274364"
+         y="48.718639">P4</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/p4.svg
+++ b/dist/icons/achievements/p4.svg
@@ -64,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:41.3704px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
-       x="7.9274364"
-       y="48.718639"
+       style="font-weight:bold;font-size:42.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.554058"
+       x="32.812469"
+       y="49.080196"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.554058"
-         x="7.9274364"
-         y="48.718639">P4</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.3333px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.554058"
+         x="32.812469"
+         y="49.080196">P4</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/queue40.svg
+++ b/dist/icons/achievements/queue40.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-       x="33.788296"
-       y="29.674192"
+       style="font-weight:bold;font-size:17.6389px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
+       x="33.835438"
+       y="29.075056"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="33.788296"
-         y="29.674192"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
+         x="33.835438"
+         y="29.075056"
          id="tspan1231">Queue</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="33.788296"
-         y="49.265194"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.6389px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
+         x="33.835438"
+         y="51.284561"
          id="tspan2003">40</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/queue40.svg
+++ b/dist/icons/achievements/queue40.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="queue40.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:15.6728px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-       x="34.312416"
-       y="30.507618"
+       x="33.788296"
+       y="29.674192"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="30.507618"
-         id="tspan1231">queue</tspan><tspan
+         x="33.788296"
+         y="29.674192"
+         id="tspan1231">Queue</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.2099"
-         x="34.312416"
-         y="50.098618"
+         x="33.788296"
+         y="49.265194"
          id="tspan2003">40</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/reputation.svg
+++ b/dist/icons/achievements/reputation.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.786999"
-       y="31.262558"
+       style="font-weight:bold;font-size:10.5833px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+       x="33.835659"
+       y="30.927116"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.786999"
-         y="31.262558"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.835659"
+         y="30.927116"
          id="tspan11099">Reputation</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.786999"
-         y="43.710495"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.5833px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
+         x="33.835659"
+         y="44.252769"
          id="tspan11415">10m</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/reputation.svg
+++ b/dist/icons/achievements/reputation.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="reputation.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.95835px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-       x="33.916092"
-       y="33.325958"
+       x="33.786999"
+       y="31.262558"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="33.325958"
+         x="33.786999"
+         y="31.262558"
          id="tspan11099">Reputation</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.13337"
-         x="33.916092"
-         y="45.773895"
+         x="33.786999"
+         y="43.710495"
          id="tspan11415">10m</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/run1000.svg
+++ b/dist/icons/achievements/run1000.svg
@@ -64,19 +64,19 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-       x="33.606461"
-       y="30.314827"
+       style="font-weight:bold;font-size:22.9306px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
+       x="33.525169"
+       y="27.497606"
        id="text8876"><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-         x="33.606461"
-         y="30.314827"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
+         x="33.525169"
+         y="27.497606"
          id="tspan3127">RUN</tspan><tspan
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-         x="33.606461"
-         y="46.577827"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.9306px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
+         x="33.525169"
+         y="56.370003"
          id="tspan5330">1000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/run1000.svg
+++ b/dist/icons/achievements/run1000.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="run1000.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="146"
      inkscape:window-y="51"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -58,18 +65,18 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:13.0104px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-       x="34.291889"
-       y="30.105789"
+       x="33.606461"
+       y="30.314827"
        id="text8876"><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-         x="34.291889"
-         y="30.105789"
+         x="33.606461"
+         y="30.314827"
          id="tspan3127">RUN</tspan><tspan
          sodipodi:role="line"
          style="text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.174244"
-         x="34.291889"
-         y="46.36879"
+         x="33.606461"
+         y="46.577827"
          id="tspan5330">1000</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/thecovenant.svg
+++ b/dist/icons/achievements/thecovenant.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 67.733332 67.733335"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="thecovenant.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -32,10 +32,17 @@
      inkscape:window-x="96"
      inkscape:window-y="79"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid824" />
+       id="grid824"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -57,14 +64,14 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="font-weight:bold;font-size:8.0461px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.107759"
-       x="2.917733"
-       y="36.395454"
+       style="font-weight:bold;font-size:9.87778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.107759"
+       x="33.925934"
+       y="37.570835"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.107759"
-         x="2.917733"
-         y="36.395454">The Covenant</tspan></text>
+         style="font-size:9.87778px;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.107759"
+         x="33.925934"
+         y="37.570835">The Covenant</tspan></text>
   </g>
 </svg>

--- a/dist/icons/achievements/thecovenant.svg
+++ b/dist/icons/achievements/thecovenant.svg
@@ -65,13 +65,13 @@
     <text
        xml:space="preserve"
        style="font-weight:bold;font-size:9.87778px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#000000;fill-opacity:1;stroke-width:0.107759"
-       x="33.925934"
-       y="37.570835"
+       x="33.820847"
+       y="37.402023"
        id="text8876"><tspan
          sodipodi:role="line"
          id="tspan8874"
-         style="font-size:9.87778px;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.107759"
-         x="33.925934"
-         y="37.570835">The Covenant</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.87778px;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.107759"
+         x="33.820847"
+         y="37.402023">The Covenant</tspan></text>
   </g>
 </svg>

--- a/src/Achievements/Achievements.ts
+++ b/src/Achievements/Achievements.ts
@@ -187,7 +187,7 @@ export const achievements: Record<string, Achievement> = {
   },
   NEUROFLUX_255: {
     ...achievementData.NEUROFLUX_255,
-    Icon: "nf255",
+    Icon: "nfg255",
     Condition: () => Player.augmentations.some((a) => a.name === AugmentationName.NeuroFluxGovernor && a.level >= 255),
   },
   NS2: {
@@ -197,7 +197,7 @@ export const achievements: Record<string, Achievement> = {
   },
   FROZE: {
     ...achievementData.FROZE,
-    Icon: "forze",
+    Icon: "frozen",
     Condition: () => location.href.includes("noScripts"),
   },
   RUNNING_SCRIPTS_1000: {

--- a/src/Achievements/README.md
+++ b/src/Achievements/README.md
@@ -9,17 +9,17 @@ Steps:
 - Clone `$PROJECT_DIR/assets/Steam/achievements/template.svg`.
 - Edit the text.
 - Object -> Align and Distribute ...
-  - Relative to: Chose "Page".
+  - Relative to: Choose "Page".
   - Press the icon having the tooltip: "Center on vertical axis".
   - Press the icon having the tooltip: "Center on horizontal axis".
 
 # Add achievements
 
-- Add the new icon (.svg file) in `$PROJECT_DIR/assets/Steam/achievements/icons`.
-- Add an entry in `$PROJECT_DIR/src/Achievements/AchievementData.json`.
-  - It should match the information for the Steam achievement, if applicable.
+- Add the new icon (.svg file) to `$PROJECT_DIR/assets/Steam/achievements/icons`.
+- Add an entry to `$PROJECT_DIR/src/Achievements/AchievementData.json`.
+  - It should match the information of the Steam achievement, if applicable.
   - Order the new achievement entry thematically.
-- Add an entry in `$PROJECT_DIR/src/Achievements/Achievements.ts`.
+- Add an entry to `$PROJECT_DIR/src/Achievements/Achievements.ts`.
   - Match the order of achievements in `AchievementData.json`.
   - `Icon` must be the name of the .svg file.
   - `NotInSteam` must be true.


### PR DESCRIPTION
When implementing #2109, I notice that the icons of many achievements are weirdly aligned to the left. This PR realigns *all* icons. I also make some changes to the text content of some icons:
- "combat 3000" -> "Combat 3000"
- "hack 100000" -> "Hack 100000"
- "queue 40" -> "Queue 40"
- "8 SLEEVE" -> "8 SLEEVES"
- "The black hand" -> "The Black Hand"
- Rename `forze.svg` to `frozen.svg`
- Rename `nf255.svg` to `nfg255.svg`. "NF 255" -> "NFG 255".

Before:

![before](https://github.com/user-attachments/assets/c2dd18df-bc02-4290-abf8-4b3b7b641056)


After:

![after](https://github.com/user-attachments/assets/303255ff-a5da-4280-a9b1-10abf21b1a4b)
