### PR TITLE
UI: Change min and step value of "Tail render interval" setting

### DIFF
--- a/src/GameOptions/ui/SystemPage.tsx
+++ b/src/GameOptions/ui/SystemPage.tsx
@@ -11,7 +11,7 @@ export const SystemPage = (): React.ReactElement => {
   const [portSize, setPortSize] = useState(Settings.MaxPortCapacity);
   const [terminalSize, setTerminalSize] = useState(Settings.MaxTerminalCapacity);
   const [autosaveInterval, setAutosaveInterval] = useState(Settings.AutosaveInterval);
-  const [tailrenderInterval, setTailRenderInterval] = useState(Settings.TailRenderInterval);
+  const [tailRenderInterval, setTailRenderInterval] = useState(Settings.TailRenderInterval);
 
   function handlePortSizeChange(_event: Event | React.SyntheticEvent, newValue: number | number[]): void {
     setPortSize(newValue as number);
@@ -120,11 +120,11 @@ export const SystemPage = (): React.ReactElement => {
         />
         <OptionsSlider
           label="Tail render interval (ms)"
-          initialValue={tailrenderInterval}
+          initialValue={tailRenderInterval}
           callback={handleTailIntervalChange}
-          step={200}
-          min={50}
-          max={5 * 1000}
+          step={100}
+          min={100}
+          max={5000}
           tooltip={
             <>
               The minimum number of milliseconds between tail rerenders. Setting this too low can result in poor


### PR DESCRIPTION
In options, each slider has a "step". The tail render interval step is 200, so we have this UX problem (quoted from Discord): `the tail render interval defaults to 1000ms, but once changed moves in 100ms steps starting from 50ms, so you can never go back to 1000ms, only 1050ms.`.

After discussing it, we agreed that setting both the min and the step to 100 is a good solution.

Note that if the player sets the min value to 50 (old min value) and then opens the new UI, the min value that they see will be 100, but the actual value is still 50. I don't think we need to write migration code for this niche case.