### PR TITLE
IPVGO: Prevent tiny islands surrounded by offline nodes during initial board generation

### DIFF
--- a/src/Go/boardState/offlineNodes.ts
+++ b/src/Go/boardState/offlineNodes.ts
@@ -3,6 +3,9 @@ import type { Board, BoardState, PointState } from "../Types";
 import { Player } from "@player";
 import { boardSizes } from "../Constants";
 import { WHRNG } from "../../Casino/RNG";
+import { getAllChains } from "../boardAnalysis/boardAnalysis";
+import { updateChains } from "./boardState";
+import { GoColor } from "@enums";
 
 type rand = (n1: number, n2: number) => number;
 
@@ -36,6 +39,8 @@ export function addObstacles(boardState: BoardState) {
   boardState.board = ensureOfflineNodes(boardState.board);
 
   boardState.board = resetCoordinates(boardState.board);
+
+  boardState.board = removeIslands(boardState.board);
 }
 
 export function resetCoordinates(board: Board) {
@@ -46,6 +51,24 @@ export function resetCoordinates(board: Board) {
       if (point) {
         point.x = x;
         point.y = y;
+      }
+    }
+  }
+  return board;
+}
+
+/**
+ * Removes all tiny islands of empty points (2 or fewer) from the board
+ * @param board
+ */
+export function removeIslands(board: Board) {
+  updateChains(board, true);
+  const chains = getAllChains(board);
+
+  for (const chain of chains) {
+    if (chain.length <= 2 && chain[0]?.color === GoColor.empty) {
+      for (const point of chain) {
+        board[point.x][point.y] = null;
       }
     }
   }

--- a/test/jest/Go/boardState.test.ts
+++ b/test/jest/Go/boardState.test.ts
@@ -1,7 +1,7 @@
 import { getNewBoardState, makeMove, passTurn, updateCaptures } from "../../../src/Go/boardState/boardState";
 import { GoColor, GoOpponent } from "@enums";
 import { boardFromSimpleBoard, simpleBoardFromBoard } from "../../../src/Go/boardAnalysis/boardAnalysis";
-import { resetCoordinates, rotate90Degrees } from "../../../src/Go/boardState/offlineNodes";
+import { removeIslands, resetCoordinates, rotate90Degrees } from "../../../src/Go/boardState/offlineNodes";
 import { bitverseBoardShape } from "../../../src/Go/Constants";
 import { getEmptyHighlightedPoints } from "../../../src/Go/Go";
 
@@ -50,6 +50,12 @@ describe("Board analysis utility tests", () => {
       resetCoordinates(rotate90Degrees(boardFromSimpleBoard(bitverseBoardShape))),
     );
     expect(boardWithNoRouters).toEqual(specialBoardTemplate);
+  });
+
+  it("removes tiny empty point chains from initial board", () => {
+    const board = boardFromSimpleBoard([".#...", "##...", ".....", "...##", "..#.."]);
+    const cleanedBoard = removeIslands(board);
+    expect(simpleBoardFromBoard(cleanedBoard)).toEqual(["##...", "##...", ".....", "...##", "..###"]);
   });
 
   it("Correctly applies moves made", () => {


### PR DESCRIPTION
Sometimes, if certain combinations of offline nodes at the edge line up just right, one or two nodes can be isolated outside of the main board, surrounded by offline nodes. They can't really be interacted with, and they look strange and confuse players. This PR ensures they are replaced with offline nodes instead, if it happens during board generation.

<img width="213" height="166" alt="image" src="https://github.com/user-attachments/assets/3ffe45bd-cfec-4f77-9bfc-f081b66da9ab" />

Context: https://discord.com/channels/415207508303544321/415213413745164318/1413635710480547901