### PR TITLE
DOCUMENTATION: Clarify cross-host characteristic of PID and port

### DIFF
--- a/markdown/bitburner.ns.exec.md
+++ b/markdown/bitburner.ns.exec.md
@@ -110,7 +110,7 @@ Run a script as a separate process on a specified server. This is similar to the
 
 If the script was successfully started, then this function returns the PID of that script. Otherwise, it returns 0.
 
-PID stands for Process ID. The PID is a unique identifier for each script. The PID will always be a positive integer.
+PID stands for Process ID. The PID is a unique identifier for each script across all hosts. The PID will always be a positive integer.
 
 Running this function with 0 or fewer threads will cause a runtime error.
 

--- a/markdown/bitburner.ns.getporthandle.md
+++ b/markdown/bitburner.ns.getporthandle.md
@@ -56,5 +56,5 @@ Port number. Must be a positive integer.
 
 RAM cost: 0 GB
 
-Get a handle to a Netscript Port.
+Get a handle to a Netscript Port. Ports are shared across all hosts and contents are reset on game restart.
 

--- a/markdown/bitburner.ns.kill.md
+++ b/markdown/bitburner.ns.kill.md
@@ -58,7 +58,7 @@ True if the script is successfully killed, and false otherwise.
 
 RAM cost: 0.5 GB
 
-Kills the script with the provided PID. To instead kill a script using its filename, host, and args, see [the other ns.kill entry](./bitburner.ns.kill_1.md)<!-- -->.
+Kills the script with the provided PID. PIDs are unique across all hosts. To instead kill a script using its filename, host, and args, see [the other ns.kill entry](./bitburner.ns.kill_1.md)<!-- -->.
 
 ## Example
 

--- a/markdown/bitburner.ns.nextportwrite.md
+++ b/markdown/bitburner.ns.nextportwrite.md
@@ -56,5 +56,5 @@ Promise&lt;void&gt;
 
 RAM cost: 0 GB
 
-Sleeps until the port is written to.
+Sleeps until the port is written to. Ports are shared across all hosts and contents are reset on game restart.
 

--- a/markdown/bitburner.ns.peek.md
+++ b/markdown/bitburner.ns.peek.md
@@ -58,5 +58,5 @@ Data in the specified port.
 
 RAM cost: 0 GB
 
-This function is used to peek at the data from a port. It returns the first element in the specified port without removing that element. If the port is empty, the string “NULL PORT DATA” will be returned.
+This function is used to peek at the data from a port. It returns the first element in the specified port without removing that element. If the port is empty, the string “NULL PORT DATA” will be returned. Ports are shared across all hosts and contents are reset on game restart.
 

--- a/markdown/bitburner.ns.readport.md
+++ b/markdown/bitburner.ns.readport.md
@@ -58,5 +58,5 @@ The data read.
 
 RAM cost: 0 GB
 
-Read data from that port. A port is a serialized queue. This function will remove the first element from that queue and return it. If the queue is empty, then the string “NULL PORT DATA” will be returned. Ports are shared across all hosts.
+Read data from that port. A port is a serialized queue. This function will remove the first element from that queue and return it. If the queue is empty, then the string “NULL PORT DATA” will be returned. Ports are shared across all hosts and contents are reset on game restart.
 

--- a/markdown/bitburner.ns.readport.md
+++ b/markdown/bitburner.ns.readport.md
@@ -58,5 +58,5 @@ The data read.
 
 RAM cost: 0 GB
 
-Read data from that port. A port is a serialized queue. This function will remove the first element from that queue and return it. If the queue is empty, then the string “NULL PORT DATA” will be returned.
+Read data from that port. A port is a serialized queue. This function will remove the first element from that queue and return it. If the queue is empty, then the string “NULL PORT DATA” will be returned. Ports are shared across all hosts.
 

--- a/markdown/bitburner.ns.run.md
+++ b/markdown/bitburner.ns.run.md
@@ -96,7 +96,7 @@ The second argument is either a thread count, or a [RunOptions](./bitburner.runo
 
 If the script was successfully started, then this functions returns the PID of that script. Otherwise, it returns 0.
 
-PID stands for Process ID. The PID is a unique identifier for each script. The PID will always be a positive integer.
+PID stands for Process ID. The PID is a unique identifier for each script across all hosts. The PID will always be a positive integer.
 
 Running this function with 0 or fewer threads will cause a runtime error.
 

--- a/markdown/bitburner.ns.trywriteport.md
+++ b/markdown/bitburner.ns.trywriteport.md
@@ -74,5 +74,5 @@ True if the data is successfully written to the port, and false otherwise.
 
 RAM cost: 0 GB
 
-Attempts to write data to the specified Netscript port. If the port is full, the data will not be written. Otherwise, the data will be written normally. Ports are shared across all hosts.
+Attempts to write data to the specified Netscript port. If the port is full, the data will not be written. Otherwise, the data will be written normally. Ports are shared across all hosts and contents are reset on game restart.
 

--- a/markdown/bitburner.ns.trywriteport.md
+++ b/markdown/bitburner.ns.trywriteport.md
@@ -74,5 +74,5 @@ True if the data is successfully written to the port, and false otherwise.
 
 RAM cost: 0 GB
 
-Attempts to write data to the specified Netscript port. If the port is full, the data will not be written. Otherwise, the data will be written normally.
+Attempts to write data to the specified Netscript port. If the port is full, the data will not be written. Otherwise, the data will be written normally. Ports are shared across all hosts.
 

--- a/markdown/bitburner.ns.writeport.md
+++ b/markdown/bitburner.ns.writeport.md
@@ -76,5 +76,5 @@ RAM cost: 0 GB
 
 Write data to the given Netscript port.
 
-There is a limit on the maximum number of ports, but you won't reach that limit in normal situations. If you do, it usually means that there is a bug in your script that leaks port data. A port is freed when it does not have any data in its underlying queue. `ns.clearPort` deletes all data on a port. `ns.readPort` reads the first element in the port's queue, then removes it from the queue.
+There is a limit on the maximum number of ports, but you won't reach that limit in normal situations. If you do, it usually means that there is a bug in your script that leaks port data. A port is freed when it does not have any data in its underlying queue. `ns.clearPort` deletes all data on a port. `ns.readPort` reads the first element in the port's queue, then removes it from the queue. Ports are shared across all hosts and contents are reset on game restart.
 

--- a/markdown/bitburner.runningscript.md
+++ b/markdown/bitburner.runningscript.md
@@ -262,7 +262,7 @@ number
 
 </td><td>
 
-A Process ID unique to this script across all hosts. Must be an integer starting from 0 as the first process spawned at game launch and incrementing from there. Note that PIDs are not saved in the savegame and are regenerated at launch.
+A Process ID unique to this script across all hosts. Must be an integer starting from 1 for the first process spawned at game launch and incrementing from there. Note that PIDs are not saved in the savegame and are regenerated at launch.
 
 
 </td></tr>

--- a/markdown/bitburner.runningscript.md
+++ b/markdown/bitburner.runningscript.md
@@ -262,7 +262,7 @@ number
 
 </td><td>
 
-Process ID. Must be an integer
+A Process ID unique to this script across all hosts. Must be an integer starting from 0 as the first process spawned at game launch and incrementing from there. Note that PIDs are not saved in the savegame and are regenerated at launch.
 
 
 </td></tr>

--- a/markdown/bitburner.runningscript.pid.md
+++ b/markdown/bitburner.runningscript.pid.md
@@ -4,7 +4,7 @@
 
 ## RunningScript.pid property
 
-Process ID. Must be an integer
+A Process ID unique to this script across all hosts. Must be an integer starting from 0 as the first process spawned at game launch and incrementing from there. Note that PIDs are not saved in the savegame and are regenerated at launch.
 
 **Signature:**
 

--- a/markdown/bitburner.runningscript.pid.md
+++ b/markdown/bitburner.runningscript.pid.md
@@ -4,7 +4,7 @@
 
 ## RunningScript.pid property
 
-A Process ID unique to this script across all hosts. Must be an integer starting from 0 as the first process spawned at game launch and incrementing from there. Note that PIDs are not saved in the savegame and are regenerated at launch.
+A Process ID unique to this script across all hosts. Must be an integer starting from 1 for the first process spawned at game launch and incrementing from there. Note that PIDs are not saved in the savegame and are regenerated at launch.
 
 **Signature:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -265,7 +265,7 @@ interface RunningScript {
   /** Number of seconds that this script has been running online */
   onlineRunningTime: number;
   /** A Process ID unique to this script across all hosts. Must be an integer starting
-   * from 0 as the first process spawned at game launch and incrementing from there.
+   * from 1 for the first process spawned at game launch and incrementing from there.
    * Note that PIDs are not saved in the savegame and are regenerated at launch.
    */
   pid: number;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -264,7 +264,10 @@ interface RunningScript {
   onlineMoneyMade: number;
   /** Number of seconds that this script has been running online */
   onlineRunningTime: number;
-  /** Process ID. Must be an integer */
+  /** A Process ID unique to this script across all hosts. Must be an integer starting
+   * from 0 as the first process spawned at game launch and incrementing from there.
+   * Note that PIDs are not saved in the savegame and are regenerated at launch.
+   */
   pid: number;
   /**
    * Process ID of the parent process.
@@ -7003,7 +7006,7 @@ export interface NS {
    * If the script was successfully started, then this functions returns the PID of that script.
    * Otherwise, it returns 0.
    *
-   * PID stands for Process ID. The PID is a unique identifier for each script.
+   * PID stands for Process ID. The PID is a unique identifier for each script across all hosts.
    * The PID will always be a positive integer.
    *
    * Running this function with 0 or fewer threads will cause a runtime error.
@@ -7037,7 +7040,7 @@ export interface NS {
    * If the script was successfully started, then this function returns the PID of that script.
    * Otherwise, it returns 0.
    *
-   * PID stands for Process ID. The PID is a unique identifier for each script.
+   * PID stands for Process ID. The PID is a unique identifier for each script across all hosts.
    * The PID will always be a positive integer.
    *
    * Running this function with 0 or fewer threads will cause a runtime error.
@@ -7715,6 +7718,7 @@ export interface NS {
    * Attempts to write data to the specified Netscript port.
    * If the port is full, the data will not be written.
    * Otherwise, the data will be written normally.
+   * Ports are shared across all hosts and contents are reset on game restart.
    *
    * @param portNumber - Port to attempt to write to. Must be a positive integer.
    * @param data - Data to write, it's cloned with structuredClone().
@@ -7728,6 +7732,7 @@ export interface NS {
    * RAM cost: 0 GB
    *
    * Sleeps until the port is written to.
+   * Ports are shared across all hosts and contents are reset on game restart.
    *
    * @param port - Port to listen for a write on. Must be a positive integer.
    */
@@ -7769,6 +7774,7 @@ export interface NS {
    * This function is used to peek at the data from a port. It returns the
    * first element in the specified port without removing that element. If
    * the port is empty, the string “NULL PORT DATA” will be returned.
+   * Ports are shared across all hosts and contents are reset on game restart.
    *
    * @param portNumber - Port to peek. Must be a positive integer.
    * @returns Data in the specified port.
@@ -7808,6 +7814,7 @@ export interface NS {
    * usually means that there is a bug in your script that leaks port data. A port is freed when it does not have any
    * data in its underlying queue. `ns.clearPort` deletes all data on a port. `ns.readPort` reads the first element in
    * the port's queue, then removes it from the queue.
+   * Ports are shared across all hosts and contents are reset on game restart.
    *
    * @param portNumber - Port to write to. Must be a positive integer.
    * @param data - Data to write, it's cloned with structuredClone().
@@ -7823,7 +7830,8 @@ export interface NS {
    * Read data from that port. A port is a serialized queue.
    * This function will remove the first element from that queue and return it.
    * If the queue is empty, then the string “NULL PORT DATA” will be returned.
-   * Ports are shared across all hosts.
+   * Ports are shared across all hosts and contents are reset on game restart.
+   *
    * @param portNumber - Port to read from. Must be a positive integer.
    * @returns The data read.
    */
@@ -7835,6 +7843,7 @@ export interface NS {
    * RAM cost: 0 GB
    *
    * Get a handle to a Netscript Port.
+   * Ports are shared across all hosts and contents are reset on game restart.
    *
    * @param portNumber - Port number. Must be a positive integer.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7106,7 +7106,7 @@ export interface NS {
    * @remarks
    * RAM cost: 0.5 GB
    *
-   * Kills the script with the provided PID.
+   * Kills the script with the provided PID. PIDs are unique across all hosts.
    * To instead kill a script using its filename, host, and args, see {@link NS.(kill:2) | the other ns.kill entry}.
    *
    * @example
@@ -7823,6 +7823,7 @@ export interface NS {
    * Read data from that port. A port is a serialized queue.
    * This function will remove the first element from that queue and return it.
    * If the queue is empty, then the string “NULL PORT DATA” will be returned.
+   * Ports are shared across all hosts.
    * @param portNumber - Port to read from. Must be a positive integer.
    * @returns The data read.
    */


### PR DESCRIPTION
CATEGORY: Change Description
# Documentation

- Changed ScriptEditor hover tooltips for ns.kill() and ns.readport() to mention that ports are shared and pids are unique across all hosts. This information was nowhere else in the game to my knowledge.
- I have run  `npm run doc` to autogenerate new markdown files that reflect the changes to NescriptDefinitons.d.ts
- Attached are images reflecting the change in game as requested.
<img width="1587" height="520" alt="Screenshot_20251006_132108-1" src="https://github.com/user-attachments/assets/ba152645-3a17-4ff0-947a-056f75bdea40" />
<img width="1522" height="505" alt="Screenshot_20251006_132157" src="https://github.com/user-attachments/assets/a426addc-d945-44c9-8a11-533239270968" />
I have run `npm run format` and `npm run lint` as requested.

Please let me know if I have screwed any or this up. I have not done this before.
