### PR TITLE
TOOLS: Update doc.sh

### DIFF
--- a/tools/doc.sh
+++ b/tools/doc.sh
@@ -11,11 +11,14 @@ echo ""
 echo "Running cleanup tasks..."
 rm input/bitburner.api.json && rm -r input
 
-# This git add is needed due to documenter using wrong line endings. Console spam discarded.
-git add markdown/ 2> /dev/null && git add tsdoc-metadata.json 2> /dev/null
-echo ""
-echo "Documentation build completed."
-
 echo ""
 echo "Bundling ingame documentation..."
 node tools/bundle-doc/index.js
+
+echo ""
+echo "Add generated docs to git..."
+# This git add is needed due to documenter using wrong line endings. Console spam discarded.
+git add markdown/ 2> /dev/null && git add tsdoc-metadata.json 2> /dev/null
+
+echo ""
+echo "Documentation build completed."

--- a/tools/doc.sh
+++ b/tools/doc.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-echo "Bundling ingame documentation..."
-node tools/bundle-doc/index.js
-
-echo ""
 echo "Using API Extractor to generate mappings for Netscript API definitions..."
 npx api-extractor run
 
@@ -19,3 +15,7 @@ rm input/bitburner.api.json && rm -r input
 git add markdown/ 2> /dev/null && git add tsdoc-metadata.json 2> /dev/null
 echo ""
 echo "Documentation build completed."
+
+echo ""
+echo "Bundling ingame documentation..."
+node tools/bundle-doc/index.js


### PR DESCRIPTION
Currently, if there are new md files generated by `api-documenter`, they won't be included in `src\Documentation\pages.ts` because `tools/bundle-doc/index.js` runs before `api-documenter`. This PR changes the order of tools in `doc.sh` to fix it.