### PR TITLE
MISC: Mention bug-report channel on Discord for reporting bugs

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -22,8 +22,8 @@ heard:
 
 ## Reporting Bugs
 
-The recommended method for reporting a bug is by opening a
-[Github Issue](https://github.com/bitburner-official/bitburner-src/issues).
+The recommended method for reporting a bug is by opening a [Github Issue](https://github.com/bitburner-official/bitburner-src/issues)
+or contacting us on the [#bug-report channel](https://discord.com/channels/415207508303544321/415213413745164318).
 
 Alternatively, you can post a bug by creating a post on the
 [game's subreddit](https://www.reddit.com/r/Bitburner/).

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -511,8 +511,8 @@ function createNewUpdateText() {
     () =>
       dialogBoxCreate(
         "New update!\n" +
-          "Please report any bugs/issues through the GitHub repository " +
-          "or the Bitburner subreddit (reddit.com/r/bitburner).\n\n" +
+          "Please report any bugs/issues through the GitHub repository (https://github.com/bitburner-official/bitburner-src/issues) " +
+          "or the #bug-report channel on Discord (https://discord.com/channels/415207508303544321/415213413745164318).\n\n" +
           CONSTANTS.LatestUpdate,
       ),
     1000,
@@ -526,7 +526,7 @@ function createBetaUpdateText() {
         "You are playing on the beta environment! This branch of the game " +
           "features the latest developments in the game. This version may be unstable.\n" +
           "Please report any bugs/issues through the github repository (https://github.com/bitburner-official/bitburner-src/issues) " +
-          "or the Bitburner subreddit (reddit.com/r/bitburner).\n\n" +
+          "or the #bug-report channel on Discord (https://discord.com/channels/415207508303544321/415213413745164318).\n\n" +
           CONSTANTS.LatestUpdate,
       ),
     1000,

--- a/src/ui/React/RecoveryRoot.tsx
+++ b/src/ui/React/RecoveryRoot.tsx
@@ -111,13 +111,13 @@ export function RecoveryRoot({ softReset, errorData, resetError }: IProps): Reac
           </Link>
         </Typography>
         <Typography>
-          <Link href="https://www.reddit.com/r/Bitburner/" target="_blank">
-            Make a reddit post
+          <Link href="https://discord.gg/TFc3hKD" target="_blank">
+            Post in the #bug-report channel on Discord.
           </Link>
         </Typography>
         <Typography>
-          <Link href="https://discord.gg/TFc3hKD" target="_blank">
-            Post in the #bug-report channel on Discord.
+          <Link href="https://www.reddit.com/r/Bitburner/" target="_blank">
+            Make a reddit post
           </Link>
         </Typography>
         <Typography>Please include your save file and the crash report.</Typography>


### PR DESCRIPTION
It's just as the title said.

I also intentionally replace the mention of the subreddit with the Discord channel in 2 popups. I don't think we need to mention the subreddit for reporting bugs. Most active contributors are not on there.