### PR TITLE
CODEBASE: Prepare for save data migration of next beta version

### DIFF
--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -551,6 +551,7 @@ Error: ${e}`,
     }
     if (found) Terminal.error("Filenames with whitespace found and corrected, see console for details.");
   }
+  // Migrate save data related to the breaking changes in the first beta of v3.0.0.
   if (ver < 44) {
     try {
       /**
@@ -637,6 +638,8 @@ Error: ${e}`,
       }
       unlocks.delete("VeChain");
     }
+  }
+  if (ver < 45) {
     showAPIBreaks("3.0.0", breakingChanges300);
   }
 }


### PR DESCRIPTION
We are going to migrate the save data for the next breaking changes (e.g., move pserver APIs, darknet). `showAPIBreaks` is called in `ver < 44`, so the scripts of current beta players won't be migrated in the next beta version.

Ideally, we should split `3.0.0.ts` into many files, with each beta version per file, but I don't think it's worth the effort. It's okay to run those script migrations many times.