### PR TITLE
CODEBASE: Allow specifying migrator when migrating player's scripts

### DIFF
--- a/src/utils/APIBreaks/APIBreak.ts
+++ b/src/utils/APIBreaks/APIBreak.ts
@@ -26,6 +26,16 @@ export interface VersionBreakingChange {
   apiBreakingChanges: APIBreakInfo[];
 }
 
+type NormalMigration = {
+  replaceValue: string;
+  migrator?: never;
+};
+
+type MigrationWithCustomLogic = {
+  replaceValue?: never;
+  migrator: (line: string) => string;
+};
+
 export interface APIBreakInfo {
   /** The API functions impacted by the API break */
   brokenAPIs: {
@@ -33,8 +43,7 @@ export interface APIBreakInfo {
     migration?: {
       /** We may need to use a custom search value instead of name */
       searchValue: string | RegExp;
-      replaceValue: string;
-    };
+    } & (NormalMigration | MigrationWithCustomLogic);
   }[];
   /** Info that should be shown to the player, alongside the list of impacted scripts */
   info: string;
@@ -67,8 +76,13 @@ function detectImpactAndMigrateLines(script: Script, brokenFunctions: APIBreakIn
         continue;
       }
       impactedLines.push(i + 1);
-      if (brokenFunction.migration) {
+      if (!brokenFunction.migration) {
+        continue;
+      }
+      if (!brokenFunction.migration.migrator) {
         lines[i] = lines[i].replaceAll(brokenFunction.migration.searchValue, brokenFunction.migration.replaceValue);
+      } else {
+        lines[i] = brokenFunction.migration.migrator(lines[i]);
       }
     }
   }


### PR DESCRIPTION
In #2417, we need to perform a non-trivial migration for the player's scripts. The current `replaceValue` is not enough to do that. This PR adds the ability to specify a migrator that can perform an arbitrarily complicated code transformation.

Test:
`src\utils\APIBreaks\3.0.0.ts`:
```ts
    {
      brokenAPIs: [
        {
          name: "createDummyContract",
          migration: {
            searchValue: "createDummyContract",
            migrator: (line: string) => {
              for (const match of line.matchAll(/createDummyContract\(.*?\)/g)) {
                line = line.replace(match[0], match[0].slice(0, match[0].length - 1) + `, "home")`);
              }
              return line;
            },
          },
        },
      ],
      info:
        "ns.codingcontract.createDummyContract might generate a contract with the same name of another contract.\n" +
        "This bug was fixed. Now this function will return null and not generate a contract if the randomized contract " +
        "name is the same as another contract's name.\n\n" +
        "ns.codingcontract.createDummyContract generated a dummy contract on home. Now you can specify the host that \n" +
        'gets the generated contract with a new optional parameter. Your code was migrated to specify "home" as the host.',
      showWarning: false,
    },
```

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  createDummyContract("Find Largest Prime Factor");
  ns.codingcontract.createDummyContract(ns.enums.CodingContractName.FindLargestPrimeFactor);
  let x= 0;createDummyContract("Find Largest Prime Factor");let y = 0;ns.codingcontract.createDummyContract(ns.enums.CodingContractName.FindLargestPrimeFactor);let z = 0;
}
```

Migrated code:
```js
/** @param {NS} ns */
export async function main(ns) {
  createDummyContract("Find Largest Prime Factor", "home");
  ns.codingcontract.createDummyContract(ns.enums.CodingContractName.FindLargestPrimeFactor, "home");
  let x= 0;createDummyContract("Find Largest Prime Factor", "home");let y = 0;ns.codingcontract.createDummyContract(ns.enums.CodingContractName.FindLargestPrimeFactor, "home");let z = 0;
}
```

Log:
```
ns.codingcontract.createDummyContract might generate a contract with the same name of another contract.
This bug was fixed. Now this function will return null and not generate a contract if the randomized contract name is the same as another contract's name.

ns.codingcontract.createDummyContract generated a dummy contract on home. Now you can specify the host that gets the generated contract with a new optional parameter. Your code was migrated to specify "home" as the host.

Usage of the following functions may have been affected:
createDummyContract

Potentially affected files on server home (with line numbers):
f.js: (Line numbers: 3, 4, 5)
```