### PR TITLE
UI: Add Script Editor toggle for Sticky Scroll

### DIFF
--- a/src/ScriptEditor/ui/Options.ts
+++ b/src/ScriptEditor/ui/Options.ts
@@ -4,6 +4,7 @@ export type WordWrapOptions = "on" | "off" | "bounded" | "wordWrapColumn";
 
 export type CursorStyle = editor.IEditorOptions["cursorStyle"];
 export type CursorBlinking = editor.IEditorOptions["cursorBlinking"];
+export type StickyScroll = editor.IEditorOptions["stickyScroll"];
 
 export interface Options {
   theme: string;
@@ -17,4 +18,5 @@ export interface Options {
   cursorStyle: CursorStyle;
   cursorBlinking: CursorBlinking;
   beautifyOnSave: boolean;
+  stickyScroll: StickyScroll;
 }

--- a/src/ScriptEditor/ui/OptionsModal.tsx
+++ b/src/ScriptEditor/ui/OptionsModal.tsx
@@ -11,7 +11,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import { useBoolean } from "../../ui/React/hooks";
 import { Modal } from "../../ui/React/Modal";
 import { ThemeEditorModal } from "./ThemeEditorModal";
-import { CursorBlinking, CursorStyle, Options, StickyScroll } from "./Options";
+import { CursorBlinking, CursorStyle, Options } from "./Options";
 
 const CURSOR_STYLES: CursorStyle[] = ["line", "block", "underline", "line-thin", "block-outline", "underline-thin"];
 const CURSOR_BLINKING_MODES: CursorBlinking[] = ["blink", "smooth", "phase", "expand", "solid"];
@@ -132,7 +132,7 @@ export function OptionsModal(props: OptionsModalProps): ReactElement {
       <div style={{ display: "flex", alignItems: "center" }}>
         <Typography marginRight={"auto"}>Cursor blinking: </Typography>
         <Select
-          onChange={(event) => props.onOptionChange("cursorBlinking", event.target.value as CursorBlinking)}
+          onChange={(event) => props.onOptionChange("cursorBlinking", event.target.value)}
           value={props.options.cursorBlinking}
         >
           {CURSOR_BLINKING_MODES.map((cursorBlinking) => (
@@ -154,7 +154,7 @@ export function OptionsModal(props: OptionsModalProps): ReactElement {
       <div style={{ display: "flex", alignItems: "center" }}>
         <Typography marginRight={"auto"}>Enable Sticky Scroll: </Typography>
         <Switch
-          onChange={(e) => props.onOptionChange("stickyScroll", { enabled: e.target.checked } as StickyScroll)}
+          onChange={(e) => props.onOptionChange("stickyScroll", { enabled: e.target.checked })}
           checked={props.options.stickyScroll?.enabled}
         />
       </div>

--- a/src/ScriptEditor/ui/OptionsModal.tsx
+++ b/src/ScriptEditor/ui/OptionsModal.tsx
@@ -11,7 +11,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import { useBoolean } from "../../ui/React/hooks";
 import { Modal } from "../../ui/React/Modal";
 import { ThemeEditorModal } from "./ThemeEditorModal";
-import { CursorBlinking, CursorStyle, Options } from "./Options";
+import { CursorBlinking, CursorStyle, Options, StickyScroll } from "./Options";
 
 const CURSOR_STYLES: CursorStyle[] = ["line", "block", "underline", "line-thin", "block-outline", "underline-thin"];
 const CURSOR_BLINKING_MODES: CursorBlinking[] = ["blink", "smooth", "phase", "expand", "solid"];
@@ -148,6 +148,14 @@ export function OptionsModal(props: OptionsModalProps): ReactElement {
         <Switch
           onChange={(e) => props.onOptionChange("beautifyOnSave", e.target.checked)}
           checked={props.options.beautifyOnSave}
+        />
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <Typography marginRight={"auto"}>Enable Sticky Scroll: </Typography>
+        <Switch
+          onChange={(e) => props.onOptionChange("stickyScroll", { enabled: e.target.checked } as StickyScroll)}
+          checked={props.options.stickyScroll?.enabled}
         />
       </div>
     </Modal>

--- a/src/ScriptEditor/ui/ScriptEditorContext.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorContext.tsx
@@ -92,6 +92,7 @@ export function ScriptEditorContextProvider({ children }: { children: React.Reac
     cursorStyle: Settings.MonacoCursorStyle,
     cursorBlinking: Settings.MonacoCursorBlinking,
     beautifyOnSave: Settings.MonacoBeautifyOnSave,
+    stickyScroll: Settings.MonacoStickyScroll,
   });
 
   function saveOptions(options: Options) {
@@ -107,6 +108,7 @@ export function ScriptEditorContextProvider({ children }: { children: React.Reac
     Settings.MonacoCursorBlinking = options.cursorBlinking;
     Settings.MonacoWordWrap = options.wordWrap;
     Settings.MonacoBeautifyOnSave = options.beautifyOnSave;
+    Settings.MonacoStickyScroll = options.stickyScroll;
   }
 
   return (

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -185,7 +185,7 @@ export const Settings = {
   /** Control the cursor animation style */
   MonacoCursorBlinking: "blink" as CursorBlinking,
   /** Toggle use of Sticky Scroll in the Script Editor */
-  MonacoStickyScroll: { enabled: true } as StickyScroll,
+  MonacoStickyScroll: { enabled: false } as StickyScroll,
   /** Whether to hide trailing zeroes on fractional part of decimal */
   hideTrailingDecimalZeros: false,
   /** Whether to hide thousands separators. */

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -1,7 +1,7 @@
 import { OwnedAugmentationsOrderSetting, PurchaseAugmentationsOrderSetting } from "./SettingEnums";
 import { defaultTheme } from "../Themes/Themes";
 import { defaultStyles } from "../Themes/Styles";
-import { CursorStyle, CursorBlinking, WordWrapOptions } from "../ScriptEditor/ui/Options";
+import { CursorStyle, CursorBlinking, WordWrapOptions, StickyScroll } from "../ScriptEditor/ui/Options";
 import { defaultMonacoTheme } from "../ScriptEditor/ui/themes";
 import { assertObject } from "../utils/TypeAssertion";
 import { Result } from "../types";
@@ -184,6 +184,8 @@ export const Settings = {
   MonacoCursorStyle: "line" as CursorStyle,
   /** Control the cursor animation style */
   MonacoCursorBlinking: "blink" as CursorBlinking,
+  /** Toggle use of Sticky Scroll in the Script Editor */
+  MonacoStickyScroll: { enabled: true } as StickyScroll,
   /** Whether to hide trailing zeroes on fractional part of decimal */
   hideTrailingDecimalZeros: false,
   /** Whether to hide thousands separators. */


### PR DESCRIPTION
Closes #2430 
There may have been a more elegant way to do this, I'll delete/rework this PR if I missed a simpler/more technically correct answer.

I also changed the default setting to off, which was the behaviour before this bug was identified. This can be reverted to current behaviour if preferred.

Ran `lint`,`format`,`test` and `doc` just in case. Screenshots of toggle and effect:
<img width="913" height="649" alt="stickyOff" src="https://github.com/user-attachments/assets/711a8bac-56eb-4a12-abab-09f76e049edd" />
<img width="1067" height="635" alt="stickyOn" src="https://github.com/user-attachments/assets/ee3dc7fb-6d8d-456e-9c46-111a0709b1b3" />

