### PR TITLE
IPVGO: Ensure that player promises are changed to "gameOver" once the game is over

### DIFF
--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -62,7 +62,6 @@ export function handleNextTurn(boardState: BoardState = Go.currentGame, useOffli
     // The game is over. We shouldn't get here in most circumstances,
     // because when the game ends resetAI() will be called to resolve promises.
     // Return an already-resolved promise until a new game is started.
-    resetAI(true);
     return Promise.resolve(gameOver);
   }
   const currentColor = previousColor === GoColor.black ? GoColor.white : GoColor.black;
@@ -138,10 +137,10 @@ export function resetAI(endOfGame = false): void {
     if (playerPromise.resolver) {
       playerPromise.resolver(gameOver);
       playerPromise.resolver = null;
-    } else {
-      playerPromise.nextTurn = Promise.resolve(gameOver);
     }
-    if (!endOfGame && !playerPromise.resolver) {
+    if (endOfGame) {
+      playerPromise.nextTurn = Promise.resolve(gameOver);
+    } else {
       createPromise(playerPromise);
     }
   }

--- a/src/Go/boardAnalysis/goAI.ts
+++ b/src/Go/boardAnalysis/goAI.ts
@@ -62,6 +62,7 @@ export function handleNextTurn(boardState: BoardState = Go.currentGame, useOffli
     // The game is over. We shouldn't get here in most circumstances,
     // because when the game ends resetAI() will be called to resolve promises.
     // Return an already-resolved promise until a new game is started.
+    resetAI(true);
     return Promise.resolve(gameOver);
   }
   const currentColor = previousColor === GoColor.black ? GoColor.white : GoColor.black;
@@ -137,6 +138,8 @@ export function resetAI(endOfGame = false): void {
     if (playerPromise.resolver) {
       playerPromise.resolver(gameOver);
       playerPromise.resolver = null;
+    } else {
+      playerPromise.nextTurn = Promise.resolve(gameOver);
     }
     if (!endOfGame && !playerPromise.resolver) {
       createPromise(playerPromise);


### PR DESCRIPTION
When the game ends, the pending player promise is updated with type "gameOver". However, previously, the other player's promise was never updated, and maintained their last move before the game ended (passing). 

This PR fixes it to ensure that those promises are updated to also show game over once the game ends. 

context:
https://discord.com/channels/415207508303544321/415213413745164318/1382003105792524359