### PR TITLE
UI: Improve instructions in recovery mode

### DIFF
--- a/src/ui/React/RecoveryRoot.tsx
+++ b/src/ui/React/RecoveryRoot.tsx
@@ -198,11 +198,14 @@ export function RecoveryRoot({ softReset, crashReport, resetError }: IProps): Re
               />
             </Paper>
           )}
+          <Typography variant="h4" color={Settings.theme.warning}>
+            Do NOT take a screenshot of this screen. You must post the bug report text below.
+          </Typography>
           <Paper sx={{ px: 2, pt: 1, pb: 2, mt: 2 }}>
             <Typography variant="h5">{crashReport.title}</Typography>
             <Box sx={{ my: 2 }}>
               <TextField
-                label="Bug Report Text"
+                label={<Typography sx={{ fontSize: "20px" }}>Bug Report Text</Typography>}
                 value={crashReport.body}
                 variant="outlined"
                 color="secondary"
@@ -210,7 +213,10 @@ export function RecoveryRoot({ softReset, crashReport, resetError }: IProps): Re
                 fullWidth
                 rows={40}
                 spellCheck={false}
-                sx={{ "& .MuiOutlinedInput-root": { color: Settings.theme.secondary } }}
+                sx={{
+                  "& .MuiOutlinedInput-root": { color: Settings.theme.secondary },
+                  "& .MuiOutlinedInput-input": { scrollbarWidth: "thin" },
+                }}
               />
             </Box>
             <Tooltip title="Submitting an issue to GitHub really helps us improve the game!">


### PR DESCRIPTION
Recently we had a player reporting an issue, and they were constantly posting a screenshot instead of the bug report text, even after I told them not to do that. It seems that they did not know the bug report text area is a text box containing the bug report in text form.

This PR adds an instruction that explicitly tells the player what they are supposed to do and a scrollbar to the text box to make it a bit clearer that the text box contains more things than what is shown on the screen.

Before:

<img width="1411" height="950" alt="before" src="https://github.com/user-attachments/assets/6c5d013e-6c57-4f30-992b-8cf4807af760" />

After:

<img width="1418" height="950" alt="after" src="https://github.com/user-attachments/assets/d28d8094-fce4-41ee-9ebd-9804d6d5bbaf" />