### PR TITLE
BUGFIX: Coding contracts may have duplicate names

### DIFF
--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -59,5 +59,6 @@ Filename of the contract.
 RAM cost: 2 GB
 
 Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
+
 If a contract of the same name already exists on the home computer, fails to generate the contract and returns null.
 

--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -50,7 +50,7 @@ Type of contract to generate
 
 **Returns:**
 
-string
+string | null
 
 Filename of the contract.
 
@@ -59,4 +59,5 @@ Filename of the contract.
 RAM cost: 2 GB
 
 Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
+If a contract of the same name already exists on the home computer, fails to generate the contract and returns null.
 

--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -58,5 +58,7 @@ Filename of the contract.
 
 RAM cost: 2 GB
 
-Generate a dummy contract on the home computer with no reward. Used to test various algorithms. If a contract of the same name already exists on the home computer, fails to generate the contract and returns null.
+Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
+
+This function will return null and not generate a contract if the randomized contract name is the same as another contract's name.
 

--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -9,7 +9,7 @@ Generate a dummy contract.
 **Signature:**
 
 ```typescript
-createDummyContract(type: CodingContractName): string;
+createDummyContract(type: CodingContractName): string | null;
 ```
 
 ## Parameters
@@ -58,7 +58,5 @@ Filename of the contract.
 
 RAM cost: 2 GB
 
-Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
-
-If a contract of the same name already exists on the home computer, fails to generate the contract and returns null.
+Generate a dummy contract on the home computer with no reward. Used to test various algorithms. If a contract of the same name already exists on the home computer, fails to generate the contract and returns null.
 

--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -50,7 +50,7 @@ Type of contract to generate
 
 **Returns:**
 
-string | null
+string \| null
 
 Filename of the contract.
 

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -252,25 +252,25 @@ function getRandomServer(): BaseServer | null {
   return randServer;
 }
 
+function getRandomB64String(length: number) {
+  const b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  return Array(length)
+    .fill(0)
+    .map(() => b64[getRandomIntInclusive(0, 63)])
+    .join("");
+}
+
 function getRandomFilename(
   server: BaseServer,
   reward: ICodingContractReward = { type: CodingContractRewardType.Money },
-): ContractFilePath {
-  let contractFn: string,
-    i = 0;
-  let contractSuffix = ".cct";
+): ContractFilePath | null {
+  let contractFn = `contract-${getRandomB64String(6)}`;
   if ("name" in reward) {
     // Only alphanumeric characters in the reward name.
-    contractSuffix = `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}` + contractSuffix;
+    contractFn += `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}`;
   }
-  do {
-    contractFn = `contract-${getRandomIntInclusive(0, 1e6)}` + contractSuffix;
-  } while (
-    server.contracts.filter((c: CodingContract) => {
-      return c.fn === contractFn;
-    }).length != 0 &&
-    ++i < 1000
-  );
+  contractFn += ".cct";
+  if (server.contracts.filter((c: CodingContract) => c.fn === contractFn).length) return null;
   const validatedPath = resolveContractFilePath(contractFn);
   if (!validatedPath) throw new Error(`Generated contract path could not be validated: ${contractFn}`);
   return validatedPath;

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -257,23 +257,21 @@ function getRandomFilename(
   reward: ICodingContractReward = { type: CodingContractRewardType.Money },
 ): ContractFilePath {
   let contractFn = `contract-${getRandomIntInclusive(0, 1e6)}`;
-
+  let contractSuffix = ".cct";
+  if ("name" in reward) {
+    // Only alphanumeric characters in the reward name.
+    contractSuffix = `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}` + contractSuffix;
+  }
   for (let i = 0; i < 1000; ++i) {
     if (
       server.contracts.filter((c: CodingContract) => {
         return c.fn === contractFn;
-      }).length <= 0
+      }).length == 0
     ) {
       break;
     }
-    contractFn = `contract-${getRandomIntInclusive(0, 1e6)}`;
+    contractFn = `contract-${getRandomIntInclusive(0, 1e6)}` + contractSuffix;
   }
-
-  if ("name" in reward) {
-    // Only alphanumeric characters in the reward name.
-    contractFn += `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}`;
-  }
-  contractFn += ".cct";
   const validatedPath = resolveContractFilePath(contractFn);
   if (!validatedPath) throw new Error(`Generated contract path could not be validated: ${contractFn}`);
   return validatedPath;

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -86,6 +86,7 @@ export function generateRandomContract(): void {
   const problemType = getRandomProblemType(maxDif);
 
   const contractFn = getRandomFilename(randServer, reward);
+  if (contractFn == null) return; //Not generate the contract
   const contract = new CodingContract(contractFn, problemType, reward);
 
   randServer.addContract(contract);
@@ -102,16 +103,19 @@ export function generateRandomContractOnHome(): void {
   const serv = Player.getHomeComputer();
 
   const contractFn = getRandomFilename(serv, reward);
+  if (contractFn == null) return; //Not generate the contract
   const contract = new CodingContract(contractFn, problemType, reward);
 
   serv.addContract(contract);
 }
 
-export const generateDummyContract = (problemType: CodingContractName): string => {
+export const generateDummyContract = (problemType: CodingContractName): string | null => {
   if (!CodingContractTypes[problemType]) throw new Error(`Invalid problem type: '${problemType}'`);
   const serv = Player.getHomeComputer();
 
   const contractFn = getRandomFilename(serv);
+  if (contractFn == null) return null; //Not generate the contract.
+  //It seems that only src/NetscriptFunctions/CodingContract.ts#L132 calls this function, and it can probably return null just fine.
   const contract = new CodingContract(contractFn, problemType, null);
   serv.addContract(contract);
 
@@ -152,7 +156,7 @@ export function generateContract(params: IGenerateContractParams): void {
   }
 
   const filename = params.fn ? params.fn : getRandomFilename(server, reward);
-
+  if (contractFn == null) return; //Not generate the contract
   const contract = new CodingContract(filename, problemType, reward);
   server.addContract(contract);
 }
@@ -252,11 +256,11 @@ function getRandomServer(): BaseServer | null {
   return randServer;
 }
 
-function getRandomB64String(length: number) {
-  const b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+function getRandomB62String(length: number) {
+  const b62 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   return Array(length)
     .fill(0)
-    .map(() => b64[getRandomIntInclusive(0, 63)])
+    .map(() => b62[getRandomIntInclusive(0, 61)])
     .join("");
 }
 
@@ -264,12 +268,14 @@ function getRandomFilename(
   server: BaseServer,
   reward: ICodingContractReward = { type: CodingContractRewardType.Money },
 ): ContractFilePath | null {
-  let contractFn = `contract-${getRandomB64String(6)}`;
+  let contractFn = `contract-${getRandomB62String(6)}`;
   if ("name" in reward) {
     // Only alphanumeric characters in the reward name.
     contractFn += `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}`;
   }
   contractFn += ".cct";
+  //Returns null sometimes. Code using this function should probably fail to generate their contract,
+  //and if they have a return value, their downstream has to be checked too.
   if (server.contracts.filter((c: CodingContract) => c.fn === contractFn).length) return null;
   const validatedPath = resolveContractFilePath(contractFn);
   if (!validatedPath) throw new Error(`Generated contract path could not be validated: ${contractFn}`);

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -115,7 +115,6 @@ export const generateDummyContract = (problemType: CodingContractName): string |
 
   const contractFn = getRandomFilename(serv);
   if (contractFn == null) return null; //Not generate the contract.
-  //It seems that only src/NetscriptFunctions/CodingContract.ts#L132 calls this function, and it can probably return null just fine.
   const contract = new CodingContract(contractFn, problemType, null);
   serv.addContract(contract);
 

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -263,12 +263,13 @@ function getRandomServer(): BaseServer | null {
   return randServer;
 }
 
-function getRandomB62String(length: number) {
-  const b62 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  return Array(length)
-    .fill(0)
-    .map(() => b62[getRandomIntInclusive(0, 61)])
-    .join("");
+function getRandomAlphanumericString(length: number) {
+  const alphanumericChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < length; ++i) {
+    result += alphanumericChars.charAt(Math.random() * alphanumericChars.length);
+  }
+  return result;
 }
 
 /**
@@ -276,11 +277,11 @@ function getRandomB62String(length: number) {
  * Callers of this function must return early and not generate a contract when it happens. It likely happens when there
  * are ~240k contracts on the specified server.
  */
-function getRandomFilename(
+export function getRandomFilename(
   server: BaseServer,
   reward: ICodingContractReward = { type: CodingContractRewardType.Money },
 ): ContractFilePath | null {
-  let contractFn = `contract-${getRandomB62String(6)}`;
+  let contractFn = `contract-${getRandomAlphanumericString(6)}`;
   if ("name" in reward) {
     // Only alphanumeric characters in the reward name.
     contractFn += `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}`;

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -86,7 +86,9 @@ export function generateRandomContract(): void {
   const problemType = getRandomProblemType(maxDif);
 
   const contractFn = getRandomFilename(randServer, reward);
-  if (contractFn == null) return; //Not generate the contract
+  if (contractFn == null) {
+    return;
+  }
   const contract = new CodingContract(contractFn, problemType, reward);
 
   randServer.addContract(contract);
@@ -103,7 +105,9 @@ export function generateRandomContractOnHome(): void {
   const serv = Player.getHomeComputer();
 
   const contractFn = getRandomFilename(serv, reward);
-  if (contractFn == null) return; //Not generate the contract
+  if (contractFn == null) {
+    return;
+  }
   const contract = new CodingContract(contractFn, problemType, reward);
 
   serv.addContract(contract);
@@ -114,7 +118,9 @@ export const generateDummyContract = (problemType: CodingContractName): string |
   const serv = Player.getHomeComputer();
 
   const contractFn = getRandomFilename(serv);
-  if (contractFn == null) return null; //Not generate the contract.
+  if (contractFn == null) {
+    return null;
+  }
   const contract = new CodingContract(contractFn, problemType, null);
   serv.addContract(contract);
 
@@ -155,7 +161,9 @@ export function generateContract(params: IGenerateContractParams): void {
   }
 
   const filename = params.fn ? params.fn : getRandomFilename(server, reward);
-  if (filename == null) return; //Not generate the contract
+  if (filename == null) {
+    return;
+  }
   const contract = new CodingContract(filename, problemType, reward);
   server.addContract(contract);
 }
@@ -263,6 +271,11 @@ function getRandomB62String(length: number) {
     .join("");
 }
 
+/**
+ * This function will return null if the randomized name collides with another contract's name on the specified server.
+ * Callers of this function must return early and not generate a contract when it happens. It likely happens when there
+ * are ~240k contracts on the specified server.
+ */
 function getRandomFilename(
   server: BaseServer,
   reward: ICodingContractReward = { type: CodingContractRewardType.Money },
@@ -273,9 +286,10 @@ function getRandomFilename(
     contractFn += `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}`;
   }
   contractFn += ".cct";
-  //Returns null sometimes. Code using this function should probably fail to generate their contract,
-  //and if they have a return value, their downstream has to be checked too.
-  if (server.contracts.filter((c: CodingContract) => c.fn === contractFn).length) return null;
+  // Return null if there is a contract with the same name.
+  if (server.contracts.filter((c: CodingContract) => c.fn === contractFn).length) {
+    return null;
+  }
   const validatedPath = resolveContractFilePath(contractFn);
   if (!validatedPath) throw new Error(`Generated contract path could not be validated: ${contractFn}`);
   return validatedPath;

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -256,22 +256,19 @@ function getRandomFilename(
   server: BaseServer,
   reward: ICodingContractReward = { type: CodingContractRewardType.Money },
 ): ContractFilePath {
-  let contractFn = `contract-${getRandomIntInclusive(0, 1e6)}`;
+  let contractFn, i = 0;
   let contractSuffix = ".cct";
   if ("name" in reward) {
     // Only alphanumeric characters in the reward name.
     contractSuffix = `-${reward.name.replace(/[^a-zA-Z0-9]/g, "")}` + contractSuffix;
   }
-  for (let i = 0; i < 1000; ++i) {
-    if (
-      server.contracts.filter((c: CodingContract) => {
-        return c.fn === contractFn;
-      }).length == 0
-    ) {
-      break;
-    }
+  do {
     contractFn = `contract-${getRandomIntInclusive(0, 1e6)}` + contractSuffix;
-  }
+  } while(
+    server.contracts.filter((c: CodingContract) => {
+      return c.fn === contractFn;
+    }).length != 0 && ++i < 1000
+  );
   const validatedPath = resolveContractFilePath(contractFn);
   if (!validatedPath) throw new Error(`Generated contract path could not be validated: ${contractFn}`);
   return validatedPath;

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -256,7 +256,8 @@ function getRandomFilename(
   server: BaseServer,
   reward: ICodingContractReward = { type: CodingContractRewardType.Money },
 ): ContractFilePath {
-  let contractFn, i = 0;
+  let contractFn: string,
+    i = 0;
   let contractSuffix = ".cct";
   if ("name" in reward) {
     // Only alphanumeric characters in the reward name.
@@ -264,10 +265,11 @@ function getRandomFilename(
   }
   do {
     contractFn = `contract-${getRandomIntInclusive(0, 1e6)}` + contractSuffix;
-  } while(
+  } while (
     server.contracts.filter((c: CodingContract) => {
       return c.fn === contractFn;
-    }).length != 0 && ++i < 1000
+    }).length != 0 &&
+    ++i < 1000
   );
   const validatedPath = resolveContractFilePath(contractFn);
   if (!validatedPath) throw new Error(`Generated contract path could not be validated: ${contractFn}`);

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -156,7 +156,7 @@ export function generateContract(params: IGenerateContractParams): void {
   }
 
   const filename = params.fn ? params.fn : getRandomFilename(server, reward);
-  if (contractFn == null) return; //Not generate the contract
+  if (filename == null) return; //Not generate the contract
   const contract = new CodingContract(filename, problemType, reward);
   server.addContract(contract);
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4058,11 +4058,12 @@ export interface CodingContract {
    * RAM cost: 2 GB
    *
    * Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
+   * If a contract of the same name already exists on the home computer, fails to generate the contract and returns null.
    *
    * @param type - Type of contract to generate
    * @returns Filename of the contract.
    */
-  createDummyContract(type: CodingContractName): string;
+  createDummyContract(type: CodingContractName): string | null;
 
   /**
    * List all contract types.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4058,7 +4058,8 @@ export interface CodingContract {
    * RAM cost: 2 GB
    *
    * Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
-   * If a contract of the same name already exists on the home computer, fails to generate the contract and returns null.
+   *
+   * This function will return null and not generate a contract if the randomized contract name is the same as another contract's name.
    *
    * @param type - Type of contract to generate
    * @returns Filename of the contract.

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -498,5 +498,13 @@ export const breakingChanges300: VersionBreakingChange = {
         'It has been automatically replaced with "ns.getBitNodeMultipliers().CloudServerMaxRam".',
       showWarning: false,
     },
+    {
+      brokenAPIs: [{ name: "createDummyContract" }],
+      info:
+        "ns.codingcontract.createDummyContract might generate a contract with the same name of another contract.\n" +
+        "This bug was fixed. Now this function will return null and not generate a contract if the randomized contract " +
+        "name is the same as another contract's name.",
+      showWarning: false,
+    },
   ],
 };

--- a/test/jest/CodingContract/ContractGenerator.test.ts
+++ b/test/jest/CodingContract/ContractGenerator.test.ts
@@ -1,0 +1,76 @@
+import { Player } from "@player";
+import {
+  generateContract,
+  generateDummyContract,
+  generateRandomContract,
+  generateRandomContractOnHome,
+  getRandomFilename,
+} from "../../../src/CodingContract/ContractGenerator";
+import { CodingContractName } from "../../../src/Enums";
+import { GetAllServers } from "../../../src/Server/AllServers";
+import type { BaseServer } from "../../../src/Server/BaseServer";
+import { SpecialServers } from "../../../src/Server/data/SpecialServers";
+import { initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
+
+beforeAll(() => {
+  initGameEnvironment();
+});
+
+beforeEach(() => {
+  setupBasicTestingEnvironment();
+  assertNumberOfContracts(0, GetAllServers());
+});
+
+function assertNumberOfContracts(expected: number, servers: BaseServer[]): void {
+  expect(servers.reduce((sum, server) => sum + server.contracts.length, 0)).toStrictEqual(expected);
+}
+
+describe("Generator", () => {
+  test("generateRandomContract", () => {
+    generateRandomContract();
+    assertNumberOfContracts(1, GetAllServers());
+  });
+  test("generateRandomContractOnHome", () => {
+    generateRandomContractOnHome();
+    assertNumberOfContracts(1, [Player.getHomeComputer()]);
+  });
+  test("generateDummyContract", () => {
+    generateDummyContract(CodingContractName.FindLargestPrimeFactor);
+    assertNumberOfContracts(1, GetAllServers());
+  });
+  // generateContract is flexible. All properties in IGenerateContractParams are optional. This test checks the usage in
+  // CodingContractsDev.tsx.
+  test("generateContract - home", () => {
+    generateContract({ problemType: CodingContractName.FindLargestPrimeFactor, server: SpecialServers.Home });
+    assertNumberOfContracts(1, [Player.getHomeComputer()]);
+  });
+  // This test checks the case in which we randomize everything (e.g., problemType, server).
+  test("generateContract - random server", () => {
+    generateContract({});
+    assertNumberOfContracts(1, GetAllServers());
+  });
+});
+
+describe("getRandomFilename", () => {
+  test("Check format and collision", () => {
+    const server = Player.getHomeComputer();
+    const set = new Set();
+    // Contract names contain only alphanumeric chars.
+    const regex = /[^a-zA-Z0-9]/g;
+    const maxIter = 1000;
+    for (let i = 0; i < maxIter; ++i) {
+      const filename = getRandomFilename(server);
+      if (filename == null) {
+        throw new Error("Cannot generate random filename");
+      }
+      expect(filename).toMatch(regex);
+      set.add(filename);
+    }
+    // getRandomFilename had a bug that made the filenames collide much easier than what we expected. Please check
+    // https://github.com/bitburner-official/bitburner-src/pull/2399 for more information.
+    // This test is designed to catch that kind of bug. The probability of collision is greater than zero, so this test
+    // may give a false positive. However, the probability is very low (0.000008802741646607437), and the error log
+    // should point that out immediately.
+    expect(set.size).toStrictEqual(maxIter);
+  });
+});


### PR DESCRIPTION
https://discord.com/channels/415207508303544321/415213413745164318/1442796583023415326

I don't know how npm works, and I don't know how to access the result of my branch (instead of the official one, which is on the official website) to test it, but I really hope there aren't any bugs.

Edit:
We check if the file name without the suffix ("contract-122706") exists, but data in `server.contracts` contains the suffix ("contract-122706.cct"), so that check does not work.

MRE:
```js
/** @param {NS} ns */
export async function main(ns) {
  console.clear();
  const s = new Set();
  for (let i = 0; i < 10000; ++i) {
    const filename = ns.codingcontract.createDummyContract("Algorithmic Stock Trader I");
    if (s.has(filename)) {
      console.error(filename, s);
      break;
    }
    s.add(filename);
  }
}
```