### PR TITLE
CORPORATION: Remove DreamSense upgrade

### DIFF
--- a/markdown/bitburner.corpupgradename.md
+++ b/markdown/bitburner.corpupgradename.md
@@ -11,7 +11,6 @@
 type CorpUpgradeName =
   | "Smart Factories"
   | "Smart Storage"
-  | "DreamSense"
   | "Wilson Analytics"
   | "Nuoptimal Nootropic Injector Implants"
   | "Speech Processor Implants"

--- a/src/Corporation/Corporation.ts
+++ b/src/Corporation/Corporation.ts
@@ -57,11 +57,7 @@ export class Corporation {
   storedCycles = 0;
 
   unlocks = new JSONSet<CorpUnlockName>();
-  upgrades = createEnumKeyedRecord(CorpUpgradeName, (name) => ({
-    level: 0,
-    // For dreamsense, value is not a multiplier so it starts at 0
-    value: name === CorpUpgradeName.DreamSense ? 0 : 1,
-  }));
+  upgrades = createEnumKeyedRecord(CorpUpgradeName, () => ({ level: 0, value: 1 }));
 
   previousTotalAssets = 150e9;
   totalAssets = 150e9;
@@ -415,7 +411,12 @@ export class Corporation {
       };
     }
     const upgrade = CorpUpgrades[upgradeName];
-    const totalCost = calculateUpgradeCost(this, upgrade, amount);
+    const totalCost = calculateUpgradeCost(
+      upgrade.basePrice,
+      upgrade.priceMult,
+      this.upgrades[upgradeName].level,
+      amount,
+    );
     if (this.funds < totalCost) {
       return {
         success: false,
@@ -445,10 +446,6 @@ export class Corporation {
 
   getStorageMultiplier(): number {
     return this.upgrades[CorpUpgradeName.SmartStorage].value;
-  }
-
-  getDreamSenseGain(): number {
-    return this.upgrades[CorpUpgradeName.DreamSense].value;
   }
 
   getAdvertisingMultiplier(): number {

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -195,17 +195,6 @@ export class Division {
       this.popularity -= marketCycles * 0.0001;
       this.popularity = Math.max(0, this.popularity);
 
-      // Process Dreamsense gains
-      const popularityGain = corporation.getDreamSenseGain(),
-        awarenessGain = popularityGain * 4;
-      if (popularityGain > 0) {
-        const awareness = this.awareness + awarenessGain * marketCycles;
-        this.awareness = Math.min(awareness, Number.MAX_VALUE);
-
-        const popularity = this.popularity + popularityGain * marketCycles;
-        this.popularity = Math.min(popularity, Number.MAX_VALUE);
-      }
-
       return;
     }
 

--- a/src/Corporation/Enums.ts
+++ b/src/Corporation/Enums.ts
@@ -43,7 +43,6 @@ export enum CorpUnlockName {
 export enum CorpUpgradeName {
   SmartFactories = "Smart Factories",
   SmartStorage = "Smart Storage",
-  DreamSense = "DreamSense",
   WilsonAnalytics = "Wilson Analytics",
   NuoptimalNootropicInjectorImplants = "Nuoptimal Nootropic Injector Implants",
   SpeechProcessorImplants = "Speech Processor Implants",

--- a/src/Corporation/data/CorporationUpgrades.ts
+++ b/src/Corporation/data/CorporationUpgrades.ts
@@ -32,20 +32,6 @@ export const CorpUpgrades: Record<CorpUpgradeName, CorpUpgrade> = {
       "Each level of this upgrade increases your global warehouse storage size by 10% (additive).",
   },
 
-  //Advertise through dreams, passive popularity/ awareness gain
-  [CorpUpgradeName.DreamSense]: {
-    name: CorpUpgradeName.DreamSense,
-    basePrice: 4e9,
-    priceMult: 1.1,
-    benefit: 0.001,
-    desc:
-      "Use DreamSense LCC Technologies to advertise your corporation " +
-      "to consumers through their dreams. Each level of this upgrade provides a passive " +
-      "increase in awareness of all of your companies (divisions) by 0.004 / market cycle," +
-      "and in popularity by 0.001 / market cycle. A market cycle is approximately " +
-      "10 seconds.",
-  },
-
   //Makes advertising more effective
   [CorpUpgradeName.WilsonAnalytics]: {
     name: CorpUpgradeName.WilsonAnalytics,

--- a/src/Corporation/helpers.ts
+++ b/src/Corporation/helpers.ts
@@ -50,10 +50,13 @@ export function costOfCreatingCorporation(restart: boolean): number {
   return 150e9;
 }
 
-export function calculateUpgradeCost(corporation: Corporation, upgrade: CorpUpgrade, amount: PositiveInteger): number {
-  const priceMult = upgrade.priceMult;
-  const level = corporation.upgrades[upgrade.name].level;
-  const baseCost = upgrade.basePrice * Math.pow(priceMult, level);
+export function calculateUpgradeCost(
+  basePrice: number,
+  priceMult: number,
+  fromLevel: number,
+  amount: PositiveInteger,
+): number {
+  const baseCost = basePrice * Math.pow(priceMult, fromLevel);
   const cost = (baseCost * (1 - Math.pow(priceMult, amount))) / (1 - priceMult);
   return cost;
 }

--- a/src/Corporation/ui/LevelableUpgrade.tsx
+++ b/src/Corporation/ui/LevelableUpgrade.tsx
@@ -27,7 +27,7 @@ export function LevelableUpgrade({ upgradeName, mult, rerender }: IProps): React
 
   const amount = mult === "MAX" ? calculateMaxAffordableUpgrade(corp, data) : mult;
 
-  const cost = amount === 0 ? 0 : calculateUpgradeCost(corp, data, amount);
+  const cost = amount === 0 ? 0 : calculateUpgradeCost(data.basePrice, data.priceMult, level, amount);
   const tooltip = data.desc;
   function onClick(): void {
     if (corp.funds < cost) return;

--- a/src/Documentation/doc/advanced/corporation/faq.md
+++ b/src/Documentation/doc/advanced/corporation/faq.md
@@ -163,10 +163,6 @@ Check this [section](./quality.md).
 
 Check this [section](./wilson-analytics-advert.md).
 
-#### Should I buy Dream Sense?
-
-No. Check this [section](./wilson-analytics-advert.md) for the reason.
-
 #### Is Wilson retroactive?
 
 No.

--- a/src/Documentation/doc/advanced/corporation/unlocks-upgrade-research.md
+++ b/src/Documentation/doc/advanced/corporation/unlocks-upgrade-research.md
@@ -60,9 +60,7 @@ $$UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{PriceMult}^{b} - {Pr
 
 $$MaxUpgradeLevel = \log_{PriceMult}\left( MaxCost\ast\frac{PriceMult - 1}{BasePrice} + (PriceMult)^{CurrentLevel} \right)$$
 
-- Benefit:
-  - All benefits are multipliers. `BaseBenefit` is 1.
-  - The only exception is DreamSense. Its benefit is raw value, its `BaseBenefit` is 0.
+- Benefit: All benefits are multipliers. `BaseBenefit` is 1.
 
 $$Benefit = BaseBenefit + Benefit\ast CurrentLevel$$
 
@@ -73,7 +71,6 @@ Normal upgrades:
 | ---------------------------------- | -------------- | -------------------- | ----------- | ----------------------- |
 | SmartFactories                     | 2e9            | 1.06                 | 0.03        | Production              |
 | SmartStorage                       | 2e9            | 1.06                 | 0.1         | Storage                 |
-| DreamSense                         | 4e9            | 1.1                  | 0.001       | Awareness/Popularity    |
 | WilsonAnalytics                    | 4e9            | 2                    | 0.005       | Advert's benefits       |
 | NuoptimalNootropicInjectorImplants | 1e9            | 1.06                 | 0.1         | Employee's creativity   |
 | SpeechProcessorImplants            | 1e9            | 1.06                 | 0.1         | Employee's charisma     |
@@ -94,7 +91,6 @@ Special upgrades:
 &nbsp;  
 Advice:
 
-- DreamSense is useless. Never buy it.
 - Round 1:
   - SmartStorage and Warehouse are the most important upgrades in this round.
   - Only buy 1 or 2 Advert level(s).

--- a/src/Documentation/doc/advanced/corporation/wilson-analytics-advert.md
+++ b/src/Documentation/doc/advanced/corporation/wilson-analytics-advert.md
@@ -8,8 +8,6 @@ Awareness and popularity are capped at `Number.MAX_VALUE` (~1.7976931348623157E+
 
 Raw values of those stats are crucial, but their ratio is also important. We want to have high ratio of popularity/awareness, check this [section](./optimal-selling-price-market-ta2.md) for formulas.
 
-DreamSense only increases popularity by 0.001/cycle/level and awareness by 0.004/cycle/level. Those benefits are minuscule. However, that's not its biggest problem, the biggest one is the ratio of popularity/awareness. We want that ratio to be as high as possible, but DreamSense constantly lowers it.
-
 Popularity decreases by 0.0001 per cycle.
 
 ## Wilson Analytics

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -90,7 +90,13 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
 
   function getUpgradeLevelCost(upgradeName: CorpUpgradeName): number {
     const corporation = getCorporation();
-    const cost = calculateUpgradeCost(corporation, CorpUpgrades[upgradeName], 1 as PositiveInteger);
+    const upgrade = CorpUpgrades[upgradeName];
+    const cost = calculateUpgradeCost(
+      upgrade.basePrice,
+      upgrade.priceMult,
+      corporation.upgrades[upgradeName].level,
+      1 as PositiveInteger,
+    );
     return cost;
   }
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -9837,7 +9837,6 @@ type CorpUnlockName =
 type CorpUpgradeName =
   | "Smart Factories"
   | "Smart Storage"
-  | "DreamSense"
   | "Wilson Analytics"
   | "Nuoptimal Nootropic Injector Implants"
   | "Speech Processor Implants"

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -210,5 +210,10 @@ export const breakingChanges300: VersionBreakingChange = {
         '"ns.enums.FactionName.BachmanAssociates" has been automatically replaced with "ns.enums.FactionName.BachmanAndAssociates".',
       showPopUp: false,
     },
+    {
+      brokenAPIs: [{ name: "DreamSense" }],
+      info: 'The "DreamSense" upgrade was removed. The cost of that upgrade was refunded.',
+      showPopUp: false,
+    },
   ],
 };

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -31,6 +31,8 @@ import { getGoSave, loadGo } from "../Go/SaveLoad";
 import { showAPIBreaks } from "./APIBreaks/APIBreak";
 import { breakInfos261 } from "./APIBreaks/2.6.1";
 import { breakingChanges300 } from "./APIBreaks/3.0.0";
+import { calculateUpgradeCost } from "../Corporation/helpers";
+import type { PositiveInteger } from "../types";
 
 /** Function for performing a series of defined replacements. See 0.58.0 for usage */
 function convert(code: string, changes: [RegExp, string][]): string {
@@ -547,6 +549,18 @@ Error: ${e}`,
     if (found) Terminal.error("Filenames with whitespace found and corrected, see console for details.");
   }
   if (ver < 44) {
+    if (Player.corporation) {
+      // Remove and refund DreamSense
+      for (const [name, upgrade] of Object.entries(Player.corporation.upgrades)) {
+        if (name !== "DreamSense") {
+          continue;
+        }
+        const cost = calculateUpgradeCost(4e9, 1.1, 0, upgrade.level as PositiveInteger);
+        Player.corporation.gainFunds(cost, "force majeure");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (Player.corporation.upgrades as Record<string, unknown>)["DreamSense"];
+    }
     showAPIBreaks("3.0.0", breakingChanges300);
   }
 }

--- a/test/jest/Corporation.test.ts
+++ b/test/jest/Corporation.test.ts
@@ -34,7 +34,13 @@ describe("Corporation", () => {
           corporation.upgrades[upgrade.name].level = currentUpgradeLevel;
 
           for (let targetUpgradeLevel = currentUpgradeLevel + 1; targetUpgradeLevel < 6; targetUpgradeLevel++) {
-            expect(calculateUpgradeCost(corporation, upgrade, targetUpgradeLevel as PositiveInteger)).toMatchSnapshot(
+            const calculatedCost = calculateUpgradeCost(
+              upgrade.basePrice,
+              upgrade.priceMult,
+              currentUpgradeLevel,
+              targetUpgradeLevel as PositiveInteger,
+            );
+            expect(calculatedCost).toMatchSnapshot(
               `${upgrade.name}: from ${currentUpgradeLevel} to ${targetUpgradeLevel}`,
             );
           }
@@ -66,7 +72,12 @@ describe("Corporation", () => {
           corporation.upgrades[upgrade.name].level = currentUpgradeLevel;
 
           for (let targetUpgradeLevel = currentUpgradeLevel + 1; targetUpgradeLevel < 100; targetUpgradeLevel++) {
-            const calculatedCost = calculateUpgradeCost(corporation, upgrade, targetUpgradeLevel as PositiveInteger);
+            const calculatedCost = calculateUpgradeCost(
+              upgrade.basePrice,
+              upgrade.priceMult,
+              currentUpgradeLevel,
+              targetUpgradeLevel as PositiveInteger,
+            );
             corporation.funds = calculatedCost + 1; // +1 for floating point accuracy issues
             expect(calculateMaxAffordableUpgrade(corporation, upgrade)).toEqual(targetUpgradeLevel);
           }

--- a/test/jest/__snapshots__/Corporation.test.ts.snap
+++ b/test/jest/__snapshots__/Corporation.test.ts.snap
@@ -30,36 +30,6 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 4 to 5 1`] = `7538045748.859352`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 0 to 1 1`] = `4000000000`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 0 to 2 1`] = `8400000000`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 0 to 3 1`] = `13240000000.000006`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 0 to 4 1`] = `18564000000.000008`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 0 to 5 1`] = `24420400000.000004`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 1 to 2 1`] = `9240000000`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 1 to 3 1`] = `14564000000.000004`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 1 to 4 1`] = `20420400000.00001`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 1 to 5 1`] = `26862440000`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 2 to 3 1`] = `16020400000.00001`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 2 to 4 1`] = `22462440000.000015`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 2 to 5 1`] = `29548684000.000008`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 3 to 4 1`] = `24708684000.00002`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 3 to 5 1`] = `32503552400.000015`;
-
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: DreamSense: from 4 to 5 1`] = `35753907640.000015`;
-
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 0 to 1 1`] = `1000000000`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 0 to 2 1`] = `2060000000.0000007`;

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -330,10 +330,6 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "level": 0,
             "value": 1,
           },
-          "DreamSense": {
-            "level": 0,
-            "value": 0,
-          },
           "FocusWires": {
             "level": 0,
             "value": 1,


### PR DESCRIPTION
Context: #2193.

Test save file:
[remove-dreamsense.gz](https://github.com/user-attachments/files/21124782/remove-dreamsense.gz)

How to test: Load the attached save file, then check the corporation's fund. It should be 110e9.

```
API BREAK INFO FOR 3.0.0

The "DreamSense" upgrade was removed. The cost of that upgrade was refunded.

Usage of the following functions may have been affected:
DreamSense

Potentially affected files on server home (with line numbers):
a.js: (Line number: 7)
```

Screenshots:

![1](https://github.com/user-attachments/assets/a704570a-97f9-4176-80c9-48f961777e69)

![2](https://github.com/user-attachments/assets/819035ce-0d6d-4122-84d0-40b7aa587475)
