### PR TITLE
DOCUMENTATION: Remove mention of NS2 in NetscriptDefinitions.d.ts

### DIFF
--- a/markdown/bitburner.ns.atexit.md
+++ b/markdown/bitburner.ns.atexit.md
@@ -27,7 +27,5 @@ void
 
 RAM cost: 0 GB
 
-NS2 exclusive
-
 Each script can only register one callback per callback ID. If another callback is registered with the same callback ID the previous callback with that ID is forgotten and will not be executed when the script dies.
 

--- a/markdown/bitburner.userinterface.setstyles.md
+++ b/markdown/bitburner.userinterface.setstyles.md
@@ -28,7 +28,6 @@ RAM cost: 0 GB
 
 ## Example
 
-Usage example (NS2)
 
 ```js
 const styles = ns.ui.getStyles();

--- a/markdown/bitburner.userinterface.settheme.md
+++ b/markdown/bitburner.userinterface.settheme.md
@@ -28,7 +28,6 @@ RAM cost: 0 GB
 
 ## Example
 
-Usage example (NS2)
 
 ```js
 const theme = ns.ui.getTheme();

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6056,7 +6056,6 @@ interface UserInterface {
    * @remarks
    * RAM cost: 0 GB
    * @example
-   * Usage example (NS2)
    * ```js
    * const theme = ns.ui.getTheme();
    * theme.primary = '#ff5500';
@@ -6086,7 +6085,6 @@ interface UserInterface {
    * @remarks
    * RAM cost: 0 GB
    * @example
-   * Usage example (NS2)
    * ```js
    * const styles = ns.ui.getStyles();
    * styles.fontFamily = 'Comic Sans Ms';
@@ -8151,8 +8149,6 @@ export interface NS {
    * Add a callback to be executed when the script dies.
    * @remarks
    * RAM cost: 0 GB
-   *
-   * NS2 exclusive
    *
    * Each script can only register one callback per callback ID.
    * If another callback is registered with the same callback ID


### PR DESCRIPTION
NS1 is gone now. We don't need to mention the exclusiveness of NS2 in some APIs.