### PR TITLE
GO: Fix columnIndexes to include all letters A-Z

### DIFF
--- a/src/Go/Constants.ts
+++ b/src/Go/Constants.ts
@@ -70,7 +70,7 @@ export const opponentDetails = {
 
 export const boardSizes = [5, 7, 9, 13, 19];
 
-export const columnIndexes = "ABCDEFGHJKLMNOPQRSTUVWXYZ";
+export const columnIndexes = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 export function newOpponentStats(): OpponentStats {
   return {


### PR DESCRIPTION
When hovering over a cell in IPvGO game the column I is skipped.

I did **not** test the change.
I did **not** run `npm run format` and `npm run lint`.
I just added the missing letter.
