### PR TITLE
UI: Prevent text from overflowing when script's args are too long in Active Scripts page

### DIFF
--- a/src/ui/ActiveScripts/RecentScriptAccordion.tsx
+++ b/src/ui/ActiveScripts/RecentScriptAccordion.tsx
@@ -77,7 +77,9 @@ export function RecentScriptAccordion(props: IProps): React.ReactElement {
               </TableRow>
               <TableRow>
                 <TableCell className={classes.noborder} colSpan={2}>
-                  <Typography>└ Args: {arrayToString(recentScript.runningScript.args)}</Typography>
+                  <Typography sx={{ overflowWrap: "anywhere" }}>
+                    └ Args: {arrayToString(recentScript.runningScript.args)}
+                  </Typography>
                 </TableCell>
               </TableRow>
               <TableRow>

--- a/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
+++ b/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
@@ -68,7 +68,7 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
       <ListItemButton onClick={() => setOpen((old) => !old)} component={Paper}>
         <ListItemText
           primary={
-            <Typography style={{ wordWrap: "break-word" }}>
+            <Typography sx={{ overflowWrap: "break-word" }}>
               └ {props.workerScript.name} {JSON.stringify(props.workerScript.args)}
             </Typography>
           }
@@ -89,7 +89,9 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
               </TableRow>
               <TableRow>
                 <TableCell className={classes.noborder} colSpan={2}>
-                  <Typography>└ Args: {arrayToString(props.workerScript.args)}</Typography>
+                  <Typography sx={{ overflowWrap: "anywhere" }}>
+                    └ Args: {arrayToString(props.workerScript.args)}
+                  </Typography>
                 </TableCell>
               </TableRow>
               <TableRow>


### PR DESCRIPTION
It's just as the title said.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  const params = {
    server1: "server-server",
    ts1: Date.now(),
    ts2: Date.now(),
    ts3: Date.now(),
    ts4: Date.now(),
    ts5: Date.now(),
    ts6: Date.now(),
    ts7: Date.now(),
    ts8: Date.now(),
    ts9: Date.now(),
    ts10: Date.now(),
    ts11: Date.now(),
  };
  ns.run("b.js", 1, JSON.stringify(params));
  ns.run("b.js", 1, "111111111111111111111111111112222222222222222222222222222222222223333333333333333333333333333333333333334444444444444444444444444444444444444444444");
  while (true) {
    await ns.sleep(1000);
  }
}
```

Before:

<img width="1043" height="655" alt="before" src="https://github.com/user-attachments/assets/c4111b39-9b09-4d8a-a47b-5c60b4bf31b9" />

After:

<img width="1054" height="639" alt="after" src="https://github.com/user-attachments/assets/98c56117-0860-4201-8ecf-dfc16f4f989b" />
