### PR TITLE
UI: Connect autocomplete lists purchased servers - alternative PR to #1905

### DIFF
--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -105,7 +105,13 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
   const addReachableServerNames = () => {
     addGeneric({
       iterable: GetAllServers()
-        .filter((server) => server.backdoorInstalled || currServ.serversOnNetwork.includes(server.hostname))
+        .filter(
+          (server) =>
+            server !== currServ &&
+            (server.backdoorInstalled ||
+              server.purchasedByPlayer ||
+              currServ.serversOnNetwork.includes(server.hostname)),
+        )
         .map((server) => server.hostname),
     });
   };


### PR DESCRIPTION
Fixes #1904

Changes per comments in #1905. Note as predicted they're at the back of the autocomplete list. EDIT: order is different since it's the order they were purchased; I reset in between screenshots.

I know this is hijacking Nerdpie's work, so they should be credited if this is merged. If the other PR is updated we can close this one, or if the concept is `wontfix` I'll close both PRs and update the issue to reflect that.

Screenshots:
No backdoors, just purchased servers (including hacknet) from not home:
<img width="763" alt="connectobackdoor" src="https://github.com/user-attachments/assets/75fed7bd-98cc-4fc3-ae4e-c7db70e1fca3" />

Backdoors and purchased servers (including hacknet) from not home:
<img width="1061" alt="connectocomplete2" src="https://github.com/user-attachments/assets/752f673e-771b-4aac-ac0c-f9d7833aa027" />
