### PR TITLE
CODEBASE: Add more debug info for troubleshooting corporation issues

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -161,9 +161,11 @@ export class Division {
     //Then calculate salaries and process the markets
     if (state === "START") {
       if (isNaN(this.thisCycleRevenue) || isNaN(this.thisCycleExpenses)) {
-        console.error("NaN in Corporation's computed revenue/expenses");
-        dialogBoxCreate(
-          "Something went wrong when compting Corporation's revenue/expenses. This is a bug. Please report to game developer",
+        exceptionAlert(
+          new Error(
+            `Invalid revenue/expenses. thisCycleRevenue: ${this.thisCycleRevenue}. thisCycleExpenses: ${this.thisCycleExpenses}`,
+          ),
+          true,
         );
         this.thisCycleRevenue = 0;
         this.thisCycleExpenses = 0;

--- a/src/Corporation/Warehouse.ts
+++ b/src/Corporation/Warehouse.ts
@@ -65,7 +65,10 @@ export class Warehouse {
       this.sizeUsed += mat.stored * MaterialInfo[matName].size;
     }
     if (this.sizeUsed > this.size) {
-      console.warn("Warehouse size used greater than capacity, something went wrong");
+      console.warn(
+        `Warehouse size used greater than capacity, something went wrong. sizeUsed: ${this.sizeUsed}. size: ${this.size}`,
+        this,
+      );
     }
   }
 


### PR DESCRIPTION
I sometimes see the warning about the warehouse size, but I have not found a way to consistently reproduce it. This PR adds more debug info for troubleshooting that issue. I also use `exceptionAlert` instead of `dialogBoxCreate` in the case of invalid `thisCycleRevenue` and `thisCycleExpenses`.