### PR TITLE
API: Make some APIs throw error when server is invalid

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -496,7 +496,7 @@ function getNormalServer(ctx: NetscriptContext, host: string): Server {
   if (!(server instanceof Server)) {
     let errorMessage = `Cannot be executed on ${host}.`;
     if (server instanceof HacknetServer) {
-      errorMessage += " It's a hacknet server.";
+      errorMessage += " The server must not be a hacknet server.";
     }
     throw helpers.errorMessage(ctx, errorMessage);
   }

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -104,6 +104,7 @@ export const helpers = {
   createPublicRunningScript,
   failOnHacknetServer,
   validateBitNodeOptions,
+  getNormalServer,
 };
 
 /** RunOptions with non-optional, type-validated members, for passing between internal functions. */
@@ -478,11 +479,26 @@ function scriptIdentifier(
  * @param {string} hostname - Hostname of the server
  * @returns {BaseServer} The specified server as a BaseServer
  */
-function getServer(ctx: NetscriptContext, hostname: string) {
+function getServer(ctx: NetscriptContext, hostname: string): BaseServer {
   const server = GetServer(hostname);
   if (server == null || (server.serversOnNetwork.length == 0 && server.hostname != "home")) {
     const str = hostname === "" ? "'' (empty string)" : "'" + hostname + "'";
     throw errorMessage(ctx, `Invalid hostname: ${str}`);
+  }
+  return server;
+}
+
+/**
+ * A "normal server" is an instance of the Server class in src/Server/Server.ts.
+ */
+function getNormalServer(ctx: NetscriptContext, host: string): Server {
+  const server = getServer(ctx, host);
+  if (!(server instanceof Server)) {
+    let errorMessage = `Cannot be executed on ${host}.`;
+    if (server instanceof HacknetServer) {
+      errorMessage += " It's a hacknet server.";
+    }
+    throw helpers.errorMessage(ctx, errorMessage);
   }
   return server;
 }
@@ -495,10 +511,7 @@ function isScriptArgs(args: unknown): args is ScriptArg[] {
 function hack(ctx: NetscriptContext, hostname: string, manual: boolean, opts: unknown): Promise<number> {
   const ws = ctx.workerScript;
   const { threads, stock, additionalMsec } = validateHGWOptions(ctx, opts);
-  const server = getServer(ctx, hostname);
-  if (!(server instanceof Server)) {
-    throw errorMessage(ctx, "Cannot be executed on this server.");
-  }
+  const server = getNormalServer(ctx, hostname);
 
   // Calculate the hacking time
   // This is in seconds
@@ -785,8 +798,8 @@ function createPublicRunningScript(runningScript: RunningScript, workerScript?: 
 /**
  * Used to fail a function if the function's target is a Hacknet Server.
  * This is used for functions that should run on normal Servers, but not Hacknet Servers
+ * @param {NetscriptContext} ctx - Netscript context
  * @param {Server} server - Target server
- * @param {string} callingFn - Name of calling function. For logging purposes
  * @returns {boolean} True if the server is a Hacknet Server, false otherwise
  */
 function failOnHacknetServer(ctx: NetscriptContext, server: BaseServer): boolean {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -202,8 +202,7 @@ export const ns: InternalAPI<NSFull> = {
     // Check argument validity
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return -1;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (isNaN(hackAmount)) {
       throw helpers.errorMessage(
@@ -231,8 +230,7 @@ export const ns: InternalAPI<NSFull> = {
 
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 0;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
 
     return calculatePercentMoneyHacked(server, Player);
@@ -243,8 +241,7 @@ export const ns: InternalAPI<NSFull> = {
       const host = helpers.string(ctx, "host", _host);
       const server = helpers.getServer(ctx, host);
       if (!(server instanceof Server)) {
-        helpers.log(ctx, () => "Cannot be executed on this server.");
-        return 0;
+        throw helpers.errorMessage(ctx, `Cannot be executed on ${host}.`);
       }
 
       const percentHacked = calculatePercentMoneyHacked(server, Player);
@@ -262,8 +259,7 @@ export const ns: InternalAPI<NSFull> = {
 
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 0;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
 
     return calculateHackingChance(server, Player);
@@ -343,9 +339,7 @@ export const ns: InternalAPI<NSFull> = {
       // Check argument validity
       const server = helpers.getServer(ctx, host);
       if (!(server instanceof Server)) {
-        // Todo 2.3: Make this throw instead of returning 0?
-        helpers.log(ctx, () => `${host} is not a hackable server. Returning 0.`);
-        return 0;
+        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
       }
       if (!Number.isFinite(mult) || mult < 1) {
         throw helpers.errorMessage(ctx, `Invalid argument: multiplier must be finite and >= 1, is ${mult}.`);
@@ -363,8 +357,7 @@ export const ns: InternalAPI<NSFull> = {
         const server = helpers.getServer(ctx, host);
 
         if (!(server instanceof Server)) {
-          helpers.log(ctx, () => "Cannot be executed on this server.");
-          return 0;
+          throw helpers.errorMessage(ctx, `Cannot be executed on ${host}.`);
         }
 
         const maxThreadsNeeded = Math.ceil(
@@ -574,8 +567,7 @@ export const ns: InternalAPI<NSFull> = {
 
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return false;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (server.hasAdminRights) {
       helpers.log(ctx, () => `Already have root access to '${server.hostname}'.`);
@@ -597,8 +589,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return false;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (!Player.hasProgram(CompletedProgramName.bruteSsh)) {
       helpers.log(ctx, () => "You do not have the BruteSSH.exe program!");
@@ -617,8 +608,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return false;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (!Player.hasProgram(CompletedProgramName.ftpCrack)) {
       helpers.log(ctx, () => "You do not have the FTPCrack.exe program!");
@@ -637,8 +627,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return false;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (!Player.hasProgram(CompletedProgramName.relaySmtp)) {
       helpers.log(ctx, () => "You do not have the relaySMTP.exe program!");
@@ -657,8 +646,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return false;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (!Player.hasProgram(CompletedProgramName.httpWorm)) {
       helpers.log(ctx, () => "You do not have the HTTPWorm.exe program!");
@@ -677,8 +665,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return false;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (!Player.hasProgram(CompletedProgramName.sqlInject)) {
       helpers.log(ctx, () => "You do not have the SQLInject.exe program!");
@@ -1009,11 +996,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 0;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 0;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     if (server.hostname == "home") {
       // Return player's money
@@ -1027,11 +1010,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 1;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 1;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     helpers.log(ctx, () => `returned ${formatSecurity(server.hackDifficulty)} for '${server.hostname}'`);
     return server.hackDifficulty;
@@ -1040,11 +1019,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 1;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 1;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     helpers.log(ctx, () => `returned ${formatSecurity(server.baseDifficulty)} for '${server.hostname}'`);
     return server.baseDifficulty;
@@ -1053,11 +1028,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 1;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 1;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     helpers.log(ctx, () => `returned ${formatSecurity(server.minDifficulty)} for ${server.hostname}`);
     return server.minDifficulty;
@@ -1066,11 +1037,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 1;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 1;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     helpers.log(ctx, () => `returned ${formatNumberNoSuffix(server.requiredHackingSkill, 0)} for '${server.hostname}'`);
     return server.requiredHackingSkill;
@@ -1079,11 +1046,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 0;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 0;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     helpers.log(ctx, () => `returned ${formatMoney(server.moneyMax)} for '${server.hostname}'`);
     return server.moneyMax;
@@ -1092,11 +1055,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 1;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 1;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     helpers.log(ctx, () => `returned ${server.serverGrowth} for '${server.hostname}'`);
     return server.serverGrowth;
@@ -1105,11 +1064,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const server = helpers.getServer(ctx, host);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => "Cannot be executed on this server.");
-      return 5;
-    }
-    if (helpers.failOnHacknetServer(ctx, server)) {
-      return 5;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
     }
     helpers.log(ctx, () => `returned ${server.numOpenPortsRequired} for '${server.hostname}'`);
     return server.numOpenPortsRequired;
@@ -1276,8 +1231,7 @@ export const ns: InternalAPI<NSFull> = {
     hostnameStr = hostnameStr.replace(/\s\s+/g, "");
     const server = GetServer(hostnameStr);
     if (!(server instanceof Server)) {
-      helpers.log(ctx, () => `Invalid argument: hostname='${hostnameStr}'`);
-      return false;
+      throw helpers.errorMessage(ctx, `Cannot be executed on ${_name}.`);
     }
 
     if (!server.purchasedByPlayer || server.hostname === "home") {
@@ -1530,11 +1484,7 @@ export const ns: InternalAPI<NSFull> = {
       const host = helpers.string(ctx, "hostname", _host);
       const server = helpers.getServer(ctx, host);
       if (!(server instanceof Server)) {
-        helpers.log(ctx, () => "invalid for this kind of server");
-        return Infinity;
-      }
-      if (helpers.failOnHacknetServer(ctx, server)) {
-        return Infinity;
+        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
       }
 
       return calculateHackingTime(server, Player) * 1000;
@@ -1545,11 +1495,7 @@ export const ns: InternalAPI<NSFull> = {
       const host = helpers.string(ctx, "host", _host);
       const server = helpers.getServer(ctx, host);
       if (!(server instanceof Server)) {
-        helpers.log(ctx, () => "invalid for this kind of server");
-        return Infinity;
-      }
-      if (helpers.failOnHacknetServer(ctx, server)) {
-        return Infinity;
+        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
       }
 
       return calculateGrowTime(server, Player) * 1000;
@@ -1560,11 +1506,7 @@ export const ns: InternalAPI<NSFull> = {
       const host = helpers.string(ctx, "hostname", _host);
       const server = helpers.getServer(ctx, host);
       if (!(server instanceof Server)) {
-        helpers.log(ctx, () => "invalid for this kind of server");
-        return Infinity;
-      }
-      if (helpers.failOnHacknetServer(ctx, server)) {
-        return Infinity;
+        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
       }
 
       return calculateWeakenTime(server, Player) * 1000;

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -51,7 +51,6 @@ import {
   renamePurchasedServer,
   upgradePurchasedServer,
 } from "./Server/ServerPurchases";
-import { Server } from "./Server/Server";
 import { influenceStockThroughServerGrow } from "./StockMarket/PlayerInfluencing";
 import { runScriptFromScript } from "./NetscriptWorker";
 import { killWorkerScript, killWorkerScriptByPid } from "./Netscript/killWorkerScript";
@@ -200,10 +199,7 @@ export const ns: InternalAPI<NSFull> = {
     const hackAmount = helpers.number(ctx, "hackAmount", _hackAmount);
 
     // Check argument validity
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (isNaN(hackAmount)) {
       throw helpers.errorMessage(
         ctx,
@@ -228,10 +224,7 @@ export const ns: InternalAPI<NSFull> = {
   hackAnalyze: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
 
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
 
     return calculatePercentMoneyHacked(server, Player);
   },
@@ -239,10 +232,7 @@ export const ns: InternalAPI<NSFull> = {
     let threads = helpers.number(ctx, "threads", _threads);
     if (_host) {
       const host = helpers.string(ctx, "host", _host);
-      const server = helpers.getServer(ctx, host);
-      if (!(server instanceof Server)) {
-        throw helpers.errorMessage(ctx, `Cannot be executed on ${host}.`);
-      }
+      const server = helpers.getNormalServer(ctx, host);
 
       const percentHacked = calculatePercentMoneyHacked(server, Player);
 
@@ -257,10 +247,7 @@ export const ns: InternalAPI<NSFull> = {
   hackAnalyzeChance: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
 
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
 
     return calculateHackingChance(server, Player);
   },
@@ -284,10 +271,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const { threads, stock, additionalMsec } = helpers.validateHGWOptions(ctx, opts);
 
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, "Cannot be executed on this server.");
-    }
+    const server = helpers.getNormalServer(ctx, host);
 
     // No root access or skill level too low
     const canHack = netscriptCanGrow(server);
@@ -337,10 +321,7 @@ export const ns: InternalAPI<NSFull> = {
       const cores = helpers.positiveInteger(ctx, "cores", _cores);
 
       // Check argument validity
-      const server = helpers.getServer(ctx, host);
-      if (!(server instanceof Server)) {
-        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-      }
+      const server = helpers.getNormalServer(ctx, host);
       if (!Number.isFinite(mult) || mult < 1) {
         throw helpers.errorMessage(ctx, `Invalid argument: multiplier must be finite and >= 1, is ${mult}.`);
       }
@@ -354,11 +335,7 @@ export const ns: InternalAPI<NSFull> = {
       if (_host) {
         const cores = helpers.number(ctx, "cores", _cores);
         const host = helpers.string(ctx, "host", _host);
-        const server = helpers.getServer(ctx, host);
-
-        if (!(server instanceof Server)) {
-          throw helpers.errorMessage(ctx, `Cannot be executed on ${host}.`);
-        }
+        const server = helpers.getNormalServer(ctx, host);
 
         const maxThreadsNeeded = Math.ceil(
           numCycleForGrowthCorrected(server, server.moneyMax, server.moneyAvailable, cores),
@@ -373,10 +350,7 @@ export const ns: InternalAPI<NSFull> = {
     const host = helpers.string(ctx, "host", _host);
     const { threads, additionalMsec } = helpers.validateHGWOptions(ctx, opts);
 
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, "Cannot be executed on this server.");
-    }
+    const server = helpers.getNormalServer(ctx, host);
 
     // No root access or skill level too low
     const canHack = netscriptCanWeaken(server);
@@ -565,10 +539,7 @@ export const ns: InternalAPI<NSFull> = {
   nuke: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
 
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (server.hasAdminRights) {
       helpers.log(ctx, () => `Already have root access to '${server.hostname}'.`);
       return true;
@@ -587,10 +558,7 @@ export const ns: InternalAPI<NSFull> = {
   },
   brutessh: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (!Player.hasProgram(CompletedProgramName.bruteSsh)) {
       helpers.log(ctx, () => "You do not have the BruteSSH.exe program!");
       return false;
@@ -606,10 +574,7 @@ export const ns: InternalAPI<NSFull> = {
   },
   ftpcrack: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (!Player.hasProgram(CompletedProgramName.ftpCrack)) {
       helpers.log(ctx, () => "You do not have the FTPCrack.exe program!");
       return false;
@@ -625,10 +590,7 @@ export const ns: InternalAPI<NSFull> = {
   },
   relaysmtp: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (!Player.hasProgram(CompletedProgramName.relaySmtp)) {
       helpers.log(ctx, () => "You do not have the relaySMTP.exe program!");
       return false;
@@ -644,10 +606,7 @@ export const ns: InternalAPI<NSFull> = {
   },
   httpworm: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (!Player.hasProgram(CompletedProgramName.httpWorm)) {
       helpers.log(ctx, () => "You do not have the HTTPWorm.exe program!");
       return false;
@@ -663,10 +622,7 @@ export const ns: InternalAPI<NSFull> = {
   },
   sqlinject: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (!Player.hasProgram(CompletedProgramName.sqlInject)) {
       helpers.log(ctx, () => "You do not have the SQLInject.exe program!");
       return false;
@@ -994,10 +950,7 @@ export const ns: InternalAPI<NSFull> = {
   },
   getServerMoneyAvailable: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     if (server.hostname == "home") {
       // Return player's money
       helpers.log(ctx, () => `returned player's money: ${formatMoney(Player.money)}`);
@@ -1008,64 +961,43 @@ export const ns: InternalAPI<NSFull> = {
   },
   getServerSecurityLevel: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     helpers.log(ctx, () => `returned ${formatSecurity(server.hackDifficulty)} for '${server.hostname}'`);
     return server.hackDifficulty;
   },
   getServerBaseSecurityLevel: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     helpers.log(ctx, () => `returned ${formatSecurity(server.baseDifficulty)} for '${server.hostname}'`);
     return server.baseDifficulty;
   },
   getServerMinSecurityLevel: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     helpers.log(ctx, () => `returned ${formatSecurity(server.minDifficulty)} for ${server.hostname}`);
     return server.minDifficulty;
   },
   getServerRequiredHackingLevel: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     helpers.log(ctx, () => `returned ${formatNumberNoSuffix(server.requiredHackingSkill, 0)} for '${server.hostname}'`);
     return server.requiredHackingSkill;
   },
   getServerMaxMoney: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     helpers.log(ctx, () => `returned ${formatMoney(server.moneyMax)} for '${server.hostname}'`);
     return server.moneyMax;
   },
   getServerGrowth: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     helpers.log(ctx, () => `returned ${server.serverGrowth} for '${server.hostname}'`);
     return server.serverGrowth;
   },
   getServerNumPortsRequired: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
-    const server = helpers.getServer(ctx, host);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-    }
+    const server = helpers.getNormalServer(ctx, host);
     helpers.log(ctx, () => `returned ${server.numOpenPortsRequired} for '${server.hostname}'`);
     return server.numOpenPortsRequired;
   },
@@ -1229,10 +1161,7 @@ export const ns: InternalAPI<NSFull> = {
     const name = helpers.string(ctx, "name", _name);
     let hostnameStr = String(name);
     hostnameStr = hostnameStr.replace(/\s\s+/g, "");
-    const server = GetServer(hostnameStr);
-    if (!(server instanceof Server)) {
-      throw helpers.errorMessage(ctx, `Cannot be executed on ${_name}.`);
-    }
+    const server = helpers.getNormalServer(ctx, hostnameStr);
 
     if (!server.purchasedByPlayer || server.hostname === "home") {
       helpers.log(ctx, () => "Cannot delete non-purchased server.");
@@ -1482,10 +1411,7 @@ export const ns: InternalAPI<NSFull> = {
     (ctx) =>
     (_host = ctx.workerScript.hostname) => {
       const host = helpers.string(ctx, "hostname", _host);
-      const server = helpers.getServer(ctx, host);
-      if (!(server instanceof Server)) {
-        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-      }
+      const server = helpers.getNormalServer(ctx, host);
 
       return calculateHackingTime(server, Player) * 1000;
     },
@@ -1493,10 +1419,7 @@ export const ns: InternalAPI<NSFull> = {
     (ctx) =>
     (_host = ctx.workerScript.hostname) => {
       const host = helpers.string(ctx, "host", _host);
-      const server = helpers.getServer(ctx, host);
-      if (!(server instanceof Server)) {
-        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-      }
+      const server = helpers.getNormalServer(ctx, host);
 
       return calculateGrowTime(server, Player) * 1000;
     },
@@ -1504,10 +1427,7 @@ export const ns: InternalAPI<NSFull> = {
     (ctx) =>
     (_host = ctx.workerScript.hostname) => {
       const host = helpers.string(ctx, "hostname", _host);
-      const server = helpers.getServer(ctx, host);
-      if (!(server instanceof Server)) {
-        throw helpers.errorMessage(ctx, `Cannot be executed on ${_host}.`);
-      }
+      const server = helpers.getNormalServer(ctx, host);
 
       return calculateWeakenTime(server, Player) * 1000;
     },

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -241,5 +241,61 @@ export const breakingChanges300: VersionBreakingChange = {
       info: 'The "VeChain" upgrade was removed. The cost of that upgrade was refunded.',
       showWarning: false,
     },
+    {
+      brokenAPIs: [
+        { name: "ns.hackAnalyzeThreads" },
+        { name: "ns.hackAnalyze" },
+        { name: "ns.hackAnalyzeSecurity" },
+        { name: "ns.hackAnalyzeChance" },
+        { name: "ns.growthAnalyze" },
+        { name: "ns.growthAnalyzeSecurity" },
+        { name: "ns.nuke" },
+        { name: "ns.brutessh" },
+        { name: "ns.ftpcrack" },
+        { name: "ns.relaysmtp" },
+        { name: "ns.httpworm" },
+        { name: "ns.sqlinject" },
+        { name: "ns.getServerMoneyAvailable" },
+        { name: "ns.getServerSecurityLevel" },
+        { name: "ns.getServerBaseSecurityLevel" },
+        { name: "ns.getServerMinSecurityLevel" },
+        { name: "ns.getServerRequiredHackingLevel" },
+        { name: "ns.getServerMaxMoney" },
+        { name: "ns.getServerGrowth" },
+        { name: "ns.getServerNumPortsRequired" },
+        { name: "ns.deleteServer" },
+        { name: "ns.getHackTime" },
+        { name: "ns.getGrowTime" },
+        { name: "ns.getWeakenTime" },
+      ],
+      info:
+        "Some APIs returned a default value when you passed the hostname of a non-hackable server (e.g., hacknet " +
+        "server) to them.\nThese APIs now throw an error. The affected APIs are:\n" +
+        "- ns.hackAnalyzeThreads\n" +
+        "- ns.hackAnalyze\n" +
+        "- ns.hackAnalyzeSecurity\n" +
+        "- ns.hackAnalyzeChance\n" +
+        "- ns.growthAnalyze\n" +
+        "- ns.growthAnalyzeSecurity\n" +
+        "- ns.nuke\n" +
+        "- ns.brutessh\n" +
+        "- ns.ftpcrack\n" +
+        "- ns.relaysmtp\n" +
+        "- ns.httpworm\n" +
+        "- ns.sqlinject\n" +
+        "- ns.getServerMoneyAvailable\n" +
+        "- ns.getServerSecurityLevel\n" +
+        "- ns.getServerBaseSecurityLevel\n" +
+        "- ns.getServerMinSecurityLevel\n" +
+        "- ns.getServerRequiredHackingLevel\n" +
+        "- ns.getServerMaxMoney\n" +
+        "- ns.getServerGrowth\n" +
+        "- ns.getServerNumPortsRequired\n" +
+        "- ns.deleteServer\n" +
+        "- ns.getHackTime\n" +
+        "- ns.getGrowTime\n" +
+        "- ns.getWeakenTime\n",
+      showWarning: false,
+    },
   ],
 };


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/pull/2180#issuecomment-3083415062

With these changes, we don't need #1128. `getServerNumPortsRequired` will throw an error if the player passes the hostname of a hacknet server.

@ficocelliguy d0sboots suggested checking if these changes affect the darknet. I don't think the player needs to pass the hostname of darknet servers to these APIs. Can you double-check them?

API list:
- `ns.hackAnalyzeThreads`
- `ns.hackAnalyze`
- `ns.hackAnalyzeSecurity`
- `ns.hackAnalyzeChance`
- `ns.growthAnalyze`
- `ns.growthAnalyzeSecurity`
- `ns.nuke`
- `ns.brutessh`
- `ns.ftpcrack`
- `ns.relaysmtp`
- `ns.httpworm`
- `ns.sqlinject`
- `ns.getServerMoneyAvailable`
- `ns.getServerSecurityLevel`
- `ns.getServerBaseSecurityLevel`
- `ns.getServerMinSecurityLevel`
- `ns.getServerRequiredHackingLevel`
- `ns.getServerMaxMoney`
- `ns.getServerGrowth`
- `ns.getServerNumPortsRequired`
- `ns.deleteServer`
- `ns.getHackTime`
- `ns.getGrowTime`
- `ns.getWeakenTime`

Test save file: 
[throw-error-when-server-is-invalid.gz](https://github.com/user-attachments/files/21369053/throw-error-when-server-is-invalid.gz)

```
Some APIs returned a default value when you passed the hostname of a non-hackable server (e.g., hacknet server) to them.
These APIs now throw an error. The affected APIs are:
- ns.hackAnalyzeThreads
- ns.hackAnalyze
- ns.hackAnalyzeSecurity
- ns.hackAnalyzeChance
- ns.growthAnalyze
- ns.growthAnalyzeSecurity
- ns.nuke
- ns.brutessh
- ns.ftpcrack
- ns.relaysmtp
- ns.httpworm
- ns.sqlinject
- ns.getServerMoneyAvailable
- ns.getServerSecurityLevel
- ns.getServerBaseSecurityLevel
- ns.getServerMinSecurityLevel
- ns.getServerRequiredHackingLevel
- ns.getServerMaxMoney
- ns.getServerGrowth
- ns.getServerNumPortsRequired
- ns.deleteServer
- ns.getHackTime
- ns.getGrowTime
- ns.getWeakenTime


Usage of the following functions may have been affected:
ns.hackAnalyzeThreads
ns.hackAnalyze
ns.hackAnalyzeSecurity
ns.hackAnalyzeChance
ns.growthAnalyze
ns.growthAnalyzeSecurity
ns.nuke
ns.brutessh
ns.ftpcrack
ns.relaysmtp
ns.httpworm
ns.sqlinject
ns.getServerMoneyAvailable
ns.getServerSecurityLevel
ns.getServerBaseSecurityLevel
ns.getServerMinSecurityLevel
ns.getServerRequiredHackingLevel
ns.getServerMaxMoney
ns.getServerGrowth
ns.getServerNumPortsRequired
ns.deleteServer
ns.getHackTime
ns.getGrowTime
ns.getWeakenTime

Potentially affected files on server home (with line numbers):
a.js: (Line numbers: 5, 5, 6, 7, 7, 8, 8, 9, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28)
```