### PR TITLE
API: Set default values for some properties of Server object returned from ns.getServer

### DIFF
--- a/markdown/bitburner.server.backdoorinstalled.md
+++ b/markdown/bitburner.server.backdoorinstalled.md
@@ -9,5 +9,5 @@ Flag indicating whether this server has a backdoor installed by a player
 **Signature:**
 
 ```typescript
-backdoorInstalled?: boolean;
+backdoorInstalled: boolean;
 ```

--- a/markdown/bitburner.server.basedifficulty.md
+++ b/markdown/bitburner.server.basedifficulty.md
@@ -9,5 +9,5 @@ Server's initial server security level at creation.
 **Signature:**
 
 ```typescript
-baseDifficulty?: number;
+baseDifficulty: number;
 ```

--- a/markdown/bitburner.server.hackdifficulty.md
+++ b/markdown/bitburner.server.hackdifficulty.md
@@ -9,5 +9,5 @@ Server Security Level
 **Signature:**
 
 ```typescript
-hackDifficulty?: number;
+hackDifficulty: number;
 ```

--- a/markdown/bitburner.server.md
+++ b/markdown/bitburner.server.md
@@ -16,27 +16,27 @@ export interface Server
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [backdoorInstalled?](./bitburner.server.backdoorinstalled.md) |  | boolean | _(Optional)_ Flag indicating whether this server has a backdoor installed by a player |
-|  [baseDifficulty?](./bitburner.server.basedifficulty.md) |  | number | _(Optional)_ Server's initial server security level at creation. |
+|  [backdoorInstalled](./bitburner.server.backdoorinstalled.md) |  | boolean | Flag indicating whether this server has a backdoor installed by a player |
+|  [baseDifficulty](./bitburner.server.basedifficulty.md) |  | number | Server's initial server security level at creation. |
 |  [cpuCores](./bitburner.server.cpucores.md) |  | number | How many CPU cores this server has. Affects magnitude of grow and weaken ran from this server. |
 |  [ftpPortOpen](./bitburner.server.ftpportopen.md) |  | boolean | Whether or not the FTP port is open |
-|  [hackDifficulty?](./bitburner.server.hackdifficulty.md) |  | number | _(Optional)_ Server Security Level |
+|  [hackDifficulty](./bitburner.server.hackdifficulty.md) |  | number | Server Security Level |
 |  [hasAdminRights](./bitburner.server.hasadminrights.md) |  | boolean | Flag indicating whether player has admin/root access to this server |
 |  [hostname](./bitburner.server.hostname.md) |  | string | Hostname. Must be unique |
 |  [httpPortOpen](./bitburner.server.httpportopen.md) |  | boolean | Whether or not the HTTP Port is open |
 |  [ip](./bitburner.server.ip.md) |  | string | IP Address. Must be unique |
 |  [isConnectedTo](./bitburner.server.isconnectedto.md) |  | boolean | Flag indicating whether player is currently connected to this server |
 |  [maxRam](./bitburner.server.maxram.md) |  | number | RAM (GB) available on this server |
-|  [minDifficulty?](./bitburner.server.mindifficulty.md) |  | number | _(Optional)_ Minimum server security level that this server can be weakened to |
-|  [moneyAvailable?](./bitburner.server.moneyavailable.md) |  | number | _(Optional)_ How much money currently resides on the server and can be hacked |
-|  [moneyMax?](./bitburner.server.moneymax.md) |  | number | _(Optional)_ Maximum amount of money that this server can hold |
-|  [numOpenPortsRequired?](./bitburner.server.numopenportsrequired.md) |  | number | _(Optional)_ Number of open ports required in order to gain admin/root access |
-|  [openPortCount?](./bitburner.server.openportcount.md) |  | number | _(Optional)_ How many ports are currently opened on the server |
+|  [minDifficulty](./bitburner.server.mindifficulty.md) |  | number | Minimum server security level that this server can be weakened to |
+|  [moneyAvailable](./bitburner.server.moneyavailable.md) |  | number | How much money currently resides on the server and can be hacked |
+|  [moneyMax](./bitburner.server.moneymax.md) |  | number | Maximum amount of money that this server can hold |
+|  [numOpenPortsRequired](./bitburner.server.numopenportsrequired.md) |  | number | Number of open ports required in order to gain admin/root access |
+|  [openPortCount](./bitburner.server.openportcount.md) |  | number | How many ports are currently opened on the server |
 |  [organizationName](./bitburner.server.organizationname.md) |  | string | Name of company/faction/etc. that this server belongs to, not applicable to all Servers |
 |  [purchasedByPlayer](./bitburner.server.purchasedbyplayer.md) |  | boolean | Flag indicating whether this is a purchased server |
 |  [ramUsed](./bitburner.server.ramused.md) |  | number | RAM (GB) used. i.e. unavailable RAM |
-|  [requiredHackingSkill?](./bitburner.server.requiredhackingskill.md) |  | number | _(Optional)_ Hacking level required to hack this server |
-|  [serverGrowth?](./bitburner.server.servergrowth.md) |  | number | _(Optional)_ Growth effectiveness statistic. Higher values produce more growth with ns.grow() |
+|  [requiredHackingSkill](./bitburner.server.requiredhackingskill.md) |  | number | Hacking level required to hack this server |
+|  [serverGrowth](./bitburner.server.servergrowth.md) |  | number | Growth effectiveness statistic. Higher values produce more growth with ns.grow() |
 |  [smtpPortOpen](./bitburner.server.smtpportopen.md) |  | boolean | Whether or not the SMTP Port is open |
 |  [sqlPortOpen](./bitburner.server.sqlportopen.md) |  | boolean | Whether or not the SQL Port is open |
 |  [sshPortOpen](./bitburner.server.sshportopen.md) |  | boolean | Whether or not the SSH Port is open |

--- a/markdown/bitburner.server.mindifficulty.md
+++ b/markdown/bitburner.server.mindifficulty.md
@@ -9,5 +9,5 @@ Minimum server security level that this server can be weakened to
 **Signature:**
 
 ```typescript
-minDifficulty?: number;
+minDifficulty: number;
 ```

--- a/markdown/bitburner.server.moneyavailable.md
+++ b/markdown/bitburner.server.moneyavailable.md
@@ -9,5 +9,5 @@ How much money currently resides on the server and can be hacked
 **Signature:**
 
 ```typescript
-moneyAvailable?: number;
+moneyAvailable: number;
 ```

--- a/markdown/bitburner.server.moneymax.md
+++ b/markdown/bitburner.server.moneymax.md
@@ -9,5 +9,5 @@ Maximum amount of money that this server can hold
 **Signature:**
 
 ```typescript
-moneyMax?: number;
+moneyMax: number;
 ```

--- a/markdown/bitburner.server.numopenportsrequired.md
+++ b/markdown/bitburner.server.numopenportsrequired.md
@@ -9,5 +9,5 @@ Number of open ports required in order to gain admin/root access
 **Signature:**
 
 ```typescript
-numOpenPortsRequired?: number;
+numOpenPortsRequired: number;
 ```

--- a/markdown/bitburner.server.openportcount.md
+++ b/markdown/bitburner.server.openportcount.md
@@ -9,5 +9,5 @@ How many ports are currently opened on the server
 **Signature:**
 
 ```typescript
-openPortCount?: number;
+openPortCount: number;
 ```

--- a/markdown/bitburner.server.requiredhackingskill.md
+++ b/markdown/bitburner.server.requiredhackingskill.md
@@ -9,5 +9,5 @@ Hacking level required to hack this server
 **Signature:**
 
 ```typescript
-requiredHackingSkill?: number;
+requiredHackingSkill: number;
 ```

--- a/markdown/bitburner.server.servergrowth.md
+++ b/markdown/bitburner.server.servergrowth.md
@@ -9,5 +9,5 @@ Growth effectiveness statistic. Higher values produce more growth with ns.grow()
 **Signature:**
 
 ```typescript
-serverGrowth?: number;
+serverGrowth: number;
 ```

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -343,8 +343,7 @@ export const ns: InternalAPI<NSFull> = {
       // Check argument validity
       const server = helpers.getServer(ctx, host);
       if (!(server instanceof Server)) {
-        // Todo 2.3: Make this throw instead of returning 0?
-        helpers.log(ctx, () => `${host} is not a hackable server. Returning 0.`);
+        helpers.log(ctx, () => "Cannot be executed on this server.");
         return 0;
       }
       if (!Number.isFinite(mult) || mult < 1) {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -623,34 +623,34 @@ export interface Server {
   purchasedByPlayer: boolean;
 
   /** Flag indicating whether this server has a backdoor installed by a player */
-  backdoorInstalled?: boolean;
+  backdoorInstalled: boolean;
 
   /** Server's initial server security level at creation. */
-  baseDifficulty?: number;
+  baseDifficulty: number;
 
   /** Server Security Level */
-  hackDifficulty?: number;
+  hackDifficulty: number;
 
   /** Minimum server security level that this server can be weakened to */
-  minDifficulty?: number;
+  minDifficulty: number;
 
   /** How much money currently resides on the server and can be hacked */
-  moneyAvailable?: number;
+  moneyAvailable: number;
 
   /** Maximum amount of money that this server can hold */
-  moneyMax?: number;
+  moneyMax: number;
 
   /** Number of open ports required in order to gain admin/root access */
-  numOpenPortsRequired?: number;
+  numOpenPortsRequired: number;
 
   /** How many ports are currently opened on the server */
-  openPortCount?: number;
+  openPortCount: number;
 
   /** Hacking level required to hack this server */
-  requiredHackingSkill?: number;
+  requiredHackingSkill: number;
 
   /** Growth effectiveness statistic. Higher values produce more growth with ns.grow() */
-  serverGrowth?: number;
+  serverGrowth: number;
 }
 
 /**

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -112,18 +112,18 @@ export abstract class BaseServer implements IServer {
   // Flag indicating whether this is a purchased server
   purchasedByPlayer = false;
 
-  // Optional, listed just so they can be accessed on a BaseServer. These will be undefined for HacknetServers.
-  backdoorInstalled?: boolean;
-  baseDifficulty?: number;
-  hackDifficulty?: number;
-  minDifficulty?: number;
-  moneyAvailable?: number;
-  moneyMax?: number;
-  numOpenPortsRequired?: number;
-  openPortCount?: number;
-  requiredHackingSkill?: number;
-  serverGrowth?: number;
-  isHacknetServer?: boolean;
+  // Inherited classes (Server and HacknetServer) should override these values and give them sensible values if needed.
+  backdoorInstalled = false;
+  baseDifficulty = 1;
+  hackDifficulty = 1;
+  minDifficulty = 1;
+  moneyAvailable = 0;
+  moneyMax = 0;
+  numOpenPortsRequired = 5;
+  openPortCount = 0;
+  requiredHackingSkill = 1;
+  serverGrowth = 1;
+  isHacknetServer = false;
 
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {
     this.ip = params.ip ? params.ip : createRandomIp();

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -179,5 +179,25 @@ export const breakingChanges300: VersionBreakingChange = {
         'It has been automatically replaced with "ns.stock.has4SDataTixApi()".',
       showPopUp: false,
     },
+    {
+      brokenAPIs: [],
+      info:
+        "Some properties of the server object returned by ns.getServer() are not optional now. When you passed the " +
+        "hostname of a hacknet server, those properties were undefined. Now they have default values:\n" +
+        "- backdoorInstalled: false\n" +
+        "- baseDifficulty: 1\n" +
+        "- hackDifficulty: 1\n" +
+        "- minDifficulty: 1\n" +
+        "- moneyAvailable: 0\n" +
+        "- moneyMax: 0\n" +
+        "- numOpenPortsRequired: 5\n" +
+        "- openPortCount: 0\n" +
+        "- requiredHackingSkill: 1\n" +
+        "- serverGrowth: 1\n" +
+        "This should not be a problem with most scripts. However, if your scripts check if those properties are " +
+        "truthy/falsy, you should double-check the logic.",
+      showPopUp: true,
+      doNotSkip: true,
+    },
   ],
 };


### PR DESCRIPTION
A few months ago, we had a long discussion about server stuff (`Server` in NS API, `BaseServer`, `Server` (internal class), `HacknetServer`, etc.). We discussed too many things, and the discussion got nowhere. G4mingJon4s made a list of suggestions based on what was discussed. The detail is at https://discord.com/channels/415207508303544321/459097632896188436/1356540719933820939. Among those suggestions, I only "agree" with [1] and [2]. Note that I don't advocate these changes. "Agree" only means that I don't veto them.

This PR implements [1]. [2] is still debatable on the implementation detail, so I won't implement it until we settle on a "spec".

With this change, I decided to *not* make the change of "Throw an error when the server is invalid" as planned in <https://discord.com/channels/415207508303544321/1355531035470860338/1355531039250059355>. It also means that #1128 is irrelevant now (i.e., 5 will be the expected default value of `numOpenPortsRequired` for hacknet servers).

I tested this change, and I don't see any problems with old sync APIs and save data, besides the breaking change of `ns.getServer`.

Test code:
```js
/** @param {NS} ns */
function test(ns, hostname) {
  ns.print(ns.getServer(hostname));
  ns.print(ns.hackAnalyzeThreads(hostname, 1));
  ns.print(ns.hackAnalyze(hostname));
  ns.print(ns.hackAnalyzeSecurity(1, hostname));
  ns.print(ns.hackAnalyzeChance(hostname));
  ns.print(ns.growthAnalyze(hostname, 1.1));
  ns.print(ns.growthAnalyzeSecurity(1, hostname));
  ns.print(ns.nuke(hostname));
  ns.print(ns.brutessh(hostname));
  ns.print(ns.ftpcrack(hostname));
  ns.print(ns.relaysmtp(hostname));
  ns.print(ns.httpworm(hostname));
  ns.print(ns.sqlinject(hostname));
  ns.print(ns.getServerMoneyAvailable(hostname));
  ns.print(ns.getServerSecurityLevel(hostname));
  ns.print(ns.getServerBaseSecurityLevel(hostname));
  ns.print(ns.getServerMinSecurityLevel(hostname));
  ns.print(ns.getServerRequiredHackingLevel(hostname));
  ns.print(ns.getServerMaxMoney(hostname));
  ns.print(ns.getServerGrowth(hostname));
  ns.print(ns.getServerNumPortsRequired(hostname));
  ns.print(ns.deleteServer(hostname));
  ns.print(ns.getHackTime(hostname));
  ns.print(ns.getGrowTime(hostname));
  ns.print(ns.getWeakenTime(hostname));
}

/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  ns.clearLog();
  ns.disableLog("ALL");
  test(ns, "home");
  test(ns, "n00dles");
  test(ns, "hacknet-server-0");
}
```

![Capture](https://github.com/user-attachments/assets/30548c5c-8b34-4426-a698-0e2d33eb0c23)
