### PR TITLE
RFA: add JSON-RPC 2.0 ping/pong to keep websockets alive across certain reverse proxies

### DIFF
--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -27,12 +27,13 @@ type ResultType =
   | FileContent[]
   | RFAServerData[]
   | {
-      identifier: string;
-      binary: boolean;
-      save: SaveData;
-    }
+    identifier: string;
+    binary: boolean;
+    save: SaveData;
+  }
   | FileMetadata
-  | FileMetadata[];
+  | FileMetadata[]
+  | {};
 type FileDescription = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -8,7 +8,6 @@ export class RFAMessage {
   public params?: FileDescription; // Optional parameters to method
   public error?: string; // Only defined on error
   public id?: number; // ID to keep track of request -> response interaction, undefined with notifications, defined with request/response
-
   constructor(
     obj: { method?: string; result?: ResultType; params?: FileDescription; error?: string; id?: number } = {},
   ) {
@@ -27,13 +26,13 @@ type ResultType =
   | FileContent[]
   | RFAServerData[]
   | {
-    identifier: string;
-    binary: boolean;
-    save: SaveData;
-  }
+      identifier: string;
+      binary: boolean;
+      save: SaveData;
+    }
   | FileMetadata
   | FileMetadata[]
-  | {};
+  | Record<string, never>;
 type FileDescription = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -12,6 +12,7 @@ export class Remote {
   connection?: WebSocket;
   ipaddr: string;
   port: number;
+  msgcount: number = 0;
 
   constructor(ip: string, port: number) {
     this.ipaddr = ip;
@@ -43,6 +44,12 @@ export class Remote {
     this.connection.addEventListener("close", () =>
       SnackbarEvents.emit("Remote API connection closed", ToastVariant.WARNING, 2000),
     );
+
+    // Sends a "ping" JSON-RPC command to remote server to keep a websocket alive over certain reverse proxies
+    setInterval(() => {
+      this.connection?.send('{"jsonrpc": "2.0", "id": "' + this.msgcount.toString() + '", "method": "ping"}')
+      this.msgcount++;
+    }, 10000);
   }
 }
 
@@ -51,7 +58,14 @@ function handleMessageEvent(this: WebSocket, e: MessageEvent): void {
    * Validating e.data and the result of JSON.parse() is too troublesome, so we typecast them here. If the data is
    * invalid, it means the RFA "client" (the tool that the player is using) is buggy, but that's not our problem.
    */
-  const msg = JSON.parse(e.data as string) as RFAMessage;
+  const msgPre = JSON.parse(e.data as string)
+
+  // Empty result is JSON-RPC "pong"
+  if ("result" in msgPre && Object.keys(msgPre.result).length === 0) {
+    return;
+  }
+
+  const msg = msgPre as RFAMessage;
 
   if (!msg.method || !RFARequestHandler[msg.method]) {
     const response = new RFAMessage({ error: "Unknown message received", id: msg.id });

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -47,7 +47,7 @@ export class Remote {
 
     // Sends a "ping" JSON-RPC command to remote server to keep a websocket alive over certain reverse proxies
     setInterval(() => {
-      this.connection?.send('{"jsonrpc": "2.0", "id": "' + this.msgcount.toString() + '", "method": "ping"}')
+      this.connection?.send('{"jsonrpc": "2.0", "id": "' + this.msgcount.toString() + '", "method": "ping"}');
       this.msgcount++;
     }, 10000);
   }
@@ -58,14 +58,12 @@ function handleMessageEvent(this: WebSocket, e: MessageEvent): void {
    * Validating e.data and the result of JSON.parse() is too troublesome, so we typecast them here. If the data is
    * invalid, it means the RFA "client" (the tool that the player is using) is buggy, but that's not our problem.
    */
-  const msgPre = JSON.parse(e.data as string)
+  const msg: RFAMessage = JSON.parse(e.data as string) as RFAMessage;
 
   // Empty result is JSON-RPC "pong"
-  if ("result" in msgPre && Object.keys(msgPre.result).length === 0) {
+  if (msg.result && Object.keys(msg.result).length === 0) {
     return;
   }
-
-  const msg = msgPre as RFAMessage;
 
   if (!msg.method || !RFARequestHandler[msg.method]) {
     const response = new RFAMessage({ error: "Unknown message received", id: msg.id });


### PR DESCRIPTION
RFA: add JSON-RPC 2.0 ping/pong to keep websockets alive across certain reverse proxies

Code has been tested and successfully keeps websocket open on Cloudflare reverse proxy. In addition, an implemented "pong" command in bitburner-filesync returns successfully.