### PR TITLE
BLADEBURNER: Reduce threshold of showing warning of low population

### DIFF
--- a/src/Bladeburner/ui/Stats.tsx
+++ b/src/Bladeburner/ui/Stats.tsx
@@ -44,7 +44,7 @@ export function Stats({ bladeburner }: StatsProps): React.ReactElement {
   if (bladeburner.getCurrentCity().pop <= 1e8) {
     populationTextColor = Settings.theme.error;
     populationWarning = "extremely low";
-  } else if (bladeburner.getCurrentCity().pop < 9e8) {
+  } else if (bladeburner.getCurrentCity().pop < 8e8) {
     populationTextColor = Settings.theme.warning;
     populationWarning = "low";
   }


### PR DESCRIPTION
I added this warning in #1856. It seems that I used the wrong value. The comment says the threshold is 8e8, but the code uses 9e8. I think the comment is correct. 9e8 is a bit too close to 1e9.