### PR TITLE
DOCUMENTATION: Clarify ns.gang.getOtherGangInformation

### DIFF
--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4197,13 +4197,13 @@ export interface Gang {
   getGangInformation(): GangGenInfo;
 
   /**
-   * Get information about the other gangs.
+   * Get information about all gangs.
    * @remarks
    * RAM cost: 2 GB
    *
    * Get territory and power information about all gangs.
    *
-   * @returns Object containing territory and power information about all gangs.
+   * @returns Object containing territory and power information about all gangs, including the player's gang, if any.
    */
   getOtherGangInformation(): Record<string, GangOtherInfoObject>;
 


### PR DESCRIPTION
Improve Gang.getOtherGangInformation() to clarify it returns all gangs including the player's own gang.

I think this PR needs the docs to be re-generated, but I'm not sure how to do that locally.