### PR TITLE
WORKFLOW: Allow enabling dev mode when deploying dev build

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -2,6 +2,12 @@ name: "Deploy new pages build"
 
 on:
   workflow_dispatch:
+    inputs:
+      enable_dev_mode:
+        description: Enable dev mode (enable dev menu, disable minification, etc.)
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -24,7 +30,14 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm run build
+      - env:
+          ENABLE_DEV_MODE: ${{ github.event.inputs.enable_dev_mode }}
+        run: |
+          if [[ "$ENABLE_DEV_MODE" == 'true' ]]; then
+            npm run build:dev
+          else
+            npm run build
+          fi
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ".app"


### PR DESCRIPTION
It's just as the title said.

Context: https://github.com/bitburner-official/bitburner-src/pull/2139/files#r2094875377

Demo (ignore the failed/skipped step; I did not enable GitHub Pages in my fork):
- Production (leave the checkbox empty): https://github.com/catloversg/bitburner-src/actions/runs/15439793021/job/43454677269
- Dev (tick the checkbox): https://github.com/catloversg/bitburner-src/actions/runs/15439917190/job/43455069827