### PR TITLE
JEST: Quiet Jest tests output on expected failures

### DIFF
--- a/test/jest/Netscript/UserInterface.test.ts
+++ b/test/jest/Netscript/UserInterface.test.ts
@@ -81,7 +81,7 @@ describe("setTheme", () => {
       expect(result.primary).toStrictEqual(defaultTheme.primary);
     });
     afterEach(() => {
-      jest.restoreAllMocks(); // e.g. console.error
+      spyConErr.mockRestore();
     });
   });
 });
@@ -156,7 +156,7 @@ describe("setStyles", () => {
       expect(result.fontFamily).toStrictEqual(defaultStyles.fontFamily);
     });
     afterEach(() => {
-      jest.restoreAllMocks();
+      spyConErr.mockRestore();
     });
   });
 });

--- a/test/jest/Netscript/UserInterface.test.ts
+++ b/test/jest/Netscript/UserInterface.test.ts
@@ -6,6 +6,7 @@ import { getNS, initGameEnvironment, setupBasicTestingEnvironment } from "./Util
 
 const themeHexColor = "#abc";
 const fontFamily = "monospace";
+const ceRestore = console.error; // to restore from mocked function
 
 beforeAll(() => {
   initGameEnvironment();
@@ -57,6 +58,9 @@ describe("setTheme", () => {
   });
 
   describe("Failure", () => {
+    beforeEach(() => {
+      console.error = jest.fn(); // Silence expected errors
+    });
     test("Full theme", () => {
       const ns = getNS();
       const newTheme = ns.ui.getTheme();
@@ -73,6 +77,9 @@ describe("setTheme", () => {
       ns.ui.setTheme(newTheme as unknown as UserInterfaceTheme);
       const result = ns.ui.getTheme();
       expect(result.primary).toStrictEqual(defaultTheme.primary);
+    });
+    afterEach(() => {
+      console.error = ceRestore; // Restore to original function
     });
   });
 });
@@ -123,6 +130,9 @@ describe("setStyles", () => {
   });
 
   describe("Failure", () => {
+    beforeEach(() => {
+      console.error = jest.fn(); // silence expected errors
+    });
     test("Full styles", () => {
       const ns = getNS();
       const newStyles = ns.ui.getStyles();
@@ -139,6 +149,9 @@ describe("setStyles", () => {
       ns.ui.setStyles(newStyles as unknown as IStyleSettings);
       const result = ns.ui.getStyles();
       expect(result.fontFamily).toStrictEqual(defaultStyles.fontFamily);
+    });
+    afterEach(() => {
+      console.error = ceRestore; // restore original functionality
     });
   });
 });

--- a/test/jest/Netscript/UserInterface.test.ts
+++ b/test/jest/Netscript/UserInterface.test.ts
@@ -6,7 +6,6 @@ import { getNS, initGameEnvironment, setupBasicTestingEnvironment } from "./Util
 
 const themeHexColor = "#abc";
 const fontFamily = "monospace";
-const ceRestore = console.error; // to restore from mocked function
 
 beforeAll(() => {
   initGameEnvironment();
@@ -58,8 +57,9 @@ describe("setTheme", () => {
   });
 
   describe("Failure", () => {
+    let spyConErr: jest.Spied<typeof console.error>;
     beforeEach(() => {
-      console.error = jest.fn(); // Silence expected errors
+      spyConErr = jest.spyOn(console, "error").mockImplementation(() => null);
     });
     test("Full theme", () => {
       const ns = getNS();
@@ -67,6 +67,7 @@ describe("setTheme", () => {
       newTheme.primary = "";
       ns.ui.setTheme(newTheme);
       const result = ns.ui.getTheme();
+      expect(spyConErr).toHaveBeenCalled();
       expect(result.primary).toStrictEqual(defaultTheme.primary);
     });
     test("Partial theme", () => {
@@ -76,10 +77,11 @@ describe("setTheme", () => {
       };
       ns.ui.setTheme(newTheme as unknown as UserInterfaceTheme);
       const result = ns.ui.getTheme();
+      expect(spyConErr).toHaveBeenCalled();
       expect(result.primary).toStrictEqual(defaultTheme.primary);
     });
     afterEach(() => {
-      console.error = ceRestore; // Restore to original function
+      jest.restoreAllMocks(); // e.g. console.error
     });
   });
 });
@@ -130,8 +132,9 @@ describe("setStyles", () => {
   });
 
   describe("Failure", () => {
+    let spyConErr: jest.Spied<typeof console.error>;
     beforeEach(() => {
-      console.error = jest.fn(); // silence expected errors
+      spyConErr = jest.spyOn(console, "error").mockImplementation(() => null);
     });
     test("Full styles", () => {
       const ns = getNS();
@@ -139,6 +142,7 @@ describe("setStyles", () => {
       (newStyles.fontFamily as unknown) = 123;
       ns.ui.setStyles(newStyles);
       const result = ns.ui.getStyles();
+      expect(spyConErr).toHaveBeenCalled();
       expect(result.fontFamily).toStrictEqual(defaultStyles.fontFamily);
     });
     test("Partial styles", () => {
@@ -148,10 +152,11 @@ describe("setStyles", () => {
       };
       ns.ui.setStyles(newStyles as unknown as IStyleSettings);
       const result = ns.ui.getStyles();
+      expect(spyConErr).toHaveBeenCalled();
       expect(result.fontFamily).toStrictEqual(defaultStyles.fontFamily);
     });
     afterEach(() => {
-      console.error = ceRestore; // restore original functionality
+      jest.restoreAllMocks();
     });
   });
 });

--- a/test/jest/Save.test.ts
+++ b/test/jest/Save.test.ts
@@ -8,8 +8,6 @@ import { PlayerObject } from "../../src/PersonObjects/Player/PlayerObject";
 import { UIEventEmitter, UIEventType } from "../../src/ui/UIEventEmitter";
 jest.useFakeTimers();
 
-const ceRestore = console.error; // store original fn, so we can mock & restore it
-
 // Direct tests of loading and saving.
 // Tests here should try to be comprehensive (cover as much stuff as possible)
 // without requiring burdensome levels of maintenance when legitimate changes
@@ -166,10 +164,6 @@ test("load/saveAllServers", () => {
   expect(JSON.stringify(JSON.parse(result), null, 2)).toMatchSnapshot();
 });
 
-beforeEach(() => {
-  console.error = jest.fn();
-});
-
 test("load/saveAllServers pruning RunningScripts", () => {
   // Feed a JSON object through loadAllServers/saveAllServers.
   // The object is a pruned set of servers that was extracted from a real (dev) game.
@@ -180,8 +174,4 @@ test("load/saveAllServers pruning RunningScripts", () => {
   Settings.ExcludeRunningScriptsFromSave = true;
   const result = saveAllServers();
   expect(JSON.stringify(JSON.parse(result), null, 2)).toMatchSnapshot();
-});
-
-afterEach(() => {
-  console.error = ceRestore;
 });

--- a/test/jest/Save.test.ts
+++ b/test/jest/Save.test.ts
@@ -8,6 +8,8 @@ import { PlayerObject } from "../../src/PersonObjects/Player/PlayerObject";
 import { UIEventEmitter, UIEventType } from "../../src/ui/UIEventEmitter";
 jest.useFakeTimers();
 
+const ceRestore = console.error; // store original fn, so we can mock & restore it
+
 // Direct tests of loading and saving.
 // Tests here should try to be comprehensive (cover as much stuff as possible)
 // without requiring burdensome levels of maintenance when legitimate changes
@@ -164,6 +166,10 @@ test("load/saveAllServers", () => {
   expect(JSON.stringify(JSON.parse(result), null, 2)).toMatchSnapshot();
 });
 
+beforeEach(() => {
+  console.error = jest.fn();
+});
+
 test("load/saveAllServers pruning RunningScripts", () => {
   // Feed a JSON object through loadAllServers/saveAllServers.
   // The object is a pruned set of servers that was extracted from a real (dev) game.
@@ -174,4 +180,8 @@ test("load/saveAllServers pruning RunningScripts", () => {
   Settings.ExcludeRunningScriptsFromSave = true;
   const result = saveAllServers();
   expect(JSON.stringify(JSON.parse(result), null, 2)).toMatchSnapshot();
+});
+
+afterEach(() => {
+  console.error = ceRestore;
 });


### PR DESCRIPTION
This patch quiets the console.error output on expected failures that are suppose to occur during `npm test`. It mocks and restores the console.error function.

For `UserInterface.test.ts` it is limited to only tests that are expected to fail.

In case of `Save.test.ts` is written as a single test, so console.error is muted for the entire test.
 