### PR TITLE
UI: Format the shared RAM multipler on the factions

### DIFF
--- a/src/Faction/ui/ShareOption.tsx
+++ b/src/Faction/ui/ShareOption.tsx
@@ -13,7 +13,7 @@ import {
   ShareBonusTime,
   startSharing,
 } from "../../NetworkShare/Share";
-import { formatRam } from "../../ui/formatNumber";
+import { formatRam, formatNumber } from "../../ui/formatNumber";
 import { dialogBoxCreate } from "../../ui/React/DialogBox";
 import { useCycleRerender } from "../../ui/React/hooks";
 import { roundToTwo } from "../../utils/helpers/roundToTwo";
@@ -62,8 +62,8 @@ export function ShareOption({ rerender }: { rerender: () => void }): React.React
         <br />
         Free RAM on home computer: {formatRam(home.maxRam - home.ramUsed)}.
         <br />
-        Current bonus: {calculateCurrentShareBonus()}. Bonus with {formatRam(ram)}:{" "}
-        {calculateShareBonusWithAdditionalThreads(threads, home.cpuCores)}
+        Current bonus: {formatNumber(calculateCurrentShareBonus())}. Bonus with {formatRam(ram)}:{" "}
+        {formatNumber(calculateShareBonusWithAdditionalThreads(threads, home.cpuCores))}
       </Typography>
 
       <TextField

--- a/src/Faction/ui/ShareOption.tsx
+++ b/src/Faction/ui/ShareOption.tsx
@@ -62,8 +62,8 @@ export function ShareOption({ rerender }: { rerender: () => void }): React.React
         <br />
         Free RAM on home computer: {formatRam(home.maxRam - home.ramUsed)}.
         <br />
-        Current bonus: {formatNumber(calculateCurrentShareBonus())}. Bonus with {formatRam(ram)}:{" "}
-        {formatNumber(calculateShareBonusWithAdditionalThreads(threads, home.cpuCores))}
+        Current bonus: {formatNumber(calculateCurrentShareBonus(), 6)}. Bonus with {formatRam(ram)}:{" "}
+        {formatNumber(calculateShareBonusWithAdditionalThreads(threads, home.cpuCores), 6)}
       </Typography>
 
       <TextField


### PR DESCRIPTION
root page. Uses default 3 decimal places, which is sufficient for showing the effect of a single thread on most(?) nodes.

Passes `npm run format:report` and `npm run lint:report`.

Before:

<img width="888" height="208" alt="before" src="https://github.com/user-attachments/assets/098360f5-23bd-4ac0-a110-6ed8d471e1b7" />

After:

<img width="893" height="209" alt="after" src="https://github.com/user-attachments/assets/fc4e3beb-3b3b-4588-9fec-6fd6dc8c78a9" />
