### PR TITLE
DOCUMENTATION: Clarify condition of joining Daedalus faction

### DIFF
--- a/src/Documentation/doc/advanced/faction_list.md
+++ b/src/Documentation/doc/advanced/faction_list.md
@@ -63,7 +63,7 @@ If you install a backdoor on a company's server, the required reputation of that
 | ------------ | ------------------------------------------------------------------------------------------------- |
 | The Covenant | \* 20 Augmentations<br />\* \$75b<br />\* Hacking Level of 850<br />\* All Combat Stats of 850    |
 | Illuminati   | \* 30 Augmentations<br />\* \$150b<br />\* Hacking Level of 1500<br />\* All Combat Stats of 1200 |
-| Daedalus     | \* 30+ Augmentations<br />\* \$100b<br />\* Hacking Level of 2500 OR All Combat Stats of 1500     |
+| Daedalus     | \* 30 Augmentations<br />\* \$100b<br />\* Hacking Level of 2500 OR All Combat Stats of 1500      |
 
 ### Endgame Factions
 


### PR DESCRIPTION
To be honest, I'm not sure if we need to clarify it. A player had a weird misunderstanding:
```
It’s a min? the ingame doc just says 20 and 30 where Daedalus says 30+ so I wasn’t sure if it was a max or exact
I’ve been sitting here trying to pick and choose which augs are best to get me there under their limits
```
I think it's fine to remove "+" in "30+ Augmentations". Every condition in that page is the min value. There is no need for adding the "+" character.