### PR TITLE
BUGFIX: Exporting game via menu of Steam app does not give export bonus

### DIFF
--- a/src/ExportBonus.tsx
+++ b/src/ExportBonus.tsx
@@ -9,8 +9,10 @@ export function canGetBonus(): boolean {
   return now - LastExportBonus > bonusTimer;
 }
 
-export function onExport(): void {
-  if (!canGetBonus()) return;
+export function giveExportBonus(): void {
+  if (!canGetBonus()) {
+    return;
+  }
   for (const facName of Player.factions) {
     Factions[facName].setFavor(Factions[facName].favor + 1);
   }

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -36,7 +36,7 @@ import { ClassWork } from "../Work/ClassWork";
 import { CreateProgramWork, isCreateProgramWork } from "../Work/CreateProgramWork";
 import { FactionWork } from "../Work/FactionWork";
 import { CompanyWork } from "../Work/CompanyWork";
-import { canGetBonus, onExport } from "../ExportBonus";
+import { canGetBonus } from "../ExportBonus";
 import { saveObject } from "../SaveObject";
 import { calculateCrimeWorkStats } from "../Work/Formulas";
 import { Engine } from "../engine";
@@ -1179,7 +1179,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     },
     exportGame: (ctx) => () => {
       helpers.checkSingularityAccess(ctx);
-      onExport();
       return saveObject.exportGame();
     },
     exportGameBonus: (ctx) => () => {

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -29,6 +29,7 @@ import { handleGetSaveDataInfoError } from "./utils/ErrorHandler";
 import { isObject, assertObject } from "./utils/TypeAssertion";
 import { evaluateVersionCompatibility } from "./utils/SaveDataMigrationUtils";
 import { Reviver } from "./utils/GenericReviver";
+import { giveExportBonus } from "./ExportBonus";
 
 /* SaveObject.js
  *  Defines the object used to save/load games
@@ -239,6 +240,8 @@ class BitburnerSaveObject implements BitburnerSaveObjectType {
   }
 
   async exportGame(): Promise<void> {
+    // Give the export bonus before exporting the save data
+    giveExportBonus();
     let saveData;
     try {
       saveData = await this.getSaveData();

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -6,7 +6,6 @@ import { makeStyles } from "tss-react/mui";
 import { Player } from "@player";
 import { installAugmentations } from "../Augmentation/AugmentationHelpers";
 import { saveObject } from "../SaveObject";
-import { onExport } from "../ExportBonus";
 import { CompletedProgramName, LocationName, SimplePage } from "@enums";
 import { ITutorial, iTutorialStart } from "../InteractiveTutorial";
 import { InteractiveTutorialRoot } from "./InteractiveTutorial/InteractiveTutorialRoot";
@@ -430,8 +429,6 @@ export function GameRoot(): React.ReactElement {
             saveObject.saveGame().catch((error) => exceptionAlert(error));
           }}
           export={() => {
-            // Apply the export bonus before saving the game
-            onExport();
             saveObject.exportGame().catch((error) => exceptionAlert(error));
           }}
           forceKill={killAllScripts}
@@ -451,8 +448,6 @@ export function GameRoot(): React.ReactElement {
       mainPage = (
         <AugmentationsRoot
           exportGameFn={() => {
-            // Apply the export bonus before saving the game
-            onExport();
             saveObject.exportGame().catch((error) => exceptionAlert(error));
           }}
           installAugmentationsFn={() => {


### PR DESCRIPTION
How to reproduce:
- Load a clean save file by Options -> Delete Save.
- Join a faction.
- File -> Export Save
- Check faction's favor.

Currently, we call `onExport` before calling `saveObject.exportGame` to give the bonus, but we forget doing that in `triggerGameExport` (`src\Electron.tsx`). This PR calls `onExport` inside `saveObject.exportGame`, so we won't see this kind of bug.