### PR TITLE
BUGFIX: Fix ctrl-clicking after the doc_en refactor

### DIFF
--- a/src/Documentation/root.ts
+++ b/src/Documentation/root.ts
@@ -1,25 +1,33 @@
 import { AllPages } from "./pages";
 import { EventEmitter } from "../utils/EventEmitter";
 
-export const getPage = (title: string): string => {
+export const resolvePage = (title: string): { pageName: string | null; pageContent: string } => {
   const lang = new Intl.Locale(navigator.language).language;
   const fallbackLang = "en"; // For untranslated languages
   let pageContent = null;
+  let pageName = null;
   if (!title.startsWith("nsDoc")) {
-    pageContent = AllPages[lang + "/" + title];
+    pageName = lang + "/" + title;
+    pageContent = AllPages[pageName];
     if (pageContent == null) {
-      pageContent = AllPages[fallbackLang + "/" + title];
+      pageName = fallbackLang + "/" + title;
+      pageContent = AllPages[pageName];
     }
   }
   if (pageContent == null) {
+    pageName = title;
     pageContent = AllPages[title];
   }
   if (pageContent == null) {
     const errorMessage = `Cannot find ${title} page.`;
     console.error(errorMessage);
-    return errorMessage;
+    return { pageName: null, pageContent: errorMessage };
   }
-  return pageContent;
+  return { pageName, pageContent };
+};
+
+export const getPage = (title: string): string => {
+  return resolvePage(title).pageContent;
 };
 
 export const DocumentationPopUpEvents = new EventEmitter<[string | undefined]>();

--- a/src/ui/React/Documentation.tsx
+++ b/src/ui/React/Documentation.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from "react";
 import { type FilePath, asFilePath } from "../../Paths/FilePath";
 import { CONSTANTS } from "../../Constants";
+import { resolvePage } from "../../Documentation/root";
 
 interface Navigator {
   navigate: (s: string, external: boolean) => void;
@@ -96,10 +97,17 @@ export function openDocExternally(path: string) {
   let url;
   if (path.startsWith("http://") || path.startsWith("https://")) {
     url = path;
-  } else if (path.startsWith("nsDoc/")) {
-    url = `https://github.com/bitburner-official/bitburner-src/blob/${ver}/markdown/${path.replace("nsDoc/", "")}`;
   } else {
-    url = `https://github.com/bitburner-official/bitburner-src/blob/${ver}/src/Documentation/doc/${path}`;
+    const title = resolvePage(path).pageName;
+    if (title == null) {
+      return; // An error was already printed to console
+    }
+    url = `https://github.com/bitburner-official/bitburner-src/blob/${ver}/`;
+    if (title.startsWith("nsDoc/")) {
+      url += `markdown/${title.replace("nsDoc/", "")}`;
+    } else {
+      url += `src/Documentation/doc/${title}`;
+    }
   }
   window.open(url, "_newtab");
 }


### PR DESCRIPTION
This refactors getPage so that the same code can be used as part of openDocExternally. This is necessary, since looking things up in AllPages is potentially required to determine which language-version of the external page to link to.

# Bug fix

Tested both regular docs and nsdoc, both ingame and ctrl-click, both standard and with a different language forced.