### PR TITLE
API: Enforce requirement of WSE account with purchaseTixApi and purchase4SMarketData APIs

### DIFF
--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -256,6 +256,10 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
         return true;
       }
 
+      if (!Player.hasWseAccount) {
+        helpers.log(ctx, () => "You need to have a WSE account");
+        return false;
+      }
       if (Player.money < getStockMarket4SDataCost()) {
         helpers.log(ctx, () => "Not enough money to purchase 4S Market Data.");
         return false;
@@ -312,6 +316,10 @@ export function NetscriptStockMarket(): InternalAPI<TIX> {
         return true;
       }
 
+      if (!Player.hasWseAccount) {
+        helpers.log(ctx, () => "You need to have a WSE account");
+        return false;
+      }
       if (Player.money < getStockMarketTixApiCost()) {
         helpers.log(ctx, () => "Not enough money to purchase TIX API Access");
         return false;

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -384,5 +384,12 @@ export const breakingChanges300: VersionBreakingChange = {
         `- "White Ferrari" was renamed to "${convertV2GangEquipmentNames("White Ferrari")}".\n`,
       showWarning: false,
     },
+    {
+      brokenAPIs: [{ name: "purchaseTixApi" }, { name: "purchase4SMarketData" }],
+      info:
+        "In order to purchase TIX API access and 4S Market Data access, you need to have a WSE account.\n" +
+        "This requirement was only enforced in UI, not NS APIs. Now, it is enforced in both.",
+      showWarning: false,
+    },
   ],
 };


### PR DESCRIPTION
In UI, in order to purchase TIX API access and 4S Market Data access, the player must have a WSE account. However, we have not enforced this requirement in NS APIs. This PR makes this requirement consistent between UI and NS APIs.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  ns.print(ns.stock.purchaseTixApi());
  ns.print(ns.stock.purchase4SMarketData());
}
```

```
In order to purchase TIX API access and 4S Market Data access, you need a WSE account.
This requirement was only enforced in UI, not NS APIs. Now, it is enforced in both.

Usage of the following functions may have been affected:
purchaseTixApi
purchase4SMarketData

Potentially affected files on server home (with line numbers):
test.js: (Line numbers: 4, 5)
```