### PR TITLE
UI: Scroll to top when opening new NS API doc page in popup mode

### DIFF
--- a/src/Documentation/ui/DocumentationPopUp.tsx
+++ b/src/Documentation/ui/DocumentationPopUp.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Modal } from "../../ui/React/Modal";
 import { defaultNsApiPage, Navigator, openDocExternally } from "../../ui/React/Documentation";
 import { MD } from "../../ui/MD/MD";
@@ -7,6 +7,7 @@ import { DocumentationPopUpEvents } from "../root";
 
 export function DocumentationPopUp({ hidden }: { hidden: boolean }) {
   const [path, setPath] = useState<FilePath | undefined>(undefined);
+  const modalWrapperRef = useRef<HTMLDivElement>(null);
   useEffect(
     () =>
       DocumentationPopUpEvents.subscribe((path?: string) => {
@@ -42,11 +43,12 @@ export function DocumentationPopUp({ hidden }: { hidden: boolean }) {
       onClose={() => {
         setPath(undefined);
       }}
+      wrapperRef={modalWrapperRef}
       wrapperStyles={{ minWidth: "90%", minHeight: "90%", scrollbarWidth: "thin" }}
       removeFocus={false}
     >
       <Navigator.Provider value={navigator}>
-        <MD pageFilePath={path} top={0} />
+        <MD pageFilePath={path} top={0} modalWrapperRef={modalWrapperRef} />
       </Navigator.Provider>
     </Modal>
   );

--- a/src/Documentation/ui/DocumentationPopUp.tsx
+++ b/src/Documentation/ui/DocumentationPopUp.tsx
@@ -8,6 +8,7 @@ import { DocumentationPopUpEvents } from "../root";
 export function DocumentationPopUp({ hidden }: { hidden: boolean }) {
   const [path, setPath] = useState<FilePath | undefined>(undefined);
   const modalWrapperRef = useRef<HTMLDivElement>(null);
+
   useEffect(
     () =>
       DocumentationPopUpEvents.subscribe((path?: string) => {
@@ -15,6 +16,14 @@ export function DocumentationPopUp({ hidden }: { hidden: boolean }) {
       }),
     [],
   );
+
+  useEffect(() => {
+    if (!modalWrapperRef || !modalWrapperRef.current) {
+      return;
+    }
+    modalWrapperRef.current.scrollTo({ top: 0, behavior: "instant" });
+  });
+
   const navigator = {
     navigate(relativePath: string, external: boolean) {
       /**
@@ -48,7 +57,7 @@ export function DocumentationPopUp({ hidden }: { hidden: boolean }) {
       removeFocus={false}
     >
       <Navigator.Provider value={navigator}>
-        <MD pageFilePath={path} top={0} modalWrapperRef={modalWrapperRef} />
+        <MD pageFilePath={path} />
       </Navigator.Provider>
     </Modal>
   );

--- a/src/Documentation/ui/DocumentationRoot.tsx
+++ b/src/Documentation/ui/DocumentationRoot.tsx
@@ -49,6 +49,16 @@ export function DocumentationRoot({ docPage }: { docPage?: string }): React.Reac
     setDeepLink(undefined);
   }, [deepLink, history]);
 
+  useEffect(() => {
+    /**
+     * Using setTimeout is a workaround. window.scrollTo does not work when we switch from Documentation tab to another
+     * tab, then switch back.
+     */
+    setTimeout(() => {
+      window.scrollTo({ top: windowTopPositionOfPages.get(history.page) ?? 0, behavior: "instant" });
+    }, 0);
+  });
+
   return (
     <>
       <Box
@@ -72,10 +82,7 @@ export function DocumentationRoot({ docPage }: { docPage?: string }): React.Reac
       </Box>
       <Box paddingTop="50px">
         <Navigator.Provider value={navigator}>
-          <MD
-            pageFilePath={deepLink ? asFilePath(deepLink) : history.page}
-            top={windowTopPositionOfPages.get(history.page) ?? 0}
-          />
+          <MD pageFilePath={deepLink ? asFilePath(deepLink) : history.page} />
         </Navigator.Provider>
       </Box>
     </>

--- a/src/ui/MD/MD.tsx
+++ b/src/ui/MD/MD.tsx
@@ -11,14 +11,40 @@ import rehypeRaw from "rehype-raw";
 import { FilePath } from "../../Paths/FilePath";
 import { getPage } from "../../Documentation/root";
 
-export function MD(props: { pageFilePath: FilePath; top: number }): React.ReactElement {
-  const pageContent = getPage(props.pageFilePath);
+export function MD({
+  pageFilePath,
+  top,
+  modalWrapperRef,
+}: {
+  pageFilePath: FilePath;
+  top: number;
+  /**
+   * If this component is used for rendering the documentation popup, this parameter is the ref of the wrapper div in
+   * the modal.
+   */
+  modalWrapperRef?: React.RefObject<HTMLDivElement>;
+}): React.ReactElement {
+  const pageContent = getPage(pageFilePath);
 
+  /**
+   * After rendering the doc page, we need to scroll it. This component is used in 2 places:
+   * - src\Documentation\ui\DocumentationRoot.tsx: The documentation tab.
+   * - src\Documentation\ui\DocumentationPopUp.tsx: The documentation popup opened by using the
+   * DocumentationAutocomplete component.
+   */
   useEffect(() => {
-    // This is a workaround. window.scrollTo does not work when we switch from Documentation tab to another tab, then
-    // switch back.
+    // With the documentation popup: Scroll by using the wrapper div in the modal.
+    if (modalWrapperRef && modalWrapperRef.current) {
+      modalWrapperRef.current.scrollTo({ top, behavior: "instant" });
+      return;
+    }
+    /**
+     * With the documentation tab: Scroll by using the window object.
+     * Using setTimeout is a workaround. window.scrollTo does not work when we switch from Documentation tab to another
+     * tab, then switch back.
+     */
     setTimeout(() => {
-      window.scrollTo({ top: props.top, behavior: "instant" });
+      window.scrollTo({ top, behavior: "instant" });
     }, 0);
   });
 

--- a/src/ui/MD/MD.tsx
+++ b/src/ui/MD/MD.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ReactMarkdown from "react-markdown";
 import { TableHead } from "@mui/material";
 import remarkGfm from "remark-gfm";
@@ -11,42 +11,8 @@ import rehypeRaw from "rehype-raw";
 import { FilePath } from "../../Paths/FilePath";
 import { getPage } from "../../Documentation/root";
 
-export function MD({
-  pageFilePath,
-  top,
-  modalWrapperRef,
-}: {
-  pageFilePath: FilePath;
-  top: number;
-  /**
-   * If this component is used for rendering the documentation popup, this parameter is the ref of the wrapper div in
-   * the modal.
-   */
-  modalWrapperRef?: React.RefObject<HTMLDivElement>;
-}): React.ReactElement {
+export function MD({ pageFilePath }: { pageFilePath: FilePath }): React.ReactElement {
   const pageContent = getPage(pageFilePath);
-
-  /**
-   * After rendering the doc page, we need to scroll it. This component is used in 2 places:
-   * - src\Documentation\ui\DocumentationRoot.tsx: The documentation tab.
-   * - src\Documentation\ui\DocumentationPopUp.tsx: The documentation popup opened by using the
-   * DocumentationAutocomplete component.
-   */
-  useEffect(() => {
-    // With the documentation popup: Scroll by using the wrapper div in the modal.
-    if (modalWrapperRef && modalWrapperRef.current) {
-      modalWrapperRef.current.scrollTo({ top, behavior: "instant" });
-      return;
-    }
-    /**
-     * With the documentation tab: Scroll by using the window object.
-     * Using setTimeout is a workaround. window.scrollTo does not work when we switch from Documentation tab to another
-     * tab, then switch back.
-     */
-    setTimeout(() => {
-      window.scrollTo({ top, behavior: "instant" });
-    }, 0);
-  });
 
   return (
     <ReactMarkdown

--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -43,6 +43,7 @@ interface ModalProps {
   onClose: () => void;
   children: React.ReactNode;
   sx?: SxProps<Theme>;
+  wrapperRef?: React.RefObject<HTMLDivElement>;
   wrapperStyles?: CSSProperties;
   removeFocus?: boolean;
   // If it's true, the player can dismiss the modal by pressing the Esc button or clicking on the backdrop.
@@ -54,6 +55,7 @@ export const Modal = ({
   onClose,
   children,
   sx,
+  wrapperRef,
   wrapperStyles,
   removeFocus = true,
   canBeDismissedEasily = true,
@@ -84,6 +86,7 @@ export const Modal = ({
     >
       <Fade in={open}>
         <div
+          ref={wrapperRef}
           className={classes.paper}
           style={wrapperStyles}
           //@ts-expect-error inert is not supported by react types yet, this is a workaround until then. https://github.com/facebook/react/pull/24730


### PR DESCRIPTION
At 00:20 of the demo video in #2163, after clicking on the link of the "Corporation" page, the popup should scroll to the top.

`window.scrollTo` does not work in this case. We need to scroll the wrapper div in the modal.

https://github.com/user-attachments/assets/f3658af4-aaec-4ff5-8da6-b69a6ba7c84e

