### PR TITLE
BUGFIX: API breaking change detector does not detect affected code in some cases

### DIFF
--- a/src/utils/APIBreaks/APIBreak.ts
+++ b/src/utils/APIBreaks/APIBreak.ts
@@ -58,7 +58,10 @@ function detectImpactAndMigrateLines(script: Script, brokenFunctions: APIBreakIn
   const lines = script.content.split("\n");
   for (let i = 0; i < lines.length; ++i) {
     for (const brokenFunction of brokenFunctions) {
-      if (!lines[i].includes(brokenFunction.name)) {
+      if (
+        !lines[i].includes(brokenFunction.name) &&
+        (!brokenFunction.migration || !lines[i].match(brokenFunction.migration.searchValue))
+      ) {
         continue;
       }
       impactedLines.push(i + 1);


### PR DESCRIPTION
Starting from #2146, `migration.searchValue` may be a substring of `name` (before that, `migration.searchValue` is always `name` or `name` + `()`), so the check in `detectImpactAndMigrateLines` does not detect the affected code properly.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  ns.clearLog();
  ns.corporation.setAutoJobAssignment("Agriculture", "Sector-12", "Engineer", 1);
  const { setAutoJobAssignment } = ns.corporation;
  setAutoJobAssignment("Agriculture", "Sector-12", "Engineer", 1);
}
```

Before:
```
API BREAK INFO FOR 3.0.0

ns.corporation.setAutoJobAssignment() was removed.
It has been automatically replaced with "ns.corporation.setJobAssignment()".



Usage of the following functions may have been affected:
ns.corporation.setAutoJobAssignment

Potentially affected files on server home (with line numbers):
test.js: (Line number: 5)
```

After
```
API BREAK INFO FOR 3.0.0

ns.corporation.setAutoJobAssignment() was removed.
It has been automatically replaced with "ns.corporation.setJobAssignment()".



Usage of the following functions may have been affected:
ns.corporation.setAutoJobAssignment

Potentially affected files on server home (with line numbers):
test.js: (Line numbers: 5, 6, 7)
```