### PR TITLE
UI: Show terminal warning instead of popup for breaking changes

### DIFF
--- a/src/utils/APIBreaks/2.6.1.ts
+++ b/src/utils/APIBreaks/2.6.1.ts
@@ -10,7 +10,7 @@ export const breakInfos261: VersionBreakingChange = {
         "Because of this change, the null case now needs to be dealt with prior to accessing properties on the return of getCurrentAction, including destructuring.\n" +
         "Additionally, any existing code for filtering out the Idle case will need to be adjusted.\n\n" +
         "See https://github.com/bitburner-official/bitburner-src/issues/1249 or PR https://github.com/bitburner-official/bitburner-src/pull/1248 for more details.",
-      showPopUp: true,
+      showWarning: true,
     },
     {
       brokenAPIs: [
@@ -27,7 +27,7 @@ export const breakInfos261: VersionBreakingChange = {
         'Previously returned -1 when called with type "Idle" and name "". This is no longer valid usage and will result in an error.\n\n' +
         "See the related changes for ns.bladeburner.getCurrentAction, which were shown earlier in these API break details.\n" +
         "In most cases, the fixes for ns.bladeburner.getCurrentAction will fix this group of issues as well.",
-      showPopUp: true,
+      showWarning: true,
     },
   ],
 };

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -9,7 +9,7 @@ export const breakingChanges300: VersionBreakingChange = {
         "ns.nFormat() was removed.\n" +
         "Use ns.formatNumber, ns.formatRam, ns.formatPercent, or JS built-in objects/functions (e.g., Intl.NumberFormat, " +
         "Intl.PluralRules, Intl.Locale) instead.",
-      showPopUp: true,
+      showWarning: true,
     },
     {
       brokenAPIs: [
@@ -60,7 +60,7 @@ export const breakingChanges300: VersionBreakingChange = {
         'It has been automatically replaced with "ns.getResetInfo().currentNode"\n\n' +
         "ns.corporation.getCorporation().state was removed.\n" +
         'It has been automatically replaced with "ns.corporation.getCorporation().nextState"',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [
@@ -73,7 +73,7 @@ export const breakingChanges300: VersionBreakingChange = {
         "The formatting functions have been moved to their own interface, ns.format.\n" +
         "Each function has been replaced with their corresponding interface variant.\n" +
         "Additionally, the naming of ns.tFormat has been changed to ns.format.time.",
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [
@@ -94,7 +94,7 @@ export const breakingChanges300: VersionBreakingChange = {
         'It has been automatically replaced with "ns.ui.closeTail()".\n\n' +
         "ns.setTitle() was removed.\n" +
         'It has been automatically replaced with "ns.ui.setTailTitle()".',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [
@@ -109,7 +109,7 @@ export const breakingChanges300: VersionBreakingChange = {
       info:
         "ns.corporation.setAutoJobAssignment() was removed.\n" +
         'It has been automatically replaced with "ns.corporation.setJobAssignment()".',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [],
@@ -126,7 +126,7 @@ export const breakingChanges300: VersionBreakingChange = {
         "- Stock position: PositionType\n" +
         "- Stock order: OrderType\n" +
         "You can access these values via ns.enums and Bladeburner APIs.",
-      showPopUp: true,
+      showWarning: true,
       doNotSkip: true,
     },
     {
@@ -141,7 +141,7 @@ export const breakingChanges300: VersionBreakingChange = {
       info:
         `ns.nuke, ns.brutessh, ns.ftpcrack, ns.relaysmtp, ns.httpworm, and ns.sqlinject now do not throw an error when you do not have the required .exe file or enough opened ports.\n` +
         "This should not be a problem with most scripts. However, if you were catching errors and branching on the result of success/failure, you will need to use the return value instead.",
-      showPopUp: true,
+      showWarning: true,
     },
     {
       brokenAPIs: [
@@ -177,7 +177,7 @@ export const breakingChanges300: VersionBreakingChange = {
         'It has been automatically replaced with "ns.stock.hasTixApiAccess()".\n\n' +
         "ns.stock.has4SDataTIXAPI() was removed.\n" +
         'It has been automatically replaced with "ns.stock.has4SDataTixApi()".',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [
@@ -189,14 +189,14 @@ export const breakingChanges300: VersionBreakingChange = {
       info:
         "ns.getBitNodeMultipliers().RepToDonateToFaction was removed.\n" +
         'It has been automatically replaced with "ns.getBitNodeMultipliers().FavorToDonateToFaction".',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [{ name: "getActionRepGain" }],
       info:
         "ns.bladeburner.getActionRepGain returned the average rank gain instead of the average reputation gain.\n" +
         "This bug was fixed. Please check your code to see if it still works as you expect.",
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [
@@ -208,24 +208,24 @@ export const breakingChanges300: VersionBreakingChange = {
       info:
         'The key of "Bachman & Associates" faction in the FactionName enum was renamed.\n' +
         '"ns.enums.FactionName.BachmanAssociates" has been automatically replaced with "ns.enums.FactionName.BachmanAndAssociates".',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [{ name: "DreamSense" }],
       info: 'The "DreamSense" upgrade was removed. The cost of that upgrade was refunded.',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [{ name: "dividendTax", migration: { searchValue: "dividendTax", replaceValue: "tributeModifier" } }],
       info:
         "ns.corporation.getCorporation().dividendTax was removed.\n" +
         'It has been automatically replaced with "ns.corporation.getCorporation().tributeModifier".',
-      showPopUp: false,
+      showWarning: false,
     },
     {
       brokenAPIs: [{ name: "Spring Water" }],
       info: 'The "Spring Water" industry was removed. The cost of all Spring Water divisions was refunded.',
-      showPopUp: false,
+      showWarning: false,
     },
   ],
 };

--- a/src/utils/APIBreaks/APIBreak.ts
+++ b/src/utils/APIBreaks/APIBreak.ts
@@ -171,7 +171,9 @@ export function showAPIBreaks(version: string, { additionalText, apiBreakingChan
       continue;
     }
     Terminal.warn(
-      `\nAPI BREAK VERSION ${version} DETAILS ${warningIndex + 1} of ${numberOfWarnings}\n\n${detail.apiBreakInfo.info}` +
+      `\nAPI BREAK VERSION ${version} DETAILS ${warningIndex + 1} of ${numberOfWarnings}\n\n${
+        detail.apiBreakInfo.info
+      }` +
         /**
          * If we can detect the affected lines via apiBreakInfo.brokenAPIs, we will show the number of affected lines.
          * However, some breaking changes cannot be reliably detected, so we intentionally leave apiBreakInfo.brokenAPIs

--- a/src/utils/APIBreaks/APIBreak.ts
+++ b/src/utils/APIBreaks/APIBreak.ts
@@ -11,7 +11,9 @@ import { pluralize } from "../I18nUtils";
 
 // Temporary until fixing alerts manager to store alerts outside of react scope
 const dialogBoxCreate = (text: string) =>
-  setTimeout(() => dialogBoxCreateOriginal(text, { html: false, canBeDismissedEasily: false }), 2000);
+  setTimeout(() => {
+    dialogBoxCreateOriginal(text, { html: false, canBeDismissedEasily: false });
+  }, 2000);
 
 /** For a single server, map of script filepath to an array of line numbers where impacted functions were detected */
 type ScriptImpactMap = Map<ScriptFilePath, number[]>;
@@ -36,19 +38,19 @@ export interface APIBreakInfo {
   }[];
   /** Info that should be shown to the player, alongside the list of impacted scripts */
   info: string;
-  /** If broken APIs can be safely migrated, we can skip displaying the notification popup */
-  showPopUp: boolean;
+  /** If broken APIs can be safely migrated, we can skip displaying the warning */
+  showWarning: boolean;
   /**
    * With a new version with breaking changes, the "showAPIBreaks" function checks all breaking changes and does 2
    * things with changes that affect the player's scripts:
    * - Write info of changes to a log file.
-   * - Show popups per change.
+   * - Show a warning per change.
    * Note that we skip changes that do not affect the player's scripts. This is problematic with some breaking changes.
    *
    * With each breaking change in "brokenAPIs", we try to detect the affected code by using "name" or
    * "migration.searchValue". However, with some breaking changes, we cannot detect the affected code reliably via
    * "brokenAPIs". In this case, instead of skipping them, we always "process" that change (i.e., write info to the log
-   * file and optionally show a popup that notifies the player about this change).
+   * file and optionally show a warning that notifies the player about this change).
    */
   doNotSkip?: boolean;
 }
@@ -103,9 +105,9 @@ export function showAPIBreaks(version: string, { additionalText, apiBreakingChan
     apiBreakInfo: APIBreakInfo;
     text: string;
     totalDetectedLines: number;
-    showPopUp: boolean;
+    showWarning: boolean;
   }[] = [];
-  let numberOfPopUps = 0;
+  let numberOfWarnings = 0;
   for (const breakInfo of apiBreakingChanges) {
     const scanResult = detectImpactAndMigrate(breakInfo.brokenAPIs);
     const impactMap = scanResult.impactMap;
@@ -138,10 +140,10 @@ export function showAPIBreaks(version: string, { additionalText, apiBreakingChan
       apiBreakInfo: breakInfo,
       text: detailText,
       totalDetectedLines: scanResult.totalDetectedLines,
-      showPopUp: breakInfo.showPopUp,
+      showWarning: breakInfo.showWarning,
     });
-    if (breakInfo.showPopUp) {
-      ++numberOfPopUps;
+    if (breakInfo.showWarning) {
+      ++numberOfWarnings;
     }
   }
   if (!details.length) {
@@ -163,13 +165,13 @@ export function showAPIBreaks(version: string, { additionalText, apiBreakingChan
       `A file with these details has also been saved on your home computer under filename ${textFileName}.` +
       (additionalText ? `\n\n${additionalText}` : ""),
   );
-  let popUpIndex = 0;
+  let warningIndex = 0;
   for (const detail of details) {
-    if (!detail.showPopUp) {
+    if (!detail.showWarning) {
       continue;
     }
-    dialogBoxCreate(
-      `API BREAK VERSION ${version} DETAILS ${popUpIndex + 1} of ${numberOfPopUps}\n\n${detail.apiBreakInfo.info}` +
+    Terminal.warn(
+      `\nAPI BREAK VERSION ${version} DETAILS ${warningIndex + 1} of ${numberOfWarnings}\n\n${detail.apiBreakInfo.info}` +
         /**
          * If we can detect the affected lines via apiBreakInfo.brokenAPIs, we will show the number of affected lines.
          * However, some breaking changes cannot be reliably detected, so we intentionally leave apiBreakInfo.brokenAPIs
@@ -180,6 +182,6 @@ export function showAPIBreaks(version: string, { additionalText, apiBreakingChan
           ? `\n\nWe found ${pluralize(detail.totalDetectedLines, "affected line")}.`
           : ""),
     );
-    ++popUpIndex;
+    ++warningIndex;
   }
 }


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/pull/2235#issuecomment-3050230804 and https://github.com/bitburner-official/bitburner-src/pull/2235#discussion_r2195973914.

I tried to make minimal changes to our current code, so everything is in yellow (warning color) and there is no dashed line between detected breaking changes. I'll change it if requested.

<img width="1089" height="735" alt="Capture" src="https://github.com/user-attachments/assets/2be4509c-5a81-45c6-a982-51ffb9aba907" />

Test save file:
[show-terminal-warning.gz](https://github.com/user-attachments/files/21263077/show-terminal-warning.gz)

