### PR TITLE
DOCUMENTATION: Fix missing/wrong TSDoc of APIs having optional host parameter

### DIFF
--- a/markdown/bitburner.codingcontract.attempt.md
+++ b/markdown/bitburner.codingcontract.attempt.md
@@ -74,7 +74,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.codingcontract.getcontract.md
+++ b/markdown/bitburner.codingcontract.getcontract.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server containing the contract. Optional. Default to the current server if not provided.
+_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.codingcontract.getcontracttype.md
+++ b/markdown/bitburner.codingcontract.getcontracttype.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.codingcontract.getdata.md
+++ b/markdown/bitburner.codingcontract.getdata.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.codingcontract.getdescription.md
+++ b/markdown/bitburner.codingcontract.getdescription.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.codingcontract.getnumtriesremaining.md
+++ b/markdown/bitburner.codingcontract.getnumtriesremaining.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.fileexists.md
+++ b/markdown/bitburner.ns.fileexists.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of target server. Optional, defaults to the server the script is running on.
+_(Optional)_ Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.getgrowtime.md
+++ b/markdown/bitburner.ns.getgrowtime.md
@@ -9,7 +9,7 @@ Get the execution time of a grow() call.
 **Signature:**
 
 ```typescript
-getGrowTime(host: string): number;
+getGrowTime(host?: string): number;
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-Hostname/IP of target server.
+_(Optional)_ Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.gethacktime.md
+++ b/markdown/bitburner.ns.gethacktime.md
@@ -9,7 +9,7 @@ Get the execution time of a hack() call.
 **Signature:**
 
 ```typescript
-getHackTime(host: string): number;
+getHackTime(host?: string): number;
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-Hostname/IP of target server.
+_(Optional)_ Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.getrunningscript.md
+++ b/markdown/bitburner.ns.getrunningscript.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of target server. Optional, defaults to the server the calling script is running on.
+_(Optional)_ Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.getscriptlogs.md
+++ b/markdown/bitburner.ns.getscriptlogs.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Optional. Hostname/IP of the server that the script is on.
+_(Optional)_ Optional. Hostname/IP of the server that the script is on. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.getscriptram.md
+++ b/markdown/bitburner.ns.getscriptram.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of target server the script is located on. This is optional. If it is not specified then the function will use the current server as the target server.
+_(Optional)_ Hostname/IP of target server the script is located on. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.getserver.md
+++ b/markdown/bitburner.ns.getserver.md
@@ -4,7 +4,7 @@
 
 ## NS.getServer() method
 
-Returns a server object for the given server. Defaults to the running script's server if host is not specified.
+Returns a server object for the given server.
 
 **Signature:**
 
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-_(Optional)_ Optional. Hostname/IP for the requested server object.
+_(Optional)_ Optional. Hostname/IP for the requested server object. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.getweakentime.md
+++ b/markdown/bitburner.ns.getweakentime.md
@@ -9,7 +9,7 @@ Get the execution time of a weaken() call.
 **Signature:**
 
 ```typescript
-getWeakenTime(host: string): number;
+getWeakenTime(host?: string): number;
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-Hostname/IP of target server.
+_(Optional)_ Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.growthanalyzesecurity.md
+++ b/markdown/bitburner.ns.growthanalyzesecurity.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Optional. Hostname/IP of the target server. If provided, security increase is limited by the number of threads needed to reach maximum money.
+_(Optional)_ Optional. Hostname/IP of the target server. If specified, the value of the "threads" parameter is limited to the number of threads needed to reach the specified server's maximum money.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.hackanalyzesecurity.md
+++ b/markdown/bitburner.ns.hackanalyzesecurity.md
@@ -4,7 +4,7 @@
 
 ## NS.hackAnalyzeSecurity() method
 
-Get the security increase for a number of threads.
+Get the security increase for a number of hack threads.
 
 **Signature:**
 
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the target server. The number of threads is limited to the number needed to hack the server's maximum amount of money.
+_(Optional)_ Optional. Hostname/IP of the target server. If specified, the value of the "threads" parameter is limited to the number of threads needed to hack the specified server's maximum amount of money.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.isrunning.md
+++ b/markdown/bitburner.ns.isrunning.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of target server. Optional, defaults to the server the calling script is running on.
+_(Optional)_ Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.kill_1.md
+++ b/markdown/bitburner.ns.kill_1.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP where the script to kill is running. Defaults to the current server.
+_(Optional)_ Hostname/IP where the script to kill is running. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.killall.md
+++ b/markdown/bitburner.ns.killall.md
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server on which to kill all scripts.
+_(Optional)_ Hostname/IP of the server on which to kill all scripts. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>
@@ -58,7 +58,7 @@ boolean
 
 </td><td>
 
-_(Optional)_ Skips the script that calls this function
+_(Optional)_ Skips the script that calls this function. Optional. Defaults to false.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -949,7 +949,7 @@ Get the ram cost of a script.
 
 </td><td>
 
-Returns a server object for the given server. Defaults to the running script's server if host is not specified.
+Returns a server object for the given server.
 
 
 </td></tr>
@@ -1180,7 +1180,7 @@ Get the chance of successfully hacking a server.
 
 </td><td>
 
-Get the security increase for a number of threads.
+Get the security increase for a number of hack threads.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.ps.md
+++ b/markdown/bitburner.ns.ps.md
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the target server. If not specified, it will be the current server’s IP by default.
+_(Optional)_ Hostname/IP of the target server. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.rm.md
+++ b/markdown/bitburner.ns.rm.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of the server on which to delete the file. Optional. Defaults to current server.
+_(Optional)_ Hostname/IP of the server on which to delete the file. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.scan.md
+++ b/markdown/bitburner.ns.scan.md
@@ -42,7 +42,7 @@ string \| null
 
 </td><td>
 
-_(Optional)_ Optional. Hostname/IP of the server to scan, default to current server.
+_(Optional)_ Optional. Hostname/IP of the server to scan. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.ns.wget.md
+++ b/markdown/bitburner.ns.wget.md
@@ -74,7 +74,7 @@ string
 
 </td><td>
 
-_(Optional)_ Optional hostname/ip of server for target file.
+_(Optional)_ Hostname/IP of server for target file. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.userinterface.opentail.md
+++ b/markdown/bitburner.userinterface.opentail.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Optional. Hostname/IP of the script being tailed. Defaults to the server this script is running on. If args are specified, this is not optional.
+_(Optional)_ Optional. Hostname/IP of the script being tailed. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/markdown/bitburner.userinterface.settailfontsize.md
+++ b/markdown/bitburner.userinterface.settailfontsize.md
@@ -74,7 +74,7 @@ string
 
 </td><td>
 
-_(Optional)_ Optional. Hostname/IP of the target script. Defaults to the server this script is running on. If args are specified, this is not optional.
+_(Optional)_ Optional. Hostname/IP of the target script. Defaults to the server the calling script is running on.
 
 
 </td></tr>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3968,8 +3968,7 @@ export interface CodingContract {
    *
    * @param answer - Attempted solution for the contract. This can be a string formatted like submitting manually, or the answer in the format of the specific contract type.
    * @param filename - Filename of the contract.
-   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to current server if not
-   *   provided.
+   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
    * @returns A reward description string on success, or an empty string on failure.
    */
   attempt(answer: any, filename: string, host?: string): string;
@@ -3983,7 +3982,7 @@ export interface CodingContract {
    * (e.g. Find Largest Prime Factor, Total Ways to Sum, etc.)
    *
    * @param filename - Filename of the contract.
-   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
    * @returns Name describing the type of problem posed by the Coding Contract.
    */
   getContractType(filename: string, host?: string): CodingContractName;
@@ -3996,7 +3995,7 @@ export interface CodingContract {
    * Get the full text description for the problem posed by the Coding Contract.
    *
    * @param filename - Filename of the contract.
-   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
    * @returns Contract’s text description.
    */
   getDescription(filename: string, host?: string): string;
@@ -4011,7 +4010,7 @@ export interface CodingContract {
    * This is just the data that the contract wants you to act on in order to solve the contract.
    *
    * @param filename - Filename of the contract.
-   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
    * @returns The specified contract’s data, data type depends on contract type.
    */
   getData(filename: string, host?: string): any;
@@ -4035,7 +4034,7 @@ export interface CodingContract {
    * ```
    *
    * @param filename - Filename of the contract.
-   * @param host - Hostname/IP of the server containing the contract. Optional. Default to the current server if not provided.
+   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
    * @returns An object containing various data about the contract specified.
    */
   getContract(filename: string, host?: string): CodingContractObject;
@@ -4048,7 +4047,7 @@ export interface CodingContract {
    * Get the number of tries remaining on the contract before it self-destructs.
    *
    * @param filename - Filename of the contract.
-   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to current server if not provided.
+   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
    * @returns How many attempts are remaining for the contract.
    */
   getNumTriesRemaining(filename: string, host?: string): number;
@@ -6016,7 +6015,7 @@ interface UserInterface {
    * ns.ui.openTail("foo.js", "foodnstuff", 1, "test");
    * ```
    * @param fn - Optional. Filename or PID of the script being tailed. If omitted, the current script is tailed.
-   * @param host - Optional. Hostname/IP of the script being tailed. Defaults to the server this script is running on. If args are specified, this is not optional.
+   * @param host - Optional. Hostname/IP of the script being tailed. Defaults to the server the calling script is running on.
    * @param args - Arguments for the script being tailed.
    */
   openTail(fn?: FilenameOrPID, host?: string, ...args: ScriptArg[]): void;
@@ -6116,7 +6115,7 @@ interface UserInterface {
    *
    * @param pixel - Optional. The new font size in pixels. If omitted, the default tail font size is used.
    * @param fn - Optional. Filename or PID of the target script. If omitted, the current script is used.
-   * @param host - Optional. Hostname/IP of the target script. Defaults to the server this script is running on. If args are specified, this is not optional.
+   * @param host - Optional. Hostname/IP of the target script. Defaults to the server the calling script is running on.
    * @param args - Arguments for the target script.
    */
   setTailFontSize(pixel?: number, fn?: FilenameOrPID, host?: string, ...args: ScriptArg[]): void;
@@ -6502,14 +6501,14 @@ export interface NS {
   hackAnalyze(host: string): number;
 
   /**
-   * Get the security increase for a number of threads.
+   * Get the security increase for a number of hack threads.
    * @remarks
    * RAM cost: 1 GB
    *
    * Returns the security increase that would occur if a hack with this many threads happened.
    *
    * @param threads - Amount of threads that will be used.
-   * @param host - Hostname/IP of the target server. The number of threads is limited to the number needed to hack the server's maximum amount of money.
+   * @param host - Optional. Hostname/IP of the target server. If specified, the value of the "threads" parameter is limited to the number of threads needed to hack the specified server's maximum amount of money.
    * @returns The security increase.
    */
   hackAnalyzeSecurity(threads: number, host?: string): number;
@@ -6571,7 +6570,7 @@ export interface NS {
    * Returns the security increase that would occur if a grow with this many threads happened.
    *
    * @param threads - Amount of threads that will be used.
-   * @param host - Optional. Hostname/IP of the target server. If provided, security increase is limited by the number of threads needed to reach maximum money.
+   * @param host - Optional. Hostname/IP of the target server. If specified, the value of the "threads" parameter is limited to the number of threads needed to reach the specified server's maximum money.
    * @param cores - Optional. The number of cores of the server that would run grow.
    * @returns The security increase.
    */
@@ -6833,7 +6832,7 @@ export interface NS {
    * ns.getScriptLogs("foo.js", "foodnstuff", 1, "test");
    * ```
    * @param fn - Optional. Filename or PID of script to get logs from.
-   * @param host - Optional. Hostname/IP of the server that the script is on.
+   * @param host - Optional. Hostname/IP of the server that the script is on. Defaults to the server the calling script is running on.
    * @param args - Arguments to identify which scripts to get logs for.
    * @returns Returns a string array, where each line is an element in the array. The most recently logged line is at the end of the array.
    */
@@ -6919,7 +6918,7 @@ export interface NS {
    * }
    * ```
    *
-   * @param host - Optional. Hostname/IP of the server to scan, default to current server.
+   * @param host - Optional. Hostname/IP of the server to scan. Defaults to the server the calling script is running on.
    * @param returnOpts - Optional. Controls whether the function returns IPs.
    * @returns Returns an array of hostnames.
    */
@@ -7194,7 +7193,7 @@ export interface NS {
    * ns.kill("foo.js", ns.getHostname(), 1, "foodnstuff", false);
    * ```
    * @param filename - Filename of the script to kill.
-   * @param host - Hostname/IP where the script to kill is running. Defaults to the current server.
+   * @param host - Hostname/IP where the script to kill is running. Optional. Defaults to the server the calling script is running on.
    * @param args - Arguments of the script to kill.
    * @returns True if the scripts were successfully killed, and false otherwise.
    */
@@ -7210,8 +7209,8 @@ export interface NS {
    * true if there are any scripts running on the target server.
    * If no host is defined, it will kill all scripts, where the script is running.
    *
-   * @param host - Hostname/IP of the server on which to kill all scripts.
-   * @param safetyGuard - Skips the script that calls this function
+   * @param host - Hostname/IP of the server on which to kill all scripts. Optional. Defaults to the server the calling script is running on.
+   * @param safetyGuard - Skips the script that calls this function. Optional. Defaults to false.
    * @returns True if any scripts were killed, and false otherwise.
    */
   killall(host?: string, safetyGuard?: boolean): boolean;
@@ -7282,7 +7281,7 @@ export interface NS {
    *   ns.tprint(script.args);
    * }
    * ```
-   * @param host - Hostname/IP of the target server. If not specified, it will be the current server’s IP by default.
+   * @param host - Hostname/IP of the target server. Optional. Defaults to the server the calling script is running on.
    * @returns Array with general information about all scripts running on the specified target server.
    */
   ps(host?: string): ProcessInfo[];
@@ -7371,11 +7370,11 @@ export interface NS {
   getHacknetMultipliers(): HacknetMultipliers;
 
   /**
-   * Returns a server object for the given server. Defaults to the running script's server if host is not specified.
+   * Returns a server object for the given server.
    *
    * @remarks
    * RAM cost: 2 GB
-   * @param host - Optional. Hostname/IP for the requested server object.
+   * @param host - Optional. Hostname/IP for the requested server object. Defaults to the server the calling script is running on.
    * @returns The requested server object.
    */
   getServer(host?: string): Server;
@@ -7535,7 +7534,7 @@ export interface NS {
    * ns.fileExists("ftpcrack.exe");
    * ```
    * @param filename - Filename of file to check.
-   * @param host - Hostname/IP of target server. Optional, defaults to the server the script is running on.
+   * @param host - Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
    * @returns True if specified file exists, and false otherwise.
    */
   fileExists(filename: string, host?: string): boolean;
@@ -7564,7 +7563,7 @@ export interface NS {
    * ns.isRunning("foo.js", "joesguns", 1, 5, "test");
    * ```
    * @param script - Filename or PID of script to check. This is case-sensitive.
-   * @param host - Hostname/IP of target server. Optional, defaults to the server the calling script is running on.
+   * @param host - Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
    * @param args - Arguments to specify/identify the script. Optional, when looking for scripts run without arguments.
    * @returns True if the specified script is running on the target server, and false otherwise.
    */
@@ -7583,7 +7582,7 @@ export interface NS {
    * functions like this that check based on filename, the filename plus arguments forms the key.)
    *
    * @param filename - Optional. Filename or PID of the script.
-   * @param host - Hostname/IP of target server. Optional, defaults to the server the calling script is running on.
+   * @param host - Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
    * @param args  - Arguments to specify/identify the script. Optional, when looking for scripts run without arguments.
    * @returns The info about the running script if found, and null otherwise.
    */
@@ -7909,7 +7908,7 @@ export interface NS {
    * type except message (.msg) files.
    *
    * @param name - Filename of file to remove. Must include the extension.
-   * @param host - Hostname/IP of the server on which to delete the file. Optional. Defaults to current server.
+   * @param host - Hostname/IP of the server on which to delete the file. Optional. Defaults to the server the calling script is running on.
    * @returns True if it successfully deletes the file, and false otherwise.
    */
   rm(name: string, host?: string): boolean;
@@ -7970,7 +7969,7 @@ export interface NS {
    * Returns 0 if the script does not exist.
    *
    * @param script - Filename of script. This is case-sensitive.
-   * @param host - Hostname/IP of target server the script is located on. This is optional. If it is not specified then the function will use the current server as the target server.
+   * @param host - Hostname/IP of target server the script is located on. Optional. Defaults to the server the calling script is running on.
    * @returns Amount of RAM (in GB) required to run the specified script on the target server, and 0 if the script does not exist.
    */
   getScriptRam(script: string, host?: string): number;
@@ -7984,10 +7983,10 @@ export interface NS {
    * Returns the amount of time in milliseconds it takes to execute the {@link NS.hack | hack} Netscript function on the target server.
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
-   * @param host - Hostname/IP of target server.
+   * @param host - Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
    * @returns Returns the amount of time in milliseconds it takes to execute the {@link NS.hack | hack} Netscript function.
    */
-  getHackTime(host: string): number;
+  getHackTime(host?: string): number;
 
   /**
    * Get the execution time of a grow() call.
@@ -7997,10 +7996,10 @@ export interface NS {
    * Returns the amount of time in milliseconds it takes to execute the grow Netscript function on the target server.
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
-   * @param host - Hostname/IP of target server.
+   * @param host - Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
    * @returns Returns the amount of time in milliseconds it takes to execute the grow Netscript function.
    */
-  getGrowTime(host: string): number;
+  getGrowTime(host?: string): number;
 
   /**
    * Get the execution time of a weaken() call.
@@ -8010,10 +8009,10 @@ export interface NS {
    * Returns the amount of time in milliseconds it takes to execute the {@link NS.weaken | weaken} Netscript function on the target server.
    * The required time is increased by the security level of the target server and decreased by the player's hacking level.
    *
-   * @param host - Hostname/IP of target server.
+   * @param host - Hostname/IP of target server. Optional. Defaults to the server the calling script is running on.
    * @returns Returns the amount of time in milliseconds it takes to execute the {@link NS.weaken | weaken} Netscript function.
    */
-  getWeakenTime(host: string): number;
+  getWeakenTime(host?: string): number;
 
   /**
    * Get the income of all scripts.
@@ -8199,7 +8198,7 @@ export interface NS {
    * ```
    * @param url - URL to pull data from.
    * @param target - Filename to write data to. Must be script or text file.
-   * @param host - Optional hostname/ip of server for target file.
+   * @param host - Hostname/IP of server for target file. Optional. Defaults to the server the calling script is running on.
    * @returns True if the data was successfully retrieved from the URL, false otherwise.
    */
   wget(url: string, target: string, host?: string): Promise<boolean>;


### PR DESCRIPTION
In #2352, d0sboots said that there is an undocumented behavior in `getHackTime` (the "host" parameter is optional). In this PR, I check all APIs that have an optional host parameter and fix them if necessary.

Notable changes:
- openTail
- setTailFontSize
- hackAnalyzeSecurity
- growthAnalyzeSecurity
- getHackTime
- getGrowTime
- getWeakenTime
