### PR TITLE
UI: Change notice for breaking changes in v2

### DIFF
--- a/src/utils/V2Modal.tsx
+++ b/src/utils/V2Modal.tsx
@@ -13,8 +13,7 @@ export const V2Modal = (): React.ReactElement => {
   const [open, setOpen] = useState(v2ModalOpen);
   return (
     <Modal open={open} onClose={() => undefined}>
-      <Typography>Welcome to bitburner v2.0.0!</Typography>{" "}
-      <Typography>While this version does not change the game a lot, it does have quite a few API breaks.</Typography>{" "}
+      <Typography>NOTICE FOR BREAKING CHANGES IN V2</Typography>
       <Typography>
         A file was added to your home computer called V2_0_0_API_BREAK.txt and it is highly recommended you take a look
         at this file. It explains where most of the API break have occurred.


### PR DESCRIPTION
When testing migration from very old save files, I notice that the popup for v2 breaking changes is like this:

<img width="1013" height="166" alt="before" src="https://github.com/user-attachments/assets/72c57302-954e-491b-a208-d04b92a9c013" />

It's weird to say `Welcome to bitburner v2.0.0!` when it's v3+. I changed the message like this:

<img width="1101" height="147" alt="after" src="https://github.com/user-attachments/assets/0b5f8779-86f8-4929-9b91-313f123202f5" />
