### PR TITLE
DOCUMENTATION: Use alternative fix for newline issue in IPvGO docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,5 @@ indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[src/ScriptEditor/NetscriptDefinitions.d.ts]
-trim_trailing_whitespace = false
-
 [*.md]
 trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,12 +151,6 @@ upstream/master
   - Keep code-changes on a branch as small as possible. This makes it easier for code review. Each branch should be its own independent feature.
   - Regularly rebase your branch against `dev` to make sure you have the latest updates pulled.
 
-### Special Exceptions
-
-- In `src/ScriptEditor/NetscriptDefinitions.d.ts`, there are two specially-formatted go boards with two trailing whitespaces.
-  Make sure your editor does not automatically format those examples.
-  You can look for changes to that part using `git diff` to make sure the whitespaces are still present.
-
 ## Running locally
 
 Install

--- a/markdown/bitburner.go.getboardstate.md
+++ b/markdown/bitburner.go.getboardstate.md
@@ -8,7 +8,19 @@ Retrieves a simplified version of the board state. "X" represents black pieces, 
 
 For example, a 5x5 board might look like this:
 
-\[<br/> "XX.O.",<br/> "X..OO",<br/> ".XO..",<br/> "XXO.\#",<br/> ".XO.\#",<br/> \]
+\[
+
+"XX.O.",
+
+"X..OO",
+
+".XO..",
+
+"XXO.\#",
+
+".XO.\#",
+
+\]
 
 Each string represents a vertical column on the board, and each character in the string represents a point.
 

--- a/markdown/bitburner.go.getmovehistory.md
+++ b/markdown/bitburner.go.getmovehistory.md
@@ -8,7 +8,19 @@ Returns all the prior moves in the current game, as an array of simple board sta
 
 For example, a single 5x5 prior move board might look like this:
 
-\[<br/> "XX.O.",<br/> "X..OO",<br/> ".XO..",<br/> "XXO.\#",<br/> ".XO.\#",<br/> \]
+\[
+
+"XX.O.",
+
+"X..OO",
+
+".XO..",
+
+"XXO.\#",
+
+".XO.\#",
+
+\]
 
 **Signature:**
 

--- a/markdown/bitburner.go.md
+++ b/markdown/bitburner.go.md
@@ -99,7 +99,19 @@ Retrieves a simplified version of the board state. "X" represents black pieces, 
 
 For example, a 5x5 board might look like this:
 
-\[<br/> "XX.O.",<br/> "X..OO",<br/> ".XO..",<br/> "XXO.\#",<br/> ".XO.\#",<br/> \]
+\[
+
+"XX.O.",
+
+"X..OO",
+
+".XO..",
+
+"XXO.\#",
+
+".XO.\#",
+
+\]
 
 Each string represents a vertical column on the board, and each character in the string represents a point.
 
@@ -142,7 +154,19 @@ Returns all the prior moves in the current game, as an array of simple board sta
 
 For example, a single 5x5 prior move board might look like this:
 
-\[<br/> "XX.O.",<br/> "X..OO",<br/> ".XO..",<br/> "XXO.\#",<br/> ".XO.\#",<br/> \]
+\[
+
+"XX.O.",
+
+"X..OO",
+
+".XO..",
+
+"XXO.\#",
+
+".XO.\#",
+
+\]
 
 
 </td></tr>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4935,13 +4935,19 @@ export interface Go {
    *
    * For example, a 5x5 board might look like this:
    *
-   [<br/>  
-      "XX.O.",<br/>  
-      "X..OO",<br/>  
-      ".XO..",<br/>  
-      "XXO.#",<br/>  
-      ".XO.#",<br/>  
-   ]
+   *[
+   *
+   *  "XX.O.",
+   *
+   *  "X..OO",
+   *
+   *  ".XO..",
+   *
+   *  "XXO.#",
+   *
+   *  ".XO.#",
+   *
+   *]
    *
    * Each string represents a vertical column on the board, and each character in the string represents a point.
    *
@@ -4961,13 +4967,19 @@ export interface Go {
    *
    * For example, a single 5x5 prior move board might look like this:
    *
-   [<br/>  
-      "XX.O.",<br/>  
-      "X..OO",<br/>  
-      ".XO..",<br/>  
-      "XXO.#",<br/>  
-      ".XO.#",<br/>  
-   ]
+   *[
+   *
+   *  "XX.O.",
+   *
+   *  "X..OO",
+   *
+   *  ".XO..",
+   *
+   *  "XXO.#",
+   *
+   *  ".XO.#",
+   *
+   *]
    */
   getMoveHistory(): string[][];
 


### PR DESCRIPTION
In #1171, I fixed the newline issue with `<br/>` and 2 space characters. It works, but it comes with a downside: other contributors have to know that those space characters are intentional. However, some IDEs tend to remove them by default. #2137 mitigates this problem a bit.

While working on dnet PR, I see that these space characters are removed again. I think we should use the alternative fix that I mentioned in #1171. The space between each line looks too big, so I did not use it, but I changed my mind now.