### PR TITLE
DOC: Change wording in Singularity.installAugmentation

### DIFF
--- a/markdown/bitburner.singularity.installaugmentations.md
+++ b/markdown/bitburner.singularity.installaugmentations.md
@@ -56,5 +56,5 @@ void
 
 RAM cost: 5 GB \* 16/4/1
 
-This function will automatically install your Augmentations, resetting the game as usual. If you do not own uninstalled Augmentations then the game will not reset.
+This function will automatically install your Augmentations, resetting the game as usual. If you do not own any queued Augmentations then the game will not reset.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2659,7 +2659,7 @@ export interface Singularity {
    * RAM cost: 5 GB * 16/4/1
    *
    *
-   * This function will automatically install your Augmentations, resetting the game as usual. If you do not own uninstalled Augmentations then the game will not reset.
+   * This function will automatically install your Augmentations, resetting the game as usual. If you do not own any queued Augmentations then the game will not reset.
    *
    * @param cbScript - This is a script that will automatically be run after Augmentations are installed (after the reset). This script will be run with no arguments and 1 thread. It must be located on your home computer.
    */


### PR DESCRIPTION
This commit changes a minor wording in the API commit. "uninstalled" implies "removed" hence the change.
