### PR TITLE
CORPORATION: Remove VeChain

### DIFF
--- a/markdown/bitburner.corpunlockname.md
+++ b/markdown/bitburner.corpunlockname.md
@@ -13,7 +13,6 @@ type CorpUnlockName =
   | "Smart Supply"
   | "Market Research - Demand"
   | "Market Data - Competition"
-  | "VeChain"
   | "Shady Accounting"
   | "Government Partnership"
   | "Warehouse API"

--- a/src/Corporation/Enums.ts
+++ b/src/Corporation/Enums.ts
@@ -32,7 +32,6 @@ export enum CorpUnlockName {
   SmartSupply = "Smart Supply",
   MarketResearchDemand = "Market Research - Demand",
   MarketDataCompetition = "Market Data - Competition",
-  VeChain = "VeChain",
   ShadyAccounting = "Shady Accounting",
   GovernmentPartnership = "Government Partnership",
   WarehouseAPI = "Warehouse API",

--- a/src/Corporation/data/CorporationUnlocks.ts
+++ b/src/Corporation/data/CorporationUnlocks.ts
@@ -46,15 +46,6 @@ export const CorpUnlocks: Record<CorpUnlockName, CorpUnlock> = {
       "every material and product.",
   },
 
-  [CorpUnlockName.VeChain]: {
-    name: CorpUnlockName.VeChain,
-    price: 10e9,
-    desc:
-      "Use AI and blockchain technology to identify where you can improve your supply chain systems. " +
-      "This upgrade will allow you to view a wide array of useful statistics about your " +
-      "Corporation.",
-  },
-
   [CorpUnlockName.ShadyAccounting]: {
     name: CorpUnlockName.ShadyAccounting,
     price: 500e12,

--- a/src/Corporation/ui/DivisionOffice.tsx
+++ b/src/Corporation/ui/DivisionOffice.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 
 import { OfficeSpace } from "../OfficeSpace";
-import { CorpUnlockName, CorpEmployeeJob, CorpUpgradeName, CorpProductResearchName } from "@enums";
+import { CorpEmployeeJob, CorpUpgradeName, CorpProductResearchName } from "@enums";
 import { buyTea } from "../Actions";
 
 import { MoneyCost } from "./MoneyCost";
@@ -202,78 +202,74 @@ function AutoManagement(props: OfficeProps): React.ReactElement {
             </Typography>
           </TableCell>
         </TableRow>
-        {corp.unlocks.has(CorpUnlockName.VeChain) && (
-          <>
-            <TableRow>
-              <TableCell>
-                <Tooltip
-                  title={
-                    <Typography component="div">
-                      The amount of material this office can produce.
-                      <br />
-                      This value is based off the productivity of your
-                      <br />
-                      Operations, Engineering, and Management employees.
-                    </Typography>
-                  }
-                >
-                  <Typography>Material Production:</Typography>
-                </Tooltip>
-              </TableCell>
-              <TableCell>
-                <Tooltip title={materialBreakdown}>
-                  <Typography align="right">{formatCorpStat(totalMaterialProduction)}</Typography>
-                </Tooltip>
-              </TableCell>
-            </TableRow>
-            {division.makesProducts ? (
-              <TableRow>
-                <TableCell>
-                  <Tooltip
-                    title={
-                      <Typography component="div">
-                        The amount of any given Product this office can produce.
-                        <br />
-                        This value is based off the productivity of your
-                        <br />
-                        Operations, Engineering, and Management employees.
-                      </Typography>
-                    }
-                  >
-                    <Typography>Product Production:</Typography>
-                  </Tooltip>
-                </TableCell>
-                <TableCell>
-                  <Tooltip title={productBreakdown}>
-                    <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
-                  </Tooltip>
-                </TableCell>
-              </TableRow>
-            ) : null}
-            <TableRow>
-              <TableCell>
-                <Tooltip
-                  title={
-                    <Typography>
-                      This office's sales effectivity for all materials and products.
-                      <br />
-                      It is based on your Business employees and your advertising.
-                      <br />
-                      This will be further modified by demand and competition for each item.
-                    </Typography>
-                  }
-                >
-                  <Typography>Sales Multiplier:</Typography>
-                </Tooltip>
-              </TableCell>
-              <TableCell align="right">
-                <Tooltip title={salesBreakdown}>
-                  <Typography>{formatCorpMultiplier(totalSaleMultiplier)}</Typography>
-                </Tooltip>
-              </TableCell>
-            </TableRow>
-          </>
+        <TableRow>
+          <TableCell>
+            <Tooltip
+              title={
+                <Typography component="div">
+                  The amount of material this office can produce.
+                  <br />
+                  This value is based off the productivity of your
+                  <br />
+                  Operations, Engineering, and Management employees.
+                </Typography>
+              }
+            >
+              <Typography>Material Production:</Typography>
+            </Tooltip>
+          </TableCell>
+          <TableCell>
+            <Tooltip title={materialBreakdown}>
+              <Typography align="right">{formatCorpStat(totalMaterialProduction)}</Typography>
+            </Tooltip>
+          </TableCell>
+        </TableRow>
+        {division.makesProducts && (
+          <TableRow>
+            <TableCell>
+              <Tooltip
+                title={
+                  <Typography component="div">
+                    The amount of any given Product this office can produce.
+                    <br />
+                    This value is based off the productivity of your
+                    <br />
+                    Operations, Engineering, and Management employees.
+                  </Typography>
+                }
+              >
+                <Typography>Product Production:</Typography>
+              </Tooltip>
+            </TableCell>
+            <TableCell>
+              <Tooltip title={productBreakdown}>
+                <Typography align="right">{formatCorpStat(totalProductProduction)}</Typography>
+              </Tooltip>
+            </TableCell>
+          </TableRow>
         )}
+        <TableRow>
+          <TableCell>
+            <Tooltip
+              title={
+                <Typography>
+                  This office's sales effectivity for all materials and products.
+                  <br />
+                  It is based on your Business employees and your advertising.
+                  <br />
+                  This will be further modified by demand and competition for each item.
+                </Typography>
+              }
+            >
+              <Typography>Sales Multiplier:</Typography>
+            </Tooltip>
+          </TableCell>
+          <TableCell align="right">
+            <Tooltip title={salesBreakdown}>
+              <Typography>{formatCorpMultiplier(totalSaleMultiplier)}</Typography>
+            </Tooltip>
+          </TableCell>
+        </TableRow>
         <AutoAssignJob
           rerender={props.rerender}
           office={props.office}

--- a/src/Corporation/ui/DivisionOverview.tsx
+++ b/src/Corporation/ui/DivisionOverview.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { MathJax } from "better-react-mathjax";
 
-import { CorpUnlockName, IndustryType } from "@enums";
+import { IndustryType } from "@enums";
 import { hireAdVert } from "../Actions";
 import { formatBigNumber, formatCorpMultiplier } from "../../ui/formatNumber";
 import { createProgressBarText } from "../../utils/helpers/createProgressBarText";
@@ -102,15 +102,11 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
   const [researchOpen, setResearchOpen] = useState(false);
   const profit = division.lastCycleRevenue - division.lastCycleExpenses;
 
-  let advertisingInfo = false;
   const advertisingFactors = division.getAdvertisingFactors();
   const awarenessFac = advertisingFactors[1];
   const popularityFac = advertisingFactors[2];
   const ratioFac = advertisingFactors[3];
   const totalAdvertisingFac = advertisingFactors[0];
-  if (corp.unlocks.has(CorpUnlockName.VeChain)) {
-    advertisingInfo = true;
-  }
 
   function convertEffectFacToGraphic(fac: number): string {
     return createProgressBarText({
@@ -131,29 +127,27 @@ export function DivisionOverview(props: DivisionOverviewProps): React.ReactEleme
           ["Popularity:", formatBigNumber(division.popularity)],
         ]}
       />
-      {advertisingInfo && (
-        <Tooltip
-          title={
-            <>
-              <Typography>Multiplier for this industry's sales due to its awareness and popularity.</Typography>
-              <br />
-              <MathJax>{`\\(\\text{${division.industry} Industry: }\\alpha = ${division.advertisingFactor}\\)`}</MathJax>
-              <MathJax>{`\\(\\text{multiplier} = \\left((\\text{awareness}+1)^{\\alpha} \\times (\\text{popularity}+1)^{\\alpha} \\times \\frac{\\text{popularity}+0.001}{\\text{awareness}}\\right)^{0.85}\\)`}</MathJax>
-              <br />
-              <StatsTable
-                rows={[
-                  ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
-                  ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
-                  ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
-                  [<b key={1}>Total:</b>, <b key={2}>{formatCorpMultiplier(totalAdvertisingFac)}</b>],
-                ]}
-              />
-            </>
-          }
-        >
-          <Typography>Advertising Multiplier: {formatCorpMultiplier(totalAdvertisingFac)}</Typography>
-        </Tooltip>
-      )}
+      <Tooltip
+        title={
+          <>
+            <Typography>Multiplier for this industry's sales due to its awareness and popularity.</Typography>
+            <br />
+            <MathJax>{`\\(\\text{${division.industry} Industry: }\\alpha = ${division.advertisingFactor}\\)`}</MathJax>
+            <MathJax>{`\\(\\text{multiplier} = \\left((\\text{awareness}+1)^{\\alpha} \\times (\\text{popularity}+1)^{\\alpha} \\times \\frac{\\text{popularity}+0.001}{\\text{awareness}}\\right)^{0.85}\\)`}</MathJax>
+            <br />
+            <StatsTable
+              rows={[
+                ["Awareness Bonus:", formatCorpMultiplier(Math.pow(awarenessFac, 0.85))],
+                ["Popularity Bonus:", formatCorpMultiplier(Math.pow(popularityFac, 0.85))],
+                ["Ratio Multiplier:", formatCorpMultiplier(Math.pow(ratioFac, 0.85))],
+                [<b key={1}>Total:</b>, <b key={2}>{formatCorpMultiplier(totalAdvertisingFac)}</b>],
+              ]}
+            />
+          </>
+        }
+      >
+        <Typography>Advertising Multiplier: {formatCorpMultiplier(totalAdvertisingFac)}</Typography>
+      </Tooltip>
       <br />
       <StatsTable
         rows={[

--- a/src/Documentation/doc/advanced/corporation/unlocks-upgrade-research.md
+++ b/src/Documentation/doc/advanced/corporation/unlocks-upgrade-research.md
@@ -8,7 +8,6 @@
 | Smart Supply              | 25e9      | Enable "Smart Supply" feature. Only buy it if you don't implement your custom [Smart Supply](./smart-supply.md) script.                                    |
 | Market Research - Demand  | 5e9       | Grant access to [Demand](./demand-competition.md) data. You need it to implement a custom [Market-TA2](./optimal-selling-price-market-ta2.md) script.      |
 | Market Data - Competition | 5e9       | Grant access to [Competition](./demand-competition.md) data. You need it to implement a custom [Market-TA2](./optimal-selling-price-market-ta2.md) script. |
-| VeChain                   | 10e9      | View more statistics about Corporation. Useless.                                                                                                           |
 | Shady Accounting          | 500e12    | Reduce [DividendTax](./financial-statement.md) by 0.05                                                                                                     |
 | Government Partnership    | 2e15      | Reduce [DividendTax](./financial-statement.md) by 0.1                                                                                                      |
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -9833,7 +9833,6 @@ type CorpUnlockName =
   | "Smart Supply"
   | "Market Research - Demand"
   | "Market Data - Competition"
-  | "VeChain"
   | "Shady Accounting"
   | "Government Partnership"
   | "Warehouse API"

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -227,5 +227,10 @@ export const breakingChanges300: VersionBreakingChange = {
       info: 'The "Spring Water" industry was removed. The cost of all Spring Water divisions was refunded.',
       showWarning: false,
     },
+    {
+      brokenAPIs: [{ name: "VeChain" }],
+      info: 'The "VeChain" upgrade was removed. The cost of that upgrade was refunded.',
+      showWarning: false,
+    },
   ],
 };

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -614,6 +614,16 @@ Error: ${e}`,
           }
         }
       }
+
+      // Remove and refund VeChain
+      const unlocks: Set<string> = Player.corporation.unlocks;
+      for (const upgrade of unlocks) {
+        if (upgrade !== "VeChain") {
+          continue;
+        }
+        Player.corporation.gainFunds(10e9, "force majeure");
+      }
+      unlocks.delete("VeChain");
     }
     showAPIBreaks("3.0.0", breakingChanges300);
   }


### PR DESCRIPTION
Context: #2193.

Test save file:
[remove-vechain.gz](https://github.com/user-attachments/files/21292868/remove-vechain.gz)

How to test: Load the attached save file, then check the corporation's fund and the division tab. The fund should be 110e9, and the additional info from VeChain is shown for free.

```
API BREAK INFO FOR 3.0.0

The "VeChain" upgrade was removed. The cost of that upgrade was refunded.

Usage of the following functions may have been affected:
VeChain

Potentially affected files on server home (with line numbers):
a.js: (Line number: 6)
```

<img width="598" height="556" alt="Capture" src="https://github.com/user-attachments/assets/7555066c-7a96-483c-9c05-35bdce61ce24" />
