### PR TITLE
CLI: Allow using E notation in expr CLI

### DIFF
--- a/src/Terminal/commands/expr.ts
+++ b/src/Terminal/commands/expr.ts
@@ -8,7 +8,7 @@ export function expr(args: (string | number | boolean)[]): void {
   const expr = args.join("");
 
   // Sanitize the math expression
-  const sanitizedExpr = expr.replace(/[^-()\d/*+.%]/g, "");
+  const sanitizedExpr = expr.replace(/[^-()\deE/*+.%]/g, "");
   let result: string;
   try {
     result = String(eval?.(sanitizedExpr));


### PR DESCRIPTION
It's just as the title said.

Before:

![before](https://github.com/user-attachments/assets/473e5628-1805-40e0-9ced-e0b6fc8785b5)

After:

![after](https://github.com/user-attachments/assets/98f26c38-e2c3-4df6-9cf5-1c88b047e6ca)
