### PR TITLE
CONTRACTS: Refresh the server info after a contract promise returns

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -513,10 +513,10 @@ export class Terminal {
     const promptResult = await contract.prompt();
 
     // Get a new copy of the server, in case it changed while the prompt was open
-    const postPromptServer = Player.getCurrentServer();
+    const postPromptServer = GetServer(server.hostname);
 
     // Check if the contract still exists by the time the promise is fulfilled
-    if (postPromptServer == null || postPromptServer.getContract(contractPath) == null) {
+    if (postPromptServer?.getContract(contractPath) == null) {
       this.contractOpen = false;
       return this.error("Contract no longer exists (Was it solved by a script?)");
     }

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -512,8 +512,11 @@ export class Terminal {
     this.contractOpen = true;
     const promptResult = await contract.prompt();
 
-    //Check if the contract still exists by the time the promise is fulfilled
-    if (server.getContract(contractPath) == null) {
+    // Get a new copy of the server, in case it changed while the prompt was open
+    const postPromptServer = Player.getCurrentServer();
+
+    // Check if the contract still exists by the time the promise is fulfilled
+    if (postPromptServer == null || postPromptServer.getContract(contractPath) == null) {
       this.contractOpen = false;
       return this.error("Contract no longer exists (Was it solved by a script?)");
     }


### PR DESCRIPTION
# Linked issues

closes #2280

# Bug fix

- Tested via loading the save file from #2280 and running the command provided there.
- Verified:
    - After this fix the credit is no longer given for a contract began before a reset and completed after a reset.
    - After this fix, credit is still give for a contract submitted without an intervening reset.
    - All format, lint, and unit tests pass