### PR TITLE
IPVGO: fix score modal styling

### DIFF
--- a/src/Go/boardState/goStyles.ts
+++ b/src/Go/boardState/goStyles.ts
@@ -625,7 +625,7 @@ export const boardStyles = makeStyles<unknown, Size | "background">({ uniqId: "b
       width: "400px",
     },
     scoreExplanationModal: {
-      width: "80vw",
+      width: "600px",
     },
     centeredText: {
       textAlign: "center",

--- a/src/Go/ui/GoScoreExplanation.tsx
+++ b/src/Go/ui/GoScoreExplanation.tsx
@@ -17,6 +17,7 @@ export const GoScoreExplanation = ({ open, onClose }: Props): React.ReactElement
       <>
         <div className={classes.scoreExplanationModal}>
           <Typography>
+            <h2>IPvGO Scoring Explanation</h2>
             IPvGO uses one of the oldest scoring systems in Go, "area scoring", rather than "territory scoring" later
             popularized by Japan. All stones are alive unless captured, chains that could be dead are not automatically
             captured after the game, and prisoners are not calculated. The displayed score is always the ending score if


### PR DESCRIPTION
Previously the IPvGO score explanation modal could get very wide, and did not have a header, which caused clipping with some of the text behind the close button.  This PR fixes it to have a better layout and fixed width to prevent that.

context:
https://discord.com/channels/415207508303544321/415213413745164318/1377664020508573727

New styles:
![image](https://github.com/user-attachments/assets/247ef749-579b-4be8-b591-ef02930fbcc7)
