### PR TITLE
MISC: Update error message when backdooring without admin rights

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -170,7 +170,7 @@ export const CONSTANTS = {
 
 ### MISC
 
-- Fixed lack of exclamation mark when backdooring without admin rights (#2416) (@kordhell)
+- Fixed lack of exclamation mark when backdooring without admin rights (#2436) (@kordhell)
 - Ensure IPvGO board has at least 1 offline node (#2072) (@ficocelliguy)
 - Fix: Game crashes when generating CCT in weird case (#2077) (@catloversg)
 - Add ns.dynamicImport() to dynamically import a script (#2036) (@shyguy1412)

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -170,6 +170,7 @@ export const CONSTANTS = {
 
 ### MISC
 
+- Fixed lack of exclamation mark when backdooring without admin rights (#2416) (@kordhell)
 - Ensure IPvGO board has at least 1 offline node (#2072) (@ficocelliguy)
 - Fix: Game crashes when generating CCT in weird case (#2077) (@catloversg)
 - Add ns.dynamicImport() to dynamically import a script (#2036) (@shyguy1412)

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -170,7 +170,6 @@ export const CONSTANTS = {
 
 ### MISC
 
-- Fixed lack of exclamation mark when backdooring without admin rights (#2436) (@kordhell)
 - Ensure IPvGO board has at least 1 offline node (#2072) (@ficocelliguy)
 - Fix: Game crashes when generating CCT in weird case (#2077) (@catloversg)
 - Add ns.dynamicImport() to dynamically import a script (#2036) (@shyguy1412)

--- a/src/Terminal/commands/backdoor.ts
+++ b/src/Terminal/commands/backdoor.ts
@@ -20,7 +20,7 @@ export function backdoor(args: (string | number | boolean)[], server: BaseServer
     return;
   }
   if (!server.hasAdminRights) {
-    Terminal.error("You do not have admin rights for this machine");
+    Terminal.error("You do not have admin rights for this machine!");
     return;
   }
   if (server.requiredHackingSkill > Player.skills.hacking) {


### PR DESCRIPTION
Misc: Fixed lack of exclamation mark when backdooring without admin rights

Tested: npm run start:dev
note the images attached (alpha-ent is pre fix, n00dles is post-fix)
Exclamation mark is added in the post-fix screenshot

<img width="565" height="122" alt="image_2025-12-27_125847056" src="https://github.com/user-attachments/assets/d7e28d18-b0ed-43ed-a184-a1a1d4e17666" />
<img width="908" height="260" alt="Screenshot 2025-12-27 at 12 57 24" src="https://github.com/user-attachments/assets/29b9774d-f7ba-4919-952c-9b2b82714cec" />