### PR TITLE
UI: Hide outline of modal

### DIFF
--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -28,6 +28,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
       display: "none",
     },
     scrollbarWidth: "none", // firefox
+    "&:focus-visible": {
+      outline: "none",
+    },
   },
   closeButton: {
     position: "absolute",


### PR DESCRIPTION
The modal usually looks like this:

<img width="578" height="218" alt="focus-visible-false" src="https://github.com/user-attachments/assets/0d0624fa-c8ed-484a-8e8d-6e6716338724" />

However, some modals (documentation popup, hashnet upgrade, etc.) look like this on Chrome:

<img width="622" height="238" alt="focus-visible-true" src="https://github.com/user-attachments/assets/b7b0949e-fb6f-474a-8fcc-5f5c0c6e6292" />

On Electron:

<img width="639" height="228" alt="focus-visible-true-electron" src="https://github.com/user-attachments/assets/549c7f88-2e0c-4102-b31f-0439c84ddac1" />

The white/yellow outline is caused a Chromium behavior. For more information, please check:
- https://github.com/mui/material-ui/issues/11504
- https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible

This is an accessibility feature, so I'm a bit hesitant when hiding it, but I don't think it's really useful. I'll close this PR if you think we should not touch this accessibility feature.