### PR TITLE
BUGFIX: Color picker appears behind theme editor

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,20 @@ ReactDOM.render(
   document.getElementById("root"),
 );
 
+// TODO: Remove this workaround when we get rid of material-ui-color and update to React 19+.
+/**
+ * With built-in MUI components, we usually customize the zIndex via styleOverrides in src\Themes\ui\Theme.tsx. However,
+ * material-ui-color uses a prefix for all class names; for example, instead of "MuiPopover-root", it's
+ * "ColorPicker-MuiPopover-root". This library does not provide good ways to customize its components extensively, so we
+ * have to find a hacky way to work around this problem.
+ */
+const styleElement = document.createElement("style");
+styleElement.textContent = `
+#color-popover {
+  z-index: 20000 !important;
+}`;
+document.head.appendChild(styleElement);
+
 setTimeout(newRemoteFileApiConnection, 2000);
 
 function rerender(): void {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,8 +27,7 @@ ReactDOM.render(
  * have to find a hacky way to work around this problem.
  */
 const styleElement = document.createElement("style");
-styleElement.textContent = `
-#color-popover {
+styleElement.textContent = `#color-popover {
   z-index: 20000 !important;
 }`;
 document.head.appendChild(styleElement);


### PR DESCRIPTION
We changed z-index of some MUI components in #2253 and #2282. This works with things using built-in MUI components, but it does not work with `material-ui-color`'s component. Please check my comment for more information. The workaround is ugly, so I'm open to other ideas. I used this one because it's simple. `material-ui-color` will be gone when we update to React 19 and MUI 7, so I don't want to waste too much time with it.

Before:

<img width="369" height="455" alt="before" src="https://github.com/user-attachments/assets/d0bbc19b-460a-4a12-8343-77f3f61cc8ef" />

After:

<img width="362" height="453" alt="after" src="https://github.com/user-attachments/assets/a9974215-229f-4f76-ad52-2dfdd8aa77f2" />
