### PR TITLE
DOCUMENTATION: Remove references to defunct wiki from Hack/Weaken/Grow

### DIFF
--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -281,13 +281,13 @@ export const HelpTexts: Record<string, string[]> = {
     "Usage: grow",
     " ",
     "Spoof transactions in the current server. Increasing the money available by hacking. Requires root access.",
-    "For additional information please go to Documentation > Resources > NS API Documentation > Grow for more details",
+    "For additional information please go to Documentation > Resources > NS API Documentation > Grow.",
     " ",
   ],
   hack: [
     "Usage: hack",
     " ",
-    "For additional information please go to Documentation > Resources > NS API Documentation > Hack for more details",
+    "For additional information please go to Documentation > Resources > NS API Documentation > Hack.",
     " ",
   ],
   help: [
@@ -526,7 +526,7 @@ export const HelpTexts: Record<string, string[]> = {
     " ",
     "Reduces the security level of the current server. Decreasing the time it takes for all operations on this server.",
     "Requires root access.",
-    "For additional information please go to Documentation > Resources > NS API Documentation > Weaken for more details",
+    "For additional information please go to Documentation > Resources > NS API Documentation > Weaken.",
     " ",
   ],
   wget: [

--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -281,13 +281,13 @@ export const HelpTexts: Record<string, string[]> = {
     "Usage: grow",
     " ",
     "Spoof transactions in the current server. Increasing the money available by hacking. Requires root access.",
-    "See the wiki page for hacking mechanics.",
+    "For additional information please go to Documentation > Resources > NS API Documentation > Grow for more details",
     " ",
   ],
   hack: [
     "Usage: hack",
     " ",
-    "Attempt to hack the current server. Requires root access in order to be run. See the wiki page for hacking mechanics",
+    "For additional information please go to Documentation > Resources > NS API Documentation > Hack for more details",
     " ",
   ],
   help: [
@@ -525,7 +525,8 @@ export const HelpTexts: Record<string, string[]> = {
     "Usage: weaken",
     " ",
     "Reduces the security level of the current server. Decreasing the time it takes for all operations on this server.",
-    "Requires root access. See the wiki page for hacking mechanics.",
+    "Requires root access.",
+    "For additional information please go to Documentation > Resources > NS API Documentation > Weaken for more details",
     " ",
   ],
   wget: [


### PR DESCRIPTION
Updated GROW WEAKEN and HACK help text to point at the ingame documentation->github locations for each.
