### PR TITLE
BUGFIX: Company's job list shows wrong starting jobs

### DIFF
--- a/src/Company/CompanyPosition.ts
+++ b/src/Company/CompanyPosition.ts
@@ -11,6 +11,7 @@ export interface CompanyPositionCtorParams {
   applyText?: string;
   hiredText?: string;
   isPartTime?: boolean;
+  isStartingJob?: boolean;
 
   reqdHacking?: number;
   reqdStrength?: number;
@@ -41,6 +42,9 @@ export class CompanyPosition {
 
   /** Field type of the position (software, it, business, etc) */
   field: JobField;
+
+  /** Whether this position is shown in the job list even when the player does not satisfy its requirements */
+  isStartingJob: boolean;
 
   /** Title of next position to be promoted to */
   nextPosition: JobName | null;
@@ -93,6 +97,7 @@ export class CompanyPosition {
   constructor(name: JobName, p: CompanyPositionCtorParams) {
     this.name = name;
     this.field = p.field;
+    this.isStartingJob = p.isStartingJob ?? false;
     this.nextPosition = p.nextPosition;
     this.baseSalary = p.baseSalary;
     this.repMultiplier = p.repMultiplier;

--- a/src/Company/data/CompanyPositionsMetadata.ts
+++ b/src/Company/data/CompanyPositionsMetadata.ts
@@ -7,6 +7,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.software0]: {
       nextPosition: JobName.software1, // Junior Software Engineer
       field: JobField.software,
+      isStartingJob: true,
       baseSalary: 33,
       charismaEffectiveness: 15,
       charismaExpGain: 0.02,
@@ -112,6 +113,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.IT0]: {
       nextPosition: JobName.IT1, // IT Analyst
       field: JobField.it,
+      isStartingJob: true,
       baseSalary: 26,
       charismaEffectiveness: 10,
       charismaExpGain: 0.01,
@@ -161,6 +163,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.securityEng]: {
       nextPosition: JobName.software5, // Head of Engineering
       field: JobField.securityEngineer,
+      isStartingJob: true,
       baseSalary: 121,
       charismaEffectiveness: 15,
       charismaExpGain: 0.05,
@@ -174,6 +177,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.networkEng0]: {
       nextPosition: JobName.networkEng1, // Network Administrator
       field: JobField.networkEngineer,
+      isStartingJob: true,
       baseSalary: 121,
       charismaEffectiveness: 15,
       charismaExpGain: 0.05,
@@ -200,6 +204,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.business0]: {
       nextPosition: JobName.business1, // Business Analyst
       field: JobField.business,
+      isStartingJob: true,
       baseSalary: 46,
       charismaEffectiveness: 90,
       charismaExpGain: 0.08,
@@ -279,6 +284,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.security0]: {
       nextPosition: JobName.security1, // Security Officer
       field: JobField.security,
+      isStartingJob: true,
       baseSalary: 50,
       hackingEffectiveness: 5,
       strengthEffectiveness: 20,
@@ -377,6 +383,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.agent0]: {
       nextPosition: JobName.agent1, // Secret Agent
       field: JobField.agent,
+      isStartingJob: true,
       baseSalary: 330,
       hackingEffectiveness: 10,
       strengthEffectiveness: 15,
@@ -452,6 +459,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.waiter]: {
       nextPosition: null,
       field: JobField.waiter,
+      isStartingJob: true,
       baseSalary: 22,
       strengthEffectiveness: 10,
       dexterityEffectiveness: 10,
@@ -469,6 +477,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.employee]: {
       nextPosition: null,
       field: JobField.employee,
+      isStartingJob: true,
       baseSalary: 22,
       strengthEffectiveness: 10,
       dexterityEffectiveness: 10,
@@ -486,6 +495,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.softwareConsult0]: {
       nextPosition: JobName.softwareConsult1, // Senior Software Consultant
       field: JobField.softwareConsultant,
+      isStartingJob: true,
       baseSalary: 66,
       hackingEffectiveness: 80,
       charismaEffectiveness: 20,
@@ -513,6 +523,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.businessConsult0]: {
       nextPosition: JobName.businessConsult1, // Senior Business Consultant
       field: JobField.businessConsultant,
+      isStartingJob: true,
       baseSalary: 66,
       hackingEffectiveness: 20,
       charismaEffectiveness: 80,
@@ -541,6 +552,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.waiterPT]: {
       nextPosition: null,
       field: JobField.waiter,
+      isStartingJob: true,
       baseSalary: 20,
       strengthEffectiveness: 10,
       dexterityEffectiveness: 10,
@@ -559,6 +571,7 @@ export function getCompanyPositionMetadata(): Record<JobName, CompanyPositionCto
     [JobName.employeePT]: {
       nextPosition: null,
       field: JobField.employee,
+      isStartingJob: true,
       baseSalary: 20,
       strengthEffectiveness: 10,
       dexterityEffectiveness: 10,

--- a/src/Company/ui/JobListings.tsx
+++ b/src/Company/ui/JobListings.tsx
@@ -23,7 +23,7 @@ export function JobListings({ company, currentPosition }: JobListingsProps): Rea
     // Don't show a job if we already qualify for a later job offered by this company
     if (nextJobName && qualifiedJobs.has(nextJobName)) continue;
     // Don't show a job if we don't qualify for it, unless it's a starting job or a promotion from current job
-    if (!qualifiedJobs.has(jobName) && job.requiredReputation > 0 && jobName !== currentPosition?.nextPosition) {
+    if (!qualifiedJobs.has(jobName) && !job.isStartingJob && jobName !== currentPosition?.nextPosition) {
       continue;
     }
     jobsToShow.push(job);


### PR DESCRIPTION
How to reproduce: Go to Volhaven and check Helios Labs:

<img width="344" height="267" alt="helios-labs" src="https://github.com/user-attachments/assets/9e1b4974-46e6-43c0-b0ed-15d83677a667" />

The duplicate entries are the senior jobs.

This list is calculated like this:
https://github.com/bitburner-official/bitburner-src/blob/bb50272e5449730f8a845b28da932349240b9644/src/Company/ui/JobListings.tsx#L19-L30

We assume that a starting job is a job that does not require reputation (`job.requiredReputation === 0`), but this is wrong.
- `Senior Software Consultant`: `requiredReputation = 0`, but it's a senior job promoted from `Software Consultant`.
- `Senior Business Consultant`: `requiredReputation = 0`, but it's a senior job promoted from `Business Consultant`.
- `Security Engineer`: `requiredReputation = 35000`. This is the only job in the `Security Engineer` field, so it's a starting job.
- `Network Engineer`: `requiredReputation = 35000`. This is the starting job in the `Network Engineer` field. This position will be promoted to `Network Administrator`.
- `Field Agent`: `requiredReputation = 8000`. This is the starting job in the `Agent` field. This position will be promoted to `Secret Agent`.

This PR fixes this bug by explicitly specifying which jobs are starting jobs.

Test code for getting debugging data:
```js
/** @param {NS} ns */
export async function main(ns) {
  console.clear();
  const showWrongJobs = false;
  const map = new Map();
  for (const [jobName, job] of Object.entries(getCompanyPositionMetadata())) {
    let l = map.get(job.field);
    if (l == null) {
      l = [];
      map.set(job.field, l);
    }
    l.push(Object.assign({ name: jobName }, job));
    if (showWrongJobs) {
      if (job.reqdReputation == null || job.reqdReputation === 0) {
        console.log(jobName, job);
      }
    } else if (job.isStartingJob) {
      console.log(jobName, job);
    }
  }
  console.log(map);
}
```

Before:

<img width="344" height="267" alt="before-1" src="https://github.com/user-attachments/assets/57f0b1f0-ad4c-499e-b5f6-dd71d38013bb" />

<img width="474" height="226" alt="before-2" src="https://github.com/user-attachments/assets/f7486d9c-5f22-4d4b-b485-60169af41a96" />

After:

<img width="354" height="271" alt="after-1" src="https://github.com/user-attachments/assets/e3f970de-844f-44ac-bd31-95f953b9c005" />

<img width="470" height="315" alt="after-2" src="https://github.com/user-attachments/assets/4fcac195-c06b-4a7f-aec8-6c456fcfcd51" />


Fixes #2386.