### PR TITLE
BUGFIX: Go history page shows favor bonus instead of reputation bonus

### DIFF
--- a/src/Go/ui/GoHistoryPage.tsx
+++ b/src/Go/ui/GoHistoryPage.tsx
@@ -115,16 +115,17 @@ export const GoHistoryPage = (): React.ReactElement => {
                   <Tooltip
                     title={
                       <>
-                        Two wins in a row against an opponent will give you {getMaxRep() / 200} rep converted to favor
-                        with that faction (up to a max of {getMaxRep()} favor), if you are a member of that faction.
+                        Two wins in a row against an opponent will give you {getMaxRep() / 200} reputation converted to
+                        favor with that faction (up to a max of {getMaxRep()} reputation), if you are a member of that
+                        faction.
                         <br />
-                        The rep is immediately applied as favor, meaning it will increase reputation gain right away
-                        without needing an install.
+                        The reputation is immediately applied as favor, meaning it will increase reputation gain right
+                        away without needing an install.
                       </>
                     }
                   >
                     <TableRow>
-                      <TableCell className={classes.cellNone}>Favor from winstreaks:</TableCell>
+                      <TableCell className={classes.cellNone}>Reputation from winstreaks:</TableCell>
                       <TableCell className={classes.cellNone}>
                         {data.rep ?? 0} {data.rep === getMaxRep() ? "(max)" : ""}
                       </TableCell>


### PR DESCRIPTION
We forgot to change this text in #2131.

Before:

<img width="284" height="297" alt="before" src="https://github.com/user-attachments/assets/2f943fd4-ff7d-403e-86d4-9524dfa81263" />

After:

<img width="283" height="293" alt="after" src="https://github.com/user-attachments/assets/6fc9861a-de7c-4b32-8a84-9145a293c9af" />
