### PR TITLE
ELECTRON: Specify mime type when loading wasm files

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -219,7 +219,11 @@ app.on("ready", async () => {
       relativePath = path.relative(__dirname, realPath);
       // Only allow access to files in "dist" folder or html files in the same directory
       if (method === "GET" && (relativePath.startsWith("dist") || relativePath.match(/^[a-zA-Z-_]*\.html/))) {
-        return new Response(readFileSync(realPath));
+        const customHeaders = {};
+        if (relativePath.endsWith(".wasm")) {
+          customHeaders["Content-Type"] = "application/wasm";
+        }
+        return new Response(readFileSync(realPath), { headers: new Headers(customHeaders) });
       }
     } catch (error) {
       log.error(error);


### PR DESCRIPTION
When testing the Electron version, I see this warning:

```
`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:
 TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
```

The warning is pretty clear. When loading wasm files, the browser expects that the `Content-Type` header is set to `application/wasm`. In the Electron version, there is no "server". All files are loaded locally, and then we "send" a custom `Response` object.

This PR sets the expected header.