### PR TITLE
BUGFIX: Electron app does not show achievement icons

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -27,8 +27,8 @@ const debounce = require("lodash/debounce");
 const Store = require("electron-store");
 const store = new Store();
 const path = require("path");
-const { realpathSync, readFileSync } = require("fs");
-const { fileURLToPath } = require("url");
+const { realpathSync } = require("fs");
+const { fileURLToPath, format } = require("url");
 
 log.transports.file.level = store.get("file-log-level", "info");
 log.transports.console.level = store.get("console-log-level", "debug");
@@ -219,11 +219,25 @@ app.on("ready", async () => {
       relativePath = path.relative(__dirname, realPath);
       // Only allow access to files in "dist" folder or html files in the same directory
       if (method === "GET" && (relativePath.startsWith("dist") || relativePath.match(/^[a-zA-Z-_]*\.html/))) {
-        const customHeaders = {};
-        if (relativePath.endsWith(".wasm")) {
-          customHeaders["Content-Type"] = "application/wasm";
-        }
-        return new Response(readFileSync(realPath), { headers: new Headers(customHeaders) });
+        return net
+          .fetch(
+            /**
+             * On Windows, passing realPath (e.g., "C:\path") directly to net.fetch is okay, but on Linux, passing
+             * realPath (e.g., /path) like that throws an error (TypeError: Failed to parse URL from /path). We have to
+             * convert it to a file:// URL.
+             */
+            format({ pathname: realPath, protocol: "file" }),
+            {
+              /**
+               * By default, requests made by net.fetch go through custom protocol handlers, so we have to explicitly tell it
+               * to bypass those handlers; otherwise, it creates an infinite loop.
+               *
+               * Ref: https://github.com/electron/electron/issues/39402
+               */
+              bypassCustomProtocolHandlers: true,
+            },
+          )
+          .catch((error) => log.error(error));
       }
     } catch (error) {
       log.error(error);


### PR DESCRIPTION
In #2114, I switch from using `net.fetch` to returning data directly via `new Response()`. The downside of this approach is we need to manually handle headers like `Content-Type`. For example, #2262 handles .wasm files.

In the Achievement tab, the Electron app does not show any icons because the svg files' `Content-Type` headers are empty.

v2.8.1 (Before we switch to `protocol.handle`):

<img width="1466" height="627" alt="2 8 1" src="https://github.com/user-attachments/assets/a77eb51b-9c1f-492c-bf06-2e0b37e24477" />

v3.0.0:

<img width="1470" height="547" alt="3 0 0" src="https://github.com/user-attachments/assets/b3d5fb6b-70df-45ab-8fda-29745a2338dc" />

Instead of manually handling headers, I think we should use what I said in #2114. I avoided it back then, but I changed my mind now.

Tested on Windows 10 and Debian 12.

<img width="1468" height="583" alt="after" src="https://github.com/user-attachments/assets/74a09979-6c37-4d64-ba38-f31d3120ce43" />
