### PR TITLE
UI: Clarify why you can't buy 4S when disabled

### DIFF
--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -247,7 +247,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
     },
     purchase4SMarketData: (ctx) => () => {
       if (Player.bitNodeOptions.disable4SData) {
-        helpers.log(ctx, () => "4S Market Data is disabled.");
+        helpers.log(ctx, () => "4S Market Data is disabled in advanced bitnode options.");
         return false;
       }
 
@@ -268,7 +268,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
     },
     purchase4SMarketDataTixApi: (ctx) => () => {
       if (Player.bitNodeOptions.disable4SData) {
-        helpers.log(ctx, () => "4S Market Data is disabled.");
+        helpers.log(ctx, () => "4S Market Data is disabled in advanced bitnode options.");
         return false;
       }
 
@@ -307,6 +307,10 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
       return true;
     },
     purchaseTixApi: (ctx) => () => {
+            if (Player.bitNodeOptions.disable4SData) {
+        helpers.log(ctx, () => "TIX API access is disabled in advanced bitnode options.");
+        return false;
+      }
       if (Player.hasTixApiAccess) {
         helpers.log(ctx, () => "Already purchased TIX API");
         return true;

--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -307,7 +307,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
       return true;
     },
     purchaseTixApi: (ctx) => () => {
-            if (Player.bitNodeOptions.disable4SData) {
+      if (Player.bitNodeOptions.disable4SData) {
         helpers.log(ctx, () => "TIX API access is disabled in advanced bitnode options.");
         return false;
       }

--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -247,7 +247,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
     },
     purchase4SMarketData: (ctx) => () => {
       if (Player.bitNodeOptions.disable4SData) {
-        helpers.log(ctx, () => "4S Market Data is disabled in advanced bitnode options.");
+        helpers.log(ctx, () => "4S Market Data is disabled in advanced BitNode options.");
         return false;
       }
 
@@ -268,7 +268,7 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
     },
     purchase4SMarketDataTixApi: (ctx) => () => {
       if (Player.bitNodeOptions.disable4SData) {
-        helpers.log(ctx, () => "4S Market Data is disabled in advanced bitnode options.");
+        helpers.log(ctx, () => "4S Market Data is disabled in advanced BitNode options.");
         return false;
       }
 
@@ -307,10 +307,6 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
       return true;
     },
     purchaseTixApi: (ctx) => () => {
-      if (Player.bitNodeOptions.disable4SData) {
-        helpers.log(ctx, () => "TIX API access is disabled in advanced bitnode options.");
-        return false;
-      }
       if (Player.hasTixApiAccess) {
         helpers.log(ctx, () => "Already purchased TIX API");
         return true;

--- a/src/StockMarket/ui/InfoAndPurchases.tsx
+++ b/src/StockMarket/ui/InfoAndPurchases.tsx
@@ -27,10 +27,13 @@ interface IProps {
 
 function Purchase4SMarketDataTixApiAccessButton(props: IProps): React.ReactElement {
   function purchase4SMarketDataTixApiAccess(): void {
+    if (Player.has4SDataTixApi) {
+      return;
+    }
     if (Player.bitNodeOptions.disable4SData) {
       return;
     }
-    if (Player.has4SDataTixApi) {
+    if (!Player.hasTixApiAccess) {
       return;
     }
     if (!Player.canAfford(getStockMarket4STixApiCost())) {
@@ -118,6 +121,9 @@ function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
     if (Player.hasTixApiAccess) {
       return;
     }
+    if (!Player.hasWseAccount) {
+      return;
+    }
     if (!Player.canAfford(StockMarketConstants.TixApiCost)) {
       return;
     }
@@ -154,10 +160,13 @@ function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
 
 function Purchase4SMarketDataButton(props: IProps): React.ReactElement {
   function purchase4SMarketData(): void {
+    if (Player.has4SData) {
+      return;
+    }
     if (Player.bitNodeOptions.disable4SData) {
       return;
     }
-    if (Player.has4SData) {
+    if (!Player.hasWseAccount) {
       return;
     }
     if (!Player.canAfford(getStockMarket4SDataCost())) {

--- a/src/StockMarket/ui/InfoAndPurchases.tsx
+++ b/src/StockMarket/ui/InfoAndPurchases.tsx
@@ -107,7 +107,7 @@ function PurchaseWseAccountButton(props: IProps): React.ReactElement {
 function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
   function purchaseTixApiAccess(): void {
     if (Player.bitNodeOptions.disable4SData) {
-      dialogBoxCreate("TIX API Access has been disabled through Advanced Bitnode options.")
+      dialogBoxCreate("TIX API Access has been disabled through Advanced Bitnode options.");
       return;
     }
     if (Player.hasTixApiAccess) {
@@ -141,7 +141,7 @@ function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
 function Purchase4SMarketDataButton(props: IProps): React.ReactElement {
   function purchase4SMarketData(): void {
     if (Player.bitNodeOptions.disable4SData) {
-      dialogBoxCreate("4S Market Data has been disabled through Advanced Bitnode options.")
+      dialogBoxCreate("4S Market Data has been disabled through Advanced Bitnode options.");
       return;
     }
     if (Player.has4SData) {

--- a/src/StockMarket/ui/InfoAndPurchases.tsx
+++ b/src/StockMarket/ui/InfoAndPurchases.tsx
@@ -10,6 +10,7 @@ import { getStockMarket4SDataCost, getStockMarket4STixApiCost } from "../StockMa
 import { StockMarketConstants } from "../data/Constants";
 import { Player } from "@player";
 import { Money } from "../../ui/React/Money";
+import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import { initStockMarket } from "../StockMarket";
 
 import Typography from "@mui/material/Typography";
@@ -106,6 +107,7 @@ function PurchaseWseAccountButton(props: IProps): React.ReactElement {
 function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
   function purchaseTixApiAccess(): void {
     if (Player.bitNodeOptions.disable4SData) {
+      dialogBoxCreate("TIX API Access has been disabled through Advanced Bitnode options.")
       return;
     }
     if (Player.hasTixApiAccess) {
@@ -139,6 +141,7 @@ function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
 function Purchase4SMarketDataButton(props: IProps): React.ReactElement {
   function purchase4SMarketData(): void {
     if (Player.bitNodeOptions.disable4SData) {
+      dialogBoxCreate("4S Market Data has been disabled through Advanced Bitnode options.")
       return;
     }
     if (Player.has4SData) {

--- a/src/StockMarket/ui/InfoAndPurchases.tsx
+++ b/src/StockMarket/ui/InfoAndPurchases.tsx
@@ -10,7 +10,6 @@ import { getStockMarket4SDataCost, getStockMarket4STixApiCost } from "../StockMa
 import { StockMarketConstants } from "../data/Constants";
 import { Player } from "@player";
 import { Money } from "../../ui/React/Money";
-import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import { initStockMarket } from "../StockMarket";
 
 import Typography from "@mui/material/Typography";
@@ -28,6 +27,9 @@ interface IProps {
 
 function Purchase4SMarketDataTixApiAccessButton(props: IProps): React.ReactElement {
   function purchase4SMarketDataTixApiAccess(): void {
+    if (Player.bitNodeOptions.disable4SData) {
+      return;
+    }
     if (Player.has4SDataTixApi) {
       return;
     }
@@ -45,30 +47,29 @@ function Purchase4SMarketDataTixApiAccessButton(props: IProps): React.ReactEleme
         Market Data TIX API Access <CheckIcon />
       </Typography>
     );
-  } else {
-    const cost = getStockMarket4STixApiCost();
-    return (
-      <Tooltip
-        title={
-          !Player.hasTixApiAccess ? (
-            <Typography>Requires TIX API Access</Typography>
-          ) : (
-            <Typography>Let you access 4S Market Data through Netscript</Typography>
-          )
-        }
-      >
-        <span>
-          <Button
-            disabled={!Player.hasTixApiAccess || !Player.canAfford(cost)}
-            onClick={purchase4SMarketDataTixApiAccess}
-          >
-            Buy 4S Market Data TIX API Access -&nbsp;
-            <Money money={cost} forPurchase={true} />
-          </Button>
-        </span>
-      </Tooltip>
-    );
   }
+  const cost = getStockMarket4STixApiCost();
+  let tooltipTitle = "Let you access 4S Market Data through Netscript";
+  if (Player.bitNodeOptions.disable4SData) {
+    tooltipTitle = "4S Market Data is disabled in advanced BitNode options";
+  } else if (!Player.hasTixApiAccess) {
+    tooltipTitle = "Requires TIX API Access";
+  } else if (!Player.canAfford(cost)) {
+    tooltipTitle = "You do not have enough money";
+  }
+  return (
+    <Tooltip title={<Typography>{tooltipTitle}</Typography>}>
+      <span>
+        <Button
+          disabled={Player.bitNodeOptions.disable4SData || !Player.hasTixApiAccess || !Player.canAfford(cost)}
+          onClick={purchase4SMarketDataTixApiAccess}
+        >
+          Buy 4S Market Data TIX API Access -&nbsp;
+          <Money money={cost} forPurchase={true} />
+        </Button>
+      </span>
+    </Tooltip>
+  );
 }
 
 function PurchaseWseAccountButton(props: IProps): React.ReactElement {
@@ -93,23 +94,27 @@ function PurchaseWseAccountButton(props: IProps): React.ReactElement {
   }
 
   const cost = StockMarketConstants.WseAccountCost;
+  let tooltipTitle = "Let you trade stock";
+  if (!Player.canAfford(cost)) {
+    tooltipTitle = "You do not have enough money";
+  }
   return (
     <>
       <Typography>To begin trading, you must first purchase an account:</Typography>
-      <Button disabled={!Player.canAfford(cost)} onClick={purchaseWseAccount}>
-        Buy WSE Account -&nbsp;
-        <Money money={cost} forPurchase={true} />
-      </Button>
+      <Tooltip title={<Typography>{tooltipTitle}</Typography>}>
+        <span>
+          <Button disabled={!Player.canAfford(cost)} onClick={purchaseWseAccount}>
+            Buy WSE Account -&nbsp;
+            <Money money={cost} forPurchase={true} />
+          </Button>
+        </span>
+      </Tooltip>
     </>
   );
 }
 
 function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
   function purchaseTixApiAccess(): void {
-    if (Player.bitNodeOptions.disable4SData) {
-      dialogBoxCreate("TIX API Access has been disabled through Advanced Bitnode options.");
-      return;
-    }
     if (Player.hasTixApiAccess) {
       return;
     }
@@ -127,21 +132,29 @@ function PurchaseTixApiAccessButton(props: IProps): React.ReactElement {
         TIX API Access <CheckIcon />
       </Typography>
     );
-  } else {
-    const cost = StockMarketConstants.TixApiCost;
-    return (
-      <Button disabled={!Player.canAfford(cost) || !Player.hasWseAccount} onClick={purchaseTixApiAccess}>
-        Buy Trade Information eXchange (TIX) API Access -&nbsp;
-        <Money money={cost} forPurchase={true} />
-      </Button>
-    );
   }
+  const cost = StockMarketConstants.TixApiCost;
+  let tooltipTitle = "Let you trade stock through Netscript";
+  if (!Player.hasWseAccount) {
+    tooltipTitle = "Requires WSE Account";
+  } else if (!Player.canAfford(cost)) {
+    tooltipTitle = "You do not have enough money";
+  }
+  return (
+    <Tooltip title={<Typography>{tooltipTitle}</Typography>}>
+      <span>
+        <Button disabled={!Player.hasWseAccount || !Player.canAfford(cost)} onClick={purchaseTixApiAccess}>
+          Buy Trade Information eXchange (TIX) API Access -&nbsp;
+          <Money money={cost} forPurchase={true} />
+        </Button>
+      </span>
+    </Tooltip>
+  );
 }
 
 function Purchase4SMarketDataButton(props: IProps): React.ReactElement {
   function purchase4SMarketData(): void {
     if (Player.bitNodeOptions.disable4SData) {
-      dialogBoxCreate("4S Market Data has been disabled through Advanced Bitnode options.");
       return;
     }
     if (Player.has4SData) {
@@ -160,21 +173,29 @@ function Purchase4SMarketDataButton(props: IProps): React.ReactElement {
         4S Market Data Access <CheckIcon />
       </Typography>
     );
-  } else {
-    const cost = getStockMarket4SDataCost();
-    return (
-      <Tooltip
-        title={<Typography>Lets you view additional pricing and volatility information about stocks</Typography>}
-      >
-        <span>
-          <Button disabled={!Player.canAfford(cost) || !Player.hasWseAccount} onClick={purchase4SMarketData}>
-            Buy 4S Market Data Access -&nbsp;
-            <Money money={cost} forPurchase={true} />
-          </Button>
-        </span>
-      </Tooltip>
-    );
   }
+  const cost = getStockMarket4SDataCost();
+  let tooltipTitle = "Lets you view additional pricing and volatility information about stocks";
+  if (Player.bitNodeOptions.disable4SData) {
+    tooltipTitle = "4S Market Data is disabled in advanced BitNode options";
+  } else if (!Player.hasWseAccount) {
+    tooltipTitle = "Requires WSE Account";
+  } else if (!Player.canAfford(cost)) {
+    tooltipTitle = "You do not have enough money";
+  }
+  return (
+    <Tooltip title={<Typography>{tooltipTitle}</Typography>}>
+      <span>
+        <Button
+          disabled={Player.bitNodeOptions.disable4SData || !Player.hasWseAccount || !Player.canAfford(cost)}
+          onClick={purchase4SMarketData}
+        >
+          Buy 4S Market Data Access -&nbsp;
+          <Money money={cost} forPurchase={true} />
+        </Button>
+      </span>
+    </Tooltip>
+  );
 }
 
 export function InfoAndPurchases(props: IProps): React.ReactElement {
@@ -193,22 +214,18 @@ export function InfoAndPurchases(props: IProps): React.ReactElement {
         the TIX API lets you write code to create your own algorithmic/automated trading strategies.
       </Typography>
       <PurchaseTixApiAccessButton {...props} />
-      {!Player.bitNodeOptions.disable4SData && (
-        <>
-          <Typography variant="h5" color="primary">
-            {FactionName.FourSigma} (4S) Market Data Feed
-          </Typography>
-          <Typography>
-            {FactionName.FourSigma}'s (4S) Market Data Feed provides information about stocks that will help your
-            trading strategies.
-            <IconButton onClick={() => setHelpOpen(true)}>
-              <HelpIcon />
-            </IconButton>
-          </Typography>
-          <Purchase4SMarketDataTixApiAccessButton {...props} />
-          <Purchase4SMarketDataButton {...props} />
-        </>
-      )}
+      <Typography variant="h5" color="primary">
+        {FactionName.FourSigma} (4S) Market Data Feed
+      </Typography>
+      <Typography>
+        {FactionName.FourSigma}'s (4S) Market Data Feed provides information about stocks that will help your trading
+        strategies.
+        <IconButton onClick={() => setHelpOpen(true)}>
+          <HelpIcon />
+        </IconButton>
+      </Typography>
+      <Purchase4SMarketDataTixApiAccessButton {...props} />
+      <Purchase4SMarketDataButton {...props} />
       <Typography>
         Commission Fees: Every transaction you make has a{" "}
         <Money money={StockMarketConstants.StockMarketCommission} forPurchase={true} /> commission fee.


### PR DESCRIPTION
When 4S is disabled before starting a bitnode using the Advanced Bitnode options, the relavent `ns.stock.purchaseX` functions aren't clear as to why 4S is disabled. This PR fixes that.

It's also more clear in the UI why 4S is disabled when you try to buy 4S through Wall Street

What happens when you try to use `ns.stock.purchaseX` to purchase 4S and 4S API access
(Upload later today)
