### PR TITLE
INFILTRATION: Tune count down time to mitigate extremely fast auto-infiltration

### DIFF
--- a/src/Infiltration/ui/Countdown.tsx
+++ b/src/Infiltration/ui/Countdown.tsx
@@ -1,27 +1,28 @@
 import { Paper, Typography } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 interface IProps {
-  onFinish: () => void;
+  time: number;
 }
 
-export function Countdown({ onFinish }: IProps): React.ReactElement {
+export function Countdown({ time }: IProps): React.ReactElement {
   const [x, setX] = useState(3);
+  const intervalId = useRef(0);
 
   useEffect(() => {
     if (x === 0) {
-      onFinish();
+      clearInterval(intervalId.current);
     }
-  }, [x, onFinish]);
+  }, [x]);
 
   useEffect(() => {
-    const id = setInterval(() => {
+    intervalId.current = window.setInterval(() => {
       setX((previousValue) => previousValue - 1);
-    }, 300);
+    }, time / 3);
     return () => {
-      clearInterval(id);
+      clearInterval(intervalId.current);
     };
-  }, []);
+  }, [time]);
 
   return (
     <Paper sx={{ p: 1, textAlign: "center" }}>

--- a/src/Infiltration/ui/Game.tsx
+++ b/src/Infiltration/ui/Game.tsx
@@ -1,5 +1,5 @@
 import { Button, Container, Paper, Typography } from "@mui/material";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { FactionName, ToastVariant } from "@enums";
 import { Router } from "../../ui/GameRoot";
 import { Page } from "../../ui/Router";
@@ -18,6 +18,7 @@ import { calculateDamageAfterFailingInfiltration } from "../utils";
 import { SnackbarEvents } from "../../ui/React/Snackbar";
 import { PlayerEventType, PlayerEvents } from "../../PersonObjects/Player/PlayerEvents";
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
+import { clampNumber } from "../../utils/helpers/clampNumber";
 
 type GameProps = {
   StartingDifficulty: number;
@@ -33,6 +34,63 @@ enum Stage {
   Sell,
 }
 
+const date = globalThis.Date;
+const defaultWaitTimeBetweenFloors = 900;
+
+function calculateCountDownTime(tsStartOfMinigame: number, gameId: number) {
+  if (gameId === -1) {
+    return defaultWaitTimeBetweenFloors;
+  }
+  /**
+   * Each game has a window timer that is the maximum allowable time for the player to complete the game.
+   * With most games, let's use the "Brutal" difficulty and assume that the player uses 70% of that time to complete
+   * each game.
+   * With SlashGame, we calculate the average guardingTime with "window" of the "Brutal" difficulty, then add 100ms of
+   * reaction time.
+   * With MinesweeperGame, all difficulties have the window of 15000. 70% of it is a bit high. Let's assume the player
+   * needs 5000ms and 2000ms of the memory phase.
+   */
+  let expectedTime;
+  const balanceMultiplier = 0.7;
+  switch (gameId) {
+    // SlashGame
+    case 0:
+      expectedTime = 2725;
+      break;
+    // BracketGame
+    case 1:
+      expectedTime = 2500 * balanceMultiplier;
+      break;
+    // BackwardGame
+    case 2:
+      expectedTime = 8000 * balanceMultiplier;
+      break;
+    // BribeGame
+    case 3:
+      expectedTime = 2500 * balanceMultiplier;
+      break;
+    // CheatCodeGame
+    case 4:
+      expectedTime = 3000 * balanceMultiplier;
+      break;
+    // Cyberpunk2077Game
+    case 5:
+      expectedTime = 10000 * balanceMultiplier;
+      break;
+    // MinesweeperGame
+    case 6:
+      expectedTime = 7000;
+      break;
+    // WireCuttingGame
+    case 7:
+      expectedTime = 4000 * balanceMultiplier;
+      break;
+    default:
+      throw new Error(`Unexpected game id: ${gameId}`);
+  }
+  return defaultWaitTimeBetweenFloors + clampNumber(expectedTime - (date.now() - tsStartOfMinigame), 0, 15000);
+}
+
 const minigames = [
   SlashGame,
   BracketGame,
@@ -44,6 +102,11 @@ const minigames = [
   WireCuttingGame,
 ];
 
+function cancel(): void {
+  Router.toPage(Page.City);
+  return;
+}
+
 export function Game(props: GameProps): React.ReactElement {
   const [level, setLevel] = useState(1);
   const [stage, setStage] = useState(Stage.Countdown);
@@ -52,20 +115,18 @@ export function Game(props: GameProps): React.ReactElement {
     lastGames: [-1, -1],
     id: Math.floor(Math.random() * minigames.length),
   });
+  const tsStartOfMinigame = useRef(date.now());
+  const timeoutId = useRef(0);
 
   const setupNextGame = useCallback(() => {
-    const nextGameId = () => {
-      let id = gameIds.lastGames[0];
-      const ids = [gameIds.lastGames[0], gameIds.lastGames[1], gameIds.id];
-      while (ids.includes(id)) {
-        id = Math.floor(Math.random() * minigames.length);
-      }
-      return id;
-    };
-
+    let id = gameIds.lastGames[0];
+    const ids = [gameIds.lastGames[0], gameIds.lastGames[1], gameIds.id];
+    while (ids.includes(id)) {
+      id = Math.floor(Math.random() * minigames.length);
+    }
     setGameIds({
       lastGames: [gameIds.lastGames[1], gameIds.id],
-      id: nextGameId(),
+      id,
     });
   }, [gameIds]);
 
@@ -82,10 +143,10 @@ export function Game(props: GameProps): React.ReactElement {
     pushResult(true);
     if (level === props.MaxLevel) {
       setStage(Stage.Sell);
-    } else {
-      setStage(Stage.Countdown);
-      setLevel(level + 1);
+      return;
     }
+    setStage(Stage.Countdown);
+    setLevel(level + 1);
     setupNextGame();
   }, [level, props.MaxLevel, setupNextGame]);
 
@@ -115,15 +176,10 @@ export function Game(props: GameProps): React.ReactElement {
     [props.StartingDifficulty, setupNextGame],
   );
 
-  function cancel(): void {
-    Router.toPage(Page.City);
-    return;
-  }
-
   let stageComponent: React.ReactNode;
   switch (stage) {
     case Stage.Countdown:
-      stageComponent = <Countdown onFinish={() => setStage(Stage.Minigame)} />;
+      stageComponent = <Countdown time={calculateCountDownTime(tsStartOfMinigame.current, gameIds.lastGames[1])} />;
       break;
     case Stage.Minigame: {
       const MiniGame = minigames[gameIds.id];
@@ -144,14 +200,16 @@ export function Game(props: GameProps): React.ReactElement {
       break;
   }
 
-  function Progress(): React.ReactElement {
-    return (
-      <Typography variant="h4">
-        <span style={{ color: "gray" }}>{results.slice(0, results.length - 1)}</span>
-        {results[results.length - 1]}
-      </Typography>
-    );
-  }
+  useEffect(() => {
+    if (stage !== Stage.Countdown) {
+      return;
+    }
+    clearTimeout(timeoutId.current);
+    timeoutId.current = window.setTimeout(() => {
+      setStage(Stage.Minigame);
+      tsStartOfMinigame.current = date.now();
+    }, calculateCountDownTime(tsStartOfMinigame.current, gameIds.lastGames[1]));
+  }, [stage, gameIds]);
 
   useEffect(() => {
     const clearSubscription = PlayerEvents.subscribe((eventType) => {
@@ -161,7 +219,10 @@ export function Game(props: GameProps): React.ReactElement {
       cancel();
       dialogBoxCreate("Infiltration was cancelled because you were hospitalized");
     });
-    return clearSubscription;
+    return () => {
+      clearSubscription();
+      clearTimeout(timeoutId.current);
+    };
   }, []);
 
   return (
@@ -175,7 +236,10 @@ export function Game(props: GameProps): React.ReactElement {
         <Typography variant="h5">
           Level {level} / {props.MaxLevel}
         </Typography>
-        <Progress />
+        <Typography variant="h4">
+          <span style={{ color: "gray" }}>{results.slice(0, results.length - 1)}</span>
+          {results[results.length - 1]}
+        </Typography>
       </Paper>
 
       {stageComponent}

--- a/src/Infiltration/ui/MinesweeperGame.tsx
+++ b/src/Infiltration/ui/MinesweeperGame.tsx
@@ -72,7 +72,15 @@ export function MinesweeperGame(props: IMinigameProps): React.ReactElement {
       }
       setAnswer((old) => {
         old[pos[1]][pos[0]] = true;
-        if (fieldEquals(minefield, old)) props.onSuccess();
+        if (fieldEquals(minefield, old)) {
+          /**
+           * Calling onSuccess() makes the parent component ("Game") rerender while this component is still rendering,
+           * so we need to put it in setTimeout().
+           */
+          setTimeout(() => {
+            props.onSuccess();
+          }, 0);
+        }
         return old;
       });
     }


### PR DESCRIPTION
In #2222, we discussed about infiltration rewards and how to rebalance them. One of the problems of auto-infil is its speed (watch the third video in the linked issue). The new "market demand multiplier" mitigates this problem a bit, but it does not solve the problem entirely. When we tune that multiplier, we need to balance between manual infiltration and auto infiltration. Nerfing auto-infil while keeping manual infiltration relatively good is hard.

Auto-infil can easily complete a game that needs 15000ms in less than 100ms, so it's impossible for us to perfectly balance the rewards without punishing manual infiltration (by human) too much. This PR focuses on the core problem: the speed. After each floor, there is a count down that lasts 900ms. This PR adds an additional delay to that count down. This delay is designed to only affect non-human infiltration. If the player infiltrate manually, they won't see this delay or only see a tiny fraction of it. For the calculation, please check `calculateCountDownTime`.

Before:

"Simulated" manual infil:

https://github.com/user-attachments/assets/983d930a-9f03-423a-b2d7-01e5a4b4474c

Auto-infil:

https://github.com/user-attachments/assets/3a80deec-b0d4-42a5-aa2f-5c9efe4a26a1

After:

"Simulated" manual infil:

https://github.com/user-attachments/assets/06cc6a71-ce80-4eaa-9d68-640ae6139c68

Auto-infil:

https://github.com/user-attachments/assets/fc632832-0fb4-41e4-a5cb-ad8cb3d859c1
