### PR TITLE
CODEBASE: Remove redundant check in getServer utility function and serverExists API

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -472,15 +472,16 @@ function scriptIdentifier(
 }
 
 /**
- * Gets the Server for a specific hostname/ip, throwing an error
- * if the server doesn't exist.
+ * Gets the server with a specific hostname/ip. Throw an error if the server does not exist or it is an isolated
+ * server (e.g., pre-TOR darkweb, pre-TRP WD).
+ *
  * @param {NetscriptContext} ctx - Context from which getServer is being called. For logging purposes.
  * @param {string} hostname - Hostname of the server
  * @returns {BaseServer} The specified server as a BaseServer
  */
 function getServer(ctx: NetscriptContext, hostname: string): BaseServer {
   const server = GetServer(hostname);
-  if (server == null || (server.serversOnNetwork.length == 0 && server.hostname != "home")) {
+  if (server == null || server.serversOnNetwork.length === 0) {
     const str = hostname === "" ? "'' (empty string)" : "'" + hostname + "'";
     throw errorMessage(ctx, `Invalid hostname: ${str}`);
   }

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1023,7 +1023,7 @@ export const ns: InternalAPI<NSFull> = {
   serverExists: (ctx) => (_host) => {
     const host = helpers.string(ctx, "host", _host);
     const server = GetServer(host);
-    return server !== null && (server.serversOnNetwork.length > 0 || server.hostname === "home");
+    return server !== null && server.serversOnNetwork.length > 0;
   },
   fileExists: (ctx) => (_filename, _host) => {
     const filename = helpers.string(ctx, "filename", _filename);

--- a/test/jest/Netscript/DisableLog.test.ts
+++ b/test/jest/Netscript/DisableLog.test.ts
@@ -1,92 +1,87 @@
 import type { Script } from "../../../src/Script/Script";
 import type { ScriptFilePath } from "../../../src/Paths/ScriptFilePath";
-import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
-import { Server } from "../../../src/Server/Server";
 import { RunningScript } from "../../../src/Script/RunningScript";
 import { CompletedProgramName } from "../../../src/Programs/Enums";
 import { WorkerScript } from "../../../src/Netscript/WorkerScript";
 import { NetscriptFunctions } from "../../../src/NetscriptFunctions";
-import { AddToAllServers, DeleteServer } from "../../../src/Server/AllServers";
+import { initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
+import { Player } from "@player";
+
+initGameEnvironment();
+
+beforeEach(() => {
+  setupBasicTestingEnvironment();
+});
 
 test("Edge cases of disableLog", function () {
-  // Ensure that formatting functions work properly
-  FormatsNeedToChange.emit();
-  let server;
-  try {
-    server = new Server({ hostname: "home", adminRights: true, maxRam: 8 });
-    server.programs.push(CompletedProgramName.bruteSsh, CompletedProgramName.ftpCrack);
-    AddToAllServers(server);
-    // We don't need this script to be runnable, it just needs to exist so that
-    // we can create a RunningScript and WorkerScript object.
-    expect(server.writeToScriptFile("test.js" as ScriptFilePath, "")).toEqual({ overwritten: false });
-    const script = server.scripts.get("test.js" as ScriptFilePath) as Script;
+  const server = Player.getHomeComputer();
+  server.programs.push(CompletedProgramName.bruteSsh, CompletedProgramName.ftpCrack);
+  // We don't need this script to be runnable, it just needs to exist so that
+  // we can create a RunningScript and WorkerScript object.
+  expect(server.writeToScriptFile("test.js" as ScriptFilePath, "")).toEqual({ overwritten: false });
+  const script = server.scripts.get("test.js" as ScriptFilePath) as Script;
 
-    const runningScript = new RunningScript(script, 2);
-    const ws = new WorkerScript(runningScript, 1, NetscriptFunctions);
+  const runningScript = new RunningScript(script, 2);
+  const ws = new WorkerScript(runningScript, 1, NetscriptFunctions);
 
-    const ns = ws.env.vars;
-    if (!ns) {
-      throw new Error("Invalid ws.env.vars");
-    }
-
-    // Generate logs in a specific pattern that checks edge cases in
-    // disableLog. We want to check various combinations of things that
-    // are/aren't disabled, as well as previously disabled.
-    ns.brutessh("home");
-    ns.ftpcrack("home");
-    ns.print("before disableLog ALL");
-
-    expect(() => ns.disableLog("all")).toThrow("Invalid argument: all.");
-    ns.disableLog("ALL");
-
-    ns.brutessh("home");
-    ns.ftpcrack("home");
-    ns.print("after disableLog ALL");
-
-    ns.enableLog("brutessh");
-    ns.brutessh("home");
-    ns.ftpcrack("home");
-    ns.print("after enableLog brutessh");
-
-    ns.disableLog("brutessh");
-    ns.enableLog("ftpcrack");
-    ns.brutessh("home");
-    ns.ftpcrack("home");
-    ns.print("after enableLog ftpcrack");
-
-    ns.enableLog("ftpcrack");
-    ns.brutessh("home");
-    ns.ftpcrack("home");
-
-    ns.print("after redundant enable");
-    ns.disableLog("ALL");
-    ns.brutessh("home");
-    ns.ftpcrack("home");
-    ns.enableLog("ALL");
-    ns.brutessh("home");
-    ns.ftpcrack("home");
-    ns.print("end");
-
-    expect(runningScript.logs).toEqual([
-      "brutessh: Executed BruteSSH.exe on 'home' to open SSH port (22).",
-      "ftpcrack: Executed FTPCrack.exe on 'home' to open FTP port (21).",
-      "before disableLog ALL",
-      "disableLog: Invalid argument: all.",
-      "after disableLog ALL",
-      "brutessh: SSH Port (22) already opened on 'home'.",
-      "after enableLog brutessh",
-      "ftpcrack: FTP Port (21) already opened on 'home'.",
-      "after enableLog ftpcrack",
-      "ftpcrack: FTP Port (21) already opened on 'home'.",
-      "after redundant enable",
-      "enableLog: Enabled logging for all functions",
-      "brutessh: SSH Port (22) already opened on 'home'.",
-      "ftpcrack: FTP Port (21) already opened on 'home'.",
-      "end",
-    ]);
-  } finally {
-    if (server) {
-      DeleteServer(server.hostname);
-    }
+  const ns = ws.env.vars;
+  if (!ns) {
+    throw new Error("Invalid ws.env.vars");
   }
+
+  // Generate logs in a specific pattern that checks edge cases in
+  // disableLog. We want to check various combinations of things that
+  // are/aren't disabled, as well as previously disabled.
+  ns.brutessh("home");
+  ns.ftpcrack("home");
+  ns.print("before disableLog ALL");
+
+  expect(() => ns.disableLog("all")).toThrow("Invalid argument: all.");
+  ns.disableLog("ALL");
+
+  ns.brutessh("home");
+  ns.ftpcrack("home");
+  ns.print("after disableLog ALL");
+
+  ns.enableLog("brutessh");
+  ns.brutessh("home");
+  ns.ftpcrack("home");
+  ns.print("after enableLog brutessh");
+
+  ns.disableLog("brutessh");
+  ns.enableLog("ftpcrack");
+  ns.brutessh("home");
+  ns.ftpcrack("home");
+  ns.print("after enableLog ftpcrack");
+
+  ns.enableLog("ftpcrack");
+  ns.brutessh("home");
+  ns.ftpcrack("home");
+
+  ns.print("after redundant enable");
+  ns.disableLog("ALL");
+  ns.brutessh("home");
+  ns.ftpcrack("home");
+  ns.enableLog("ALL");
+  ns.brutessh("home");
+  ns.ftpcrack("home");
+  ns.print("end");
+
+  expect(runningScript.logs).toEqual([
+    "brutessh: Executed BruteSSH.exe on 'home' to open SSH port (22).",
+    "ftpcrack: Executed FTPCrack.exe on 'home' to open FTP port (21).",
+    "before disableLog ALL",
+    "disableLog: Invalid argument: all.",
+    "after disableLog ALL",
+    "brutessh: SSH Port (22) already opened on 'home'.",
+    "after enableLog brutessh",
+    "ftpcrack: FTP Port (21) already opened on 'home'.",
+    "after enableLog ftpcrack",
+    "ftpcrack: FTP Port (21) already opened on 'home'.",
+    "after redundant enable",
+    "enableLog: Enabled logging for all functions",
+    "brutessh: SSH Port (22) already opened on 'home'.",
+    "ftpcrack: FTP Port (21) already opened on 'home'.",
+    "end",
+  ]);
 });

--- a/test/jest/Netscript/RunScript.test.ts
+++ b/test/jest/Netscript/RunScript.test.ts
@@ -1,10 +1,8 @@
-import type { Script } from "../../../src/Script/Script";
 import type { ScriptFilePath } from "../../../src/Paths/ScriptFilePath";
 import { runScriptFromScript, startWorkerScript } from "../../../src/NetscriptWorker";
 import { workerScripts } from "../../../src/Netscript/WorkerScripts";
-import { Server } from "../../../src/Server/Server";
 import { RunningScript } from "../../../src/Script/RunningScript";
-import { AddToAllServers, DeleteServer, GetServerOrThrow } from "../../../src/Server/AllServers";
+import { GetServerOrThrow } from "../../../src/Server/AllServers";
 import { AlertEvents } from "../../../src/ui/React/AlertManager";
 import { fixDoImportIssue, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
 import { Terminal } from "../../../src/Terminal";
@@ -20,74 +18,6 @@ import { ErrorState } from "../../../src/ErrorHandling/ErrorState";
 fixDoImportIssue();
 
 initGameEnvironment();
-
-test.each([
-  {
-    name: "NS2 test /w import",
-    expected: ["false home 8", "Script finished running"],
-    scripts: [
-      {
-        name: "import.js",
-        code: `
-        export function getInfo(ns) {
-          return ns.stock.has4SData();
-        }
-      `,
-      },
-      {
-        name: "simple_test.js",
-        code: `
-        import { getInfo } from "./import.js";
-
-        export async function main(ns) {
-          var access = getInfo(ns);
-          var server = ns.getServer();
-          ns.printf("%s %s %d", access, server.hostname, server.maxRam);
-        }
-      `,
-      },
-    ],
-  },
-])("Netscript execution: $name", async function ({ expected: expectedLog, scripts }) {
-  let server = {} as Server;
-  const eventDelete = () => {};
-  let alertDelete = () => {};
-  try {
-    const alerted = new Promise((resolve) => {
-      alertDelete = AlertEvents.subscribe((x) => resolve(x));
-    });
-    server = new Server({ hostname: "home", adminRights: true, maxRam: 8 });
-    AddToAllServers(server);
-    for (const s of scripts) {
-      expect(server.writeToScriptFile(s.name as ScriptFilePath, s.code)).toEqual({ overwritten: false });
-    }
-
-    const script = server.scripts.get(scripts[scripts.length - 1].name as ScriptFilePath) as Script;
-    expect(script.filename).toEqual(scripts[scripts.length - 1].name);
-
-    const ramUsage = script.getRamUsage(server.scripts);
-    if (!ramUsage) throw new Error(`ramUsage calculated to be ${ramUsage}`);
-    const runningScript = new RunningScript(script, ramUsage);
-    const pid = startWorkerScript(runningScript, server);
-    expect(pid).toBeGreaterThan(0);
-    // Manually attach an atExit to the now-created WorkerScript, so we can
-    // await script death.
-    const ws = workerScripts.get(pid);
-    expect(ws).toBeDefined();
-    const result = await Promise.race([
-      alerted,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- ws was asserted above
-      new Promise<void>((resolve) => (ws!.atExit = new Map([["default", resolve]]))),
-    ]);
-    // If an error alert was thrown, we catch it here.
-    expect(result).not.toBeDefined();
-    expect(runningScript.logs).toEqual(expectedLog);
-  } finally {
-    eventDelete();
-    if (server) DeleteServer(server.hostname);
-    alertDelete();
-  }
-});
 
 const testScriptPath = "test.js" as ScriptFilePath;
 const parentTestScriptPath = "parent_script.js" as ScriptFilePath;
@@ -125,32 +55,86 @@ async function expectErrorWhenRunningScript(
   expect(workerScript.scriptRef.logs[0]).toContain(errorMessage);
 }
 
+let alertEventCleanUpFunction: () => void;
+let alerted: Promise<unknown>;
+let errorPopUpEventCleanUpFunction: () => void;
+let errorShown: Promise<unknown>;
+
+beforeEach(() => {
+  setupBasicTestingEnvironment();
+  Terminal.clear();
+  resetPidCounter();
+
+  alerted = new Promise((resolve) => {
+    alertEventCleanUpFunction = AlertEvents.subscribe((x) => resolve(x));
+  });
+  errorShown = new Promise((resolve) => {
+    errorPopUpEventCleanUpFunction = ErrorState.ErrorUpdate.subscribe((x) => resolve(x));
+  });
+});
+
+afterEach(() => {
+  alertEventCleanUpFunction();
+  errorPopUpEventCleanUpFunction();
+  ErrorState.ActiveError = null;
+  ErrorState.Errors.length = 0;
+  ErrorState.UnreadErrors = 0;
+});
+
+test("Netscript execution", async () => {
+  const scripts = [
+    {
+      name: "import.js",
+      code: `
+        export function getInfo(ns) {
+          return ns.stock.has4SData();
+        }
+      `,
+    },
+    {
+      name: "simple_test.js",
+      code: `
+        import { getInfo } from "./import.js";
+
+        export async function main(ns) {
+          var access = getInfo(ns);
+          var server = ns.getServer();
+          ns.printf("%s %s %d", access, server.hostname, server.maxRam);
+        }
+      `,
+    },
+  ];
+
+  const server = Player.getHomeComputer();
+  for (const script of scripts) {
+    expect(server.writeToScriptFile(script.name as ScriptFilePath, script.code)).toEqual({ overwritten: false });
+  }
+  const script = server.scripts.get(scripts[scripts.length - 1].name as ScriptFilePath);
+  if (!script) {
+    throw new Error("Invalid script");
+  }
+  expect(script.filename).toEqual(scripts[scripts.length - 1].name);
+  const ramUsage = script.getRamUsage(server.scripts);
+  if (!ramUsage) {
+    throw new Error(`ramUsage calculated to be ${ramUsage}`);
+  }
+  const runningScript = new RunningScript(script, ramUsage);
+  const pid = startWorkerScript(runningScript, server);
+  expect(pid).toBeGreaterThan(0);
+  const workerScript = workerScripts.get(pid);
+  if (!workerScript) {
+    throw new Error(`Invalid worker script`);
+  }
+
+  const result = await Promise.race([
+    alerted,
+    new Promise<void>((resolve) => (workerScript.atExit = new Map([["default", resolve]]))),
+  ]);
+  expect(result).not.toBeDefined();
+  expect(runningScript.logs).toStrictEqual(["false home 8", "Script finished running"]);
+});
+
 describe("runScript and runScriptFromScript", () => {
-  let alertEventCleanUpFunction: () => void;
-  let alerted: Promise<unknown>;
-  let errorPopUpEventCleanUpFunction: () => void;
-  let errorShown: Promise<unknown>;
-
-  beforeEach(() => {
-    setupBasicTestingEnvironment();
-    Terminal.clear();
-    resetPidCounter();
-
-    alerted = new Promise((resolve) => {
-      alertEventCleanUpFunction = AlertEvents.subscribe((x) => resolve(x));
-    });
-    errorShown = new Promise((resolve) => {
-      errorPopUpEventCleanUpFunction = ErrorState.ErrorUpdate.subscribe((x) => resolve(x));
-    });
-  });
-  afterEach(() => {
-    alertEventCleanUpFunction();
-    errorPopUpEventCleanUpFunction();
-    ErrorState.ActiveError = null;
-    ErrorState.Errors.length = 0;
-    ErrorState.UnreadErrors = 0;
-  });
-
   describe("runScript", () => {
     describe("Success", () => {
       test("Normal", async () => {


### PR DESCRIPTION
This function was changed in #855. The redundant check was used as a workaround for a failed Jest test. I refactored that test to make it work without this check.