### PR TITLE
CCT: Clarify description of "Array Jumping Game II" coding contract

### DIFF
--- a/src/CodingContract/contracts/ArrayJumpingGame.ts
+++ b/src/CodingContract/contracts/ArrayJumpingGame.ts
@@ -64,8 +64,8 @@ export const arrayJumpingGame: Pick<
         "i to i+n.",
         "\n\nAssuming you are initially positioned",
         "at the start of the array, determine the minimum number of",
-        "jumps to reach the end of the array.\n\n",
-        "If it's impossible to reach the end, then the answer should be 0.",
+        "jumps to reach the last index.\n\n",
+        "If it's impossible to reach the last index, then the answer should be 0.",
       ].join(" ");
     },
     difficulty: 3,


### PR DESCRIPTION
Improve contract description for `ArrayJumpingGameII`.

I initially misunderstood "the end of the array" to mean getting beyond the last index (e.g. different to ArrayJumpingGame , which says

> ... determine whether you are able to reach the last index.

I think ArrayJumpingGameII is unclearly worded, because it uses different terminology about the goal. It might be reasonable to think that an input like [1,1,1,0] would be unsolvable, because you can't get "to the end" / past the last index.

This change uses the same wording as ArrayJumpingGame to clarify what is expected.