### PR TITLE
MISC: Fix typos and duplicating ms per cycle constant

### DIFF
--- a/markdown/bitburner.singularity.purchaseprogram.md
+++ b/markdown/bitburner.singularity.purchaseprogram.md
@@ -52,7 +52,7 @@ Name of program to purchase.
 
 boolean
 
-True if the specified program is purchased, and false otherwise.
+True if the specified program is purchased or if you already own it, and false otherwise.
 
 ## Remarks
 

--- a/src/CodingContract/contracts/UniquePathsInAGrid.ts
+++ b/src/CodingContract/contracts/UniquePathsInAGrid.ts
@@ -58,7 +58,7 @@ export const uniquePathsInAGrid: Pick<
       return [
         "You are located in the top-left corner of the following grid:\n\n",
         `${gridString}\n`,
-        "You are trying reach the bottom-right corner of the grid, but you can only",
+        "You are trying to reach the bottom-right corner of the grid, but you can only",
         "move down or right on each step. Furthermore, there are obstacles on the grid",
         "that you cannot move onto. These obstacles are denoted by '1', while empty",
         "spaces are denoted by 0.\n\n",

--- a/src/NetscriptFunctions/Bladeburner.ts
+++ b/src/NetscriptFunctions/Bladeburner.ts
@@ -20,6 +20,7 @@ import { BlackOperations, blackOpsArray } from "../Bladeburner/data/BlackOperati
 import { checkSleeveAPIAccess, checkSleeveNumber } from "../NetscriptFunctions/Sleeve";
 import { canAccessBitNodeFeature } from "../BitNode/BitNodeUtils";
 import { calculateActionRankGain, calculateActionReputationGain } from "../Bladeburner/Formulas";
+import { CONSTANTS } from "../Constants";
 
 export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
   const checkBladeburnerAccess = function (ctx: NetscriptContext): void {
@@ -348,7 +349,7 @@ export function NetscriptBladeburner(): InternalAPI<INetscriptBladeburner> {
     },
     getBonusTime: (ctx) => () => {
       const bladeburner = getBladeburner(ctx);
-      return bladeburner.storedCycles * 200;
+      return bladeburner.storedCycles * CONSTANTS.MilliPerCycle;
     },
     nextUpdate: (ctx) => () => {
       checkBladeburnerAccess(ctx);

--- a/src/NetscriptFunctions/Corporation.ts
+++ b/src/NetscriptFunctions/Corporation.ts
@@ -72,6 +72,7 @@ import {
 import { PositiveInteger } from "../types";
 import { getRecordKeys } from "../Types/Record";
 import { setDeprecatedProperties } from "../utils/DeprecationHelper";
+import { CONSTANTS } from "../Constants";
 
 export function NetscriptCorporation(): InternalAPI<NSCorporation> {
   function hasUnlock(unlockName: CorpUnlockName): boolean {
@@ -802,7 +803,7 @@ export function NetscriptCorporation(): InternalAPI<NSCorporation> {
     },
     getBonusTime: (ctx) => () => {
       checkAccess(ctx);
-      return getCorporation().storedCycles * 200;
+      return getCorporation().storedCycles * CONSTANTS.MilliPerCycle;
     },
     nextUpdate: (ctx) => () => {
       checkAccess(ctx);

--- a/src/NetscriptFunctions/Gang.ts
+++ b/src/NetscriptFunctions/Gang.ts
@@ -13,6 +13,7 @@ import { GangMemberTasks } from "../Gang/GangMemberTasks";
 import { GangMemberUpgrades } from "../Gang/GangMemberUpgrades";
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { getEnumHelper } from "../utils/EnumHelper";
+import { CONSTANTS } from "../Constants";
 
 export function NetscriptGang(): InternalAPI<IGang> {
   /** Functions as an API check and also returns the gang object */
@@ -353,7 +354,7 @@ export function NetscriptGang(): InternalAPI<IGang> {
     },
     getBonusTime: (ctx) => () => {
       const gang = getGang(ctx);
-      return gang.storedCycles * 200;
+      return gang.storedCycles * CONSTANTS.MilliPerCycle;
     },
     nextUpdate: (ctx) => () => {
       getGang(ctx);

--- a/src/NetscriptFunctions/StockMarket.ts
+++ b/src/NetscriptFunctions/StockMarket.ts
@@ -23,6 +23,7 @@ import { setRemovedFunctions, type InternalAPI, type NetscriptContext } from "..
 import { helpers } from "../Netscript/NetscriptHelpers";
 import { StockMarketConstants } from "../StockMarket/data/Constants";
 import { getEnumHelper } from "../utils/EnumHelper";
+import { CONSTANTS } from "../Constants";
 
 export function NetscriptStockMarket(): InternalAPI<StockAPI> {
   /** Checks if the player has TIX API access. Throws an error if the player does not */
@@ -332,7 +333,7 @@ export function NetscriptStockMarket(): InternalAPI<StockAPI> {
     },
     getBonusTime: (ctx) => () => {
       checkTixApiAccess(ctx);
-      return StockMarket.storedCycles * 200;
+      return StockMarket.storedCycles * CONSTANTS.MilliPerCycle;
     },
     nextUpdate: (ctx) => () => {
       checkTixApiAccess(ctx);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1986,7 +1986,7 @@ export interface Singularity {
    * if (!success) ns.tprint(`ERROR: Failed to purchase ${programName}`);
    * ```
    * @param programName - Name of program to purchase.
-   * @returns True if the specified program is purchased, and false otherwise.
+   * @returns True if the specified program is purchased or if you already own it, and false otherwise.
    */
   purchaseProgram(programName: string): boolean;
 


### PR DESCRIPTION
Not very exciting, I'm sorry. Couple of tweaks to aid in clarity:

- A `Unique Paths` sentence was missing a "to".
- The `singularity.purchaseProgram` function return description was slightly misleading if you already own a program and try to buy it.
- 200 was used in a few places instead of our ms/cycle constant.

`lint`, `format`, `test` and `doc` successfully run.