### PR TITLE
BUGFIX: Active Scripts page may mix up UI after prestige

### DIFF
--- a/src/Netscript/RecentScripts.ts
+++ b/src/Netscript/RecentScripts.ts
@@ -3,12 +3,15 @@ import type { WorkerScript } from "./WorkerScript";
 import { Settings } from "../Settings/Settings";
 
 export const recentScripts: RecentScript[] = [];
+let recentScriptId = 0;
 
 export function AddRecentScript(workerScript: WorkerScript): void {
   if (recentScripts.find((r) => r.runningScript.pid === workerScript.pid)) return;
 
   const killedTime = new Date();
+  ++recentScriptId;
   recentScripts.unshift({
+    id: recentScriptId,
     timeOfDeath: killedTime,
     runningScript: workerScript.scriptRef,
   });
@@ -19,6 +22,7 @@ export function AddRecentScript(workerScript: WorkerScript): void {
 }
 
 export interface RecentScript {
+  id: number;
   timeOfDeath: Date;
   runningScript: RunningScript;
 }

--- a/src/ui/ActiveScripts/RecentScriptsPage.tsx
+++ b/src/ui/ActiveScripts/RecentScriptsPage.tsx
@@ -13,7 +13,7 @@ export function RecentScriptsPage(): React.ReactElement {
     <>
       <Typography>List of all recently killed scripts.</Typography>
       {recentScripts.map((r) => (
-        <RecentScriptAccordion key={r.runningScript.pid} recentScript={r} />
+        <RecentScriptAccordion key={r.id} recentScript={r} />
       ))}
     </>
   );


### PR DESCRIPTION
After prestige, PID is reset to 0, but we use PID as the key of each `RecentScriptAccordion`, so React misbehaves when it sees duplicate keys. This PR fixes this issue by using a new id of `RecentScript` as the key.

Save file: 
[recent-scripts-bug.gz](https://github.com/user-attachments/files/22039156/recent-scripts-bug.gz)

How to reproduce:
- Load the attached save file. There are 2 running instances of `test.js` printing PID.
- Options -> Soft Reset
- Active Scripts -> Recently Killed. Open the first instance of `test.js`. Press Log.
- Rerun -> Stop -> Rerun

<img width="746" height="543" alt="1" src="https://github.com/user-attachments/assets/b3f9a745-82a1-426d-b533-ca9a1f447d6d" />

Check console:

```
Warning: Encountered two children with the same key, `1`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

Switch to Active tab:

<img width="695" height="223" alt="2" src="https://github.com/user-attachments/assets/4757fb6f-0a65-4183-bced-eeaf2f5e4c6f" />

Switch to "Create Program" page:

<img width="721" height="141" alt="3" src="https://github.com/user-attachments/assets/85464d6a-cffd-4b40-8efc-90500afc4874" />
