### PR TITLE
BUGFIX: Bladeburner console prints main body's HP instead of sleeve's HP

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1162,9 +1162,9 @@ export class Bladeburner implements OperationTeam {
             this.stamina = Math.min(this.maxStamina, this.stamina + staminaGain);
             if (this.logging.general) {
               let extraLog = "";
-              if (Player.hp.current > currentHp) {
+              if (person.hp.current > currentHp) {
                 extraLog += ` Restored ${formatHp(BladeburnerConstants.HrcHpGain)} HP. Current HP is ${formatHp(
-                  Player.hp.current,
+                  person.hp.current,
                 )}.`;
               }
               if (this.stamina > currentStamina) {


### PR DESCRIPTION
When checking HP, we need to use `person.hp.current`, but we mistakely use `Player.hp.current` in 2 places.

How to reproduce: Load the attached save file and check the Bladeburner console.

Save file: 
[wrong-log-hp-bb-console.gz](https://github.com/user-attachments/files/23673770/wrong-log-hp-bb-console.gz)

Before:

<img width="847" height="63" alt="before" src="https://github.com/user-attachments/assets/2c3d6516-68b4-456f-8469-47e3ecb3c484" />

After:

<img width="820" height="55" alt="after" src="https://github.com/user-attachments/assets/7fc8f0cc-30f2-49da-b65d-8dc79eb764e0" />
