### PR TITLE
CORPORATION: Fix typo in #2237

### DIFF
--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -375,7 +375,8 @@ function DividendsStats({ profit }: IDividendsStatsProps): React.ReactElement {
                   <br />
                   Although your corporation grants you unlimited wealth, nobody dares try to sabotage your corporation
                   and take that wealth away from you. Why? All (alive) CEOs know this unspoken rule: If you pay a
-                  "small" tribute to "them", "they" will protect you. Just a small free, and you are safe. Guaranteed.
+                  "small" tribute to "them", "they" will protect you. Just pay a small fee, and you are safe.
+                  Guaranteed.
                   <br />
                   <br />
                   Who are "they"? Nobody knows for certain. There is a rumour that they are{" "}


### PR DESCRIPTION
I made a typo in #2237. I mean "pay a small fee", not "a small free".

Before:

<img width="986" height="305" alt="before" src="https://github.com/user-attachments/assets/4b7951ea-4aa7-4e86-8e74-51b599dec14d" />

After:

<img width="989" height="302" alt="after" src="https://github.com/user-attachments/assets/994b1e5c-8910-4f98-8615-1573c8fd7cf9" />

This is a tiny patch, so I will use it to test my merge permission.