### PR TITLE
CD: Split build-artifacts.yml into 2 workflows

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,8 +1,8 @@
 name: Build artifacts
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_call:
 
 env:
   GH_TOKEN: ${{ github.token }}
@@ -88,28 +88,3 @@ jobs:
           include-hidden-files: true
           path: .build/*.zip
           if-no-files-found: error
-
-  upload:
-    name: Upload
-    runs-on: ubuntu-latest
-    needs: [build-windows, build-linux, build-mac]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "npm"
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: .build
-          pattern: build-artifacts-*
-          merge-multiple: true
-      - name: List files
-        run: ls -la .build
-      - name: Upload to release
-        env:
-          GH_REF_NAME: ${{ github.ref_name }}
-        run: |
-          for i in .build/*.zip; do gh release upload "$GH_REF_NAME" "$i" --clobber; done;

--- a/.github/workflows/build-upload-artifacts.yml
+++ b/.github/workflows/build-upload-artifacts.yml
@@ -1,4 +1,4 @@
-name: Upload artifacts
+name: Build and upload artifacts
 
 on:
   release:

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -1,0 +1,40 @@
+name: Upload artifacts
+
+on:
+  release:
+    types: [published]
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  build:
+    name: Build artifacts
+    uses: ./.github/workflows/build-artifacts.yml
+
+  upload:
+    name: Upload
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .build
+          pattern: build-artifacts-*
+          merge-multiple: true
+      - name: List files
+        run: ls -la .build
+      - name: Upload to release
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+        run: |
+          for i in .build/*.zip; do gh release upload "$GH_REF_NAME" "$i" --clobber; done;


### PR DESCRIPTION
In #2120, I added a workflow to build artifacts and upload them to the new release. This PR splits that workflow into 2 smaller ones: one to build and one to upload.

The current workflow only runs after Snarling creates a new release, but they may want to build artifacts even when there is no new release. This is also useful when Snarling or other contributors want to build a universal macOS binary without a Mac machine.

Test:
- https://github.com/catloversg/bitburner-src/actions/runs/17485307596
- https://github.com/catloversg/bitburner-src/actions/runs/17485343612