### PR TITLE
UI: Change status bar progress animation to be forward-only

### DIFF
--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -8,10 +8,27 @@ interface LinearForwardProgressProps {
   barColor?: React.CSSProperties["color"];
 }
 
+// Round percentage to nearest 5% interval to limit keyframe definitions
+const roundToInterval = (value: number, interval = 5): number => {
+  return Math.round(value / interval) * interval;
+};
+
+// Generate predefined keyframes for forward animations
+const generateKeyframes = (startPercent: number, endPercent: number) => {
+  const startPos = startPercent - 100;
+  const endPos = endPercent - 100;
+
+  return {
+    "0%": { transform: `translateX(${startPos}%)` },
+    "50%": { transform: "translateX(0%)" },
+    "50.01%": { transform: "translateX(-100%)" },
+    "100%": { transform: `translateX(${endPos}%)` },
+  };
+};
+
 export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProgressProps>(
   function LinearForwardProgress({ value, backgroundColor, barColor, ...otherProps }, ref): React.ReactElement {
     const previousValueRef = useRef(value);
-    const animationKeyRef = useRef(0);
 
     const isDecreasing = value < previousValueRef.current;
     const previousValue = previousValueRef.current;
@@ -19,43 +36,24 @@ export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProg
     // Update ref for next render
     previousValueRef.current = value;
 
+    let animationStyles = {};
+
     if (isDecreasing) {
-      // Increment animation key to force new CSS animation
-      animationKeyRef.current += 1;
+      // Round values to 5% intervals to limit keyframe definitions
+      const roundedStartPercent = roundToInterval(previousValue);
+      const roundedEndPercent = roundToInterval(value);
 
-      // MUI LinearProgress uses translateX where:
-      // translateX(-100%) = 0% progress, translateX(0%) = 100% progress
-      const startPos = previousValue - 100;
-      const endPos = value - 100;
-      const animationName = `forwardAnim${animationKeyRef.current}`;
+      // Use rounded values for animation name to ensure reuse of keyframes
+      const animationName = `forwardAnim_${roundedStartPercent}_${roundedEndPercent}`;
 
-      // Calculate timing: proportional split between fill-to-100% and reset-to-final phases
-      const firstPhasePercent = ((100 - previousValue) / (100 - previousValue + value)).toFixed(2);
+      const keyframes = generateKeyframes(roundedStartPercent, roundedEndPercent);
 
-      return (
-        <LinearProgress
-          variant="determinate"
-          value={value}
-          ref={ref}
-          {...otherProps}
-          sx={{
-            backgroundColor,
-            "& .MuiLinearProgress-bar1Determinate": {
-              backgroundColor: barColor,
-              [`@keyframes ${animationName}`]: {
-                "0%": { transform: `translateX(${startPos}%)` },
-                [`${firstPhasePercent}%`]: { transform: "translateX(0%)" },
-                [`${firstPhasePercent + 0.01}%`]: { transform: "translateX(-100%)" },
-                "100%": { transform: `translateX(${endPos}%)` },
-              },
-              animation: `${animationName} 0.4s ease-out`,
-            },
-          }}
-        />
-      );
+      animationStyles = {
+        [`@keyframes ${animationName}`]: keyframes,
+        animation: `${animationName} 0.2s linear`,
+      };
     }
 
-    // Normal increasing progress - use default MUI transition
     return (
       <LinearProgress
         variant="determinate"
@@ -67,6 +65,7 @@ export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProg
           "& .MuiLinearProgress-bar1Determinate": {
             backgroundColor: barColor,
             transition: "transform 0.2s linear",
+            ...animationStyles,
           },
         }}
       />

--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -23,9 +23,14 @@ export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProg
       // Increment animation key to force new CSS animation
       animationKeyRef.current += 1;
 
+      // MUI LinearProgress uses translateX where:
+      // translateX(-100%) = 0% progress, translateX(0%) = 100% progress
       const startPos = previousValue - 100;
       const endPos = value - 100;
       const animationName = `forwardAnim${animationKeyRef.current}`;
+
+      // Calculate timing: proportional split between fill-to-100% and reset-to-final phases
+      const firstPhasePercent = ((100 - previousValue) / (100 - previousValue + value)).toFixed(2);
 
       return (
         <LinearProgress
@@ -39,8 +44,8 @@ export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProg
               backgroundColor: barColor,
               [`@keyframes ${animationName}`]: {
                 "0%": { transform: `translateX(${startPos}%)` },
-                "50%": { transform: "translateX(0%)" },
-                "50.01%": { transform: "translateX(-100%)" },
+                [`${firstPhasePercent}%`]: { transform: "translateX(0%)" },
+                [`${firstPhasePercent + 0.01}%`]: { transform: "translateX(-100%)" },
                 "100%": { transform: `translateX(${endPos}%)` },
               },
               animation: `${animationName} 0.4s ease-out`,

--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -9,7 +9,7 @@ interface LinearForwardProgressProps {
 }
 
 // Round percentage to nearest 5% interval to limit keyframe definitions
-const roundToInterval = (value: number, interval = 5): number => {
+const roundToInterval = (value: number, interval = 10): number => {
   return Math.round(value / interval) * interval;
 };
 

--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -8,97 +8,97 @@ interface LinearForwardProgressProps {
   barColor?: React.CSSProperties["color"];
 }
 
-export function LinearForwardProgress({
-  value,
-  backgroundColor,
-  barColor,
-}: LinearForwardProgressProps): React.ReactElement {
-  const TRANSITION_TO_FULL_DURATION = 200;
-  const ONE_FRAME_RESET_DELAY = 16;
+export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProgressProps>(
+  function LinearForwardProgress({ value, backgroundColor, barColor, ...otherProps }, ref): React.ReactElement {
+    const TRANSITION_TO_FULL_DURATION = 200;
+    const ONE_FRAME_RESET_DELAY = 16;
 
-  const [displayProgress, setDisplayProgress] = useState(value);
-  const [isInDecreasingAnimation, setIsInDecreasingAnimation] = useState(false);
-  const [isAnimatingToFull, setIsAnimatingToFull] = useState(false);
+    const [displayProgress, setDisplayProgress] = useState(value);
+    const [isInDecreasingAnimation, setIsInDecreasingAnimation] = useState(false);
+    const [isAnimatingToFull, setIsAnimatingToFull] = useState(false);
 
-  const previousProgressRef = useRef(value);
-  const animationTimeouts = useRef<number[]>([]);
+    const previousProgressRef = useRef(value);
+    const animationTimeouts = useRef<number[]>([]);
 
-  const clearAnimationTimeouts = useCallback(() => {
-    animationTimeouts.current.forEach((timeout) => {
-      if (timeout) clearTimeout(timeout);
-    });
-    animationTimeouts.current = [];
-  }, []);
+    const clearAnimationTimeouts = useCallback(() => {
+      animationTimeouts.current.forEach((timeout) => {
+        if (timeout) clearTimeout(timeout);
+      });
+      animationTimeouts.current = [];
+    }, []);
 
-  const startDecreasingAnimation = useCallback(() => {
-    setIsInDecreasingAnimation(true);
-    setIsAnimatingToFull(true);
+    const startDecreasingAnimation = useCallback(() => {
+      setIsInDecreasingAnimation(true);
+      setIsAnimatingToFull(true);
 
-    // Phase 1: Animate to 100% with linear transition
-    setDisplayProgress(100);
+      // Phase 1: Animate to 100% with linear transition
+      setDisplayProgress(100);
 
-    // Phase 2: After reaching 100%, reset to 0% and animate to new value
-    const fullTransitionTimeout = window.setTimeout(() => {
-      setIsAnimatingToFull(false);
-      setDisplayProgress(0); // Instant reset with no transition
+      // Phase 2: After reaching 100%, reset to 0% and animate to new value
+      const fullTransitionTimeout = window.setTimeout(() => {
+        setIsAnimatingToFull(false);
+        setDisplayProgress(0); // Instant reset with no transition
 
-      // Phase 3: Brief delay, then animate to final value
-      const resetTimeout = window.setTimeout(() => {
+        // Phase 3: Brief delay, then animate to final value
+        const resetTimeout = window.setTimeout(() => {
+          setDisplayProgress(value);
+          setIsInDecreasingAnimation(false);
+        }, ONE_FRAME_RESET_DELAY);
+
+        animationTimeouts.current[1] = resetTimeout;
+      }, TRANSITION_TO_FULL_DURATION);
+
+      animationTimeouts.current[0] = fullTransitionTimeout;
+    }, [value]);
+
+    useEffect(() => {
+      if (value === previousProgressRef.current || isInDecreasingAnimation) {
+        return;
+      }
+
+      clearAnimationTimeouts();
+
+      if (value > previousProgressRef.current) {
+        // Progress increased: use normal MUI transition
         setDisplayProgress(value);
-        setIsInDecreasingAnimation(false);
-      }, ONE_FRAME_RESET_DELAY);
+      } else {
+        // Progress decreased: use two-phase forward-only animation
+        startDecreasingAnimation();
+      }
 
-      animationTimeouts.current[1] = resetTimeout;
-    }, TRANSITION_TO_FULL_DURATION);
+      previousProgressRef.current = value;
+    }, [value, isInDecreasingAnimation, clearAnimationTimeouts, startDecreasingAnimation]);
 
-    animationTimeouts.current[0] = fullTransitionTimeout;
-  }, [value]);
+    // Cleanup timeouts on component unmount
+    useEffect(() => {
+      return clearAnimationTimeouts;
+    }, [clearAnimationTimeouts]);
 
-  useEffect(() => {
-    if (value === previousProgressRef.current || isInDecreasingAnimation) {
-      return;
-    }
+    const getTransitionStyle = () => {
+      if (isAnimatingToFull) {
+        return { transition: `transform ${TRANSITION_TO_FULL_DURATION}ms linear` };
+      }
+      if (isInDecreasingAnimation && displayProgress === 0) {
+        return { transition: "none" };
+      }
+      // Default MUI transition
+      return {};
+    };
 
-    clearAnimationTimeouts();
-
-    if (value > previousProgressRef.current) {
-      // Progress increased: use normal MUI transition
-      setDisplayProgress(value);
-    } else {
-      // Progress decreased: use two-phase forward-only animation
-      startDecreasingAnimation();
-    }
-
-    previousProgressRef.current = value;
-  }, [value, isInDecreasingAnimation, clearAnimationTimeouts, startDecreasingAnimation]);
-
-  // Cleanup timeouts on component unmount
-  useEffect(() => {
-    return clearAnimationTimeouts;
-  }, [clearAnimationTimeouts]);
-
-  const getTransitionStyle = () => {
-    if (isAnimatingToFull) {
-      return { transition: `transform ${TRANSITION_TO_FULL_DURATION}ms linear` };
-    }
-    if (isInDecreasingAnimation && displayProgress === 0) {
-      return { transition: "none" };
-    }
-    // Default MUI transition
-    return {};
-  };
-
-  return (
-    <LinearProgress
-      variant="determinate"
-      value={displayProgress}
-      sx={{
-        backgroundColor,
-        "& .MuiLinearProgress-bar1Determinate": {
-          backgroundColor: barColor,
-          ...getTransitionStyle(),
-        },
-      }}
-    />
-  );
-}
+    return (
+      <LinearProgress
+        variant="determinate"
+        value={displayProgress}
+        ref={ref}
+        {...otherProps}
+        sx={{
+          backgroundColor,
+          "& .MuiLinearProgress-bar1Determinate": {
+            backgroundColor: barColor,
+            ...getTransitionStyle(),
+          },
+        }}
+      />
+    );
+  },
+);

--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -8,7 +8,7 @@ interface LinearForwardProgressProps {
   barColor?: React.CSSProperties["color"];
 }
 
-// Round percentage to nearest 5% interval to limit keyframe definitions
+// Round percentage to nearest interval to limit keyframe definitions
 const roundToInterval = (value: number, interval = 10): number => {
   return Math.round(value / interval) * interval;
 };
@@ -39,7 +39,7 @@ export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProg
     let animationStyles = {};
 
     if (isDecreasing) {
-      // Round values to 5% intervals to limit keyframe definitions
+      // Round values to limit keyframe definitions
       const roundedStartPercent = roundToInterval(previousValue);
       const roundedEndPercent = roundToInterval(value);
 

--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -21,7 +21,7 @@ export function LinearForwardProgress({
   const [isAnimatingToFull, setIsAnimatingToFull] = useState(false);
 
   const previousProgressRef = useRef(value);
-  const animationTimeouts = useRef<(NodeJS.Timeout | null)[]>([]);
+  const animationTimeouts = useRef<number[]>([]);
 
   const clearAnimationTimeouts = useCallback(() => {
     animationTimeouts.current.forEach((timeout) => {
@@ -38,12 +38,12 @@ export function LinearForwardProgress({
     setDisplayProgress(100);
 
     // Phase 2: After reaching 100%, reset to 0% and animate to new value
-    const fullTransitionTimeout = setTimeout(() => {
+    const fullTransitionTimeout = window.setTimeout(() => {
       setIsAnimatingToFull(false);
       setDisplayProgress(0); // Instant reset with no transition
 
       // Phase 3: Brief delay, then animate to final value
-      const resetTimeout = setTimeout(() => {
+      const resetTimeout = window.setTimeout(() => {
         setDisplayProgress(value);
         setIsInDecreasingAnimation(false);
       }, ONE_FRAME_RESET_DELAY);

--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
+import LinearProgress from "@mui/material/LinearProgress";
+
+interface LinearForwardProgressProps {
+  value: number;
+  backgroundColor?: React.CSSProperties["color"];
+  barColor?: React.CSSProperties["color"];
+}
+
+export function LinearForwardProgress({
+  value,
+  backgroundColor,
+  barColor,
+}: LinearForwardProgressProps): React.ReactElement {
+  const TRANSITION_TO_FULL_DURATION = 200;
+  const ONE_FRAME_RESET_DELAY = 16;
+
+  const [displayProgress, setDisplayProgress] = useState(value);
+  const [isInDecreasingAnimation, setIsInDecreasingAnimation] = useState(false);
+  const [isAnimatingToFull, setIsAnimatingToFull] = useState(false);
+
+  const previousProgressRef = useRef(value);
+  const animationTimeouts = useRef<(NodeJS.Timeout | null)[]>([]);
+
+  const clearAnimationTimeouts = useCallback(() => {
+    animationTimeouts.current.forEach((timeout) => {
+      if (timeout) clearTimeout(timeout);
+    });
+    animationTimeouts.current = [];
+  }, []);
+
+  const startDecreasingAnimation = useCallback(() => {
+    setIsInDecreasingAnimation(true);
+    setIsAnimatingToFull(true);
+
+    // Phase 1: Animate to 100% with linear transition
+    setDisplayProgress(100);
+
+    // Phase 2: After reaching 100%, reset to 0% and animate to new value
+    const fullTransitionTimeout = setTimeout(() => {
+      setIsAnimatingToFull(false);
+      setDisplayProgress(0); // Instant reset with no transition
+
+      // Phase 3: Brief delay, then animate to final value
+      const resetTimeout = setTimeout(() => {
+        setDisplayProgress(value);
+        setIsInDecreasingAnimation(false);
+      }, ONE_FRAME_RESET_DELAY);
+
+      animationTimeouts.current[1] = resetTimeout;
+    }, TRANSITION_TO_FULL_DURATION);
+
+    animationTimeouts.current[0] = fullTransitionTimeout;
+  }, [value]);
+
+  useEffect(() => {
+    if (value === previousProgressRef.current || isInDecreasingAnimation) {
+      return;
+    }
+
+    clearAnimationTimeouts();
+
+    if (value > previousProgressRef.current) {
+      // Progress increased: use normal MUI transition
+      setDisplayProgress(value);
+    } else {
+      // Progress decreased: use two-phase forward-only animation
+      startDecreasingAnimation();
+    }
+
+    previousProgressRef.current = value;
+  }, [value, isInDecreasingAnimation, clearAnimationTimeouts, startDecreasingAnimation]);
+
+  // Cleanup timeouts on component unmount
+  useEffect(() => {
+    return clearAnimationTimeouts;
+  }, [clearAnimationTimeouts]);
+
+  const getTransitionStyle = () => {
+    if (isAnimatingToFull) {
+      return { transition: `transform ${TRANSITION_TO_FULL_DURATION}ms linear` };
+    }
+    if (isInDecreasingAnimation && displayProgress === 0) {
+      return { transition: "none" };
+    }
+    // Default MUI transition
+    return {};
+  };
+
+  return (
+    <LinearProgress
+      variant="determinate"
+      value={displayProgress}
+      sx={{
+        backgroundColor,
+        "& .MuiLinearProgress-bar1Determinate": {
+          backgroundColor: barColor,
+          ...getTransitionStyle(),
+        },
+      }}
+    />
+  );
+}

--- a/src/ui/React/LinearForwardProgress.tsx
+++ b/src/ui/React/LinearForwardProgress.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useRef } from "react";
 import LinearProgress from "@mui/material/LinearProgress";
 
 interface LinearForwardProgressProps {
@@ -10,92 +10,58 @@ interface LinearForwardProgressProps {
 
 export const LinearForwardProgress = React.forwardRef<unknown, LinearForwardProgressProps>(
   function LinearForwardProgress({ value, backgroundColor, barColor, ...otherProps }, ref): React.ReactElement {
-    const TRANSITION_TO_FULL_DURATION = 200;
-    const ONE_FRAME_RESET_DELAY = 16;
+    const previousValueRef = useRef(value);
+    const animationKeyRef = useRef(0);
 
-    const [displayProgress, setDisplayProgress] = useState(value);
-    const [isInDecreasingAnimation, setIsInDecreasingAnimation] = useState(false);
-    const [isAnimatingToFull, setIsAnimatingToFull] = useState(false);
+    const isDecreasing = value < previousValueRef.current;
+    const previousValue = previousValueRef.current;
 
-    const previousProgressRef = useRef(value);
-    const animationTimeouts = useRef<number[]>([]);
+    // Update ref for next render
+    previousValueRef.current = value;
 
-    const clearAnimationTimeouts = useCallback(() => {
-      animationTimeouts.current.forEach((timeout) => {
-        if (timeout) clearTimeout(timeout);
-      });
-      animationTimeouts.current = [];
-    }, []);
+    if (isDecreasing) {
+      // Increment animation key to force new CSS animation
+      animationKeyRef.current += 1;
 
-    const startDecreasingAnimation = useCallback(() => {
-      setIsInDecreasingAnimation(true);
-      setIsAnimatingToFull(true);
+      const startPos = previousValue - 100;
+      const endPos = value - 100;
+      const animationName = `forwardAnim${animationKeyRef.current}`;
 
-      // Phase 1: Animate to 100% with linear transition
-      setDisplayProgress(100);
+      return (
+        <LinearProgress
+          variant="determinate"
+          value={value}
+          ref={ref}
+          {...otherProps}
+          sx={{
+            backgroundColor,
+            "& .MuiLinearProgress-bar1Determinate": {
+              backgroundColor: barColor,
+              [`@keyframes ${animationName}`]: {
+                "0%": { transform: `translateX(${startPos}%)` },
+                "50%": { transform: "translateX(0%)" },
+                "50.01%": { transform: "translateX(-100%)" },
+                "100%": { transform: `translateX(${endPos}%)` },
+              },
+              animation: `${animationName} 0.4s ease-out`,
+            },
+          }}
+        />
+      );
+    }
 
-      // Phase 2: After reaching 100%, reset to 0% and animate to new value
-      const fullTransitionTimeout = window.setTimeout(() => {
-        setIsAnimatingToFull(false);
-        setDisplayProgress(0); // Instant reset with no transition
-
-        // Phase 3: Brief delay, then animate to final value
-        const resetTimeout = window.setTimeout(() => {
-          setDisplayProgress(value);
-          setIsInDecreasingAnimation(false);
-        }, ONE_FRAME_RESET_DELAY);
-
-        animationTimeouts.current[1] = resetTimeout;
-      }, TRANSITION_TO_FULL_DURATION);
-
-      animationTimeouts.current[0] = fullTransitionTimeout;
-    }, [value]);
-
-    useEffect(() => {
-      if (value === previousProgressRef.current || isInDecreasingAnimation) {
-        return;
-      }
-
-      clearAnimationTimeouts();
-
-      if (value > previousProgressRef.current) {
-        // Progress increased: use normal MUI transition
-        setDisplayProgress(value);
-      } else {
-        // Progress decreased: use two-phase forward-only animation
-        startDecreasingAnimation();
-      }
-
-      previousProgressRef.current = value;
-    }, [value, isInDecreasingAnimation, clearAnimationTimeouts, startDecreasingAnimation]);
-
-    // Cleanup timeouts on component unmount
-    useEffect(() => {
-      return clearAnimationTimeouts;
-    }, [clearAnimationTimeouts]);
-
-    const getTransitionStyle = () => {
-      if (isAnimatingToFull) {
-        return { transition: `transform ${TRANSITION_TO_FULL_DURATION}ms linear` };
-      }
-      if (isInDecreasingAnimation && displayProgress === 0) {
-        return { transition: "none" };
-      }
-      // Default MUI transition
-      return {};
-    };
-
+    // Normal increasing progress - use default MUI transition
     return (
       <LinearProgress
         variant="determinate"
-        value={displayProgress}
+        value={value}
         ref={ref}
         {...otherProps}
         sx={{
           backgroundColor,
           "& .MuiLinearProgress-bar1Determinate": {
             backgroundColor: barColor,
-            ...getTransitionStyle(),
+            transition: "transform 0.2s linear",
           },
         }}
       />

--- a/src/ui/React/StatsProgressBar.tsx
+++ b/src/ui/React/StatsProgressBar.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import LinearProgress from "@mui/material/LinearProgress";
 import { TableCell, Tooltip, Typography } from "@mui/material";
 import { useStyles } from "./CharacterOverview";
 import { ISkillProgress } from "../../PersonObjects/formulas/skill";
 import { formatExp } from "../formatNumber";
+import { LinearForwardProgress } from "./LinearForwardProgress";
 
 interface IProgressProps {
   min: number;
@@ -39,16 +39,7 @@ export function StatsProgressBar({
 
   return (
     <Tooltip title={tooltip}>
-      <LinearProgress
-        variant="determinate"
-        value={progress}
-        sx={{
-          backgroundColor: "#111111",
-          "& .MuiLinearProgress-bar1Determinate": {
-            backgroundColor: color,
-          },
-        }}
-      />
+      <LinearForwardProgress value={progress} backgroundColor="#111111" barColor={color} />
     </Tooltip>
   );
 }


### PR DESCRIPTION
# UI: Change status bar progress animation to be forward-only

Currently, when a skill is gained, and the percentage on a status bar goes from a high value to a lower one, the animation makes the bar decrease. It's somewhat ok IMO when it's 80-100% to 0-20%, as it happens on low XP gain, but when we start getting high XP, it becomes a bit random, just jumping between percentages.

Tech aspects:
I've created a new LinearForwardProgress element, that is visual only and easily replace (and uses) @mui/material/LinearProgress. It just identify the case when the progress is going down, and instead of animating directly, it first animates to 100% and then from 0 to the new value. 

I've attached below the difference from current to proposed change as gif and video. GIF is good to quick check without opening but the video has better framerate.

Current behavior:
Low XP gain:
![current-slow](https://github.com/user-attachments/assets/d3040b36-04ac-4066-a480-d30b7412add9)
https://github.com/user-attachments/assets/25b00a47-5d0c-4253-85f2-63b960e748b4

High XP gain:
![current-fast](https://github.com/user-attachments/assets/9725ff60-7445-4942-993e-d7c91be0c300)
https://github.com/user-attachments/assets/d3cee133-0899-4f20-8e22-f2a74a24692b

With this change:
Low XP gain:
![forward-only-slow](https://github.com/user-attachments/assets/b3389c6c-509e-4775-88dc-41463f866d7c)
https://github.com/user-attachments/assets/f23040cd-3912-43d1-8ef6-496aae6f0cb7

High XP gain:
![forward-only-fast](https://github.com/user-attachments/assets/bf9a4da7-d0e3-4b70-b57f-36b15258ade9)
https://github.com/user-attachments/assets/95527837-040a-4ba3-a254-65b1423334db


