### PR TITLE
CODEBASE: Follow-up of #2344

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -548,13 +548,14 @@ function hack(ctx: NetscriptContext, hostname: string, manual: boolean, opts: un
       let moneyDrained = server.moneyAvailable * percentHacked * threads;
 
       // Over-the-top safety checks
-      if (moneyDrained <= 0) {
+      if (moneyDrained < 0) {
         moneyDrained = 0;
         expGainedOnSuccess = expGainedOnFailure;
       }
       if (moneyDrained > server.moneyAvailable) {
         moneyDrained = server.moneyAvailable;
       }
+
       server.moneyAvailable -= moneyDrained;
       if (server.moneyAvailable < 0) {
         server.moneyAvailable = 0;

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -550,10 +550,13 @@ function hack(ctx: NetscriptContext, hostname: string, manual: boolean, opts: un
       // Over-the-top safety checks
       if (moneyDrained < 0) {
         moneyDrained = 0;
-        expGainedOnSuccess = expGainedOnFailure;
       }
       if (moneyDrained > server.moneyAvailable) {
         moneyDrained = server.moneyAvailable;
+      }
+
+      if (moneyDrained === 0) {
+        expGainedOnSuccess = expGainedOnFailure;
       }
 
       server.moneyAvailable -= moneyDrained;

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -253,7 +253,7 @@ export class Terminal {
     // Calculate whether hack was successful
     const hackChance = calculateHackingChance(server, Player);
     const rand = Math.random();
-    const expGainedOnSuccess = calculateHackingExpGain(server, Player);
+    let expGainedOnSuccess = calculateHackingExpGain(server, Player);
     const expGainedOnFailure = expGainedOnSuccess / 4;
     if (rand < hackChance) {
       // Success!
@@ -268,9 +268,14 @@ export class Terminal {
 
       let moneyDrained = server.moneyAvailable * calculatePercentMoneyHacked(server, Player);
 
+      // Over-the-top safety checks
       if (moneyDrained < 0) {
         moneyDrained = 0;
-      } // Safety check
+        expGainedOnSuccess = expGainedOnFailure;
+      }
+      if (moneyDrained > server.moneyAvailable) {
+        moneyDrained = server.moneyAvailable;
+      }
 
       server.moneyAvailable -= moneyDrained;
       if (server.moneyAvailable < 0) {

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -271,10 +271,13 @@ export class Terminal {
       // Over-the-top safety checks
       if (moneyDrained < 0) {
         moneyDrained = 0;
-        expGainedOnSuccess = expGainedOnFailure;
       }
       if (moneyDrained > server.moneyAvailable) {
         moneyDrained = server.moneyAvailable;
+      }
+
+      if (moneyDrained === 0) {
+        expGainedOnSuccess = expGainedOnFailure;
       }
 
       server.moneyAvailable -= moneyDrained;


### PR DESCRIPTION
These changes should have been in #2344. This PR makes those "Over-the-top safety checks" the same in both implementations of `hack` CLI and `hack` NS API.

To be honest, these changes are useless. I thought about ignoring them but decided to commit it anyway.