### PR TITLE
UI: Show money in exponential form instead of "0.000" when it's > 0 but still too small

### DIFF
--- a/src/Corporation/ui/Overview.tsx
+++ b/src/Corporation/ui/Overview.tsx
@@ -364,7 +364,10 @@ function DividendsStats({ profit }: IDividendsStatsProps): React.ReactElement {
       rows={[
         ["Retained Profits (after dividends):", <MoneyRate key="profits" money={retainedEarnings} />],
         ["Dividend Percentage:", formatPercent(corp.dividendRate, 0)],
-        ["Dividends per share:", <MoneyRate key="dividends" money={dividendsPerShare} />],
+        [
+          "Dividends per share:",
+          <MoneyRate key="dividends" money={dividendsPerShare} useExponentialFormForSmallValue={true} />,
+        ],
         [
           <>
             <Tooltip

--- a/src/ui/React/Money.tsx
+++ b/src/ui/React/Money.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { formatMoney } from "../formatNumber";
 import { Player } from "@player";
-import { Theme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
 import { makeStyles } from "tss-react/mui";
 
 const useStyles = makeStyles()((theme: Theme) => ({
@@ -14,17 +14,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
 }));
 
 interface IProps {
-  money: number | string;
+  money: number;
   forPurchase?: boolean;
 }
 export function Money(props: IProps): React.ReactElement {
   const { classes } = useStyles();
-  if (props.forPurchase) {
-    if (typeof props.money !== "number")
-      throw new Error("if value is for a purchase, money should be number, contact dev");
-    if (!Player.canAfford(props.money)) return <span className={classes.unbuyable}>{formatMoney(props.money)}</span>;
-  }
   return (
-    <span className={classes.money}>{typeof props.money === "number" ? formatMoney(props.money) : props.money}</span>
+    <span className={props.forPurchase && !Player.canAfford(props.money) ? classes.unbuyable : classes.money}>
+      {formatMoney(props.money)}
+    </span>
   );
 }

--- a/src/ui/React/MoneyRate.tsx
+++ b/src/ui/React/MoneyRate.tsx
@@ -9,7 +9,13 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
 }));
 
-export function MoneyRate({ money }: { money: number }): JSX.Element {
+export function MoneyRate({
+  money,
+  useExponentialFormForSmallValue,
+}: {
+  money: number;
+  useExponentialFormForSmallValue?: boolean;
+}): JSX.Element {
   const { classes } = useStyles();
-  return <span className={classes.money}>{formatMoney(money)} / sec</span>;
+  return <span className={classes.money}>{formatMoney(money, useExponentialFormForSmallValue)} / sec</span>;
 }

--- a/src/ui/React/MoneyRate.tsx
+++ b/src/ui/React/MoneyRate.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import { formatMoney } from "../formatNumber";
-import { Money } from "./Money";
+import type { Theme } from "@mui/material/styles";
+import { makeStyles } from "tss-react/mui";
+
+const useStyles = makeStyles()((theme: Theme) => ({
+  money: {
+    color: theme.colors.money,
+  },
+}));
 
 export function MoneyRate({ money }: { money: number }): JSX.Element {
-  return <Money money={`${formatMoney(money)} / sec`} />;
+  const { classes } = useStyles();
+  return <span className={classes.money}>{formatMoney(money)} / sec</span>;
 }

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -196,7 +196,9 @@ export const formatThreads = formatHp;
 export const formatSkill = (n: number) => formatNumber(n, 3, 1e9, true);
 
 /** Display standard money formatting, including the preceding $. */
-export const formatMoney = (n: number) => "$" + formatNumber(n);
+export const formatMoney = (n: number): string => {
+  return `$${n === 0 || n >= 0.001 ? formatNumber(n) : n.toExponential(3)}`;
+};
 
 /** Display a decimal number with increased precision (5 fractional digits) */
 export const formatRespect = (n: number) => formatNumber(n, 5);

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -196,8 +196,8 @@ export const formatThreads = formatHp;
 export const formatSkill = (n: number) => formatNumber(n, 3, 1e9, true);
 
 /** Display standard money formatting, including the preceding $. */
-export const formatMoney = (n: number): string => {
-  return `$${n === 0 || n >= 0.001 ? formatNumber(n) : n.toExponential(3)}`;
+export const formatMoney = (n: number, useExponentialFormForSmallValue = false): string => {
+  return `$${!useExponentialFormForSmallValue || n === 0 || n >= 0.001 ? formatNumber(n) : n.toExponential(3)}`;
 };
 
 /** Display a decimal number with increased precision (5 fractional digits) */


### PR DESCRIPTION
It's just as the title said.

Before:

<img width="412" height="123" alt="before" src="https://github.com/user-attachments/assets/3dee928d-1003-4557-be1a-7a64f54ca30b" />

After:

<img width="412" height="126" alt="after" src="https://github.com/user-attachments/assets/07772aa8-9633-4a9f-959a-aa30eaeae792" />
