### PR TITLE
API: Change alert to accept multiple args as other print functions

### DIFF
--- a/markdown/bitburner.ns.alert.md
+++ b/markdown/bitburner.ns.alert.md
@@ -9,14 +9,14 @@ Open up a message box.
 **Signature:**
 
 ```typescript
-alert(msg: string): void;
+alert(...args: any[]): void;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  msg | string | Message to alert. |
+|  args | any\[\] | Value(s) to be alerted. |
 
 **Returns:**
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1473,10 +1473,15 @@ export const ns: InternalAPI<NSFull> = {
       }
       return runningScript.onlineExpGained / runningScript.onlineRunningTime;
     },
-  alert: (ctx) => (_message) => {
-    const message = helpers.string(ctx, "message", _message);
-    dialogBoxCreate(message, { html: true, canBeDismissedEasily: true });
-  },
+  alert:
+    (ctx) =>
+    (...args) => {
+      if (args.length === 0) {
+        throw helpers.errorMessage(ctx, "Takes at least 1 argument.");
+      }
+      const message = helpers.argsToString(args);
+      dialogBoxCreate(message, { html: true, canBeDismissedEasily: true });
+    },
   toast:
     (ctx) =>
     (_message, _variant = ToastVariant.SUCCESS, _duration = 2000) => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -8109,9 +8109,9 @@ export interface NS {
 
   /**
    * Open up a message box.
-   * @param msg - Message to alert.
+   * @param args - Value(s) to be alerted.
    */
-  alert(msg: string): void;
+  alert(...args: any[]): void;
 
   /**
    * Queue a toast (bottom-right notification).


### PR DESCRIPTION
# API: Change alert to accept multiple args as other print functions

Small quality of life change to make alert behave as the other print functions, accepting a list of strings instead of just one.

This is mostly just adding the possibility of more than one param, but during development I had to choose between:
- Keeping it consistent with other print functions, using helpers.argsToString, and allow non-strings to be printed, instead of throwing error.
- Keep it completely backwards compatible, and use helpers.string when receiving one string, then helpers.argsToString to multiple.

I choose the first, to keep the consistency not just with other print functions, but also with itself.
If backward compatibility on that is deemed more important than that, I can change it though.
