### PR TITLE
DOCUMENTATION: Improve wording around host argument of getScriptRam

### DIFF
--- a/markdown/bitburner.ns.getscriptram.md
+++ b/markdown/bitburner.ns.getscriptram.md
@@ -58,7 +58,7 @@ string
 
 </td><td>
 
-_(Optional)_ Hostname/IP of target server the script is located on. Optional. Defaults to the server the calling script is running on.
+_(Optional)_ Hostname/IP of the server the target script is located on. Optional. Defaults to the server the calling script is running on.
 
 
 </td></tr>
@@ -68,7 +68,7 @@ _(Optional)_ Hostname/IP of target server the script is located on. Optional. De
 
 number
 
-Amount of RAM (in GB) required to run the specified script on the target server, and 0 if the script does not exist.
+Amount of RAM (in GB) required to run the specified script, and 0 if the script does not exist.
 
 ## Remarks
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7969,7 +7969,7 @@ export interface NS {
    * Returns 0 if the script does not exist.
    *
    * @param script - Filename of script. This is case-sensitive.
-   * @param host - Hostname/IP of the server the script is located on. Optional. Defaults to the server the calling script is running on.
+   * @param host - Hostname/IP of the server the target script is located on. Optional. Defaults to the server the calling script is running on.
    * @returns Amount of RAM (in GB) required to run the specified script, and 0 if the script does not exist.
    */
   getScriptRam(script: string, host?: string): number;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7969,8 +7969,8 @@ export interface NS {
    * Returns 0 if the script does not exist.
    *
    * @param script - Filename of script. This is case-sensitive.
-   * @param host - Hostname/IP of target server the script is located on. Optional. Defaults to the server the calling script is running on.
-   * @returns Amount of RAM (in GB) required to run the specified script on the target server, and 0 if the script does not exist.
+   * @param host - Hostname/IP of the server the script is located on. Optional. Defaults to the server the calling script is running on.
+   * @returns Amount of RAM (in GB) required to run the specified script, and 0 if the script does not exist.
    */
   getScriptRam(script: string, host?: string): number;
 


### PR DESCRIPTION
Although "target" is technically accurate here, I found it confusing because this function takes a script as a parameter, and I assumed "target server" was what that script would be running on, and therefore the ram cost would depend on which server the script in question would be run on.