### PR TITLE
DOCUMENTATION: Fix minor problem in old changelog

### DIFF
--- a/src/Documentation/doc/changelog.md
+++ b/src/Documentation/doc/changelog.md
@@ -1392,7 +1392,7 @@ API
 - More ports (previously max 20, now practically unlimited) (by @Hoekstraa)
 - Corp functions now return copy of constant arrays instead of the original (by @Mughur)
 - All the player sub-objects need to be copied for `getPlayer`. (by @MageKing17)
-- add corp get<constant> functions, UI (by @Mughur)
+- add corp get constant functions, UI (by @Mughur)
 - destroyW0r1dD43m0n now properly gives achievements
 - favor now properly syncs across pages and the Donate achievement is now given correctly (by @Aerophia)
 - getCrimeStats use bitnode multipliers in the output of crime stats (by @phyzical)


### PR DESCRIPTION
While testing #2202, I saw this React warning: `Warning: The tag <constant> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.`.

When checking `src\Documentation\doc\changelog.md`, I found out that we accidentally used `<constant>` which is considered an unrecognized HTML tag.

Before:

![before](https://github.com/user-attachments/assets/eeb87715-0b4a-4538-96cc-1ab6650cc2ca)

After:

![after](https://github.com/user-attachments/assets/fd13f384-082c-4162-a6a6-f46b7ee0234c)
