### PR TITLE
UI: Show server's money in exponential form if it's too small

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -396,7 +396,9 @@ export class Terminal {
         this.print("Time to hack: " + (!isHacknet ? convertTimeMsToTimeElapsedString(hackingTime, true) : "N/A"));
       }
       this.print(
-        `Total money available on server: ${currServ instanceof Server ? formatMoney(currServ.moneyAvailable) : "N/A"}`,
+        `Total money available on server: ${
+          currServ instanceof Server ? formatMoney(currServ.moneyAvailable, true) : "N/A"
+        }`,
       );
       if (currServ instanceof Server) {
         const numPort = currServ.numOpenPortsRequired;


### PR DESCRIPTION
We often receive 2 questions from new players:
- `analyze` CLI shows that the server's money is 0 ("0.000"). Why do I not have the "Big trouble" achievement. [1]
- I ran `hack` command successfully. Why does it say I gain 0 ("0.000") money? [2]

When we display the money in these cases, if the value is too small, it's rounded down to "0.000". This PR fixes [1]. [2] requires a non-UI change, so I'll do it in another PR.

Before:

<img width="423" height="437" alt="before" src="https://github.com/user-attachments/assets/600e93a6-f49b-4027-8219-166abb781428" />

After:

<img width="420" height="439" alt="after" src="https://github.com/user-attachments/assets/072999b6-d1e8-48d4-88a3-98553390b843" />
