### PR TITLE
BUGFIX: Dropdown list appears behind modal when it's used in modal

### DIFF
--- a/src/Themes/ui/Theme.tsx
+++ b/src/Themes/ui/Theme.tsx
@@ -408,6 +408,13 @@ export function refreshTheme(): void {
           },
         },
       },
+      MuiModal: {
+        styleOverrides: {
+          root: {
+            zIndex: 20000,
+          },
+        },
+      },
     },
   });
 

--- a/src/ui/React/Modal.tsx
+++ b/src/ui/React/Modal.tsx
@@ -82,7 +82,6 @@ export const Modal = ({
       }}
       closeAfterTransition
       className={classes.modal}
-      style={{ zIndex: 20000 }}
       sx={sx}
     >
       <Fade in={open}>


### PR DESCRIPTION
#2253 sets the z-index of our custom modal (20000), but some MUI components also use MUI modal internally. By default, the z-index of MUI modals is 1300, so when we display those MUI components in our custom modal, they appear behind the modal.

<img width="329" height="300" alt="Capture" src="https://github.com/user-attachments/assets/9722f3f3-4137-48c0-8ba4-f67d9062b4c6" />

This PR moves the CSS style from our custom modal to the generic `MuiModal` theme setting.