### PR TITLE
BUGFIX: Current work is not shown in edge cases

### DIFF
--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -194,7 +194,15 @@ export function WorkInProgressRoot(): React.ReactElement {
   };
 
   if (Player.currentWork === null) {
-    setTimeout(() => Router.toPage(Page.Terminal));
+    setTimeout(() => {
+      /**
+       * We must check again before routing to the Terminal page. The player might have started an action right before
+       * the callback of setTimeout is called.
+       */
+      if (Player.currentWork === null) {
+        Router.toPage(Page.Terminal);
+      }
+    });
     return <></>;
   }
 


### PR DESCRIPTION
How to reproduce:
- Expose `Player` and run test code.
- After "Augmented Targeting I" is grafted, the UI shows the Terminal page. It looks like nothing is being grafted, but `Player.currentWork` shows that "Augmented Targeting II" is being grafted.

The flow is like this:
- Start grafting "Augmented Targeting I".
- `WorkInProgressRoot` is shown.
- After a while, "Augmented Targeting I" is grafted, `WorkInProgressRoot` checks `Player.currentWork` and call `setTimeout`.
- Start grafting "Augmented Targeting II". `Player.currentWork` and `Player.focus` are set properly. `WorkInProgressRoot` is shown.
- The callback of `setTimeout` is called and the UI is routed to the Terminal page.

The problem is in the callback. We have to check `Player.currentWork` again before routing.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  Player.augmentations = [];
  ns.singularity.stopAction();
  ns.grafting.graftAugmentation("Augmented Targeting I", true);
  await ns.grafting.waitForOngoingGrafting();
  ns.grafting.graftAugmentation("Augmented Targeting II", true);
}
```

Fixes #504.