### PR TITLE
UI: Close coding contract popup on prestige

### DIFF
--- a/src/CodingContract/CodingContractEventEmitter.ts
+++ b/src/CodingContract/CodingContractEventEmitter.ts
@@ -1,0 +1,19 @@
+import { EventEmitter } from "../utils/EventEmitter";
+import type { CodingContract } from "./Contract";
+
+export type CodingContractEventData = {
+  codingContract: CodingContract;
+  onClose: () => void;
+  onAttempt: (answer: string) => void;
+};
+
+type CodingContractEvent =
+  | {
+      type: "run";
+      data: CodingContractEventData;
+    }
+  | {
+      type: "close";
+    };
+
+export const CodingContractEventEmitter = new EventEmitter<[CodingContractEvent]>();

--- a/src/CodingContract/Contract.ts
+++ b/src/CodingContract/Contract.ts
@@ -2,10 +2,10 @@ import { FactionName, CodingContractName } from "@enums";
 import { CodingContractTypes } from "./ContractTypes";
 
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, constructorsForReviver } from "../utils/JSONReviver";
-import { CodingContractEvent } from "../ui/React/CodingContractModal";
 import { ContractFilePath, resolveContractFilePath } from "../Paths/ContractFilePath";
 import { assertObject } from "../utils/TypeAssertion";
 import { Result } from "../types";
+import { CodingContractEventEmitter } from "./CodingContractEventEmitter";
 
 // Numeric enum
 /** Enum representing the different types of rewards a Coding Contract can give */
@@ -150,13 +150,16 @@ export class CodingContract {
   /** Creates a popup to prompt the player to solve the problem */
   async prompt(): Promise<{ result: CodingContractResult; message?: string }> {
     return new Promise((resolve) => {
-      CodingContractEvent.emit({
-        c: this,
-        onClose: () => {
-          resolve({ result: CodingContractResult.Cancelled });
-        },
-        onAttempt: (val: string) => {
-          resolve(this.isSolution(val));
+      CodingContractEventEmitter.emit({
+        type: "run",
+        data: {
+          codingContract: this,
+          onClose: () => {
+            resolve({ result: CodingContractResult.Cancelled });
+          },
+          onAttempt: (val: string) => {
+            resolve(this.isSolution(val));
+          },
         },
       });
     });

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -30,6 +30,7 @@ import { calculateExp } from "./PersonObjects/formulas/skill";
 import { currentNodeMults } from "./BitNode/BitNodeMultipliers";
 import { canAccessBitNodeFeature } from "./BitNode/BitNodeUtils";
 import { pendingUIShareJobIds } from "./NetworkShare/Share";
+import { CodingContractEventEmitter } from "./CodingContract/CodingContractEventEmitter";
 
 const BitNode8StartingMoney = 250e6;
 function delayedDialog(message: string, canBeDismissedEasily = true) {
@@ -51,6 +52,9 @@ function setInitialExpForPlayer() {
 export function prestigeAugmentation(): void {
   // We must kill all scripts before doing anything else.
   prestigeWorkerScripts();
+
+  // Close coding contract modal
+  CodingContractEventEmitter.emit({ type: "close" });
 
   initBitNodeMultipliers();
 
@@ -194,6 +198,9 @@ export function prestigeAugmentation(): void {
 export function prestigeSourceFile(isFlume: boolean): void {
   // We must kill all scripts before doing anything else.
   prestigeWorkerScripts();
+
+  // Close coding contract modal
+  CodingContractEventEmitter.emit({ type: "close" });
 
   initBitNodeMultipliers();
 

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -53,9 +53,6 @@ export function prestigeAugmentation(): void {
   // We must kill all scripts before doing anything else.
   prestigeWorkerScripts();
 
-  // Close coding contract modal
-  CodingContractEventEmitter.emit({ type: "close" });
-
   initBitNodeMultipliers();
 
   // Maintain invites to factions with the 'keepOnInstall' flag, and rumors about others
@@ -108,6 +105,9 @@ export function prestigeAugmentation(): void {
   }
   Terminal.clear();
   LogBoxClearEvents.emit();
+
+  // Close coding contract modal
+  CodingContractEventEmitter.emit({ type: "close" });
 
   // Recalculate the bonus for circadian modulator aug
   initCircadianModulator();
@@ -199,9 +199,6 @@ export function prestigeSourceFile(isFlume: boolean): void {
   // We must kill all scripts before doing anything else.
   prestigeWorkerScripts();
 
-  // Close coding contract modal
-  CodingContractEventEmitter.emit({ type: "close" });
-
   initBitNodeMultipliers();
 
   Player.prestigeSourceFile();
@@ -215,6 +212,9 @@ export function prestigeSourceFile(isFlume: boolean): void {
   }
   Terminal.clear();
   LogBoxClearEvents.emit();
+
+  // Close coding contract modal
+  CodingContractEventEmitter.emit({ type: "close" });
 
   // Delete all servers except home computer
   prestigeAllServers(); // Must be done before initForeignServers()

--- a/src/ui/React/CodingContractModal.tsx
+++ b/src/ui/React/CodingContractModal.tsx
@@ -1,38 +1,50 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { KEY } from "../../utils/KeyboardEventKey";
 
-import { CodingContract } from "../../CodingContract/Contract";
 import { CodingContractTypes } from "../../CodingContract/ContractTypes";
 import { CopyableText } from "./CopyableText";
 import { Modal } from "./Modal";
-import { EventEmitter } from "../../utils/EventEmitter";
 import Typography from "@mui/material/Typography";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import { pluralize } from "../../utils/I18nUtils";
-
-interface CodingContractProps {
-  c: CodingContract;
-  onClose: () => void;
-  onAttempt: (answer: string) => void;
-}
-
-export const CodingContractEvent = new EventEmitter<[CodingContractProps]>();
+import {
+  type CodingContractEventData,
+  CodingContractEventEmitter,
+} from "../../CodingContract/CodingContractEventEmitter";
 
 export function CodingContractModal(): React.ReactElement {
-  const [contract, setContract] = useState<CodingContractProps | null>(null);
+  const [eventData, setEventData] = useState<CodingContractEventData | null>(null);
   const [answer, setAnswer] = useState("");
 
-  useEffect(() => {
-    return CodingContractEvent.subscribe((props) => setContract(props));
+  const close = useCallback(() => {
+    setEventData((old) => {
+      old?.onClose();
+      return null;
+    });
   }, []);
+
+  useEffect(
+    () =>
+      CodingContractEventEmitter.subscribe((event) => {
+        switch (event.type) {
+          case "run":
+            setEventData(event.data);
+            break;
+          case "close":
+            close();
+            break;
+        }
+      }),
+    [close],
+  );
   useEffect(() => {
     return () => {
-      contract?.onClose();
+      eventData?.onClose();
     };
-  }, [contract]);
+  }, [eventData]);
 
-  if (contract === null) {
+  if (eventData === null) {
     return <></>;
   }
 
@@ -41,30 +53,22 @@ export function CodingContractModal(): React.ReactElement {
   }
 
   function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
-    if (contract === null) {
+    if (eventData === null) {
       return;
     }
     const value = event.currentTarget.value;
 
     if (event.key === KEY.ENTER && value !== "") {
       event.preventDefault();
-      contract.onAttempt(answer);
+      eventData.onAttempt(answer);
       setAnswer("");
       close();
     }
   }
 
-  function close(): void {
-    if (contract === null) {
-      return;
-    }
-    contract.onClose();
-    setContract(null);
-  }
-
-  const contractType = CodingContractTypes[contract.c.type];
+  const contractType = CodingContractTypes[eventData.codingContract.type];
   const description = [];
-  for (const [i, value] of contractType.desc(contract.c.getData()).split("\n").entries()) {
+  for (const [i, value] of contractType.desc(eventData.codingContract.getData()).split("\n").entries()) {
     description.push(
       <span key={i} style={{ whiteSpace: "pre-wrap" }}>
         {value} <br />
@@ -72,12 +76,12 @@ export function CodingContractModal(): React.ReactElement {
     );
   }
   return (
-    <Modal open={contract !== null} onClose={close}>
-      <CopyableText variant="h4" value={contract.c.type} />
+    <Modal open={eventData !== null} onClose={close}>
+      <CopyableText variant="h4" value={eventData.codingContract.type} />
       <Typography>
         You are attempting to solve a Coding Contract. You have{" "}
-        {pluralize(contract.c.getMaxNumTries() - contract.c.tries, "try", "tries")} remaining, after which the contract
-        will self-destruct.
+        {pluralize(eventData.codingContract.getMaxNumTries() - eventData.codingContract.tries, "try", "tries")}{" "}
+        remaining, after which the contract will self-destruct.
       </Typography>
       <br />
       <Typography>{description}</Typography>
@@ -96,7 +100,7 @@ export function CodingContractModal(): React.ReactElement {
           endAdornment: (
             <Button
               onClick={() => {
-                contract.onAttempt(answer);
+                eventData.onAttempt(answer);
                 setAnswer("");
                 close();
               }}


### PR DESCRIPTION
On prestige, all servers (except home) are reset, so all coding contracts are removed. In #2280, we see that the popup still exists after prestige even when the contract was removed. This PR closes this popup on prestige. This is consistent with other UI elements; for example, we close all log windows after stopping all scripts.

https://github.com/user-attachments/assets/6ebe3da9-5e98-462a-92ef-fb70e7d83868
