### PR TITLE
API: Add more enums to ns.enums

### DIFF
--- a/markdown/bitburner.nsenums.md
+++ b/markdown/bitburner.nsenums.md
@@ -21,7 +21,11 @@ type NSEnums = {
   CompanyName: CompanyNameEnumType;
   FactionName: FactionNameEnumType;
   CodingContractName: CodingContractNameEnumType;
+  PositionType: PositionEnumType;
+  OrderType: OrderEnumType;
+  BladeburnerActionType: BladeburnerActionEnumType;
+  SpecialBladeburnerActionTypeForSleeve: SpecialBladeburnerActionEnumTypeForSleeve;
 };
 ```
-**References:** [CityNameEnumType](./bitburner.citynameenumtype.md)<!-- -->, [CrimeEnumType](./bitburner.crimeenumtype.md)<!-- -->, [FactionWorkEnumType](./bitburner.factionworkenumtype.md)<!-- -->, [GymEnumType](./bitburner.gymenumtype.md)<!-- -->, [JobNameEnumType](./bitburner.jobnameenumtype.md)<!-- -->, [JobFieldEnumType](./bitburner.jobfieldenumtype.md)<!-- -->, [LocationNameEnumType](./bitburner.locationnameenumtype.md)<!-- -->, [ToastVariantEnumType](./bitburner.toastvariantenumtype.md)<!-- -->, [UniversityClassEnumType](./bitburner.universityclassenumtype.md)<!-- -->, [CompanyNameEnumType](./bitburner.companynameenumtype.md)<!-- -->, [FactionNameEnumType](./bitburner.factionnameenumtype.md)<!-- -->, [CodingContractNameEnumType](./bitburner.codingcontractnameenumtype.md)
+**References:** [CityNameEnumType](./bitburner.citynameenumtype.md)<!-- -->, [CrimeEnumType](./bitburner.crimeenumtype.md)<!-- -->, [FactionWorkEnumType](./bitburner.factionworkenumtype.md)<!-- -->, [GymEnumType](./bitburner.gymenumtype.md)<!-- -->, [JobNameEnumType](./bitburner.jobnameenumtype.md)<!-- -->, [JobFieldEnumType](./bitburner.jobfieldenumtype.md)<!-- -->, [LocationNameEnumType](./bitburner.locationnameenumtype.md)<!-- -->, [ToastVariantEnumType](./bitburner.toastvariantenumtype.md)<!-- -->, [UniversityClassEnumType](./bitburner.universityclassenumtype.md)<!-- -->, [CompanyNameEnumType](./bitburner.companynameenumtype.md)<!-- -->, [FactionNameEnumType](./bitburner.factionnameenumtype.md)<!-- -->, [CodingContractNameEnumType](./bitburner.codingcontractnameenumtype.md)<!-- -->, [PositionEnumType](./bitburner.positionenumtype.md)<!-- -->, [OrderEnumType](./bitburner.orderenumtype.md)<!-- -->, [BladeburnerActionEnumType](./bitburner.bladeburneractionenumtype.md)<!-- -->, [SpecialBladeburnerActionEnumTypeForSleeve](./bitburner.specialbladeburneractionenumtypeforsleeve.md)
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -28,6 +28,10 @@ import {
   CompanyName,
   FactionName,
   type MessageFilename,
+  PositionType,
+  OrderType,
+  BladeburnerActionType,
+  SpecialBladeburnerActionTypeForSleeve,
 } from "@enums";
 import { PromptEvent } from "./ui/React/PromptManager";
 import { GetServer, DeleteServer, AddToAllServers, createUniqueRandomIp } from "./Server/AllServers";
@@ -128,6 +132,10 @@ export const enums: NSEnums = {
   CompanyName,
   FactionName,
   CodingContractName,
+  PositionType,
+  OrderType,
+  BladeburnerActionType,
+  SpecialBladeburnerActionTypeForSleeve,
 };
 for (const val of Object.values(enums)) Object.freeze(val);
 Object.freeze(enums);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -8754,6 +8754,10 @@ type NSEnums = {
   CompanyName: CompanyNameEnumType;
   FactionName: FactionNameEnumType;
   CodingContractName: CodingContractNameEnumType;
+  PositionType: PositionEnumType;
+  OrderType: OrderEnumType;
+  BladeburnerActionType: BladeburnerActionEnumType;
+  SpecialBladeburnerActionTypeForSleeve: SpecialBladeburnerActionEnumTypeForSleeve;
 };
 
 /**


### PR DESCRIPTION
We need to expose these enums due to #2149. For more information, please check https://github.com/bitburner-official/bitburner-src/pull/2149#discussion_r2105832271.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  console.log(ns.enums);
}
```

![enums](https://github.com/user-attachments/assets/7e20f93d-93fd-407b-942f-db55939a2f82)

