### PR TITLE
DOC: Clarification of Singularity costs inside BN4

### DIFF
--- a/markdown/bitburner.singularity.md
+++ b/markdown/bitburner.singularity.md
@@ -14,7 +14,7 @@ export interface Singularity
 
 ## Remarks
 
-This API requires Source-File 4 to use. The RAM cost of all these functions is multiplied by 16/4/1 based on Source-File 4 levels.
+This API requires Source-File 4 to use outside of BitNode 4. Additionally, outside of BitNode 4 the RAM cost of all these functions is multiplied by 16/4/1 based on Source-File 4 levels.
 
 ## Methods
 

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -171,8 +171,8 @@ export function initBitNodes() {
     ),
     (
       <>
-        This Source-File lets you access and use the Singularity functions in other BitNodes. Each level of this
-        Source-File reduces the RAM cost of singularity functions:
+        This Source-File lets you access and use the Singularity functions outside of this BitNode. Each level of this
+        Source-File reduces the RAM cost of singularity functions in other BitNodes:
         <ul>
           <li>Level 1: 16x</li>
           <li>Level 2: 4x</li>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1861,7 +1861,7 @@ export interface BitNodeBooleanOptions {
 /**
  * Singularity API
  * @remarks
- * This API requires Source-File 4 to use. The RAM cost of all these functions is multiplied by 16/4/1 based on
+ * This API requires Source-File 4 to use outside of BitNode 4. Additionally, outside of BitNode 4 the RAM cost of all these functions is multiplied by 16/4/1 based on
  * Source-File 4 levels.
  * @public
  */


### PR DESCRIPTION
From chat at [discord](https://discord.com/channels/415207508303544321/415213413745164318/1443536483586936874).  Very minor doc updates covering:
 - changing BN4 description to highlight SF levels impact use of singularity functions in other BNs specifically,
 - adding detail to singularity API description to highlight the same.
 
 Standard suite of `lint`, `format`, `test` and `doc` carried out so hopefully the checks pass first time.