### PR TITLE
BUGFIX: Stat levels are not recalculated after grafting augs or accepting Stanek's Gift

### DIFF
--- a/src/Augmentation/AugmentationHelpers.ts
+++ b/src/Augmentation/AugmentationHelpers.ts
@@ -48,6 +48,9 @@ export function applyAugmentation(aug: PlayerOwnedAugmentation, reapply = false)
     Player.applyEntropy(Player.entropy);
   }
 
+  // Recalculate skill levels after applying multipliers.
+  Player.updateSkillLevels();
+
   // Special logic for NeuroFlux Governor
   const ownedNfg = Player.augmentations.find((pAug) => pAug.name === AugmentationName.NeuroFluxGovernor);
   if (aug.name === AugmentationName.NeuroFluxGovernor && !reapply && ownedNfg) {


### PR DESCRIPTION
I found this bug while investigating the issue mentioned in #2315.

How to reproduce: Grafting:
- Set SF12 to a high level to see the stat changes easier. Bitflume.
- Queue `CongruityImplant` and install it as normal.
- Graft an augmentation.
- After the grafting finishes, notice that the stat levels are not changed, but the multipliers are changed.
- Run `ns.getHackingLevel()`. The stat levels are changed now.

How to reproduce: Stanek's Gift:
- Accept Stanek's Gift. This step is important to ensure the reproducibility. `StaneksGift.justCharged` is true, by default. After accepting the gift, the engine automatically charges the gift once and set `justCharged` to false.
- Set SF12 to a high level to see the stat changes easier. Bitflume.
- Run `ns.stanek.acceptGift()`. Notice that the stat levels are not changed, but the multipliers are changed.
- Run `ns.getHackingLevel()`. The stat levels are changed now.

The issue in #2315 is the same. The mults are changed correctly, but the stat levels are wrong. Calling `Player.reapplyAllAugmentations();` and `Player.reapplyAllSourceFiles();` work because those functions also call `Player.updateSkillLevels()`.