### PR TITLE
UI: Correct wording in SmartSonar description

### DIFF
--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -1471,7 +1471,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
     [AugmentationName.SmartSonar]: {
       repCost: 2.25e4,
       moneyCost: 7.5e7,
-      info: "A cochlear implant that helps the player detect and locate enemies using sound propagation.",
+      info: "A cochlear implant that helps the user detect and locate enemies using sound propagation.",
       dexterity: 1.1,
       dexterity_exp: 1.15,
       crime_money: 1.25,


### PR DESCRIPTION
Changed the wording of the SmartSonar Implant description to make it consistent with other augment descriptions.
The word "player" breaks immersion.

Ran:  `npm run lint` , `npm run format` and `npm run test`.

Before:
<img width="888" height="187" alt="UI_Before" src="https://github.com/user-attachments/assets/43d165e5-11e7-4710-acd5-10ee5ff96f0f" />
After:
<img width="867" height="187" alt="UI_After" src="https://github.com/user-attachments/assets/1f40bf94-1305-4ff2-8325-5d25e7641a1b" />
