### PR TITLE
CLI: Do not round down amount of hacked money in "hack" CLI

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -266,9 +266,9 @@ export class Terminal {
       Engine.Counters.checkFactionInvitations = 0;
       Engine.checkCounters();
 
-      let moneyDrained = Math.floor(server.moneyAvailable * calculatePercentMoneyHacked(server, Player));
+      let moneyDrained = server.moneyAvailable * calculatePercentMoneyHacked(server, Player);
 
-      if (moneyDrained <= 0) {
+      if (moneyDrained < 0) {
         moneyDrained = 0;
       } // Safety check
 
@@ -289,7 +289,7 @@ export class Terminal {
       const newSec = server.hackDifficulty;
 
       this.print(
-        `Hack successful on '${server.hostname}'! Gained ${formatMoney(moneyGained)} and ${formatExp(
+        `Hack successful on '${server.hostname}'! Gained ${formatMoney(moneyGained, true)} and ${formatExp(
           expGainedOnSuccess,
         )} hacking exp`,
       );


### PR DESCRIPTION
Context: #2343.

In `ns.hack`, we also do not round down.

Before:

<img width="522" height="136" alt="before" src="https://github.com/user-attachments/assets/6f259c02-3c58-4329-ad0b-c3741dde49b2" />

After:

<img width="541" height="132" alt="after" src="https://github.com/user-attachments/assets/8aac86af-6759-4d7c-ba9c-e4b5eb7ab373" />
