### PR TITLE
UI: Place tooltips and popups in front of log windows

### DIFF
--- a/src/Themes/ui/Theme.tsx
+++ b/src/Themes/ui/Theme.tsx
@@ -259,6 +259,9 @@ export function refreshTheme(): void {
             border: "2px solid " + Settings.theme.white,
             maxWidth: "100vh",
           },
+          popper: {
+            zIndex: 25000,
+          },
         },
         defaultProps: {
           disableInteractive: true,

--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -82,6 +82,7 @@ export const Modal = ({
       }}
       closeAfterTransition
       className={classes.modal}
+      style={{ zIndex: 20000 }}
       sx={sx}
     >
       <Fade in={open}>


### PR DESCRIPTION
Context: #2249.

Before:

<img width="788" height="323" alt="before1" src="https://github.com/user-attachments/assets/800682bf-2f8d-40ca-974b-277987d37efe" />

<img width="532" height="421" alt="before2" src="https://github.com/user-attachments/assets/172530f3-17f3-4db3-95d0-a74f9c9e8641" />

After:

<img width="795" height="364" alt="after1" src="https://github.com/user-attachments/assets/c14b2470-e7b8-42e6-8756-cc0a12f3a1d4" />

<img width="541" height="404" alt="after2" src="https://github.com/user-attachments/assets/dcb20e89-ef50-4697-8698-a9e9d481c966" />

Closes #2249.