### PR TITLE
IPVGO: Ensure getValidMoves correctly handles playing as white

### DIFF
--- a/src/Go/boardState/boardState.ts
+++ b/src/Go/boardState/boardState.ts
@@ -71,11 +71,16 @@ export function getNewBoardStateFromSimpleBoard(
   simpleBoard: SimpleBoard,
   priorSimpleBoard?: SimpleBoard,
   ai: GoOpponent = GoOpponent.Netburners,
+  priorColor: GoColor | undefined = undefined,
 ): BoardState {
   const newState = getNewBoardState(simpleBoard.length, ai, false, updatedBoardFromSimpleBoard(simpleBoard));
   if (priorSimpleBoard) {
     newState.previousBoards.push(priorSimpleBoard.join(""));
+  }
 
+  if (priorColor) {
+    newState.previousPlayer = priorColor;
+  } else if (priorSimpleBoard) {
     // Identify the previous player based on the difference in pieces
     const priorWhitePieces = priorSimpleBoard.join("").match(/O/g)?.length ?? 0;
     const priorBlackPieces = priorSimpleBoard.join("").match(/X/g)?.length ?? 0;

--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -426,6 +426,7 @@ export function validateBoardState(
   error: (s: string) => never,
   _boardState?: unknown,
   _priorBoardState?: unknown,
+  playAsWhite = false,
 ): BoardState | undefined {
   const simpleBoard = getSimpleBoardFromUnknown(error, _boardState);
   const priorSimpleBoard = getSimpleBoardFromUnknown(error, _priorBoardState);
@@ -435,7 +436,12 @@ export function validateBoardState(
   }
 
   try {
-    return getNewBoardStateFromSimpleBoard(simpleBoard, priorSimpleBoard);
+    return getNewBoardStateFromSimpleBoard(
+      simpleBoard,
+      priorSimpleBoard,
+      undefined,
+      playAsWhite ? GoColor.black : GoColor.white,
+    );
   } catch (e) {
     error(boardValidity.failedToCreateBoard);
   }

--- a/src/NetscriptFunctions/Go.ts
+++ b/src/NetscriptFunctions/Go.ts
@@ -97,7 +97,7 @@ export function NetscriptGo(): InternalAPI<NSGo> {
           return getValidMoves(undefined, true);
         }
         const playAsWhite = helpers.boolean(ctx, "playAsWhite", _playAsWhite ?? false);
-        const State = validateBoardState(error(ctx), _boardState, _priorBoardState);
+        const State = validateBoardState(error(ctx), _boardState, _priorBoardState, playAsWhite);
         return getValidMoves(State, playAsWhite);
       },
       getChains: (ctx) => (_boardState) => {


### PR DESCRIPTION
Previously, getValidMoves would sometimes return "false" for ALL moves when analyzing moves as white, because it incorrectly assumed it was black's turn on the given analysis board. This PR ensures that the specified color that moves are being validated for is also the next player to play on the analysis board under the hood doing the calculations.


context:
https://discord.com/channels/415207508303544321/1221920484111814828/1408070576463024170