### PR TITLE
UI: Improve dev menu for augmentations

### DIFF
--- a/src/DevMenu/ui/AugmentationsDev.tsx
+++ b/src/DevMenu/ui/AugmentationsDev.tsx
@@ -1,6 +1,6 @@
 import { Player } from "@player";
 import React from "react";
-import { Clear, ExpandMore } from "@mui/icons-material";
+import { ExpandMore } from "@mui/icons-material";
 import {
   AccordionDetails,
   AccordionSummary,
@@ -19,6 +19,7 @@ import { Factions } from "../../Faction/Factions";
 import { FactionChooser } from "./FactionChooser";
 import { getFactionAugmentationsFiltered } from "../../Faction/FactionHelpers";
 import { AutoExpandAccordion } from "../../ui/AutoExpand/AutoExpandAccordion";
+import { applyAugmentation } from "../../Augmentation/AugmentationHelpers";
 
 export function AugmentationsDev(): React.ReactElement {
   const [augmentation, setAugmentation] = React.useState<AugmentationName | null>(null);
@@ -63,9 +64,18 @@ export function AugmentationsDev(): React.ReactElement {
 
   function clearAugs(): void {
     Player.augmentations = [];
+    Player.reapplyAllAugmentations();
+    Player.reapplyAllSourceFiles();
   }
 
   function clearQueuedAugs(): void {
+    Player.queuedAugmentations = [];
+  }
+
+  function installAugs(): void {
+    for (const aug of Player.queuedAugmentations) {
+      applyAugmentation(aug);
+    }
     Player.queuedAugmentations = [];
   }
 
@@ -101,13 +111,14 @@ export function AugmentationsDev(): React.ReactElement {
               setAugmentation(augmentationName);
             }}
           ></Autocomplete>
-          <Tooltip title="Clear augmentations" style={{ marginLeft: "8px" }}>
-            <Button onClick={clearAugs}>
-              <Clear />
-            </Button>
-          </Tooltip>
         </Box>
-        <Button onClick={clearQueuedAugs}>Clear queued augmentations</Button>
+        <Button onClick={installAugs} style={{ marginRight: "8px" }}>
+          {`Quick-install ${Player.queuedAugmentations.length} queued augmentations`}
+        </Button>
+        <Button onClick={clearQueuedAugs} style={{ marginRight: "8px" }}>
+          {`Clear ${Player.queuedAugmentations.length} queued augmentations`}
+        </Button>
+        <Button onClick={clearAugs}>{`Uninstall ${Player.augmentations.length} installed augmentations`}</Button>
         <Box display="flex" marginTop="8px">
           <Tooltip title="Queue all augmentations offered by faction, except NFG">
             <Button onClick={queueAllAugsOfFaction}>

--- a/src/DevMenu/ui/AugmentationsDev.tsx
+++ b/src/DevMenu/ui/AugmentationsDev.tsx
@@ -77,13 +77,6 @@ export function AugmentationsDev(): React.ReactElement {
       applyAugmentation(aug);
     }
     Player.queuedAugmentations = [];
-    // For some reason, applyAugmentation doesn't handle everything fully.
-    // That says some worrisome things about grafting, but I'm too lazy to
-    // track it down right now.
-    // You can reproduce this by adding all augmentations from a blank slate
-    // without these lines, and noting the stat difference after reloading the save.
-    Player.reapplyAllAugmentations();
-    Player.reapplyAllSourceFiles();
   }
 
   const options = Object.values(AugmentationName).filter(

--- a/src/DevMenu/ui/AugmentationsDev.tsx
+++ b/src/DevMenu/ui/AugmentationsDev.tsx
@@ -77,6 +77,13 @@ export function AugmentationsDev(): React.ReactElement {
       applyAugmentation(aug);
     }
     Player.queuedAugmentations = [];
+    // For some reason, applyAugmentation doesn't handle everything fully.
+    // That says some worrisome things about grafting, but I'm too lazy to
+    // track it down right now.
+    // You can reproduce this by adding all augmentations from a blank slate
+    // without these lines, and noting the stat difference after reloading the save.
+    Player.reapplyAllAugmentations();
+    Player.reapplyAllSourceFiles();
   }
 
   const options = Object.values(AugmentationName).filter(


### PR DESCRIPTION
The button layout was confusing, there was no quick way to install augs, and uninstalled augs didn't properly lose their stat effects.

Unsurprisingly, this was wanted for testing Infiltration.

<img width="973" height="206" alt="image" src="https://github.com/user-attachments/assets/f7dfe481-7689-48b3-8970-7e1413200fb9" />
