### PR TITLE
BUGFIX: ns.mv writes to destination file even if it cannot delete source file

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1619,11 +1619,13 @@ export const ns: InternalAPI<NSFull> = {
         () =>
           `ERROR: Failed. Was unable to remove file ${sourcePath} from its original location. If ${sourcePath} is a script, make sure that it is NOT running before trying to use 'mv' on it.`,
       );
+      return;
     }
     const { overwritten } = server.writeToContentFile(destinationPath, sourceContentFile.content);
-    if (overwritten) helpers.log(ctx, () => `WARNING: Overwriting file ${destinationPath} on ${host}`);
+    if (overwritten) {
+      helpers.log(ctx, () => `WARNING: Overwriting file ${destinationPath} on ${host}`);
+    }
     helpers.log(ctx, () => `Moved ${sourcePath} to ${destinationPath} on ${host}`);
-    return;
   },
   getResetInfo: () => () => ({
     lastAugReset: Player.lastAugReset,


### PR DESCRIPTION
#2160 does not inverse the check like I suggested at https://github.com/bitburner-official/bitburner-src/pull/2160/files/1e6b5ef52b6374761380c42745e0089e1d516fda#r2106262967. It moves `return;` to the wrong place.

<img width="407" height="124" alt="Capture" src="https://github.com/user-attachments/assets/b4b71fdc-86d8-41c9-ae0a-05ed613200f6" />
