### PR TITLE
RFA: add ping function to respond to JSON-RPC pings

### DIFF
--- a/src/Documentation/doc/en/programming/remote_api.md
+++ b/src/Documentation/doc/en/programming/remote_api.md
@@ -323,3 +323,23 @@ Output:
                 "purchasedByPlayer": boolean
             }[]
         }
+
+### ping
+
+Return a pong.
+
+Input:
+
+        {
+            "jsonrpc": "2.0",
+            "id": number,
+            "method": "ping"
+        }
+
+Output:
+
+        {
+            "jsonrpc": "2.0",
+            "id": number,
+            "result": {}
+        }

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -32,7 +32,8 @@ type ResultType =
       save: SaveData;
     }
   | FileMetadata
-  | FileMetadata[];
+  | FileMetadata[]
+  | Record<string, never>;
 type FileDescription = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -260,4 +260,8 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
 
     return new RFAMessage({ result: servers, id: msg.id });
   },
+
+  ping: function (msg: RFAMessage): RFAMessage {
+    return new RFAMessage({ result: {}, id: msg.id });
+  },
 };


### PR DESCRIPTION
PR includes no ns API changes but the documentation for RFA methods has been updated as part of this pull request.

npm run format and npm run lint have been run.

Has been tested both with a server with and without ping functionality and works fine.

Corresponds to https://github.com/bitburner-official/bitburner-filesync/pull/35