### PR TITLE
MISC: Export save data before migrating to v3

### DIFF
--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -490,7 +490,7 @@ async function loadGame(saveData: SaveData): Promise<boolean> {
       if (typeof ver !== "string" && typeof ver !== "number") {
         throw new Error(`Invalid VersionSave: ${saveObj.VersionSave}`);
       }
-      evaluateVersionCompatibility(ver);
+      await evaluateVersionCompatibility(ver);
       if (CONSTANTS.isDevBranch) {
         // Beta branch, always show changes
         createBetaUpdateText();

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -34,6 +34,8 @@ import { breakingChanges300 } from "./APIBreaks/3.0.0";
 import { calculateOfficeSizeUpgradeCost, calculateUpgradeCost } from "../Corporation/helpers";
 import type { PositiveInteger } from "../types";
 import { officeInitialCost, officeInitialSize, warehouseInitialCost } from "../Corporation/data/Constants";
+import { load } from "../db";
+import { downloadContentAsFile } from "./FileUtils";
 
 /** Function for performing a series of defined replacements. See 0.58.0 for usage */
 function convert(code: string, changes: [RegExp, string][]): string {
@@ -64,7 +66,7 @@ function removeWhitespace(hostname: ServerName, file: ContentFile, files: Conten
 
 // Makes necessary changes to the loaded/imported data to ensure
 // the game stills works with new versions
-export function evaluateVersionCompatibility(ver: string | number): void {
+export async function evaluateVersionCompatibility(ver: string | number): Promise<void> {
   // We have to do this because ts won't let us otherwise
   const anyPlayer = Player as any;
   if (typeof ver === "string") {
@@ -550,6 +552,16 @@ Error: ${e}`,
     if (found) Terminal.error("Filenames with whitespace found and corrected, see console for details.");
   }
   if (ver < 44) {
+    try {
+      /**
+       * Backup pre-v3 save data. We must use the data in IndexedDB instead of calling saveObject.getSaveData().
+       * getSaveData() returns data in v3 format, so the exported data will not be importable in pre-v3.
+       */
+      const saveData = await load();
+      downloadContentAsFile(saveData, `bitburnerSave_backup_${Math.round(Date.now() / 1000)}.json.gz`);
+    } catch (error) {
+      console.error("Cannot export pre-v3 save data", error);
+    }
     if (Player.corporation) {
       // Remove and refund DreamSense
       for (const [name, upgrade] of Object.entries(Player.corporation.upgrades)) {

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -558,7 +558,7 @@ Error: ${e}`,
        * getSaveData() returns data in v3 format, so the exported data will not be importable in pre-v3.
        */
       const saveData = await load();
-      downloadContentAsFile(saveData, `bitburnerSave_backup_${Math.round(Date.now() / 1000)}.json.gz`);
+      downloadContentAsFile(saveData, `bitburnerSave_backup_2.8.1_${Math.round(Player.lastUpdate / 1000)}.json.gz`);
     } catch (error) {
       console.error("Cannot export pre-v3 save data", error);
     }


### PR DESCRIPTION
It's just as the title said.

Save file: 
[v2.8.1.gz](https://github.com/user-attachments/files/22094712/v2.8.1.gz)

How to test:
- Load the attached save file.
- Check `a.js` and corporation:
  - `a.js`: `ns.tail()` was converted to `ns.ui.openTail()`.
  - DreamSense was removed and refunded.
- Check if there is a new downloaded save file. It should be named in this format: `bitburnerSave_backup_${timestamp}.json.gz`.
- Load the new downloaded save file back to v2.8.1. Check `a.js` and corporation again.