### PR TITLE
MISC: Fix typo in KARMA_1000000 achievement

### DIFF
--- a/src/Achievements/AchievementData.json
+++ b/src/Achievements/AchievementData.json
@@ -213,7 +213,7 @@
     },
     "KARMA_1000000": {
       "ID": "KARMA_1000000",
-      "Name": "Wretched hive of scum and vilany",
+      "Name": "Wretched hive of scum and villainy",
       "Description": "Reach -1m karma."
     },
     "STOCK_1q": {


### PR DESCRIPTION
# Linked issues

None

# Documentation

No changes needed

# Bug fix

Formatted and linted

# Note

I did look for other instances, but couldn't find any - the steam achievement is spelt correctly too.
