### PR TITLE
LORE: Add literature expanding the augment prestige lore

### DIFF
--- a/src/Literature/Enums.ts
+++ b/src/Literature/Enums.ts
@@ -20,4 +20,5 @@ export enum LiteratureName {
   TheNewGod = "the-new-god.lit",
   NewTriads = "new-triads.lit",
   TheSecretWar = "the-secret-war.lit",
+  BeyondCyberpsychosis = "beyond-cyberpsychosis.lit",
 }

--- a/src/Literature/Enums.ts
+++ b/src/Literature/Enums.ts
@@ -20,5 +20,5 @@ export enum LiteratureName {
   TheNewGod = "the-new-god.lit",
   NewTriads = "new-triads.lit",
   TheSecretWar = "the-secret-war.lit",
-  BeyondCyberpsychosis = "beyond-cyberpsychosis.lit",
+  ABriefHistoryOfTranshumanism = "a-brief-history-of-transhumanism.lit",
 }

--- a/src/Literature/Literatures.tsx
+++ b/src/Literature/Literatures.tsx
@@ -672,4 +672,51 @@ export const Literatures: Record<LiteratureName, Literature> = {
     filename: LiteratureName.TheSecretWar,
     text: <Typography></Typography>,
   }),
+  [LiteratureName.BeyondCyberpsychosis]: new Literature({
+    title: "Beyond Cyberpsychosis",
+    filename: LiteratureName.BeyondCyberpsychosis,
+    text: (
+      <Typography>
+        Human augmentation has come a long way since the first prosthetics and implants. Now any and all parts of the
+        human body are able to be improved by technology: strength, speed, perception, intelligence. A large variety of
+        powerful augmentations have been developed, but for most they may as well not exist. How did things end up like
+        this?
+        <br />
+        <br />
+        Part of the answer is, unfortunately, that the exact technology that has allowed us to come so far in human
+        augmentation is also responsible for it's great expense and exclusivity.
+        <br />
+        The early days of human augmentation were plagued with issues. Immunosupressants were needed to keep people's
+        bodies from rejecting the foreign bodies we were implanting, with the body constantly trying to "restore" itself
+        to it's natural state. On top of that, with the messy nature of biology any replacement for a natural organ
+        would fall short of full functionality. Your arm bones don't just provide structural support and anchors for
+        muscles, they also help produce the blood in your body in the marrow. Even the fat in the body is a living organ
+        that produces hormones helping to regulate it's activity.
+        <br />
+        <br />
+        Thus, we were limited by the capacity of our bodies to accept and deal with these changes. Biology is redundant
+        and flexible, so replacing a few bone's won't impact the bodies functioning too badly. But every addition and
+        change would add up, ultimately severly limiting the body's capacity for augmentation.
+        <br />
+        <br />
+        Ultimately it was {CompanyName.VitaLife} who found a way around this limitation, though only at great expense...
+        They discovered that by using a radical new form of gene therapy to reshape a person's body to not only
+        accomodate but integrate the augmentations into their body at a cellular level, they could completely eliminate
+        the side-effects of augmenting.
+        <br />
+        <br />
+        The downside, of course, is the extreme expense and complexity of the process. Not only must each augment be
+        tailored for it's intended recipiant and a custom genetic therapy program developed, but to truely avoid any
+        side-effects this program must take into account the interactions between augmentations when multiple are
+        installed. The combinatoric explosion in complexity leads to exponentially increasing costs when more than one
+        augment is installed at the same time. Despite this most still prefer to install as many as possible at once,
+        because in addition the radical transforation their body undergoes leaves them relearning to use their body for
+        weeks or even months afterward.
+        <br />
+        <br />
+        In the end we're left with the theoretical capacity to transform ourselves to the limits of our imaginination,
+        but the practical reality that the expense of even basic augmentations is beyond 95% of the population.
+      </Typography>
+    ),
+  }),
 };

--- a/src/Literature/Literatures.tsx
+++ b/src/Literature/Literatures.tsx
@@ -672,9 +672,9 @@ export const Literatures: Record<LiteratureName, Literature> = {
     filename: LiteratureName.TheSecretWar,
     text: <Typography></Typography>,
   }),
-  [LiteratureName.BeyondCyberpsychosis]: new Literature({
-    title: "Beyond Cyberpsychosis",
-    filename: LiteratureName.BeyondCyberpsychosis,
+  [LiteratureName.ABriefHistoryOfTranshumanism]: new Literature({
+    title: "A Brief History of Transhumanism",
+    filename: LiteratureName.ABriefHistoryOfTranshumanism,
     text: (
       <Typography>
         Human augmentation has come a long way since the first prosthetics and implants. Now any and all parts of the
@@ -684,37 +684,37 @@ export const Literatures: Record<LiteratureName, Literature> = {
         <br />
         <br />
         Part of the answer is, unfortunately, that the exact technology that has allowed us to come so far in human
-        augmentation is also responsible for it's great expense and exclusivity.
+        augmentation is also responsible for its great expense and exclusivity.
         <br />
-        The early days of human augmentation were plagued with issues. Immunosupressants were needed to keep people's
-        bodies from rejecting the foreign bodies we were implanting, with the body constantly trying to "restore" itself
-        to it's natural state. On top of that, with the messy nature of biology any replacement for a natural organ
-        would fall short of full functionality. Your arm bones don't just provide structural support and anchors for
-        muscles, they also help produce the blood in your body in the marrow. Even the fat in the body is a living organ
-        that produces hormones helping to regulate it's activity.
+        The early days of human augmentation were plagued with issues. Immunosuppressants were needed to keep people's
+        bodies from rejecting the foreign bodies being implanted, with the body constantly trying to "restore" itself
+        to its natural state. On top of that, with the messy nature of biology any replacement for a natural organ
+        would fall short of full functionality. The skeleton doesn't just provide structural support and anchors for
+        muscles; it also helps produce the blood in your body in the marrow. Even the fat in the body is a living organ
+        that produces hormones helping to regulate its activity.
         <br />
         <br />
-        Thus, we were limited by the capacity of our bodies to accept and deal with these changes. Biology is redundant
-        and flexible, so replacing a few bone's won't impact the bodies functioning too badly. But every addition and
-        change would add up, ultimately severly limiting the body's capacity for augmentation.
+        Thus, the process was limited by the capacity of the human body to accept and deal with these changes. Biology is redundant
+        and flexible, so replacing a few bones won't impact the body's functioning too badly. But every addition and
+        change would add up, ultimately severely limiting the body's capacity for augmentation.
         <br />
         <br />
         Ultimately it was {CompanyName.VitaLife} who found a way around this limitation, though only at great expense...
         They discovered that by using a radical new form of gene therapy to reshape a person's body to not only
-        accomodate but integrate the augmentations into their body at a cellular level, they could completely eliminate
+        accommodate but integrate the augmentations into their body at a cellular level, they could completely eliminate
         the side-effects of augmenting.
         <br />
         <br />
         The downside, of course, is the extreme expense and complexity of the process. Not only must each augment be
-        tailored for it's intended recipiant and a custom genetic therapy program developed, but to truely avoid any
+        tailored for its intended recipient and a custom genetic therapy program developed, but to truly avoid any
         side-effects this program must take into account the interactions between augmentations when multiple are
         installed. The combinatoric explosion in complexity leads to exponentially increasing costs when more than one
         augment is installed at the same time. Despite this most still prefer to install as many as possible at once,
-        because in addition the radical transforation their body undergoes leaves them relearning to use their body for
+        because in addition the radical transformation their body undergoes leaves them relearning to use their body for
         weeks or even months afterward.
         <br />
         <br />
-        In the end we're left with the theoretical capacity to transform ourselves to the limits of our imaginination,
+        In the end humanity is left with the theoretical capacity to transform themselves to the limits of their imagininations,
         but the practical reality that the expense of even basic augmentations is beyond 95% of the population.
       </Typography>
     ),

--- a/src/Literature/Literatures.tsx
+++ b/src/Literature/Literatures.tsx
@@ -687,16 +687,16 @@ export const Literatures: Record<LiteratureName, Literature> = {
         augmentation is also responsible for its great expense and exclusivity.
         <br />
         The early days of human augmentation were plagued with issues. Immunosuppressants were needed to keep people's
-        bodies from rejecting the foreign bodies being implanted, with the body constantly trying to "restore" itself
-        to its natural state. On top of that, with the messy nature of biology any replacement for a natural organ
-        would fall short of full functionality. The skeleton doesn't just provide structural support and anchors for
-        muscles; it also helps produce the blood in your body in the marrow. Even the fat in the body is a living organ
-        that produces hormones helping to regulate its activity.
+        bodies from rejecting the foreign bodies being implanted, with the body constantly trying to "restore" itself to
+        its natural state. On top of that, with the messy nature of biology any replacement for a natural organ would
+        fall short of full functionality. The skeleton doesn't just provide structural support and anchors for muscles;
+        it also helps produce the blood in your body in the marrow. Even the fat in the body is a living organ that
+        produces hormones helping to regulate its activity.
         <br />
         <br />
-        Thus, the process was limited by the capacity of the human body to accept and deal with these changes. Biology is redundant
-        and flexible, so replacing a few bones won't impact the body's functioning too badly. But every addition and
-        change would add up, ultimately severely limiting the body's capacity for augmentation.
+        Thus, the process was limited by the capacity of the human body to accept and deal with these changes. Biology
+        is redundant and flexible, so replacing a few bones won't impact the body's functioning too badly. But every
+        addition and change would add up, ultimately severely limiting the body's capacity for augmentation.
         <br />
         <br />
         Ultimately it was {CompanyName.VitaLife} who found a way around this limitation, though only at great expense...
@@ -714,8 +714,9 @@ export const Literatures: Record<LiteratureName, Literature> = {
         weeks or even months afterward.
         <br />
         <br />
-        In the end humanity is left with the theoretical capacity to transform themselves to the limits of their imagininations,
-        but the practical reality that the expense of even basic augmentations is beyond 95% of the population.
+        In the end humanity is left with the theoretical capacity to transform themselves to the limits of their
+        imagininations, but the practical reality that the expense of even basic augmentations is beyond 95% of the
+        population.
       </Typography>
     ),
   }),

--- a/src/Server/data/servers.ts
+++ b/src/Server/data/servers.ts
@@ -1388,6 +1388,7 @@ export const serverMetadata: IServerMetadata[] = [
       min: 55,
     },
     hostname: "powerhouse-fitness",
+    literature: [LiteratureName.ABriefHistoryOfTranshumanism],
     maxRamExponent: {
       max: 6,
       min: 4,
@@ -1467,7 +1468,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 0,
     hostname: SpecialServers.NiteSecServer,
-    literature: [LiteratureName.DemocracyIsDead, LiteratureName.BeyondCyberpsychosis],
+    literature: [LiteratureName.DemocracyIsDead],
     maxRamExponent: {
       max: 7,
       min: 4,

--- a/src/Server/data/servers.ts
+++ b/src/Server/data/servers.ts
@@ -1467,7 +1467,7 @@ export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 0,
     hostname: SpecialServers.NiteSecServer,
-    literature: [LiteratureName.DemocracyIsDead],
+    literature: [LiteratureName.DemocracyIsDead, LiteratureName.BeyondCyberpsychosis],
     maxRamExponent: {
       max: 7,
       min: 4,


### PR DESCRIPTION
This adds a literature file attempting to provide a lore justification for augment prestiging in the game.

Basically, the idea is that in order to avoid complications from augments such as rejection by the immune system or other unforeseen biological interactions, in the Bitburner universe augment installation involves extensive gene therapy to thoroughly integrate the augment into the users body, with no side-effects.

This can help explain stat resets as the player's body is reconfigured biologically in the process. It can also account for the exponentially rising cost of augments before resetting, as the gene therapy needs to account for all interactions between augments leading to a combinatoric explosion in effort.

This also very naturally explains Grafting: grafting simply doesn't use this advanced process and so every augmentation you graft places an increasing burden on your body. VitaLife's innovation in developing the Grafting process is just finding a way to add augments that has relatively minimal side effects without requiring the full gene therapy process.

Also I recorded VitaLife as being the original creator of the augmentation prestige process just to tie the explanation into the world more, as it seemed like it would make sense.