### PR TITLE
CODEBASE: Improve clarifications around special codebase exceptions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,8 @@ indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[src/ScriptEditor/NetscriptDefinitions.d.ts]
+trim_trailing_whitespace = false
+
 [*.md]
 trim_trailing_whitespace = false

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -151,6 +151,12 @@ upstream/master
   - Keep code-changes on a branch as small as possible. This makes it easier for code review. Each branch should be its own independent feature.
   - Regularly rebase your branch against `dev` to make sure you have the latest updates pulled.
 
+### Special Exceptions
+
+- In `src/ScriptEditor/NetscriptDefinitions.d.ts`, there are two specially-formatted go boards with two trailing whitespaces.
+  Make sure your editor does not automatically format those examples.
+  You can look for changes to that part using `git diff` to make sure the whitespaces are still present.
+
 ## Running locally
 
 Install


### PR DESCRIPTION
There are a few "weird" sections in the codebase that are unclear for someone starting out contributing.
This PR tries to point out some of those special exceptions. Currently, I only mention the trailing whitespaces on some of the GO board examples. If there are any other special sections I should add, feel free to mention them!
I added an exception to the `.editorconfig` for `src/ScriptEditor/NetscriptDefinitions.d.ts` for the trailing whitespaces, since some editors do format based on that config.