### PR TITLE
API: Make ns.codingcontract.createDummyContract throw error if type is invalid

### DIFF
--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -9,14 +9,14 @@ Generate a dummy contract.
 **Signature:**
 
 ```typescript
-createDummyContract(type: string): string;
+createDummyContract(type: CodingContractName): string;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  type | string | Type of contract to generate |
+|  type | [CodingContractName](./bitburner.codingcontractname.md) | Type of contract to generate |
 
 **Returns:**
 

--- a/src/CodingContract/ContractTypes.ts
+++ b/src/CodingContract/ContractTypes.ts
@@ -103,9 +103,6 @@ export function convert2DArrayToString(arr: number[][]): string {
   return components.join(",").replace(/\s/g, "");
 }
 
-export const isCodingContractName = (v: unknown): v is CodingContractName =>
-  Object.values(CodingContractName).some((a) => a === v);
-
 export const CodingContractDefinitions: CodingContractTypes = {
   ...algorithmicStockTrader,
   ...arrayJumpingGame,

--- a/src/DevMenu/ui/CodingContractsDev.tsx
+++ b/src/DevMenu/ui/CodingContractsDev.tsx
@@ -21,7 +21,7 @@ export function CodingContractsDev(): React.ReactElement {
   const [codingcontract, setCodingcontract] = useState(CodingContractName.FindLargestPrimeFactor);
   function setCodingcontractDropdown(event: SelectChangeEvent): void {
     const value = event.target.value;
-    if (!getEnumHelper("CodingContractName").isMember(value)){
+    if (!getEnumHelper("CodingContractName").isMember(value)) {
       return;
     }
     setCodingcontract(value);

--- a/src/DevMenu/ui/CodingContractsDev.tsx
+++ b/src/DevMenu/ui/CodingContractsDev.tsx
@@ -14,14 +14,16 @@ import {
   generateRandomContract,
   generateRandomContractOnHome,
 } from "../../CodingContract/ContractGenerator";
-import { isCodingContractName } from "../../CodingContract/ContractTypes";
 import { CodingContractName } from "@enums";
+import { getEnumHelper } from "../../utils/EnumHelper";
 
 export function CodingContractsDev(): React.ReactElement {
   const [codingcontract, setCodingcontract] = useState(CodingContractName.FindLargestPrimeFactor);
   function setCodingcontractDropdown(event: SelectChangeEvent): void {
     const value = event.target.value;
-    if (!isCodingContractName(value)) return;
+    if (!getEnumHelper("CodingContractName").isMember(value)){
+      return;
+    }
     setCodingcontract(value);
   }
 

--- a/src/NetscriptFunctions/CodingContract.ts
+++ b/src/NetscriptFunctions/CodingContract.ts
@@ -5,9 +5,9 @@ import { InternalAPI, NetscriptContext } from "../Netscript/APIWrapper";
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { CodingContractName } from "@enums";
 import { generateDummyContract } from "../CodingContract/ContractGenerator";
-import { isCodingContractName } from "../CodingContract/ContractTypes";
 import { type BaseServer } from "../Server/BaseServer";
 import { exceptionAlert } from "../utils/helpers/exceptionAlert";
+import { getEnumHelper } from "../utils/EnumHelper";
 
 export function NetscriptCodingContract(): InternalAPI<ICodingContract> {
   const getCodingContract = function (ctx: NetscriptContext, hostname: string, filename: string): CodingContract {
@@ -128,9 +128,7 @@ export function NetscriptCodingContract(): InternalAPI<ICodingContract> {
       return contract.getMaxNumTries() - contract.tries;
     },
     createDummyContract: (ctx) => (_type) => {
-      const type = helpers.string(ctx, "type", _type);
-      if (!isCodingContractName(type))
-        return helpers.errorMessage(ctx, `The given type is not a valid contract type. Got '${type}'`);
+      const type = getEnumHelper("CodingContractName").nsGetMember(ctx, _type);
       return generateDummyContract(type);
     },
     getContractTypes: () => () => Object.values(CodingContractName),

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4022,7 +4022,7 @@ export interface CodingContract {
    * @param type - Type of contract to generate
    * @returns Filename of the contract.
    */
-  createDummyContract(type: string): string;
+  createDummyContract(type: CodingContractName): string;
 
   /**
    * List all contract types.


### PR DESCRIPTION
PR #1892 had 2 problems:
- Create and use `isCodingContractName` instead of using `getEnumHelper`.
- Return the error message instead of throwing it.

This PR fixes them.

Before:

![before](https://github.com/user-attachments/assets/176ba7bb-9c09-4169-8e3d-931ff5385223)

After:

![after](https://github.com/user-attachments/assets/5ecbac75-ebdf-419f-91cf-ce75c2e5c23a)
