### PR TITLE
DEVMENU: Fix wrong stat level due to floating-point imprecision

### DIFF
--- a/src/DevMenu/ui/StatsDev.tsx
+++ b/src/DevMenu/ui/StatsDev.tsx
@@ -55,28 +55,41 @@ function setStatLevel(stat: string, level: number): void {
     dialogBoxCreate(`Invalid level.`);
     return;
   }
+  const multForFixingFloatingPointImprecision = 1.0000000001;
   switch (stat) {
     case "Hacking":
-      Player.exp.hacking = calculateExp(level, Player.mults.hacking * currentNodeMults.HackingLevelMultiplier);
+      Player.exp.hacking =
+        calculateExp(level, Player.mults.hacking * currentNodeMults.HackingLevelMultiplier) *
+        multForFixingFloatingPointImprecision;
       break;
     case "Strength":
-      Player.exp.strength = calculateExp(level, Player.mults.strength * currentNodeMults.StrengthLevelMultiplier);
+      Player.exp.strength =
+        calculateExp(level, Player.mults.strength * currentNodeMults.StrengthLevelMultiplier) *
+        multForFixingFloatingPointImprecision;
       break;
     case "Defense":
-      Player.exp.defense = calculateExp(level, Player.mults.defense * currentNodeMults.DefenseLevelMultiplier);
+      Player.exp.defense =
+        calculateExp(level, Player.mults.defense * currentNodeMults.DefenseLevelMultiplier) *
+        multForFixingFloatingPointImprecision;
       break;
     case "Dexterity":
-      Player.exp.dexterity = calculateExp(level, Player.mults.dexterity * currentNodeMults.DexterityLevelMultiplier);
+      Player.exp.dexterity =
+        calculateExp(level, Player.mults.dexterity * currentNodeMults.DexterityLevelMultiplier) *
+        multForFixingFloatingPointImprecision;
       break;
     case "Agility":
-      Player.exp.agility = calculateExp(level, Player.mults.agility * currentNodeMults.AgilityLevelMultiplier);
+      Player.exp.agility =
+        calculateExp(level, Player.mults.agility * currentNodeMults.AgilityLevelMultiplier) *
+        multForFixingFloatingPointImprecision;
       break;
     case "Charisma":
-      Player.exp.charisma = calculateExp(level, Player.mults.charisma * currentNodeMults.CharismaLevelMultiplier);
+      Player.exp.charisma =
+        calculateExp(level, Player.mults.charisma * currentNodeMults.CharismaLevelMultiplier) *
+        multForFixingFloatingPointImprecision;
       break;
     case "Intelligence":
       Player.exp.intelligence = 0;
-      Player.gainIntelligenceExp(calculateExp(level, 1));
+      Player.gainIntelligenceExp(calculateExp(level, 1) * multForFixingFloatingPointImprecision);
       break;
   }
   Player.updateSkillLevels();


### PR DESCRIPTION
Due to floating-point imprecision, the stat tool may not set the value that we want.

Before:

<img width="901" height="266" alt="before" src="https://github.com/user-attachments/assets/eb7408a2-b529-4b49-aca6-2a5a55cc762f" />

After:

<img width="901" height="254" alt="after" src="https://github.com/user-attachments/assets/673abb76-a2f4-43df-838b-b4f9945b93fa" />
