### PR TITLE
DOCUMENTATION: Fix wrong param/return type and clarify ns.sleep, ns.asleep, ns.singularity.exportGame

### DIFF
--- a/markdown/bitburner.ns.asleep.md
+++ b/markdown/bitburner.ns.asleep.md
@@ -9,14 +9,14 @@ Suspends the script for n milliseconds. Doesn't block with concurrent calls.
 **Signature:**
 
 ```typescript
-asleep(millis: number): Promise<true>;
+asleep(millis?: number): Promise<true>;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  millis | number | Number of milliseconds to sleep. |
+|  millis | number | _(Optional)_ Number of milliseconds to sleep. Default to 0. |
 
 **Returns:**
 
@@ -27,4 +27,6 @@ A promise that resolves to true when the sleep is completed.
 ## Remarks
 
 RAM cost: 0 GB
+
+Note that the actual delay may be longer than intended. For more information, please check https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout\#delay.
 

--- a/markdown/bitburner.ns.sleep.md
+++ b/markdown/bitburner.ns.sleep.md
@@ -9,14 +9,14 @@ Suspends the script for n milliseconds.
 **Signature:**
 
 ```typescript
-sleep(millis: number): Promise<true>;
+sleep(millis?: number): Promise<true>;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  millis | number | Number of milliseconds to sleep. |
+|  millis | number | _(Optional)_ Number of milliseconds to sleep. Default to 0. |
 
 **Returns:**
 
@@ -27,6 +27,8 @@ A promise that resolves to true when the sleep is completed.
 ## Remarks
 
 RAM cost: 0 GB
+
+Note that the actual delay may be longer than intended. For more information, please check https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout\#delay.
 
 ## Example
 

--- a/markdown/bitburner.singularity.exportgame.md
+++ b/markdown/bitburner.singularity.exportgame.md
@@ -9,11 +9,11 @@ Backup game save.
 **Signature:**
 
 ```typescript
-exportGame(): void;
+exportGame(): Promise<void>;
 ```
 **Returns:**
 
-void
+Promise&lt;void&gt;
 
 ## Remarks
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1862,7 +1862,7 @@ export interface Singularity {
    * This function will automatically open the backup save prompt and claim the free faction favour if available.
    *
    */
-  exportGame(): void;
+  exportGame(): Promise<void>;
 
   /**
    * Returns Backup save bonus availability.
@@ -6528,7 +6528,10 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * @param millis - Number of milliseconds to sleep.
+   * Note that the actual delay may be longer than intended. For more information, please check
+   * https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay.
+   *
+   * @param millis - Number of milliseconds to sleep. Default to 0.
    * @example
    * ```js
    * // This will count from 1 to 10 in your terminal, with one number every 5 seconds
@@ -6539,17 +6542,20 @@ export interface NS {
    * ```
    * @returns A promise that resolves to true when the sleep is completed.
    */
-  sleep(millis: number): Promise<true>;
+  sleep(millis?: number): Promise<true>;
 
   /**
    * Suspends the script for n milliseconds. Doesn't block with concurrent calls.
    * @remarks
    * RAM cost: 0 GB
    *
-   * @param millis - Number of milliseconds to sleep.
+   * Note that the actual delay may be longer than intended. For more information, please check
+   * https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay.
+   *
+   * @param millis - Number of milliseconds to sleep. Default to 0.
    * @returns A promise that resolves to true when the sleep is completed.
    */
-  asleep(millis: number): Promise<true>;
+  asleep(millis?: number): Promise<true>;
 
   /**
    * Prints one or more values or variables to the script’s logs.


### PR DESCRIPTION
This PR makes these changes:
- sleep/asleep:
  - `millis` is optional.
  - Add a note about the actual delay.
- exportGame: Return `Promise<void>` instead of `void`. This API returns a promise.