### PR TITLE
CORPORATION: Prevent purchasing product-only research for material industries

### DIFF
--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -55,7 +55,7 @@ export async function main(ns) {
 
 |  Method | Description |
 |  --- | --- |
-|  [alert(msg)](./bitburner.ns.alert.md) | Open up a message box. |
+|  [alert(args)](./bitburner.ns.alert.md) | Open up a message box. |
 |  [asleep(millis)](./bitburner.ns.asleep.md) | Suspends the script for n milliseconds. Doesn't block with concurrent calls. |
 |  [atExit(f, id)](./bitburner.ns.atexit.md) | Add a callback to be executed when the script dies. |
 |  [brutessh(host)](./bitburner.ns.brutessh.md) | Runs BruteSSH.exe on a server. |

--- a/markdown/bitburner.officeapi.md
+++ b/markdown/bitburner.officeapi.md
@@ -29,7 +29,7 @@ Requires the Office API upgrade from your corporation.
 |  [hasResearched(divisionName, researchName)](./bitburner.officeapi.hasresearched.md) | Check if you unlocked a research. |
 |  [hireAdVert(divisionName)](./bitburner.officeapi.hireadvert.md) | Hire AdVert. |
 |  [hireEmployee(divisionName, city, employeePosition)](./bitburner.officeapi.hireemployee.md) | Hire an employee. |
-|  [research(divisionName, researchName)](./bitburner.officeapi.research.md) | Purchase a research. |
+|  [research(divisionName, researchName)](./bitburner.officeapi.research.md) | <p>Purchase a research.</p><p>Some research is only available for product industries. This function does not do anything if you purchase that research for a material industry.</p> |
 |  [setJobAssignment(divisionName, city, job, amount)](./bitburner.officeapi.setjobassignment.md) | Set the job assignment for a job. |
 |  [throwParty(divisionName, city, costPerEmployee)](./bitburner.officeapi.throwparty.md) | Throw a party for your employees. |
 |  [upgradeOfficeSize(divisionName, city, size)](./bitburner.officeapi.upgradeofficesize.md) | Upgrade office size. |

--- a/markdown/bitburner.officeapi.research.md
+++ b/markdown/bitburner.officeapi.research.md
@@ -6,6 +6,8 @@
 
 Purchase a research.
 
+Some research is only available for product industries. This function does not do anything if you purchase that research for a material industry.
+
 **Signature:**
 
 ```typescript

--- a/src/Corporation/Actions.ts
+++ b/src/Corporation/Actions.ts
@@ -505,7 +505,10 @@ export function research(researchingDivision: Division, researchName: CorpResear
   if (researchTree === undefined) throw new Error(`No research tree for industry '${researchingDivision.industry}'`);
   const research = ResearchMap[researchName];
   const researchNode = researchTree.findNode(researchName);
-  const researchPreReq = researchNode?.parent?.researchName;
+  if (!researchNode) {
+    return;
+  }
+  const researchPreReq = researchNode.parent?.researchName;
   //Check to see if the research request has any pre-reqs that need to be researched first.
   if (researchPreReq) {
     if (!researchingDivision.researched?.has(researchPreReq)) {

--- a/src/Documentation/pages.ts
+++ b/src/Documentation/pages.ts
@@ -1231,6 +1231,7 @@ import nsDoc_bitburner_singularity_getfactionfavorgain_md from "../../markdown/b
 import nsDoc_bitburner_singularity_getfactioninviterequirements_md from "../../markdown/bitburner.singularity.getfactioninviterequirements.md?raw";
 import nsDoc_bitburner_singularity_getfactionrep_md from "../../markdown/bitburner.singularity.getfactionrep.md?raw";
 import nsDoc_bitburner_singularity_getfactionworktypes_md from "../../markdown/bitburner.singularity.getfactionworktypes.md?raw";
+import nsDoc_bitburner_singularity_gethackinglevelrequirementofprogram_md from "../../markdown/bitburner.singularity.gethackinglevelrequirementofprogram.md?raw";
 import nsDoc_bitburner_singularity_getownedaugmentations_md from "../../markdown/bitburner.singularity.getownedaugmentations.md?raw";
 import nsDoc_bitburner_singularity_getownedsourcefiles_md from "../../markdown/bitburner.singularity.getownedsourcefiles.md?raw";
 import nsDoc_bitburner_singularity_getsavedata_md from "../../markdown/bitburner.singularity.getsavedata.md?raw";
@@ -2734,6 +2735,7 @@ AllPages["nsDoc/bitburner.singularity.getfactionfavorgain.md"] = nsDoc_bitburner
 AllPages["nsDoc/bitburner.singularity.getfactioninviterequirements.md"] = nsDoc_bitburner_singularity_getfactioninviterequirements_md;
 AllPages["nsDoc/bitburner.singularity.getfactionrep.md"] = nsDoc_bitburner_singularity_getfactionrep_md;
 AllPages["nsDoc/bitburner.singularity.getfactionworktypes.md"] = nsDoc_bitburner_singularity_getfactionworktypes_md;
+AllPages["nsDoc/bitburner.singularity.gethackinglevelrequirementofprogram.md"] = nsDoc_bitburner_singularity_gethackinglevelrequirementofprogram_md;
 AllPages["nsDoc/bitburner.singularity.getownedaugmentations.md"] = nsDoc_bitburner_singularity_getownedaugmentations_md;
 AllPages["nsDoc/bitburner.singularity.getownedsourcefiles.md"] = nsDoc_bitburner_singularity_getownedsourcefiles_md;
 AllPages["nsDoc/bitburner.singularity.getsavedata.md"] = nsDoc_bitburner_singularity_getsavedata_md;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -8893,6 +8893,9 @@ export interface OfficeAPI {
   /**
    * Purchase a research.
    *
+   * Some research is only available for product industries. This function does not do anything if you purchase that
+   * research for a material industry.
+   *
    * @remarks
    * RAM cost: 20 GB
    *


### PR DESCRIPTION
While testing a player's save file, I saw this warning: `ResearchTree.research() did not find the specified Research node for: uPgrade: Fulcrum`. Their material divisions have research that is only for product industries. This only happens when purchasing research via NS APIs. The research tree on UI correctly excludes non-available research.

To avoid unnecessary breaking in the player's scripts, I make `ns.corporation.research` silently fail instead of throwing an error. It seems that this bug does not crash the engine or UI, so I don't migrate the old save file.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  ns.clearLog();
  Player.money = 1e100;
  Player.corporation = null;
  const divisionName = "Agriculture";
  ns.corporation.createCorporation("Corp");
  ns.corporation.expandIndustry("Agriculture", divisionName);
  Player.corporation.divisions.get(divisionName).researchPoints = 1e10;
  ns.corporation.research(divisionName, "Hi-Tech R&D Laboratory");
  ns.corporation.research(divisionName, "uPgrade: Fulcrum");
}
```