### PR TITLE
DOCUMENTATION: Fix missing and outdated info of optional parameter

### DIFF
--- a/markdown/bitburner.corporation.createcorporation.md
+++ b/markdown/bitburner.corporation.createcorporation.md
@@ -13,7 +13,7 @@ Create a Corporation. You should use [canCreateCorporation](./bitburner.corporat
 **Signature:**
 
 ```typescript
-createCorporation(corporationName: string, selfFund: boolean): boolean;
+createCorporation(corporationName: string, selfFund?: boolean): boolean;
 ```
 
 ## Parameters
@@ -21,7 +21,7 @@ createCorporation(corporationName: string, selfFund: boolean): boolean;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  corporationName | string | Name of the corporation. It must be a non-empty string. |
-|  selfFund | boolean | If you want to self-fund. Defaults to true, false will only work in BitNode 3. |
+|  selfFund | boolean | _(Optional)_ If you want to self-fund. Defaults to true, false will only work in BitNode 3. |
 
 **Returns:**
 

--- a/markdown/bitburner.singularity.workforcompany.md
+++ b/markdown/bitburner.singularity.workforcompany.md
@@ -16,7 +16,7 @@ workForCompany(companyName: CompanyName, focus?: boolean): boolean;
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  companyName | [CompanyName](./bitburner.companyname.md) | Name of company to work for. Must be an exact match. Optional. If not specified, this argument defaults to the last job that you worked. |
+|  companyName | [CompanyName](./bitburner.companyname.md) | Name of company to work for. Must be an exact match. |
 |  focus | boolean | _(Optional)_ Acquire player focus on this work operation. Optional. Defaults to true. |
 
 **Returns:**

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2130,8 +2130,7 @@ export interface Singularity {
    * const success = ns.singularity.workForCompany(companyName);
    * if (!success) ns.tprint(`ERROR: Failed to start work at ${companyName}.`);
    * ```
-   * @param companyName - Name of company to work for. Must be an exact match. Optional. If not specified, this
-   *   argument defaults to the last job that you worked.
+   * @param companyName - Name of company to work for. Must be an exact match.
    * @param focus - Acquire player focus on this work operation. Optional. Defaults to true.
    * @returns True if the player starts working, and false otherwise.
    */
@@ -9324,7 +9323,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    * @param selfFund - If you want to self-fund. Defaults to true, false will only work in BitNode 3.
    * @returns true if created and false if not
    */
-  createCorporation(corporationName: string, selfFund: boolean): boolean;
+  createCorporation(corporationName: string, selfFund?: boolean): boolean;
 
   /**
    * Check if you have a one-time unlockable upgrade.


### PR DESCRIPTION
This PR fixes:
- `ns.singularity.workForCompany`: `companyName` is not optional now.
- `ns.corporation.createCorporation`: We forget to mark `selfFund` as optional.