### PR TITLE
UI: Add option to set fractional digits

### DIFF
--- a/src/GameOptions/ui/NumericDisplayOptions.tsx
+++ b/src/GameOptions/ui/NumericDisplayOptions.tsx
@@ -85,7 +85,7 @@ export const NumericDisplayPage = (): React.ReactElement => {
         step={1}
         min={0}
         max={5}
-        tooltip={<>The number of digits of precision to display on small numbers.</>}
+        tooltip={<>The default number of decimal places to display on small numbers.</>}
       />
       <Select startAdornment={<Typography>Locale&nbsp;</Typography>} value={locale} onChange={handleLocaleChange}>
         <MenuItem value="en">en</MenuItem>

--- a/src/GameOptions/ui/NumericDisplayOptions.tsx
+++ b/src/GameOptions/ui/NumericDisplayOptions.tsx
@@ -65,12 +65,7 @@ export const NumericDisplayPage = (): React.ReactElement => {
         step={1}
         min={0}
         max={5}
-        tooltip={
-          <>
-            The default number of decimal places to display on small numbers.
-            Default value: 3
-          </>
-        }
+        tooltip={<>The default number of decimal places to display on small numbers. Default value: 3</>}
       />
       <OptionSwitch
         checked={Settings.hideTrailingDecimalZeros}

--- a/src/GameOptions/ui/NumericDisplayOptions.tsx
+++ b/src/GameOptions/ui/NumericDisplayOptions.tsx
@@ -13,6 +13,7 @@ export const NumericDisplayPage = (): React.ReactElement => {
     Settings.fractionalDigits = newValue as number;
     FormatsNeedToChange.emit();
   }
+  
   function handleLocaleChange(event: SelectChangeEvent): void {
     setLocale(event.target.value);
     Settings.Locale = event.target.value;

--- a/src/GameOptions/ui/NumericDisplayOptions.tsx
+++ b/src/GameOptions/ui/NumericDisplayOptions.tsx
@@ -13,7 +13,7 @@ export const NumericDisplayPage = (): React.ReactElement => {
     Settings.fractionalDigits = newValue as number;
     FormatsNeedToChange.emit();
   }
-  
+
   function handleLocaleChange(event: SelectChangeEvent): void {
     setLocale(event.target.value);
     Settings.Locale = event.target.value;
@@ -58,6 +58,20 @@ export const NumericDisplayPage = (): React.ReactElement => {
         text="Hide thousands separator"
         tooltip={<>If this is set, thousands separators will not be displayed.</>}
       />
+      <OptionsSlider
+        label="Fractional Digits"
+        initialValue={Settings.fractionalDigits}
+        callback={handleFractionalDigitChange}
+        step={1}
+        min={0}
+        max={5}
+        tooltip={
+          <>
+            The default number of decimal places to display on small numbers.
+            Default value: 3
+          </>
+        }
+      />
       <OptionSwitch
         checked={Settings.hideTrailingDecimalZeros}
         onChange={(newValue) => {
@@ -77,15 +91,6 @@ export const NumericDisplayPage = (): React.ReactElement => {
         tooltip={
           <>If this is set all references to memory will use GiB instead of GB, in accordance with IEC 60027-2.</>
         }
-      />
-      <OptionsSlider
-        label="Fractional Digits"
-        initialValue={Settings.fractionalDigits}
-        callback={handleFractionalDigitChange}
-        step={1}
-        min={0}
-        max={5}
-        tooltip={<>The default number of decimal places to display on small numbers.</>}
       />
       <Select startAdornment={<Typography>Locale&nbsp;</Typography>} value={locale} onChange={handleLocaleChange}>
         <MenuItem value="en">en</MenuItem>

--- a/src/GameOptions/ui/NumericDisplayOptions.tsx
+++ b/src/GameOptions/ui/NumericDisplayOptions.tsx
@@ -4,10 +4,15 @@ import { Settings } from "../../Settings/Settings";
 import { OptionSwitch } from "../../ui/React/OptionSwitch";
 import { GameOptionsPage } from "./GameOptionsPage";
 import { FormatsNeedToChange } from "../../ui/formatNumber";
+import { OptionsSlider } from "./OptionsSlider";
 
 export const NumericDisplayPage = (): React.ReactElement => {
   const [locale, setLocale] = useState(Settings.Locale);
 
+  function handleFractionalDigitChange(_event: Event | React.SyntheticEvent, newValue: number | number[]): void {
+    Settings.fractionalDigits = newValue as number;
+    FormatsNeedToChange.emit();
+  }
   function handleLocaleChange(event: SelectChangeEvent): void {
     setLocale(event.target.value);
     Settings.Locale = event.target.value;
@@ -71,6 +76,15 @@ export const NumericDisplayPage = (): React.ReactElement => {
         tooltip={
           <>If this is set all references to memory will use GiB instead of GB, in accordance with IEC 60027-2.</>
         }
+      />
+      <OptionsSlider
+        label="Fractional Digits"
+        initialValue={Settings.fractionalDigits}
+        callback={handleFractionalDigitChange}
+        step={1}
+        min={0}
+        max={10}
+        tooltip={<>The amount of digits displayed after the period '.' in a number.</>}
       />
       <Select startAdornment={<Typography>Locale&nbsp;</Typography>} value={locale} onChange={handleLocaleChange}>
         <MenuItem value="en">en</MenuItem>

--- a/src/GameOptions/ui/NumericDisplayOptions.tsx
+++ b/src/GameOptions/ui/NumericDisplayOptions.tsx
@@ -83,7 +83,7 @@ export const NumericDisplayPage = (): React.ReactElement => {
         callback={handleFractionalDigitChange}
         step={1}
         min={0}
-        max={10}
+        max={5}
         tooltip={<>The number of digits of precision to display on small numbers.</>}
       />
       <Select startAdornment={<Typography>Locale&nbsp;</Typography>} value={locale} onChange={handleLocaleChange}>

--- a/src/GameOptions/ui/NumericDisplayOptions.tsx
+++ b/src/GameOptions/ui/NumericDisplayOptions.tsx
@@ -84,7 +84,7 @@ export const NumericDisplayPage = (): React.ReactElement => {
         step={1}
         min={0}
         max={10}
-        tooltip={<>The amount of digits displayed after the period '.' in a number.</>}
+        tooltip={<>The number of digits of precision to display on small numbers.</>}
       />
       <Select startAdornment={<Typography>Locale&nbsp;</Typography>} value={locale} onChange={handleLocaleChange}>
         <MenuItem value="en">en</MenuItem>

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -192,7 +192,7 @@ export const Settings = {
   useEngineeringNotation: false,
   /** Whether to disable suffixes and always use exponential form (scientific or engineering). */
   disableSuffixes: false,
-  /** The default amount of digits displayed after the period '.' in a number. */
+  /** The default amount of digits displayed after the decimal separator. */
   fractionalDigits: 3,
   /**
    * Player-defined key bindings. Don't use this property directly. It must be merged with DefaultKeyBindings in

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -192,6 +192,8 @@ export const Settings = {
   useEngineeringNotation: false,
   /** Whether to disable suffixes and always use exponential form (scientific or engineering). */
   disableSuffixes: false,
+  /** The amount of digits displayed after the period '.' in a number. */
+  fractionalDigits: 3,
   /**
    * Player-defined key bindings. Don't use this property directly. It must be merged with DefaultKeyBindings in
    * src\utils\KeyBindingUtils.ts.

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -192,7 +192,7 @@ export const Settings = {
   useEngineeringNotation: false,
   /** Whether to disable suffixes and always use exponential form (scientific or engineering). */
   disableSuffixes: false,
-  /** The amount of digits displayed after the period '.' in a number. */
+  /** The default amount of digits displayed after the period '.' in a number. */
   fractionalDigits: 3,
   /**
    * Player-defined key bindings. Don't use this property directly. It must be merged with DefaultKeyBindings in

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -119,7 +119,12 @@ export function formatPercent(n: number, fractionalDigits = 2, multStart = 1e6) 
   return getFormatter(fractionalDigits, percentFormats, { style: "percent" }).format(n);
 }
 
-export function formatNumber(n: number, fractionalDigits = Settings.fractionalDigits, suffixStart = 1000, isInteger = false) {
+export function formatNumber(
+  n: number,
+  fractionalDigits = Settings.fractionalDigits,
+  suffixStart = 1000,
+  isInteger = false,
+) {
   // NaN does not get formatted
   if (Number.isNaN(n)) return "NaN";
   const nAbs = Math.abs(n);

--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -119,7 +119,7 @@ export function formatPercent(n: number, fractionalDigits = 2, multStart = 1e6) 
   return getFormatter(fractionalDigits, percentFormats, { style: "percent" }).format(n);
 }
 
-export function formatNumber(n: number, fractionalDigits = 3, suffixStart = 1000, isInteger = false) {
+export function formatNumber(n: number, fractionalDigits = Settings.fractionalDigits, suffixStart = 1000, isInteger = false) {
   // NaN does not get formatted
   if (Number.isNaN(n)) return "NaN";
   const nAbs = Math.abs(n);


### PR DESCRIPTION
Adds a slider to the Numeric Display options page which effects the amount of fractional digits displayed in a regular number.
The slider allows a value between 0 and 5

Settings default:
<img width="810" height="298" alt="Settings menu" src="https://github.com/user-attachments/assets/fa753238-23d0-4fc8-966f-cf9e971335e8" />

0 fractional digits:
<img width="1116" height="657" alt="0 fractional digits:" src="https://github.com/user-attachments/assets/5f9e8e92-985b-4586-a3ee-671ae3d724fd" />

5 fractional digits:
<img width="1163" height="650" alt="5 fractional digits" src="https://github.com/user-attachments/assets/e41c527c-b535-461b-bf15-aaae2b7a28c0" />

### Possible edge case
Setting the option to 0 works as intended, the formatter removes the separator entirely and displays an integer instead of any amount of fractions behind it. 
Although, I did notice a minor edge case where the number sometimes displays a comma separated value like for example 1,000K when its really close to being a million, like 999995. 
I dont think this is caused by the changes applied in this fork.

### Relevant commits
- MISC: Add fractional digit settings field
- MISC: formatNumber fractionalDigits parameter default to Settings field
- UI: Add Fractional Digits option slider

### Credits
Thanks to @ficocelliguy for explaining the ropes of how to set up a PR.
Thanks to @shyguy1412 for being there at the right time with right answer to something very specific.
