### PR TITLE
ELECTRON: macOS Universal Build

### DIFF
--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -19,11 +19,11 @@ BUILD_PLATFORM="${1:-"all"}"
 # And finally build the app.
 case $BUILD_PLATFORM in
   "win")
-    electron-packager .package bitburner --platform win32 --arch x64,arm64 --out .build --overwrite --icon .package/icon.ico --app-copyright "Copyright (C) 2024 Bitburner";;
+    electron-packager .package bitburner --platform win32 --arch x64,arm64 --out .build --overwrite --icon .package/icon.ico --app-copyright "Copyright (C) 2025 Bitburner";;
   "linux")
-    electron-packager .package bitburner --platform linux --arch x64,arm64 --out .build --overwrite --app-copyright "Copyright (C) 2024 Bitburner";;
+    electron-packager .package bitburner --platform linux --arch x64,arm64 --out .build --overwrite --app-copyright "Copyright (C) 2025 Bitburner";;
   "mac")
-    electron-packager .package bitburner --platform darwin --arch x64,arm64 --out .build --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2024 Bitburner";;
+    electron-packager .package bitburner --platform darwin --arch x64,arm64 --out .build --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
   *)
-    electron-packager .package bitburner --platform win32,linux,darwin --arch x64,arm64 --out .build --overwrite --icon .package/icon --app-copyright "Copyright (C) 2024 Bitburner";;
+    electron-packager .package bitburner --platform win32,linux,darwin --arch x64,arm64 --out .build --overwrite --icon .package/icon --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
 esac

--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -23,7 +23,7 @@ case $BUILD_PLATFORM in
   "linux")
     electron-packager .package bitburner --platform linux --arch x64,arm64 --out .build --overwrite --app-copyright "Copyright (C) 2025 Bitburner";;
   "mac")
-    electron-packager .package bitburner --platform darwin --arch x64,arm64,universal --out .build --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
+    electron-packager .package bitburner --platform darwin --arch x64,arm64,universal --out .build --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
   *)
-    electron-packager .package bitburner --platform win32,linux,darwin --arch x64,arm64,universal --out .build --overwrite --icon .package/icon --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
+    electron-packager .package bitburner --platform win32,linux,darwin --arch x64,arm64,universal --out .build --overwrite --icon .package/icon --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
 esac

--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -23,7 +23,7 @@ case $BUILD_PLATFORM in
   "linux")
     electron-packager .package bitburner --platform linux --arch x64,arm64 --out .build --overwrite --app-copyright "Copyright (C) 2025 Bitburner";;
   "mac")
-    electron-packager .package bitburner --platform darwin --arch x64,arm64 --out .build --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
+    electron-packager .package bitburner --platform darwin --arch x64,arm64,universal --out .build --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
   *)
-    electron-packager .package bitburner --platform win32,linux,darwin --arch x64,arm64 --out .build --overwrite --icon .package/icon --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
+    electron-packager .package bitburner --platform win32,linux,darwin --arch x64,arm64,universal --out .build --overwrite --icon .package/icon --app-copyright "Copyright (C) 2025 Bitburner" --osx-universal.mergeASARs="true" --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*";;
 esac


### PR DESCRIPTION
Pull request adds a universal build for macOS, tested on macOS 15.6.1 both silicon and rosetta. Also bumps copyright year.