### PR TITLE
UI: Do not show error popup related to Stanek's Gift data when loading save files from pre-v1.1.0

### DIFF
--- a/src/CotMG/Helper.tsx
+++ b/src/CotMG/Helper.tsx
@@ -6,10 +6,11 @@ import { BaseGift } from "./BaseGift";
 
 import { StaneksGift } from "./StaneksGift";
 import { Result } from "../types";
+import { isStanekGiftImplemented } from "../utils/ErrorHelper";
 
 export let staneksGift = new StaneksGift();
 
-export function loadStaneksGift(saveString: string): void {
+export function loadStaneksGift(saveString: string, versionSave?: string): void {
   let staneksGiftData: unknown;
   try {
     staneksGiftData = JSON.parse(saveString, Reviver);
@@ -20,9 +21,11 @@ export function loadStaneksGift(saveString: string): void {
     console.error(error);
     console.error("Invalid StaneksGiftSave:", saveString);
     staneksGift = new StaneksGift();
-    setTimeout(() => {
-      dialogBoxCreate(`Cannot load data of Stanek's Gift. Stanek's Gift is reset. Error: ${error}.`);
-    }, 1000);
+    if (isStanekGiftImplemented(versionSave)) {
+      setTimeout(() => {
+        dialogBoxCreate(`Cannot load data of Stanek's Gift. Stanek's Gift is reset. Error: ${error}.`);
+      }, 1000);
+    }
     return;
   }
   staneksGift = staneksGiftData;

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -165,12 +165,20 @@ function assertParsedSaveData(parsedSaveData: unknown): asserts parsedSaveData i
  * contains only what we need.
  */
 export const loadedSaveObjectMiniDump = {
-  /**
-   * If VersionSave exists, it is always a string. It has 3 formats:
-   * - x.y: Very early versions (0.1-0.17) used this format.
-   * - x.y.z: Starting from roughly 0.17, we used this format. Note that in some commits, we mistakenly used the x.y format.
-   * - x: Starting from v1, we used the version number instead of the version string.
-   */
+  // VersionSave is always a string. It has 3 formats/possible values:
+  // - Empty string: Pre-v0.20.0.
+  // - '"x.y.z"': v0.20.0 to the last v0 version. Notice how I use both single quotes and double quotes. The double
+  // quotes are part of the string value. For example, with v0.20.0, the string value is "0.20.0" (8 chars, not 6 chars).
+  // - x: Starting from v1, we used the version number instead of the version string.
+  //
+  // The history of this property in the save data is complicated. In v0, we used the version string in src\Constants.ts,
+  // then we switched to the version number in v1. In v0, the version string has 2 formats:
+  // - x.y: Very early versions (v0.1 to roughly v0.17) used this format.
+  // - x.y.z: Starting from roughly v0.17, we used this format. Note that in some commits, we mistakenly used the x.y
+  // format.
+  //
+  // However, the save data only contains VersionSave starting from v0.20.0, so if we load a pre-v0.20.0 save file, this
+  // property will be an empty string.
   VersionSave: undefined as string | undefined,
 };
 
@@ -473,7 +481,7 @@ async function loadGame(saveData: SaveData): Promise<boolean> {
   }
 
   // "Optional 1"
-  loadStaneksGift(saveObj.StaneksGiftSave);
+  loadStaneksGift(saveObj.StaneksGiftSave, loadedSaveObjectMiniDump.VersionSave);
   try {
     loadStockMarket(saveObj.StockMarketSave);
   } catch (e) {

--- a/src/utils/ErrorHelper.ts
+++ b/src/utils/ErrorHelper.ts
@@ -200,12 +200,30 @@ export function isSaveDataFromNewerVersions(versionSave?: string): boolean {
   if (versionSave == null) {
     return false;
   }
-  // x.y and x.y.z formats are from pre-v1 versions.
-  if (versionSave.includes(".")) {
+  // The empty string and the x.y.z format are from pre-v1 versions.
+  if (versionSave === "" || versionSave.includes(".")) {
     return false;
   }
   const versionNumber = Number(versionSave);
   if (!Number.isFinite(versionNumber) || versionNumber <= CONSTANTS.VersionNumber) {
+    return false;
+  }
+  return true;
+}
+
+export function isStanekGiftImplemented(versionSave?: string): boolean {
+  // It's debatable if we should return true or false here. If versionSave is undefined, there must be something wrong
+  // with the loading process. I think we should return true here and let the caller show the error popup.
+  if (versionSave == null) {
+    return true;
+  }
+  // The empty string and the x.y.z format are from pre-v1 versions.
+  if (versionSave === "" || versionSave.includes(".")) {
+    return false;
+  }
+  const versionNumber = Number(versionSave);
+  // Stanek's Gift was added in v1.1.0 (VersionNumber = 6).
+  if (!Number.isFinite(versionNumber) || versionNumber <= 5) {
     return false;
   }
   return true;


### PR DESCRIPTION
Stanek's Gift was added in v1.1.0, so when the player loads a save file older than that, we will show this popup:

<img width="864" height="54" alt="Capture" src="https://github.com/user-attachments/assets/9395fd56-7a3a-4ed9-9c98-2e3bf37597e1" />

This is not wrong, but it's (kind of) a false-positive warning. This PR prevents showing this error popup when loading save files from pre-v1.1.0. When hydroflame notified us about this popup, he also said that the stock market also had this problem. I'll test it and open another PR for it later if needed.

Save file for testing:
[1.0.0.json](https://github.com/user-attachments/files/24261776/1.0.0.json)
[1.1.0.json](https://github.com/user-attachments/files/24261778/1.1.0.json)
[3.0.0-with-invalid-stanek-data.gz](https://github.com/user-attachments/files/24261779/3.0.0-with-invalid-stanek-data.gz)

Edit: I confirm that we need to do this with the stock market data check as well. While testing it, I also found other problems with the migration code when processing very old save files (v0 save files). This is really a PITA. I'll open separate PRs for them.