### PR TITLE
IPVGO: Correctly end game & winstreak if a cheat attempt critically fails

### DIFF
--- a/src/Go/boardAnalysis/scoring.ts
+++ b/src/Go/boardAnalysis/scoring.ts
@@ -91,6 +91,20 @@ export function endGoGame(boardState: BoardState) {
 }
 
 /**
+ * Forcefully ends the game, resetting the winstreak (if any) and ending the game without applying node power bonuses.
+ * Used for critically failing a cheat attempt.
+ * @param boardState - the boardstate to reset
+ */
+export function forceEndGoGame(boardState: BoardState) {
+  resetWinstreak(boardState.ai, false);
+  boardState.previousPlayer = null;
+  Go.currentGame = boardState;
+  Go.previousGame = boardState;
+  resetAI(true);
+  GoEvents.emit();
+}
+
+/**
  * Sets the winstreak to zero for the given opponent, and adds a loss
  */
 export function resetWinstreak(opponent: GoOpponent, gameComplete: boolean) {

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -19,7 +19,7 @@ import {
   simpleBoardFromBoard,
   simpleBoardFromBoardString,
 } from "../boardAnalysis/boardAnalysis";
-import { endGoGame, getOpponentStats, getScore, resetWinstreak } from "../boardAnalysis/scoring";
+import { forceEndGoGame, getOpponentStats, getScore, resetWinstreak } from "../boardAnalysis/scoring";
 import { WHRNG } from "../../Casino/RNG";
 import { getRecordKeys } from "../../Types/Record";
 import { CalculateEffect, getEffectTypeForFaction } from "./effect";
@@ -505,7 +505,7 @@ export function determineCheatSuccess(
   // If there have been prior cheat attempts, and the cheat fails, there is a 10% chance of instantly losing
   else if (priorCheatCount && (ejectRngOverride ?? rng.random()) < 0.1 && state.ai !== GoOpponent.none) {
     logger(`Cheat failed! You have been ejected from the subnet.`);
-    endGoGame(state);
+    forceEndGoGame(state);
     return handleNextTurn(state, true);
   } else {
     // If the cheat fails, your turn is skipped


### PR DESCRIPTION
Previously, a player could intentionally fail to cheat in order to lock in a not-yet-completed go game where they were ahead, which was not the intention.

This change fixes that, so that failing to cheat and hitting the 10% critical fail chance correctly kicks you out of the game and resets your winstreak without giving node power.

context: https://discord.com/channels/415207508303544321/459097632896188436/1371139321687445614