### PR TITLE
CONTRACTS: Generate test contracts on executing host by default. Add support for optional parameter to specify the server.

### DIFF
--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -9,7 +9,7 @@ Generate a dummy contract.
 **Signature:**
 
 ```typescript
-createDummyContract(type: CodingContractName): string | null;
+createDummyContract(type: CodingContractName, host?: string): string | null;
 ```
 
 ## Parameters
@@ -46,6 +46,22 @@ Type of contract to generate
 
 
 </td></tr>
+<tr><td>
+
+host
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+_(Optional)_ Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
+
+
+</td></tr>
 </tbody></table>
 
 **Returns:**
@@ -58,7 +74,7 @@ Filename of the contract.
 
 RAM cost: 2 GB
 
-Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
+Generate a dummy contract on the current computer with no reward. Used to test various algorithms.
 
 This function will return null and not generate a contract if the randomized contract name is the same as another contract's name.
 

--- a/markdown/bitburner.codingcontract.createdummycontract.md
+++ b/markdown/bitburner.codingcontract.createdummycontract.md
@@ -74,7 +74,7 @@ Filename of the contract.
 
 RAM cost: 2 GB
 
-Generate a dummy contract on the current computer with no reward. Used to test various algorithms.
+Generate a dummy contract on the current server with no reward. Used to test various algorithms.
 
 This function will return null and not generate a contract if the randomized contract name is the same as another contract's name.
 

--- a/markdown/bitburner.codingcontract.md
+++ b/markdown/bitburner.codingcontract.md
@@ -38,7 +38,7 @@ Attempts a coding contract, returning a reward string on success or empty string
 </td></tr>
 <tr><td>
 
-[createDummyContract(type)](./bitburner.codingcontract.createdummycontract.md)
+[createDummyContract(type, host)](./bitburner.codingcontract.createdummycontract.md)
 
 
 </td><td>

--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -113,16 +113,15 @@ export function generateRandomContractOnHome(): void {
   serv.addContract(contract);
 }
 
-export const generateDummyContract = (problemType: CodingContractName): string | null => {
+export const generateDummyContract = (problemType: CodingContractName, server: BaseServer): string | null => {
   if (!CodingContractTypes[problemType]) throw new Error(`Invalid problem type: '${problemType}'`);
-  const serv = Player.getHomeComputer();
 
-  const contractFn = getRandomFilename(serv);
+  const contractFn = getRandomFilename(server);
   if (contractFn == null) {
     return null;
   }
   const contract = new CodingContract(contractFn, problemType, null);
-  serv.addContract(contract);
+  server.addContract(contract);
 
   return contractFn;
 };

--- a/src/NetscriptFunctions/CodingContract.ts
+++ b/src/NetscriptFunctions/CodingContract.ts
@@ -127,9 +127,11 @@ export function NetscriptCodingContract(): InternalAPI<ICodingContract> {
       const contract = getCodingContract(ctx, host, filename);
       return contract.getMaxNumTries() - contract.tries;
     },
-    createDummyContract: (ctx) => (_type) => {
+    createDummyContract: (ctx) => (_type, _host?) => {
       const type = getEnumHelper("CodingContractName").nsGetMember(ctx, _type);
-      return generateDummyContract(type);
+      const host = _host ? helpers.string(ctx, "host", _host) : ctx.workerScript.hostname;
+      const server = helpers.getServer(ctx, host);
+      return generateDummyContract(type, server);
     },
     getContractTypes: () => () => Object.values(CodingContractName),
   };

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4057,7 +4057,7 @@ export interface CodingContract {
    * @remarks
    * RAM cost: 2 GB
    *
-   * Generate a dummy contract on the current computer with no reward. Used to test various algorithms.
+   * Generate a dummy contract on the current server with no reward. Used to test various algorithms.
    *
    * This function will return null and not generate a contract if the randomized contract name is the same as another contract's name.
    *

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4057,14 +4057,15 @@ export interface CodingContract {
    * @remarks
    * RAM cost: 2 GB
    *
-   * Generate a dummy contract on the home computer with no reward. Used to test various algorithms.
+   * Generate a dummy contract on the current computer with no reward. Used to test various algorithms.
    *
    * This function will return null and not generate a contract if the randomized contract name is the same as another contract's name.
    *
    * @param type - Type of contract to generate
+   * @param host - Hostname/IP of the server containing the contract. Optional. Defaults to the server the calling script is running on.
    * @returns Filename of the contract.
    */
-  createDummyContract(type: CodingContractName): string | null;
+  createDummyContract(type: CodingContractName, host?: string): string | null;
 
   /**
    * List all contract types.

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -499,11 +499,26 @@ export const breakingChanges300: VersionBreakingChange = {
       showWarning: false,
     },
     {
-      brokenAPIs: [{ name: "createDummyContract" }],
+      brokenAPIs: [
+        {
+          name: "createDummyContract",
+          migration: {
+            searchValue: "createDummyContract",
+            migrator: (line: string) => {
+              for (const match of line.matchAll(/createDummyContract\([^,]*?\)/g)) {
+                line = line.replace(match[0], match[0].slice(0, match[0].length - 1) + `, "home")`);
+              }
+              return line;
+            },
+          },
+        },
+      ],
       info:
         "ns.codingcontract.createDummyContract might generate a contract with the same name of another contract.\n" +
         "This bug was fixed. Now this function will return null and not generate a contract if the randomized contract " +
-        "name is the same as another contract's name.",
+        "name is the same as another contract's name.\n\n" +
+        "ns.codingcontract.createDummyContract generated a dummy contract on home. Now you can specify the host that \n" +
+        'gets the generated contract with a new optional parameter. Your code was migrated to specify "home" as the host.',
       showWarning: false,
     },
   ],

--- a/test/jest/CodingContract/ContractGenerator.test.ts
+++ b/test/jest/CodingContract/ContractGenerator.test.ts
@@ -35,7 +35,7 @@ describe("Generator", () => {
     assertNumberOfContracts(1, [Player.getHomeComputer()]);
   });
   test("generateDummyContract", () => {
-    generateDummyContract(CodingContractName.FindLargestPrimeFactor);
+    generateDummyContract(CodingContractName.FindLargestPrimeFactor, Player.getHomeComputer());
     assertNumberOfContracts(1, GetAllServers());
   });
   // generateContract is flexible. All properties in IGenerateContractParams are optional. This test checks the usage in


### PR DESCRIPTION
This modifies the `ns.codingcontract.createDummyContract()` method to be more consistent with other methods that operate on filesystems. First, it generates contracts by default on the executing host. Second it accepts an optional hostname argument that specifies a host to generate the contract on.

I added the change to the default in this PR in part because it matched the other methods in `CodingContract.ts` to generate the `BaseServer` there and pass that in rather than handle the default in `ContractGenerator.ts`.

This is a **breaking change** but I'm guessing the number of people depending on code running on remote servers to generate files on home is very small compared to people creating dummy contracts on home from home.

Testing:

The test script used:
```ts
export async function main(ns: NS) {
  const sqrt = ns.enums.CodingContractName.SquareRoot
  const local = ns.codingcontract.createDummyContract(sqrt)
  const remote = ns.codingcontract.createDummyContract(sqrt, "n00dles")
  ns.tprintf("Created %s locally and %s remotely", local, remote)
}
```
* A script was created which generates a Square Root test contract locally and on `n00dles` using the optional argument. It also tests that the filenames are returned regardless of the server that it's generated on.
* The script was copied to `foodnstuff` and run from there.
* The script was modified so that `n00dles` is `blah` instead. The program generated an error modal as expected.
<img width="747" height="451" alt="Screenshot 2025-12-14 at 12 39 13 AM" src="https://github.com/user-attachments/assets/323e2953-5694-4547-a49b-5b898212ea1d" />
* The script was also modified so that `n00dles` is `home` instead and it behaves as expected, creating both scripts on the home server when run from home.