### PR TITLE
DOCUMENTATION: Specify param type of many Corporation APIs

### DIFF
--- a/markdown/bitburner.corporation.getunlockcost.md
+++ b/markdown/bitburner.corporation.getunlockcost.md
@@ -9,14 +9,14 @@ Get the cost to unlock a one-time unlockable upgrade.
 **Signature:**
 
 ```typescript
-getUnlockCost(upgradeName: string): number;
+getUnlockCost(upgradeName: CorpUnlockName): number;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  upgradeName | string | Name of the upgrade |
+|  upgradeName | [CorpUnlockName](./bitburner.corpunlockname.md) | Name of the upgrade |
 
 **Returns:**
 

--- a/markdown/bitburner.corporation.getupgradelevel.md
+++ b/markdown/bitburner.corporation.getupgradelevel.md
@@ -9,14 +9,14 @@ Get the level of a levelable upgrade.
 **Signature:**
 
 ```typescript
-getUpgradeLevel(upgradeName: string): number;
+getUpgradeLevel(upgradeName: CorpUpgradeName): number;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  upgradeName | string | Name of the upgrade |
+|  upgradeName | [CorpUpgradeName](./bitburner.corpupgradename.md) | Name of the upgrade |
 
 **Returns:**
 

--- a/markdown/bitburner.corporation.getupgradelevelcost.md
+++ b/markdown/bitburner.corporation.getupgradelevelcost.md
@@ -9,14 +9,14 @@ Get the cost to unlock the next level of a levelable upgrade.
 **Signature:**
 
 ```typescript
-getUpgradeLevelCost(upgradeName: string): number;
+getUpgradeLevelCost(upgradeName: CorpUpgradeName): number;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  upgradeName | string | Name of the upgrade |
+|  upgradeName | [CorpUpgradeName](./bitburner.corpupgradename.md) | Name of the upgrade |
 
 **Returns:**
 

--- a/markdown/bitburner.corporation.hasunlock.md
+++ b/markdown/bitburner.corporation.hasunlock.md
@@ -9,14 +9,14 @@ Check if you have a one-time unlockable upgrade.
 **Signature:**
 
 ```typescript
-hasUnlock(upgradeName: string): boolean;
+hasUnlock(upgradeName: CorpUnlockName): boolean;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  upgradeName | string | Name of the upgrade |
+|  upgradeName | [CorpUnlockName](./bitburner.corpunlockname.md) | Name of the upgrade |
 
 **Returns:**
 

--- a/markdown/bitburner.corporation.levelupgrade.md
+++ b/markdown/bitburner.corporation.levelupgrade.md
@@ -9,14 +9,14 @@ Level up an upgrade.
 **Signature:**
 
 ```typescript
-levelUpgrade(upgradeName: string): void;
+levelUpgrade(upgradeName: CorpUpgradeName): void;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  upgradeName | string | Name of the upgrade |
+|  upgradeName | [CorpUpgradeName](./bitburner.corpupgradename.md) | Name of the upgrade |
 
 **Returns:**
 

--- a/markdown/bitburner.corporation.purchaseunlock.md
+++ b/markdown/bitburner.corporation.purchaseunlock.md
@@ -9,14 +9,14 @@ Unlock an upgrade.
 **Signature:**
 
 ```typescript
-purchaseUnlock(upgradeName: string): void;
+purchaseUnlock(upgradeName: CorpUnlockName): void;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  upgradeName | string | Name of the upgrade |
+|  upgradeName | [CorpUnlockName](./bitburner.corpunlockname.md) | Name of the upgrade |
 
 **Returns:**
 

--- a/markdown/bitburner.officeapi.getresearchcost.md
+++ b/markdown/bitburner.officeapi.getresearchcost.md
@@ -9,7 +9,7 @@ Get the cost to unlock a research.
 **Signature:**
 
 ```typescript
-getResearchCost(divisionName: string, researchName: string): number;
+getResearchCost(divisionName: string, researchName: CorpResearchName): number;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ getResearchCost(divisionName: string, researchName: string): number;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
-|  researchName | string | Name of the research |
+|  researchName | [CorpResearchName](./bitburner.corpresearchname.md) | Name of the research |
 
 **Returns:**
 

--- a/markdown/bitburner.officeapi.hasresearched.md
+++ b/markdown/bitburner.officeapi.hasresearched.md
@@ -9,7 +9,7 @@ Check if you unlocked a research.
 **Signature:**
 
 ```typescript
-hasResearched(divisionName: string, researchName: string): boolean;
+hasResearched(divisionName: string, researchName: CorpResearchName): boolean;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ hasResearched(divisionName: string, researchName: string): boolean;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
-|  researchName | string | Name of the research |
+|  researchName | [CorpResearchName](./bitburner.corpresearchname.md) | Name of the research |
 
 **Returns:**
 

--- a/markdown/bitburner.officeapi.research.md
+++ b/markdown/bitburner.officeapi.research.md
@@ -9,7 +9,7 @@ Purchase a research.
 **Signature:**
 
 ```typescript
-research(divisionName: string, researchName: string): void;
+research(divisionName: string, researchName: CorpResearchName): void;
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ research(divisionName: string, researchName: string): void;
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
-|  researchName | string | Name of the research |
+|  researchName | [CorpResearchName](./bitburner.corpresearchname.md) | Name of the research |
 
 **Returns:**
 

--- a/markdown/bitburner.warehouseapi.bulkpurchase.md
+++ b/markdown/bitburner.warehouseapi.bulkpurchase.md
@@ -9,7 +9,7 @@ Set material to bulk-buy.
 **Signature:**
 
 ```typescript
-bulkPurchase(divisionName: string, city: CityName, materialName: string, amt: number): void;
+bulkPurchase(divisionName: string, city: CityName, materialName: CorpMaterialName, amt: number): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ bulkPurchase(divisionName: string, city: CityName, materialName: string, amt: nu
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 |  amt | number | Amount of material to buy |
 
 **Returns:**

--- a/markdown/bitburner.warehouseapi.buymaterial.md
+++ b/markdown/bitburner.warehouseapi.buymaterial.md
@@ -9,7 +9,7 @@ Set material buy data.
 **Signature:**
 
 ```typescript
-buyMaterial(divisionName: string, city: CityName, materialName: string, amt: number): void;
+buyMaterial(divisionName: string, city: CityName, materialName: CorpMaterialName, amt: number): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ buyMaterial(divisionName: string, city: CityName, materialName: string, amt: num
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 |  amt | number | Amount of material to buy |
 
 **Returns:**

--- a/markdown/bitburner.warehouseapi.cancelexportmaterial.md
+++ b/markdown/bitburner.warehouseapi.cancelexportmaterial.md
@@ -14,7 +14,7 @@ cancelExportMaterial(
     sourceCity: CityName,
     targetDivision: string,
     targetCity: CityName,
-    materialName: string,
+    materialName: CorpMaterialName,
   ): void;
 ```
 
@@ -26,7 +26,7 @@ cancelExportMaterial(
 |  sourceCity | [CityName](./bitburner.cityname.md) | Source city |
 |  targetDivision | string | Target division |
 |  targetCity | [CityName](./bitburner.cityname.md) | Target city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 
 **Returns:**
 

--- a/markdown/bitburner.warehouseapi.exportmaterial.md
+++ b/markdown/bitburner.warehouseapi.exportmaterial.md
@@ -14,7 +14,7 @@ exportMaterial(
     sourceCity: CityName,
     targetDivision: string,
     targetCity: CityName,
-    materialName: string,
+    materialName: CorpMaterialName,
     amt: number | string,
   ): void;
 ```
@@ -27,7 +27,7 @@ exportMaterial(
 |  sourceCity | [CityName](./bitburner.cityname.md) | Source city |
 |  targetDivision | string | Target division |
 |  targetCity | [CityName](./bitburner.cityname.md) | Target city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 |  amt | number \| string | Amount of material to export. |
 
 **Returns:**

--- a/markdown/bitburner.warehouseapi.getmaterial.md
+++ b/markdown/bitburner.warehouseapi.getmaterial.md
@@ -9,7 +9,7 @@ Get material data.
 **Signature:**
 
 ```typescript
-getMaterial(divisionName: string, city: CityName, materialName: string): Material;
+getMaterial(divisionName: string, city: CityName, materialName: CorpMaterialName): Material;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ getMaterial(divisionName: string, city: CityName, materialName: string): Materia
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 
 **Returns:**
 

--- a/markdown/bitburner.warehouseapi.limitmaterialproduction.md
+++ b/markdown/bitburner.warehouseapi.limitmaterialproduction.md
@@ -9,7 +9,7 @@ Limit material production.
 **Signature:**
 
 ```typescript
-limitMaterialProduction(divisionName: string, city: CityName, materialName: string, qty: number): void;
+limitMaterialProduction(divisionName: string, city: CityName, materialName: CorpMaterialName, qty: number): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ limitMaterialProduction(divisionName: string, city: CityName, materialName: stri
 |  --- | --- | --- |
 |  divisionName | string | Name of the division. |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city. |
-|  materialName | string | Name of the material. |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material. |
 |  qty | number | Amount to limit to. Pass a negative value to remove the limit instead. |
 
 **Returns:**

--- a/markdown/bitburner.warehouseapi.sellmaterial.md
+++ b/markdown/bitburner.warehouseapi.sellmaterial.md
@@ -9,7 +9,7 @@ Set material sell data.
 **Signature:**
 
 ```typescript
-sellMaterial(divisionName: string, city: CityName, materialName: string, amt: string, price: string): void;
+sellMaterial(divisionName: string, city: CityName, materialName: CorpMaterialName, amt: string, price: string): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ sellMaterial(divisionName: string, city: CityName, materialName: string, amt: st
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 |  amt | string | Amount to sell, can be "MAX" |
 |  price | string | Price to sell, can be "MP" |
 

--- a/markdown/bitburner.warehouseapi.setmaterialmarketta1.md
+++ b/markdown/bitburner.warehouseapi.setmaterialmarketta1.md
@@ -9,7 +9,7 @@ Set Market-TA1 for a material.
 **Signature:**
 
 ```typescript
-setMaterialMarketTA1(divisionName: string, city: CityName, materialName: string, on: boolean): void;
+setMaterialMarketTA1(divisionName: string, city: CityName, materialName: CorpMaterialName, on: boolean): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ setMaterialMarketTA1(divisionName: string, city: CityName, materialName: string,
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 |  on | boolean | Use true to enable, false otherwise. |
 
 **Returns:**

--- a/markdown/bitburner.warehouseapi.setmaterialmarketta2.md
+++ b/markdown/bitburner.warehouseapi.setmaterialmarketta2.md
@@ -9,7 +9,7 @@ Set Market-TA2 for a material.
 **Signature:**
 
 ```typescript
-setMaterialMarketTA2(divisionName: string, city: CityName, materialName: string, on: boolean): void;
+setMaterialMarketTA2(divisionName: string, city: CityName, materialName: CorpMaterialName, on: boolean): void;
 ```
 
 ## Parameters
@@ -18,7 +18,7 @@ setMaterialMarketTA2(divisionName: string, city: CityName, materialName: string,
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 |  on | boolean | Use true to enable, false otherwise. |
 
 **Returns:**

--- a/markdown/bitburner.warehouseapi.setsmartsupplyoption.md
+++ b/markdown/bitburner.warehouseapi.setsmartsupplyoption.md
@@ -9,7 +9,12 @@ Set whether smart supply uses leftovers before buying.
 **Signature:**
 
 ```typescript
-setSmartSupplyOption(divisionName: string, city: CityName, materialName: string, option: CorpSmartSupplyOption): void;
+setSmartSupplyOption(
+    divisionName: string,
+    city: CityName,
+    materialName: CorpMaterialName,
+    option: CorpSmartSupplyOption,
+  ): void;
 ```
 
 ## Parameters
@@ -18,7 +23,7 @@ setSmartSupplyOption(divisionName: string, city: CityName, materialName: string,
 |  --- | --- | --- |
 |  divisionName | string | Name of the division |
 |  city | [CityName](./bitburner.cityname.md) | Name of the city |
-|  materialName | string | Name of the material |
+|  materialName | [CorpMaterialName](./bitburner.corpmaterialname.md) | Name of the material |
 |  option | [CorpSmartSupplyOption](./bitburner.corpsmartsupplyoption.md) | Smart supply option. Set "leftovers" to use leftovers, "imports" to use only imported materials, and "none" to not use stored materials. |
 
 **Returns:**

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -8845,7 +8845,7 @@ export interface OfficeAPI {
    * @param divisionName - Name of the division
    * @param researchName - Name of the research
    */
-  research(divisionName: string, researchName: string): void;
+  research(divisionName: string, researchName: CorpResearchName): void;
 
   /**
    * Get data about an office.
@@ -8891,7 +8891,7 @@ export interface OfficeAPI {
    * @param researchName - Name of the research
    * @returns Cost
    */
-  getResearchCost(divisionName: string, researchName: string): number;
+  getResearchCost(divisionName: string, researchName: CorpResearchName): number;
 
   /**
    * Check if you unlocked a research.
@@ -8903,7 +8903,7 @@ export interface OfficeAPI {
    * @param researchName - Name of the research
    * @returns true is unlocked, false if not
    */
-  hasResearched(divisionName: string, researchName: string): boolean;
+  hasResearched(divisionName: string, researchName: CorpResearchName): boolean;
 
   /**
    * Set the job assignment for a job.
@@ -8959,7 +8959,7 @@ export interface WarehouseAPI {
    * @param amt - Amount to sell, can be "MAX"
    * @param price - Price to sell, can be "MP"
    */
-  sellMaterial(divisionName: string, city: CityName, materialName: string, amt: string, price: string): void;
+  sellMaterial(divisionName: string, city: CityName, materialName: CorpMaterialName, amt: string, price: string): void;
 
   /**
    * Set product sell data.
@@ -9017,7 +9017,12 @@ export interface WarehouseAPI {
    * @param materialName - Name of the material
    * @param option - Smart supply option. Set "leftovers" to use leftovers, "imports" to use only imported materials, and "none" to not use stored materials.
    */
-  setSmartSupplyOption(divisionName: string, city: CityName, materialName: string, option: CorpSmartSupplyOption): void;
+  setSmartSupplyOption(
+    divisionName: string,
+    city: CityName,
+    materialName: CorpMaterialName,
+    option: CorpSmartSupplyOption,
+  ): void;
 
   /**
    * Set material buy data.
@@ -9030,7 +9035,7 @@ export interface WarehouseAPI {
    * @param materialName - Name of the material
    * @param amt - Amount of material to buy
    */
-  buyMaterial(divisionName: string, city: CityName, materialName: string, amt: number): void;
+  buyMaterial(divisionName: string, city: CityName, materialName: CorpMaterialName, amt: number): void;
 
   /**
    * Set material to bulk-buy.
@@ -9043,7 +9048,7 @@ export interface WarehouseAPI {
    * @param materialName - Name of the material
    * @param amt - Amount of material to buy
    */
-  bulkPurchase(divisionName: string, city: CityName, materialName: string, amt: number): void;
+  bulkPurchase(divisionName: string, city: CityName, materialName: CorpMaterialName, amt: number): void;
 
   /**
    * Get warehouse data.
@@ -9081,7 +9086,7 @@ export interface WarehouseAPI {
    * @param materialName - Name of the material
    * @returns Material data
    */
-  getMaterial(divisionName: string, city: CityName, materialName: string): Material;
+  getMaterial(divisionName: string, city: CityName, materialName: CorpMaterialName): Material;
 
   /**
    * Set Market-TA1 for a material.
@@ -9094,7 +9099,7 @@ export interface WarehouseAPI {
    * @param materialName - Name of the material
    * @param on - Use true to enable, false otherwise.
    */
-  setMaterialMarketTA1(divisionName: string, city: CityName, materialName: string, on: boolean): void;
+  setMaterialMarketTA1(divisionName: string, city: CityName, materialName: CorpMaterialName, on: boolean): void;
 
   /**
    * Set Market-TA2 for a material.
@@ -9107,7 +9112,7 @@ export interface WarehouseAPI {
    * @param materialName - Name of the material
    * @param on - Use true to enable, false otherwise.
    */
-  setMaterialMarketTA2(divisionName: string, city: CityName, materialName: string, on: boolean): void;
+  setMaterialMarketTA2(divisionName: string, city: CityName, materialName: CorpMaterialName, on: boolean): void;
 
   /**
    * Set Market-TA1 for a product.
@@ -9151,7 +9156,7 @@ export interface WarehouseAPI {
     sourceCity: CityName,
     targetDivision: string,
     targetCity: CityName,
-    materialName: string,
+    materialName: CorpMaterialName,
     amt: number | string,
   ): void;
 
@@ -9172,7 +9177,7 @@ export interface WarehouseAPI {
     sourceCity: CityName,
     targetDivision: string,
     targetCity: CityName,
-    materialName: string,
+    materialName: CorpMaterialName,
   ): void;
 
   /**
@@ -9229,7 +9234,7 @@ export interface WarehouseAPI {
    * @param materialName - Name of the material.
    * @param qty - Amount to limit to. Pass a negative value to remove the limit instead.
    */
-  limitMaterialProduction(divisionName: string, city: CityName, materialName: string, qty: number): void;
+  limitMaterialProduction(divisionName: string, city: CityName, materialName: CorpMaterialName, qty: number): void;
 
   /**
    * Limit product production.
@@ -9334,7 +9339,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    * @param upgradeName - Name of the upgrade
    * @returns true if unlocked and false if not
    */
-  hasUnlock(upgradeName: string): boolean;
+  hasUnlock(upgradeName: CorpUnlockName): boolean;
 
   /**
    * Get the cost to unlock a one-time unlockable upgrade.
@@ -9345,7 +9350,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    * @param upgradeName - Name of the upgrade
    * @returns Cost of the upgrade
    */
-  getUnlockCost(upgradeName: string): number;
+  getUnlockCost(upgradeName: CorpUnlockName): number;
 
   /**
    * Get the level of a levelable upgrade.
@@ -9356,7 +9361,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    * @param upgradeName - Name of the upgrade
    * @returns The level of the upgrade
    */
-  getUpgradeLevel(upgradeName: string): number;
+  getUpgradeLevel(upgradeName: CorpUpgradeName): number;
 
   /**
    * Get the cost to unlock the next level of a levelable upgrade.
@@ -9367,7 +9372,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    * @param upgradeName - Name of the upgrade
    * @returns Cost of the upgrade
    */
-  getUpgradeLevelCost(upgradeName: string): number;
+  getUpgradeLevelCost(upgradeName: CorpUpgradeName): number;
 
   /**
    * Get an offer for investment based on current corporation valuation.
@@ -9504,7 +9509,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    *
    * @param upgradeName - Name of the upgrade
    */
-  purchaseUnlock(upgradeName: string): void;
+  purchaseUnlock(upgradeName: CorpUnlockName): void;
 
   /**
    * Level up an upgrade.
@@ -9514,7 +9519,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    *
    * @param upgradeName - Name of the upgrade
    */
-  levelUpgrade(upgradeName: string): void;
+  levelUpgrade(upgradeName: CorpUpgradeName): void;
 
   /**
    * Issue dividends.


### PR DESCRIPTION
We use `string` for many parameters that have specific types. For example, `materialName` in `buyMaterial` is `string` instead of `CorpMaterialName`. This PR fixes all of them.