### PR TITLE
DOCUMENTATION: Update math notations in corporation docs

### DIFF
--- a/src/Documentation/doc/en/advanced/corporation/basic-gameplay-and-term.md
+++ b/src/Documentation/doc/en/advanced/corporation/basic-gameplay-and-term.md
@@ -14,7 +14,9 @@ Each division can expand to 6 cities.
 
 Each industry has different input materials and output materials/products. For example: Agriculture needs Water and Chemicals to produce Plants and Food. The number next to each material is its "coefficient" (You can call it "weight" or "factor" if you want).
 
-$$0.5\ \textit{Water}+0.2\ \textit{Chemicals} \Rightarrow 1\ \textit{Plants}+1\ \textit{Food}$$
+$$
+0.5\ \textit{Water}+0.2\ \textit{Chemicals} \Rightarrow 1\ \textit{Plants}+1\ \textit{Food}
+$$
 
 There is no "offline progress" in corporation. When you go offline, the corporation accumulates bonus time.
 

--- a/src/Documentation/doc/en/advanced/corporation/boost-material.md
+++ b/src/Documentation/doc/en/advanced/corporation/boost-material.md
@@ -60,15 +60,21 @@ Let's define:
 
 Assuming the same warehouse setup in all cities, the division production multiplier is:
 
-$$F(x,y,z,w) = \sum_{i = 1}^{6}\left( (1 + 0.002\ast x)^{c_{1}}\ast(1 + 0.002\ast y)^{c_{2}}{\ast(1 + 0.002\ast z)}^{c_{3}}{\ast(1 + 0.002\ast w)}^{c_{4}} \right)^{0.73}$$
+$$
+F(x,y,z,w) = \sum_{i = 1}^{6}\left( (1 + 0.002\ast x)^{c_{1}}\ast(1 + 0.002\ast y)^{c_{2}}{\ast(1 + 0.002\ast z)}^{c_{3}}{\ast(1 + 0.002\ast w)}^{c_{4}} \right)^{0.73}
+$$
 
 In order to find the maximum of the function above, we can find the maximum of this function:
 
-$$F(x,y,z,w) = (1 + 0.002\ast x)^{c_{1}}\ast(1 + 0.002\ast y)^{c_{2}}{\ast(1 + 0.002\ast z)}^{c_{3}}{\ast(1 + 0.002\ast w)}^{c_{4}}$$
+$$
+F(x,y,z,w) = (1 + 0.002\ast x)^{c_{1}}\ast(1 + 0.002\ast y)^{c_{2}}{\ast(1 + 0.002\ast z)}^{c_{3}}{\ast(1 + 0.002\ast w)}^{c_{4}}
+$$
 
 Constraint function (S is storage space):
 
-$$G(x,y,z,w) = s_{1}\ast x + s_{2}\ast y + s_{3}\ast z + s_{4}\ast w = S$$
+$$
+G(x,y,z,w) = s_{1}\ast x + s_{2}\ast y + s_{3}\ast z + s_{4}\ast w = S
+$$
 
 Problem: Find the maximum of $F(x,y,z,w)$ with constraint $G(x,y,z,w)$.
 
@@ -80,88 +86,132 @@ Disclaimer: This is based on discussion between \@Jesus and \@yichizhng on Disco
 
 By using the [Lagrange multiplier](https://en.wikipedia.org/wiki/Lagrange_multiplier) method, we have this system:
 
-$$\begin{cases} \frac{\partial F}{\partial x} &= \lambda\frac{\partial G}{\partial x} \newline \frac{\partial F}{\partial y} &= \lambda\frac{\partial G}{\partial y} \newline \frac{\partial F}{\partial z} &= \lambda\frac{\partial G}{\partial z} \newline \frac{\partial F}{\partial w} &= \lambda\frac{\partial G}{\partial w} \newline G(x,y,z,w) &= S\end{cases}$$
+$$
+\begin{cases} \frac{\partial F}{\partial x} &= \lambda\frac{\partial G}{\partial x} \newline \frac{\partial F}{\partial y} &= \lambda\frac{\partial G}{\partial y} \newline \frac{\partial F}{\partial z} &= \lambda\frac{\partial G}{\partial z} \newline \frac{\partial F}{\partial w} &= \lambda\frac{\partial G}{\partial w} \newline G(x,y,z,w) &= S\end{cases}
+$$
 
 In order to solve this system, we have 2 choices:
 
 - Solve that system with [Ceres Solver](./miscellany.md).
 - Do the hard work with basic calculus and algebra. This is the optimal way in both accuracy and performance, so we'll focus on it. In the following sections, I'll show the proof for this solution.
 
-$$x\ast s_{1} = \frac{S - 500\ast\left( \frac{s_{1}}{c_{1}}\ast\left( c_{2} + c_{3} + c_{4} \right) - \left( s_{2} + s_{3} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{1}}}$$
+$$
+x\ast s_{1} = \frac{S - 500\ast\left( \frac{s_{1}}{c_{1}}\ast\left( c_{2} + c_{3} + c_{4} \right) - \left( s_{2} + s_{3} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{1}}}
+$$
 
-$$y\ast s_{2} = \frac{S - 500\ast\left( \frac{s_{2}}{c_{2}}\ast\left( c_{1} + c_{3} + c_{4} \right) - \left( s_{1} + s_{3} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{2}}}$$
+$$
+y\ast s_{2} = \frac{S - 500\ast\left( \frac{s_{2}}{c_{2}}\ast\left( c_{1} + c_{3} + c_{4} \right) - \left( s_{1} + s_{3} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{2}}}
+$$
 
-$$z\ast s_{3} = \frac{S - 500\ast\left( \frac{s_{3}}{c_{3}}\ast\left( c_{1} + c_{2} + c_{4} \right) - \left( s_{1} + s_{2} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{3}}}$$
+$$
+z\ast s_{3} = \frac{S - 500\ast\left( \frac{s_{3}}{c_{3}}\ast\left( c_{1} + c_{2} + c_{4} \right) - \left( s_{1} + s_{2} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{3}}}
+$$
 
-$$w\ast s_{4} = \frac{S - 500\ast\left( \frac{s_{4}}{c_{4}}\ast\left( c_{1} + c_{2} + c_{3} \right) - \left( s_{1} + s_{2} + s_{3} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{4}}}$$
+$$
+w\ast s_{4} = \frac{S - 500\ast\left( \frac{s_{4}}{c_{4}}\ast\left( c_{1} + c_{2} + c_{3} \right) - \left( s_{1} + s_{2} + s_{3} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{4}}}
+$$
 
 ## Proof
 
 Define: $k = 0.002$
 
-$$\begin{cases}\frac{\partial F}{\partial x} = \left( k\ast c_{1}\ast(1 + k\ast x)^{c_{1} - 1} \right)\ast(1 + k\ast y)^{c_{2}}\ast(1 + k\ast z)^{c_{3}}\ast(1 + k\ast w)^{c_{4}} = \lambda\ast s_{1} \newline \frac{\partial F}{\partial y} = (1 + k\ast x)^{c_{1}}\ast\left( k\ast c_{2}\ast(1 + k\ast y)^{c_{2} - 1} \right)\ast(1 + k\ast z)^{c_{3}}\ast(1 + k\ast w)^{c_{4}} = \lambda\ast s_{2} \end{cases}$$
+$$
+\begin{cases}\frac{\partial F}{\partial x} = \left( k\ast c_{1}\ast(1 + k\ast x)^{c_{1} - 1} \right)\ast(1 + k\ast y)^{c_{2}}\ast(1 + k\ast z)^{c_{3}}\ast(1 + k\ast w)^{c_{4}} = \lambda\ast s_{1} \newline \frac{\partial F}{\partial y} = (1 + k\ast x)^{c_{1}}\ast\left( k\ast c_{2}\ast(1 + k\ast y)^{c_{2} - 1} \right)\ast(1 + k\ast z)^{c_{3}}\ast(1 + k\ast w)^{c_{4}} = \lambda\ast s_{2} \end{cases}
+$$
 
 ≡
 
-$$k\ast c_{1}\ast(1 + k\ast x)^{- 1}\ast s_{2} = k\ast c_{2}\ast(1 + k\ast y)^{- 1}\ast s_{1}$$
+$$
+k\ast c_{1}\ast(1 + k\ast x)^{- 1}\ast s_{2} = k\ast c_{2}\ast(1 + k\ast y)^{- 1}\ast s_{1}
+$$
 
 ≡
 
-$$c_{1}\ast s_{2}\ast(1 + k\ast y) = c_{2}\ast s_{1}\ast(1 + k\ast x)$$
+$$
+c_{1}\ast s_{2}\ast(1 + k\ast y) = c_{2}\ast s_{1}\ast(1 + k\ast x)
+$$
 
 ≡
 
-$$1 + k\ast y = \frac{c_{2}\ast s_{1}}{c_{1}\ast s_{2}}\ast(1 + k\ast x)$$
+$$
+1 + k\ast y = \frac{c_{2}\ast s_{1}}{c_{1}\ast s_{2}}\ast(1 + k\ast x)
+$$
 
 ≡
 
-$$y = \frac{c_{2}\ast s_{1} + k\ast x\ast c_{2}\ast s_{1} - c_{1}\ast s_{2}}{k\ast c_{1}\ast s_{2}}$$
+$$
+y = \frac{c_{2}\ast s_{1} + k\ast x\ast c_{2}\ast s_{1} - c_{1}\ast s_{2}}{k\ast c_{1}\ast s_{2}}
+$$
 
 ≡
 
-$$y\ast s_{2} = \frac{c_{2}\ast s_{1}\ast s_{2} + k\ast x\ast c_{2}\ast s_{1}\ast s_{2} - c_{1}\ast s_{2}\ast s_{2}}{k\ast c_{1}\ast s_{2}}$$
+$$
+y\ast s_{2} = \frac{c_{2}\ast s_{1}\ast s_{2} + k\ast x\ast c_{2}\ast s_{1}\ast s_{2} - c_{1}\ast s_{2}\ast s_{2}}{k\ast c_{1}\ast s_{2}}
+$$
 
 ≡
 
-$$y\ast s_{2} = \frac{c_{2}\ast s_{1}}{k\ast c_{1}} + \frac{x\ast c_{2}\ast s_{1}}{c_{1}} - \frac{s_{2}}{k}$$
+$$
+y\ast s_{2} = \frac{c_{2}\ast s_{1}}{k\ast c_{1}} + \frac{x\ast c_{2}\ast s_{1}}{c_{1}} - \frac{s_{2}}{k}
+$$
 
 ≡
 
-$$y\ast s_{2} = \frac{c_{2}}{c_{1}}\ast x\ast s_{1} + \frac{1}{k}\ast\frac{c_{2}\ast s_{1} - c_{1}\ast s_{2}}{c_{1}}$$
+$$
+y\ast s_{2} = \frac{c_{2}}{c_{1}}\ast x\ast s_{1} + \frac{1}{k}\ast\frac{c_{2}\ast s_{1} - c_{1}\ast s_{2}}{c_{1}}
+$$
 
 ≡
 
-$$y\ast s_{2} = \frac{c_{2}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{2}\ast s_{1} - c_{1}\ast s_{2}}{c_{1}}$$
+$$
+y\ast s_{2} = \frac{c_{2}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{2}\ast s_{1} - c_{1}\ast s_{2}}{c_{1}}
+$$
 
 Repeating the above steps, we have:
 
-$$z\ast s_{3} = \frac{c_{3}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{3}\ast s_{1} - c_{1}\ast s_{3}}{c_{1}}$$
+$$
+z\ast s_{3} = \frac{c_{3}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{3}\ast s_{1} - c_{1}\ast s_{3}}{c_{1}}
+$$
 
-$$w\ast s_{4} = \frac{c_{4}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{4}\ast s_{1} - c_{1}\ast s_{4}}{c_{1}}$$
+$$
+w\ast s_{4} = \frac{c_{4}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{4}\ast s_{1} - c_{1}\ast s_{4}}{c_{1}}
+$$
 
 Substituting into the constraint function:
 
-$$x\ast s_{1} + y\ast s_{2} + z\ast s_{3} + w\ast s_{4} = S$$
+$$
+x\ast s_{1} + y\ast s_{2} + z\ast s_{3} + w\ast s_{4} = S
+$$
 
 ≡
 
-$$x\ast s_{1} + \frac{c_{2}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{2}\ast s_{1} - c_{1}\ast s_{2}}{c_{1}} + \frac{c_{3}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{3}\ast s_{1} - c_{1}\ast s_{3}}{c_{1}} + \frac{c_{4}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{4}\ast s_{1} - c_{1}\ast s_{4}}{c_{1}} = S$$
+$$
+x\ast s_{1} + \frac{c_{2}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{2}\ast s_{1} - c_{1}\ast s_{2}}{c_{1}} + \frac{c_{3}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{3}\ast s_{1} - c_{1}\ast s_{3}}{c_{1}} + \frac{c_{4}}{c_{1}}\ast x\ast s_{1} + 500\ast\frac{c_{4}\ast s_{1} - c_{1}\ast s_{4}}{c_{1}} = S
+$$
 
 ≡
 
-$$\frac{x\ast s_{1}\ast\left( c_{1} + c_{2} + c_{3} + c_{4} \right)}{c_{1}} + \frac{500}{c_{1}}\ast\left( c_{2}\ast s_{1} - c_{1}\ast s_{2} + c_{3}\ast s_{1} - c_{1}\ast s_{3} + c_{4}\ast s_{1} - c_{1}\ast s_{4} \right) = S$$
+$$
+\frac{x\ast s_{1}\ast\left( c_{1} + c_{2} + c_{3} + c_{4} \right)}{c_{1}} + \frac{500}{c_{1}}\ast\left( c_{2}\ast s_{1} - c_{1}\ast s_{2} + c_{3}\ast s_{1} - c_{1}\ast s_{3} + c_{4}\ast s_{1} - c_{1}\ast s_{4} \right) = S
+$$
 
 ≡
 
-$$\frac{x\ast s_{1}\ast\left( c_{1} + c_{2} + c_{3} + c_{4} \right)}{c_{1}} + \frac{500}{c_{1}}\ast\left( s_{1}\ast\left( c_{2} + c_{3} + c_{4}\  \right) - c_{1}\ast\left( s_{2} + s_{3} + s_{4} \right) \right) = S$$
+$$
+\frac{x\ast s_{1}\ast\left( c_{1} + c_{2} + c_{3} + c_{4} \right)}{c_{1}} + \frac{500}{c_{1}}\ast\left( s_{1}\ast\left( c_{2} + c_{3} + c_{4}\  \right) - c_{1}\ast\left( s_{2} + s_{3} + s_{4} \right) \right) = S
+$$
 
 ≡
 
-$$x\ast s_{1}\ast\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{1}} + \frac{500}{c_{1}}\ast\left( s_{1}\ast\left( c_{2} + c_{3} + c_{4}\  \right) - c_{1}\ast\left( s_{2} + s_{3} + s_{4} \right) \right) = S$$
+$$
+x\ast s_{1}\ast\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{1}} + \frac{500}{c_{1}}\ast\left( s_{1}\ast\left( c_{2} + c_{3} + c_{4}\  \right) - c_{1}\ast\left( s_{2} + s_{3} + s_{4} \right) \right) = S
+$$
 
 ≡
 
-$$x\ast s_{1} = \frac{S - 500\ast\left( \frac{s_{1}}{c_{1}}\ast\left( c_{2} + c_{3} + c_{4} \right) - \left( s_{2} + s_{3} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{1}}}$$
+$$
+x\ast s_{1} = \frac{S - 500\ast\left( \frac{s_{1}}{c_{1}}\ast\left( c_{2} + c_{3} + c_{4} \right) - \left( s_{2} + s_{3} + s_{4} \right) \right)}{\frac{c_{1} + c_{2} + c_{3} + c_{4}}{c_{1}}}
+$$
 
 We can do the same steps for y,z,w.
 

--- a/src/Documentation/doc/en/advanced/corporation/demand-competition.md
+++ b/src/Documentation/doc/en/advanced/corporation/demand-competition.md
@@ -40,7 +40,9 @@ During the START state, the game decreases `demand` and increases `competition` 
 
 - Amount of change:
 
-$$AmountOfChange = Random(0,3)*0.0004$$
+$$
+AmountOfChange = Random(0,3)*0.0004
+$$
 
 - This amount is multiplied by 3 if the industry is Pharmaceutical, Software or Robotics.
 

--- a/src/Documentation/doc/en/advanced/corporation/financial-statement.md
+++ b/src/Documentation/doc/en/advanced/corporation/financial-statement.md
@@ -33,7 +33,9 @@ Cycle's valuation:
 
 - AssetDelta:
 
-$$AssetDelta = \frac{TotalAssets - PreviousTotalAssets}{10}$$
+$$
+AssetDelta = \frac{TotalAssets - PreviousTotalAssets}{10}
+$$
 
 - Pre-IPO:
   - If `AssetDelta` is greater than 0, it's used for calculating valuation.
@@ -45,7 +47,9 @@ $$AssetDelta = \frac{TotalAssets - PreviousTotalAssets}{10}$$
     $$AssetDelta = AssetDelta\ast(1 - DividendRate)$$
   - Formula:
 
-$$Valuation = (Funds + AssetDelta\ast 85000)\ast\left(\sqrt[12]{1.1}\right)^{NumberOfOfficesAndWarehouses}$$
+$$
+Valuation = (Funds + AssetDelta\ast 85000)\ast\left(\sqrt[12]{1.1}\right)^{NumberOfOfficesAndWarehouses}
+$$
 
 - Minimum value of valuation is $10^{10}$.
 - Valuation is multiplied by `CorporationValuation`. Many BitNodes cripple Corporation via this multiplier.
@@ -65,7 +69,9 @@ Each round has its own `FundingRoundShares` and `FundingRoundMultiplier`.
 
 Formula:
 
-$$Offer = CorporationValuation\ast FundingRoundShares\ast FundingRoundMultiplier$$
+$$
+Offer = CorporationValuation\ast FundingRoundShares\ast FundingRoundMultiplier
+$$
 
 Analyses:
 
@@ -79,7 +85,9 @@ Analyses:
 
 Your dividend is negatively affected by a penalty modifier called `TributeModifier`. `TributeModifier` depends on `CorporationSoftcap`. In BN3, `CorporationSoftcap` is 1.
 
-$$TributeModifier = 1.15 - CorporationSoftcap$$
+$$
+TributeModifier = 1.15 - CorporationSoftcap
+$$
 
 `ShadyAccounting` reduces `TributeModifier` by 0.05.
 
@@ -87,13 +95,19 @@ $$TributeModifier = 1.15 - CorporationSoftcap$$
 
 Formula:
 
-$$TotalDividends = DividendRate\ast(Revenue - Expenses)\ast 10$$
+$$
+TotalDividends = DividendRate\ast(Revenue - Expenses)\ast 10
+$$
 
-$$Dividend = \left(OwnedShares\ast\frac{TotalDividends}{TotalShares}\right)^{1 - TributeModifier}$$
+$$
+Dividend = \left(OwnedShares\ast\frac{TotalDividends}{TotalShares}\right)^{1 - TributeModifier}
+$$
 
 Retained earning:
 
-$$RetainedEarning = (1 - DividendRate)\ast(Revenue - Expenses)\ast 10$$
+$$
+RetainedEarning = (1 - DividendRate)\ast(Revenue - Expenses)\ast 10
+$$
 
 Dividend is added to player's money. Retained earning is added to corporation's funds. This means if we increase `DividendRate`, corporation's valuation is dwindled.
 
@@ -117,15 +131,21 @@ If your corporation is self-funded and you sell CEO position, you only need 50b 
 
 `TargetSharePrice`:
 
-$$OwnershipPercentage = \frac{OwnedShares}{TotalShares}$$
+$$
+OwnershipPercentage = \frac{OwnedShares}{TotalShares}
+$$
 
-$$TargetSharePrice = \frac{CorporationValuation*\left(0.5+\sqrt{OwnershipPercentage}\right)}{TotalShares}$$
+$$
+TargetSharePrice = \frac{CorporationValuation*\left(0.5+\sqrt{OwnershipPercentage}\right)}{TotalShares}
+$$
 
 When corporation goes public, the initial share price is `TargetSharePrice`.
 
 Share price is updated in START state.
 
-$$SharePrice = \begin{cases} SharePrice\ast(1 + Math.random()\ast 0.01), & SharePrice \leq TargetSharePrice \newline SharePrice\ast(1 - Math.random()\ast 0.01), & SharePrice > TargetSharePrice\end{cases}$$
+$$
+SharePrice = \begin{cases} SharePrice\ast(1 + Math.random()\ast 0.01), & SharePrice \leq TargetSharePrice \newline SharePrice\ast(1 - Math.random()\ast 0.01), & SharePrice > TargetSharePrice\end{cases}
+$$
 
 Minimum share price is 0.01.
 
@@ -135,17 +155,28 @@ Issue new shares:
 - The number of new shares issued must be a multiple of 10 million.
 - New share price:
 
-$$NewOwnershipPercentage = \frac{OwnedShares}{TotalShares+NewShares}$$
+$$
+NewOwnershipPercentage = \frac{OwnedShares}{TotalShares+NewShares}
+$$
 
-$$NewSharePrice = \frac{CorporationValuation\ast\left(0.5+\sqrt{NewOwnershipPercentage}\right)}{TotalShares}$$
+$$
+NewSharePrice = \frac{CorporationValuation\ast\left(0.5+\sqrt{NewOwnershipPercentage}\right)}{TotalShares}
+$$
 
 - Profit:
 
-$$Profit = {NewShares\ast(SharePrice + NewSharePrice)}\ast{0.5}$$
+$$
+Profit = {NewShares\ast(SharePrice + NewSharePrice)}\ast{0.5}
+$$
 
 - Profit is added to corporation's funds.
 - `DefaultCooldown` is 4 hours.
-- Cooldown: $$Cooldown = DefaultCooldown\ast\frac{TotalShares}{10^{9}}$$
+- Cooldown:
+
+$$
+Cooldown = DefaultCooldown\ast\frac{TotalShares}{10^{9}}
+$$
+
 - Part of the new shares are added to `InvestorShares`. The remaining ones are added to `IssuedShares`.
   - `MaxPrivateShares`:
     $$MaxPrivateShares = {NewShares}\ast{0.5}\ast\frac{InvestorShares}{TotalShares}$$
@@ -174,8 +205,14 @@ Sold/bought back shares are processed in multiple "iterations".
 - Number of shares processed each iteration is shareSalesUntilPriceUpdate. Default value is $10^6$.
 - Share price is recalculated each iteration.
 
-$$OwnershipPercentage = \frac{OwnedShares - ProcessedShares}{TotalShares}$$
+$$
+OwnershipPercentage = \frac{OwnedShares - ProcessedShares}{TotalShares}
+$$
 
-$$TargetSharePrice = \frac{CorporationValuation\ast\left(0.5 + \sqrt{OwnershipPercentage}\right)}{TotalShares}$$
+$$
+TargetSharePrice = \frac{CorporationValuation\ast\left(0.5 + \sqrt{OwnershipPercentage}\right)}{TotalShares}
+$$
 
-$$SharePrice = \begin{cases} SharePrice\ast 1.005, SharePrice \leq TargetSharePrice \newline SharePrice\ast 0.995, SharePrice > TargetSharePrice\end{cases}$$
+$$
+SharePrice = \begin{cases} SharePrice\ast 1.005, SharePrice \leq TargetSharePrice \newline SharePrice\ast 0.995, SharePrice > TargetSharePrice\end{cases}
+$$

--- a/src/Documentation/doc/en/advanced/corporation/miscellany.md
+++ b/src/Documentation/doc/en/advanced/corporation/miscellany.md
@@ -48,7 +48,9 @@ The optimal export string is `(IPROD+IINV/10)*(-1)`. For example: export "Chemic
   - IINV = 700
 - "Export" is expressed by number of units per second, so we want to export:
 
-$$\left(100-\frac{700}{10}\right)=\left(-100+\frac{700}{10}\right)\ast(-1)=\left(IPROD+\frac{IINV}{10}\right)\ast(-1)$$
+$$
+\left(100-\frac{700}{10}\right)=\left(-100+\frac{700}{10}\right)\ast(-1)=\left(IPROD+\frac{IINV}{10}\right)\ast(-1)
+$$
 
 Export route is FIFO. You can remove an export route by using `cancelExportMaterial` NS API.
 

--- a/src/Documentation/doc/en/advanced/corporation/office.md
+++ b/src/Documentation/doc/en/advanced/corporation/office.md
@@ -25,43 +25,61 @@ Total experience is increased in these cases:
 - Hire a new employee. Each new employee increases total experience by `getRandomInt(50, 100)`.
 - In the START state. Gain per cycle:
 
-$$TotalExperienceGain = 0.0015\ast(TotalEmployees - UnassignedEmployees + InternEmployees\ast 9)$$
+$$
+TotalExperienceGain = 0.0015\ast(TotalEmployees - UnassignedEmployees + InternEmployees\ast 9)
+$$
 
 - If an office has 100 employees and all employees are assigned to non-intern positions, it gains 0.15 experience/cycle. It's 54 experience/hour without bonus time.
 
 Salary per cycle:
 
-$$Salary = 3\ast TotalEmployees\ast\left(AvgIntelligence+AvgCharisma+AvgCreativity+AvgEfficiency+\frac{TotalExperience}{TotalEmployees}\right)$$
+$$
+Salary = 3\ast TotalEmployees\ast\left(AvgIntelligence+AvgCharisma+AvgCreativity+AvgEfficiency+\frac{TotalExperience}{TotalEmployees}\right)
+$$
 
 ## Upgrade
 
 Upgrade cost:
 
-$$UpgradeCost = BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast{1.09}^{\frac{CurrentSize}{3}}$$
+$$
+UpgradeCost = BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast{1.09}^{\frac{CurrentSize}{3}}
+$$
 
 Upgrade cost from size 3 to size n:
 
-$$UpgradeCost_{From\ 3\ to\ n} = \sum_{k = 3}^{n - 1}{BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast{1.09}^{\frac{k}{3}}}$$
+$$
+UpgradeCost_{From\ 3\ to\ n} = \sum_{k = 3}^{n - 1}{BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast{1.09}^{\frac{k}{3}}}
+$$
 
 ≡
 
-$$UpgradeCost_{From\ 3\ to\ n} = \sum_{k = 3}^{n - 1}{BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast\left( \sqrt[3]{1.09} \right)^{k}}$$
+$$
+UpgradeCost_{From\ 3\ to\ n} = \sum_{k = 3}^{n - 1}{BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast\left( \sqrt[3]{1.09} \right)^{k}}
+$$
 
 ≡
 
-$$UpgradeCost_{From\ 3\ to\ n} = BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast\left( \frac{\left( \sqrt[3]{1.09} \right)^{n} - 1.09}{\sqrt[3]{1.09} - 1} \right)$$
+$$
+UpgradeCost_{From\ 3\ to\ n} = BasePrice\ast\left( \frac{\sqrt[3]{1.09} - 1}{0.09} \right)\ast\left( \frac{\left( \sqrt[3]{1.09} \right)^{n} - 1.09}{\sqrt[3]{1.09} - 1} \right)
+$$
 
 ≡
 
-$$UpgradeCost_{From\ 3\ to\ n} = BasePrice\ast\left( \frac{{1.09}^{\frac{n}{3}} - 1.09}{0.09} \right)$$
+$$
+UpgradeCost_{From\ 3\ to\ n} = BasePrice\ast\left( \frac{{1.09}^{\frac{n}{3}} - 1.09}{0.09} \right)
+$$
 
 Upgrade cost size a to size b:
 
-$$UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{1.09}^{\frac{b}{3}} - {1.09}^{\frac{a}{3}}}{0.09} \right)$$
+$$
+UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{1.09}^{\frac{b}{3}} - {1.09}^{\frac{a}{3}}}{0.09} \right)
+$$
 
 Maximum size with a given `MaxCost`:
 
-$$MaxSize = 3\ast\log_{1.09}\left( MaxCost\ast\frac{0.09}{BasePrice} + {1.09}^{\frac{CurrentSize}{3}} \right)$$
+$$
+MaxSize = 3\ast\log_{1.09}\left( MaxCost\ast\frac{0.09}{BasePrice} + {1.09}^{\frac{CurrentSize}{3}} \right)
+$$
 
 ## Energy and morale
 
@@ -71,17 +89,25 @@ They start dropping when your office's number of employees is greater than or eq
 
 PerfMult is a multiplier that increases/decreases energy/morale.
 
-$$InternMultiplier = 0.002\ast Min\left(\frac{1}{9},\frac{InternEmployees}{TotalEmployees}-\frac{1}{9}\right)\ast 9$$
+$$
+InternMultiplier = 0.002\ast Min\left(\frac{1}{9},\frac{InternEmployees}{TotalEmployees}-\frac{1}{9}\right)\ast 9
+$$
 
-$$PenaltyMultiplier = \begin{cases}0, & (CorpFunds > 0) \vee (DivisionLastCycleRevenue > DivisionLastCycleExpenses) \newline 0.001, & (CorpFunds < 0) \land (DivisionLastCycleRevenue < DivisionLastCycleExpenses)\end{cases}$$
+$$
+PenaltyMultiplier = \begin{cases}0, & (CorpFunds > 0) \vee (DivisionLastCycleRevenue > DivisionLastCycleExpenses) \newline 0.001, & (CorpFunds < 0) \land (DivisionLastCycleRevenue < DivisionLastCycleExpenses)\end{cases}
+$$
 
-$$PerfMult = \begin{cases}1.002, & TotalEmployees < 9 \newline 1 + InternMultiplier - PenaltyMultiplier, & TotalEmployees \geq 9\end{cases}$$
+$$
+PerfMult = \begin{cases}1.002, & TotalEmployees < 9 \newline 1 + InternMultiplier - PenaltyMultiplier, & TotalEmployees \geq 9\end{cases}
+$$
 
 Buying tea gives a flat +2 to energy. It costs 500e3 per employee.
 
 When throwing party, `PartyMult` is calculated. It's used in the calculation of morale in the next cycle.
 
-$$PartyMult = 1 + \frac{PartyCostPerEmployee}{10^{7}}$$
+$$
+PartyMult = 1 + \frac{PartyCostPerEmployee}{10^{7}}
+$$
 
 `PartyMult` is not affected by the number of employees. Therefore, you can throw a "big party" (high `PartyCostPerEmployee`) when you have 1 employee at low total cost (due to having only 1 employee), then hire the rest of the employees later.
 
@@ -89,11 +115,15 @@ There is a flat randomized reduction of energy/morale per cycle. It's capped at 
 
 There is a flat increase of morale if `PartyMult` is greater than 1. `PartyMult` is based on `PartyCostPerEmployee`, so this increase is based on `PartyCostPerEmployee`.
 
-$$IncreaseOfMorale = (PartyMult - 1)\ast 10$$
+$$
+IncreaseOfMorale = (PartyMult - 1)\ast 10
+$$
 
 ≡
 
-$$IncreaseOfMorale = \frac{PartyCostPerEmployee}{10^{6}}$$
+$$
+IncreaseOfMorale = \frac{PartyCostPerEmployee}{10^{6}}
+$$
 
 ```typescript
 const reduction = 0.002 * marketCycles;
@@ -120,27 +150,43 @@ Optimal `PartyCostPerEmployee`:
 - The flat randomized reduction is tiny, so we can ignore it.
 - We want to increase `AvgMorale` from `CurrentMorale` to `MaxMorale`:
 
-$$\left( CurrentMorale\ast PerfMult + \frac{PartyCostPerEmployee}{10^{6}} \right)\ast\left( 1 + \frac{PartyCostPerEmployee}{10^{7}} \right) = MaxMorale$$
+$$
+\left( CurrentMorale\ast PerfMult + \frac{PartyCostPerEmployee}{10^{6}} \right)\ast\left( 1 + \frac{PartyCostPerEmployee}{10^{7}} \right) = MaxMorale
+$$
 
 - Define:
 
-$$a = CurrentMorale$$
+$$
+a = CurrentMorale
+$$
 
-$$b = MaxMorale$$
+$$
+b = MaxMorale
+$$
 
-$$k = PerfMult$$
+$$
+k = PerfMult
+$$
 
-$$x = PartyCostPerEmployee$$
+$$
+x = PartyCostPerEmployee
+$$
 
 - We have equation:
 
-$$\left( a\ast k + \frac{x}{10^{6}} \right)\ast\left( 1 + \frac{x}{10^{7}} \right) = b$$
+$$
+\left( a\ast k + \frac{x}{10^{6}} \right)\ast\left( 1 + \frac{x}{10^{7}} \right) = b
+$$
 
 ≡
 
-$$x_{1} = - 500000\ast\left( \sqrt{(a\ast k - 10)^{2} + 40\ast b} + a\ast k + 10 \right)$$
+$$
+x_{1} = - 500000\ast\left( \sqrt{(a\ast k - 10)^{2} + 40\ast b} + a\ast k + 10 \right)
+$$
 
-$$x_{2} = 500000\ast\left( \sqrt{(a\ast k - 10)^{2} + 40\ast b} - a\ast k - 10 \right)$$
+$$
+x_{2} = 500000\ast\left( \sqrt{(a\ast k - 10)^{2} + 40\ast b} - a\ast k - 10 \right)
+$$
 
 - $x_{1}$ is always negative. Therefore, $x_{2}$ is the only solution.
 
@@ -167,11 +213,15 @@ Formulas:
 - Calculate multipliers of Intelligence, Charisma, Creativity, and Efficiency. They are the product of average values, upgrade benefit and research benefit.
 - Production base:
 
-$$ProductionBase = AvgMorale\ast AvgEnergy\ast 10^{-4}$$
+$$
+ProductionBase = AvgMorale\ast AvgEnergy\ast 10^{-4}
+$$
 
 - Experience:
 
-$$Exp = \frac{TotalExperience}{TotalEmployees}$$
+$$
+Exp = \frac{TotalExperience}{TotalEmployees}
+$$
 
 - Production multiplier:
   - Operations: $$ProductionMultiplier = 0.6\ast IntelligenceMult + 0.1\ast CharismaMult + Exp + 0.5\ast CreativityMult + EfficiencyMult$$
@@ -182,7 +232,9 @@ $$Exp = \frac{TotalExperience}{TotalEmployees}$$
 - $EmployeesJobCount = office.employeeJobs[JobName]$
 - Employee production by job:
 
-$$EmployeeProductionByJob = EmployeesJobCount\ast ProductionMultiplier\ast ProductionBase$$
+$$
+EmployeeProductionByJob = EmployeesJobCount\ast ProductionMultiplier\ast ProductionBase
+$$
 
 ## Calculate employee's stat
 

--- a/src/Documentation/doc/en/advanced/corporation/optimal-selling-price-market-ta2.md
+++ b/src/Documentation/doc/en/advanced/corporation/optimal-selling-price-market-ta2.md
@@ -9,18 +9,24 @@ Market price:
   - $n = {Number\ of\ input\ materials}$
   - $ProductMarketPriceMult = 5$
 
-$$ProductMarketPrice = ProductMarketPriceMult\ast\sum_{i = 1}^{n}{MaterialMarketPrice_i\ast MaterialCoefficient_i}$$
+$$
+ProductMarketPrice = ProductMarketPriceMult\ast\sum_{i = 1}^{n}{MaterialMarketPrice_i\ast MaterialCoefficient_i}
+$$
 
 Markup limit: This is how high you can raise the price above the market price before the sales volume is affected negatively.
 For example: Let's say a product has MarketPrice = 5000 and MarkupLimit = 700. If you set the price smaller than or equal to 5700, the sales volume of this product will not be penalized.
 
 - Material:
 
-$$MaterialMarkupLimit = \frac{MaterialQuality}{MaterialMarkup}$$
+$$
+MaterialMarkupLimit = \frac{MaterialQuality}{MaterialMarkup}
+$$
 
 - Product:
 
-$$ProductMarkupLimit = \frac{Max(ProductEffectiveRating,0.001)}{ProductMarkup}$$
+$$
+ProductMarkupLimit = \frac{Max(ProductEffectiveRating,0.001)}{ProductMarkup}
+$$
 
 ## Sales volume
 
@@ -30,7 +36,9 @@ $$ProductMarkupLimit = \frac{Max(ProductEffectiveRating,0.001)}{ProductMarkup}$$
 
 `MarkupMultiplier` is defined by a piecewise function depending on selling price, market price, and markup limit.
 
-$$MaxSalesVolume = PotentialSalesVolume\ast MarkupMultiplier$$
+$$
+MaxSalesVolume = PotentialSalesVolume\ast MarkupMultiplier
+$$
 
 ### Potential sales volume
 
@@ -44,7 +52,9 @@ $$MaxSalesVolume = PotentialSalesVolume\ast MarkupMultiplier$$
 
 It is the product of 6 multipliers:
 
-$$PotentialSalesVolume = \ ItemMultiplier\ast BusinessFactor\ast AdvertFactor\ast MarketFactor\ast SaleBotsBonus\ast ResearchBonus$$
+$$
+PotentialSalesVolume = \ ItemMultiplier\ast BusinessFactor\ast AdvertFactor\ast MarketFactor\ast SaleBotsBonus\ast ResearchBonus
+$$
 
 - Quality/EffectiveRating multiplier:
   - Material:
@@ -54,28 +64,42 @@ $$PotentialSalesVolume = \ ItemMultiplier\ast BusinessFactor\ast AdvertFactor\as
 - Business factor:
   - `BusinessProduction = 1 + office.employeeProductionByJob["Business"]`
 
-$${BusinessFactor = (BusinessProduction)}^{0.26} + \left({BusinessProduction}\ast{0.0001}\right)$$
+$$
+{BusinessFactor = (BusinessProduction)}^{0.26} + \left({BusinessProduction}\ast{0.0001}\right)
+$$
 
 - Advert factor:
 
-$$AwarenessFactor = (Awareness + 1)^{IndustryAdvertisingFactor}$$
+$$
+AwarenessFactor = (Awareness + 1)^{IndustryAdvertisingFactor}
+$$
 
-$$PopularityFactor = (Popularity + 1)^{IndustryAdvertisingFactor}$$
+$$
+PopularityFactor = (Popularity + 1)^{IndustryAdvertisingFactor}
+$$
 
-$$RatioFactor = \begin{cases}Max(0.01,\frac{Popularity + 0.001}{Awareness}), & Awareness \neq 0 \newline 0.01, & Awareness = 0 \end{cases}$$
+$$
+RatioFactor = \begin{cases}Max(0.01,\frac{Popularity + 0.001}{Awareness}), & Awareness \neq 0 \newline 0.01, & Awareness = 0 \end{cases}
+$$
 
-$$AdvertFactor = (AwarenessFactor\ast PopularityFactor\ast RatioFactor)^{0.85}$$
+$$
+AdvertFactor = (AwarenessFactor\ast PopularityFactor\ast RatioFactor)^{0.85}
+$$
 
 - Market factor:
 
-$$MarketFactor = Max\left(0.1,{Demand\ast(100 - Competition)}\ast{0.01}\right)$$
+$$
+MarketFactor = Max\left(0.1,{Demand\ast(100 - Competition)}\ast{0.01}\right)
+$$
 
 - Corporation's upgrade bonus: `SalesBots` bonus.
 - Division's research bonus: this is always 1. Currently there is not any research that increases the sales bonus.
 
 ### Markup multiplier
 
-$$MarkupMultiplier = \begin{cases}10^{12} & SellingPrice \in (-\infty, 0] \newline \frac{MarketPrice}{SellingPrice} & SellingPrice \in (0, MarketPrice] \newline 1 & SellingPrice \in (MarketPrice, MarketPrice + MarkupLimit] \newline \left(\frac{MarkupLimit}{SellingPrice - MarketPrice}\right)^{2} & SellingPrice \in (MarketPrice + MarkupLimit, \infty) \end{cases}$$
+$$
+MarkupMultiplier = \begin{cases}10^{12} & SellingPrice \in (-\infty, 0] \newline \frac{MarketPrice}{SellingPrice} & SellingPrice \in (0, MarketPrice] \newline 1 & SellingPrice \in (MarketPrice, MarketPrice + MarkupLimit] \newline \left(\frac{MarkupLimit}{SellingPrice - MarketPrice}\right)^{2} & SellingPrice \in (MarketPrice + MarkupLimit, \infty) \end{cases}
+$$
 
 Analysis for 4 ranges, in the same order of the above formula:
 
@@ -98,27 +122,39 @@ In order to increase `MaxSalesVolume`, you can:
 
 Let's say that we want to sell all stored units. Define:
 
-$$ExpectedSalesVolume = \frac{StoredUnits}{10}$$
+$$
+ExpectedSalesVolume = \frac{StoredUnits}{10}
+$$
 
 Assume that we can sell all stored units.
 
-$$MaxSalesVolume = ExpectedSalesVolume$$
+$$
+MaxSalesVolume = ExpectedSalesVolume
+$$
 
 ≡
 
-$$PotentialSalesVolume\ast MarkupMultiplier = ExpectedSalesVolume$$
+$$
+PotentialSalesVolume\ast MarkupMultiplier = ExpectedSalesVolume
+$$
 
 ≡
 
-$$PotentialSalesVolume\ast\left(\frac{MarkupLimit}{SellingPrice - MarketPrice}\right)^{2} = ExpectedSalesVolume$$
+$$
+PotentialSalesVolume\ast\left(\frac{MarkupLimit}{SellingPrice - MarketPrice}\right)^{2} = ExpectedSalesVolume
+$$
 
 ≡
 
-$$\frac{MarkupLimit}{SellingPrice - MarketPrice} = \sqrt{\frac{ExpectedSalesVolume}{PotentialSalesVolume}}$$
+$$
+\frac{MarkupLimit}{SellingPrice - MarketPrice} = \sqrt{\frac{ExpectedSalesVolume}{PotentialSalesVolume}}
+$$
 
 ≡
 
-$$SellingPrice = \frac{MarkupLimit\ast\sqrt{PotentialSalesVolume}}{\sqrt{ExpectedSalesVolume}} + MarketPrice$$
+$$
+SellingPrice = \frac{MarkupLimit\ast\sqrt{PotentialSalesVolume}}{\sqrt{ExpectedSalesVolume}} + MarketPrice
+$$
 
 There are 2 cases:
 

--- a/src/Documentation/doc/en/advanced/corporation/product.md
+++ b/src/Documentation/doc/en/advanced/corporation/product.md
@@ -33,96 +33,150 @@ Office setup is important to efficiently develop new products. Check this [secti
 
 - Total employee production:
 
-$$TotalEmployeeProd = OperationsProd + EngineerProd + ManagementProd$$
+$$
+TotalEmployeeProd = OperationsProd + EngineerProd + ManagementProd
+$$
 
 - Management factor:
 
-$$ManagementFactor = 1 + \frac{ManagementProd}{1.2\ast TotalEmployeeProd}$$
+$$
+ManagementFactor = 1 + \frac{ManagementProd}{1.2\ast TotalEmployeeProd}
+$$
 
 - Product development multiplier:
 
-$$ProductDevelopmentMultiplier = \left( (EngineerProd)^{0.34} + (OperationsProd)^{0.2} \right)\ast ManagementFactor$$
+$$
+ProductDevelopmentMultiplier = \left( (EngineerProd)^{0.34} + (OperationsProd)^{0.2} \right)\ast ManagementFactor
+$$
 
 - Progress:
 
-$$Progress = 0.01\ast ProductDevelopmentMultiplier$$
+$$
+Progress = 0.01\ast ProductDevelopmentMultiplier
+$$
 
 - Development progress:
 
-$$DevelopmentProgress = DevelopmentProgress + Progress$$
+$$
+DevelopmentProgress = DevelopmentProgress + Progress
+$$
 
 - `CreationJobFactors[JobName]`:
 
-$$CreationJobFactors\lbrack JobName\rbrack = CreationJobFactors\lbrack JobName\rbrack + {\lbrace EmployeeJob\rbrace Prod\ast Progress}\ast{0.01}$$
+$$
+CreationJobFactors\lbrack JobName\rbrack = CreationJobFactors\lbrack JobName\rbrack + {\lbrace EmployeeJob\rbrace Prod\ast Progress}\ast{0.01}
+$$
 
 &nbsp;  
 When `DevelopmentProgress` reaches 100, product is finished.
 
 - Define:
 
-$$A = \ CreationJobFactors\lbrack Engineer\rbrack$$
+$$
+A = \ CreationJobFactors\lbrack Engineer\rbrack
+$$
 
-$$B = \ CreationJobFactors\lbrack Management\rbrack$$
+$$
+B = \ CreationJobFactors\lbrack Management\rbrack
+$$
 
-$$C = \ CreationJobFactors\lbrack RnD\rbrack$$
+$$
+C = \ CreationJobFactors\lbrack RnD\rbrack
+$$
 
-$$D = \ CreationJobFactors\lbrack Operations\rbrack$$
+$$
+D = \ CreationJobFactors\lbrack Operations\rbrack
+$$
 
-$$E = \ CreationJobFactors\lbrack Business\rbrack$$
+$$
+E = \ CreationJobFactors\lbrack Business\rbrack
+$$
 
-$$TotalCreationJobFactors = A + B + C + D + E$$
+$$
+TotalCreationJobFactors = A + B + C + D + E
+$$
 
 - {JobName}Ratio:
 
-$$EngineerRatio = \frac{A}{TotalCreationJobFactors}$$
+$$
+EngineerRatio = \frac{A}{TotalCreationJobFactors}
+$$
 
-$$ManagementRatio = \frac{B}{TotalCreationJobFactors}$$
+$$
+ManagementRatio = \frac{B}{TotalCreationJobFactors}
+$$
 
-$$RnDRatio = \frac{C}{TotalCreationJobFactors}$$
+$$
+RnDRatio = \frac{C}{TotalCreationJobFactors}
+$$
 
-$$OperationsRatio = \frac{D}{TotalCreationJobFactors}$$
+$$
+OperationsRatio = \frac{D}{TotalCreationJobFactors}
+$$
 
-$$BusinessRatio = \frac{E}{TotalCreationJobFactors}$$
+$$
+BusinessRatio = \frac{E}{TotalCreationJobFactors}
+$$
 
 - Design investment multiplier:
 
-$$DesignInvestMult = 1 + {(DesignInvestment)^{0.1}}\ast{0.01}$$
+$$
+DesignInvestMult = 1 + {(DesignInvestment)^{0.1}}\ast{0.01}
+$$
 
 - Science multiplier:
 
-$$ScienceMult = 1 + {(RP)^{ResearchFactor}}\ast{0.00125}$$
+$$
+ScienceMult = 1 + {(RP)^{ResearchFactor}}\ast{0.00125}
+$$
 
 - Balance multiplier:
 
-$$BalanceMult = 1.2\ast EngineerRatio + 0.9\ast ManagementRatio + 1.3\ast RnDRatio + 1.5\ast OperationsRatio + BusinessRatio$$
+$$
+BalanceMult = 1.2\ast EngineerRatio + 0.9\ast ManagementRatio + 1.3\ast RnDRatio + 1.5\ast OperationsRatio + BusinessRatio
+$$
 
 - Total multiplier:
 
-$$TotalMult = BalanceMult\ast DesignInvestMult\ast ScienceMult$$
+$$
+TotalMult = BalanceMult\ast DesignInvestMult\ast ScienceMult
+$$
 
 - Product's quality:
 
-$$TotalMult\ast (0.1\ast A + 0.05\ast B + 0.05\ast C + 0.02\ast D + 0.02\ast E)$$
+$$
+TotalMult\ast (0.1\ast A + 0.05\ast B + 0.05\ast C + 0.02\ast D + 0.02\ast E)
+$$
 
 - Product's performance:
 
-$$TotalMult\ast (0.15\ast A + 0.02\ast B + 0.02\ast C + 0.02\ast D + 0.02\ast E)$$
+$$
+TotalMult\ast (0.15\ast A + 0.02\ast B + 0.02\ast C + 0.02\ast D + 0.02\ast E)
+$$
 
 - Product's durability:
 
-$$TotalMult\ast (0.05\ast A + 0.02\ast B + 0.08\ast C + 0.05\ast D + 0.05\ast E)$$
+$$
+TotalMult\ast (0.05\ast A + 0.02\ast B + 0.08\ast C + 0.05\ast D + 0.05\ast E)
+$$
 
 - Product's reliability:
 
-$$TotalMult\ast (0.02\ast A + 0.08\ast B + 0.02\ast C + 0.05\ast D + 0.08\ast E)$$
+$$
+TotalMult\ast (0.02\ast A + 0.08\ast B + 0.02\ast C + 0.05\ast D + 0.08\ast E)
+$$
 
 - Product's aesthetics:
 
-$$TotalMult\ast (0.08\ast B + 0.05\ast C + 0.02\ast D + 0.1\ast E)$$
+$$
+TotalMult\ast (0.08\ast B + 0.05\ast C + 0.02\ast D + 0.1\ast E)
+$$
 
 - Product's features:
 
-$$TotalMult\ast (0.08\ast A + 0.05\ast B + 0.02\ast C + 0.05\ast D + 0.05\ast E)$$
+$$
+TotalMult\ast (0.08\ast A + 0.05\ast B + 0.02\ast C + 0.05\ast D + 0.05\ast E)
+$$
 
 - Product's rating:
   - If an industry produces product, it has its own `RatingWeights` for its product. `RatingWeights` contains coefficients of 6 stats: quality, performance, durability, reliability, aesthetics, features. For example: Tobacco's `RatingWeights`:
@@ -132,33 +186,47 @@ $$TotalMult\ast (0.08\ast A + 0.05\ast B + 0.02\ast C + 0.05\ast D + 0.05\ast E)
   - `RatingWeights` is `industryData.product.ratingWeights`.
   - Formula:
 
-$$ProductRating = \sum_{i = 1}^{6}{{ProductStat}_i\ast{StatCoefficient}_i}$$
+$$
+ProductRating = \sum_{i = 1}^{6}{{ProductStat}_i\ast{StatCoefficient}_i}
+$$
 
 - Advertising investment multiplier:
 
-$$AdvertInvestMult = 1 + {(AdvertisingInvestment)^{0.1}}\ast{0.01}$$
+$$
+AdvertInvestMult = 1 + {(AdvertisingInvestment)^{0.1}}\ast{0.01}
+$$
 
 - Business-Management ratio:
 
-$$BusinessManagementRatio = Max\left( BusinessRatio + ManagementRatio,\ \left( \frac{1}{TotalCreationJobFactors} \right) \right)$$
+$$
+BusinessManagementRatio = Max\left( BusinessRatio + ManagementRatio,\ \left( \frac{1}{TotalCreationJobFactors} \right) \right)
+$$
 
 - Product's markup:
 
-$$ProductMarkup = \frac{100}{AdvertInvestMult\ast(ProductQuality + 0.001)^{0.65}\ast BusinessManagementRatio}$$
+$$
+ProductMarkup = \frac{100}{AdvertInvestMult\ast(ProductQuality + 0.001)^{0.65}\ast BusinessManagementRatio}
+$$
 
 - Product's demand:
 
-$$Demand = \begin{cases}Min(100,AdvertInvestMult\ast(100\ast(Popularity/Awareness))), & Awareness \neq 0 \newline 20, & Awareness = 0 \end{cases}$$
+$$
+Demand = \begin{cases}Min(100,AdvertInvestMult\ast(100\ast(Popularity/Awareness))), & Awareness \neq 0 \newline 20, & Awareness = 0 \end{cases}
+$$
 
 - Product's competition:
 
-$$Competition = Random(0,70)$$
+$$
+Competition = Random(0,70)
+$$
 
 - Product's size:
   - It's `product.size`.
   - Formula:
 
-$$ProductSize = \sum_{i = 1}^{NumberOfInputMaterials}{{InputMaterialSize}_i\ast{InputMaterialCoefficient}_i}$$
+$$
+ProductSize = \sum_{i = 1}^{NumberOfInputMaterials}{{InputMaterialSize}_i\ast{InputMaterialCoefficient}_i}
+$$
 
 ## Approximation value of product markup
 

--- a/src/Documentation/doc/en/advanced/corporation/quality.md
+++ b/src/Documentation/doc/en/advanced/corporation/quality.md
@@ -18,13 +18,17 @@ When you import/export your materials between different divisions, you can see q
 
 In PURCHASE state, material's quality is "diluted" by low-quality purchased material (quality 1).
 
-$$Quality = \frac{Quality\ast CurrentQuantity + BuyAmount}{CurrentQuantity + BuyAmount}$$
+$$
+Quality = \frac{Quality\ast CurrentQuantity + BuyAmount}{CurrentQuantity + BuyAmount}
+$$
 
 In PRODUCTION state, the "diluted" quality value is used for calculating `AvgInputQuality`.
 
 In EXPORT state:
 
-$$Quality = \frac{Quality\ast CurrentQuantity + ImportQuality\ast ImportAmount}{CurrentQuantity + ImportAmount}$$
+$$
+Quality = \frac{Quality\ast CurrentQuantity + ImportQuality\ast ImportAmount}{CurrentQuantity + ImportAmount}
+$$
 
 The production capability of support division should be balanced. The `ImportAmount` (the number of material units that the support division exports) does not need to equal the required number of input material units, but it should also not be too small.
 
@@ -35,19 +39,27 @@ The production capability of support division should be balanced. The `ImportAmo
 - Engineer summand:
   - `EngineerProduction = office.employeeProductionByJob["Engineer"]`
 
-$$EngineerSummand = \frac{EngineerProduction}{90}$$
+$$
+EngineerSummand = \frac{EngineerProduction}{90}
+$$
 
 - Research point summand:
 
-$$ResearchPointSummand = (RP)^{IndustryScienceFactor}$$
+$$
+ResearchPointSummand = (RP)^{IndustryScienceFactor}
+$$
 
 - AI Cores summand (if there is AI Cores in the warehouse):
 
-$$AICoresSummand = AICoresQuantity^{IndustryAICoreFactor}\ast{0.001}$$
+$$
+AICoresSummand = AICoresQuantity^{IndustryAICoreFactor}\ast{0.001}
+$$
 
 Output quality:
 
-$$OutputQuality = \sqrt{MaxOutputQuality}\ast AvgInputQuality$$
+$$
+OutputQuality = \sqrt{MaxOutputQuality}\ast AvgInputQuality
+$$
 
 With formulas above, we have these conclusions:
 
@@ -66,6 +78,8 @@ Game UI shows `OutputRating` as "Effective rating"
 
 Output rating:
 
-$$OutputRating = \sqrt{MaxOutputRating}\ast AvgInputQuality$$
+$$
+OutputRating = \sqrt{MaxOutputRating}\ast AvgInputQuality
+$$
 
 Use same strategy as material for checking `AvgInputQuality`.

--- a/src/Documentation/doc/en/advanced/corporation/unlocks-upgrade-research.md
+++ b/src/Documentation/doc/en/advanced/corporation/unlocks-upgrade-research.md
@@ -29,39 +29,57 @@ Normal upgrade's formulas:
 
 - Upgrade cost:
 
-$$UpgradeCost = BasePrice\ast{PriceMult}^{CurrentLevel}$$
+$$
+UpgradeCost = BasePrice\ast{PriceMult}^{CurrentLevel}
+$$
 
 - Upgrade cost from level 0 to level n:
 
-$$UpgradeCost_{From\ 0\ to\ n} = \sum_{k = 0}^{n - 1}{BasePrice\ast {PriceMult}^k}$$
+$$
+UpgradeCost_{From\ 0\ to\ n} = \sum_{k = 0}^{n - 1}{BasePrice\ast {PriceMult}^k}
+$$
 
 ≡
 
-$$UpgradeCost_{From\ 0\ to\ n} = BasePrice\ast\left( \frac{1 - {PriceMult}^{n}}{1 - PriceMult} \right)$$
+$$
+UpgradeCost_{From\ 0\ to\ n} = BasePrice\ast\left( \frac{1 - {PriceMult}^{n}}{1 - PriceMult} \right)
+$$
 
 ≡
 
-$$UpgradeCost_{From\ 0\ to\ n} = BasePrice\ast\left( \frac{{PriceMult}^{n} - 1}{PriceMult - 1} \right)$$
+$$
+UpgradeCost_{From\ 0\ to\ n} = BasePrice\ast\left( \frac{{PriceMult}^{n} - 1}{PriceMult - 1} \right)
+$$
 
 - Upgrade cost level a to level b:
 
-$$UpgradeCost_{From\ a\ to\ b} = \sum_{k = 0}^{b - 1}{BasePrice\ast {PriceMult}^k} - \sum_{k = 0}^{a - 1}{BasePrice\ast {PriceMult}^k}$$
+$$
+UpgradeCost_{From\ a\ to\ b} = \sum_{k = 0}^{b - 1}{BasePrice\ast {PriceMult}^k} - \sum_{k = 0}^{a - 1}{BasePrice\ast {PriceMult}^k}
+$$
 
 ≡
 
-$$UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{PriceMult}^{b} - 1}{PriceMult - 1} \right) - BasePrice\ast\left( \frac{{PriceMult}^{a} - 1}{PriceMult - 1} \right)$$
+$$
+UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{PriceMult}^{b} - 1}{PriceMult - 1} \right) - BasePrice\ast\left( \frac{{PriceMult}^{a} - 1}{PriceMult - 1} \right)
+$$
 
 ≡
 
-$$UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{PriceMult}^{b} - {PriceMult}^{a}}{PriceMult - 1} \right)$$
+$$
+UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{PriceMult}^{b} - {PriceMult}^{a}}{PriceMult - 1} \right)
+$$
 
 - Maximum upgrade level with a given `MaxCost`:
 
-$$MaxUpgradeLevel = \log_{PriceMult}\left( MaxCost\ast\frac{PriceMult - 1}{BasePrice} + (PriceMult)^{CurrentLevel} \right)$$
+$$
+MaxUpgradeLevel = \log_{PriceMult}\left( MaxCost\ast\frac{PriceMult - 1}{BasePrice} + (PriceMult)^{CurrentLevel} \right)
+$$
 
 - Benefit: All benefits are multipliers. `BaseBenefit` is 1.
 
-$$Benefit = BaseBenefit + Benefit\ast CurrentLevel$$
+$$
+Benefit = BaseBenefit + Benefit\ast CurrentLevel
+$$
 
 &nbsp;  
 Normal upgrades:
@@ -169,6 +187,8 @@ RP gain rate:
 - RP gain per city per state:
   - `RnDProduction = office.employeeProductionByJob["Research & Development"]`
 
-$$RPGain = 0.004\ast(RnDProduction)^{0.5}\ast UpgradeMultiplier\ast ResearchMultiplier$$
+$$
+RPGain = 0.004\ast(RnDProduction)^{0.5}\ast UpgradeMultiplier\ast ResearchMultiplier
+$$
 
 - Industry's `ScienceFactor` does not affect RP gain rate.

--- a/src/Documentation/doc/en/advanced/corporation/warehouse.md
+++ b/src/Documentation/doc/en/advanced/corporation/warehouse.md
@@ -6,27 +6,39 @@ Warehouse starts at level 1 after being bought. The initial price is 5e9.
 
 Warehouse upgrade cost: its formula is a bit different from other upgrades (the exponent is `CurrentLevel+1` instead of `CurrentLevel`):
 
-$$UpgradeCost = BasePrice\ast{1.07}^{CurrentLevel + 1}$$
+$$
+UpgradeCost = BasePrice\ast{1.07}^{CurrentLevel + 1}
+$$
 
 Upgrade cost for buying from level 1 to level n:
 
-$$UpgradeCost_{From\ 1\ to\ n} = \sum_{k = 2}^{n}{BasePrice\ast {1.07}^k}$$
+$$
+UpgradeCost_{From\ 1\ to\ n} = \sum_{k = 2}^{n}{BasePrice\ast {1.07}^k}
+$$
 
 ≡
 
-$$UpgradeCost_{From\ 1\ to\ n} = BasePrice\ast\left( \frac{{1.07}^{n + 1} - {1.07}^{2}}{0.07} \right)$$
+$$
+UpgradeCost_{From\ 1\ to\ n} = BasePrice\ast\left( \frac{{1.07}^{n + 1} - {1.07}^{2}}{0.07} \right)
+$$
 
 Upgrade cost for buying from level a to level b:
 
-$$UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{1.07}^{b + 1} - {1.07}^{a + 1}}{0.07} \right)$$
+$$
+UpgradeCost_{From\ a\ to\ b} = BasePrice\ast\left( \frac{{1.07}^{b + 1} - {1.07}^{a + 1}}{0.07} \right)
+$$
 
 Maximum level with a given `MaxCost`:
 
-$$MaxLevel = (log_{1.07}\left(MaxCost\ast\frac{0.07}{BasePrice} + {1.07}^{CurrentLevel+1} \right)) - 1$$
+$$
+MaxLevel = (log_{1.07}\left(MaxCost\ast\frac{0.07}{BasePrice} + {1.07}^{CurrentLevel+1} \right)) - 1
+$$
 
 Warehouse size:
 
 - Upgrade multiplier: multiplier from Smart Storage.
 - Research multiplier: multiplier from research.
 
-$$WarehouseSize = WarehouseLevel\ast 100\ast UpgradeMultiplier\ast ResearchMultiplier$$
+$$
+WarehouseSize = WarehouseLevel\ast 100\ast UpgradeMultiplier\ast ResearchMultiplier
+$$

--- a/src/Documentation/doc/en/advanced/corporation/wilson-analytics-advert.md
+++ b/src/Documentation/doc/en/advanced/corporation/wilson-analytics-advert.md
@@ -24,11 +24,17 @@ Cost: use the formulas in this [section](./unlocks-upgrade-research.md) with `Ba
 
 Benefit:
 
-$$AdvertMultiplier = WilsonUpgradeBenefit\ast ResearchAdvertisingMultiplier$$
+$$
+AdvertMultiplier = WilsonUpgradeBenefit\ast ResearchAdvertisingMultiplier
+$$
 
-$$Awareness = (Awareness + 3\ast AdvertMultiplier)\ast(1.005*AdvertMultiplier)$$
+$$
+Awareness = (Awareness + 3\ast AdvertMultiplier)\ast(1.005*AdvertMultiplier)
+$$
 
-$$Popularity = (Popularity + AdvertMultiplier)\ast(1 + {Random(1,3)}\ast{0.005})\ast AdvertMultiplier$$
+$$
+Popularity = (Popularity + AdvertMultiplier)\ast(1 + {Random(1,3)}\ast{0.005})\ast AdvertMultiplier
+$$
 
 ## Advice
 

--- a/src/ThirdParty/RehypePlugin.mjs
+++ b/src/ThirdParty/RehypePlugin.mjs
@@ -305,6 +305,8 @@ export function createPlugin(createRenderer) {
         try {
           result = renderer.render(text, { display });
         } catch (error) {
+          // Print the error to the console to debug the issue easier.
+          console.error(error);
           const cause = /** @type {Error} */ (error);
 
           file.message("Could not render math with mathjax", {


### PR DESCRIPTION
We used remark-math to render math notations in the in-game markdown docs viewer. Under the hood, remark-math uses micromark-extension-math. When writing Tex with these plugins, we need to use their syntax. There are two "modes": inline (also called "text") and block (also called "flow").

This is an example:
```
Inline 1: $x+y$

Inline 2: $$x+y$$

Block:

$$
x+y
$$
```
Notice how the "block" mode requires a newline after the opening `$$` and the closing `$$`. If `$$` (the "fence") is on the same line as the notation, the notation is always considered "inline". However, this is their rule, not a universal rule. In fact, there are no universal rules when it comes to math notation in markdown. Let's render this example in GitHub UI and VSCode's markdown preview mode:
```
Foo: $$x+y$$

$$x+y$$

$$
x+y
$$
```
GitHub UI:

<img width="1069" height="167" alt="github-1" src="https://github.com/user-attachments/assets/9d9644af-ccd6-4377-9eb6-29bdcef38b2d" />

VSCode:

<img width="948" height="163" alt="vscode" src="https://github.com/user-attachments/assets/e5384315-35c6-4c3a-aac0-bb6786464e17" />

As you can see in the screenshots, `$$x+y$$` can be inline or block, depending on the renderer.

In our corp docs, we usually `$$foo$$` (no newlines), so the math notations are rendered differently on GitHub UI and the in-game viewer:
GitHub:

<img width="1208" height="715" alt="github-2" src="https://github.com/user-attachments/assets/6dbfb84d-a85b-4fab-a52a-eac789416368" />

In-game viewer (current):

<img width="1639" height="536" alt="before" src="https://github.com/user-attachments/assets/4a525e1e-6779-4e3a-8f64-2b133022ae04" />

This PR changes most of `$$foo$$` (no newlines) to the ones with newlines. After the changes:

<img width="1630" height="528" alt="after" src="https://github.com/user-attachments/assets/bfc017d8-7d14-43e6-a321-5e7120dd7f2e" />

Note that there are still some unchanged notations. They are notations used in a multi-level list. For example:
```
- foo 1
  - bar 1
  - bar 2:
    $$x + y$$
  - bar 3
- foo 2
```
In these cases, we have a problem with GitHub UI and prettier.

On GitHub, the example above is rendered in the inline mode, if we want it to render in the block mode, we need to write it like this:
```
- foo 1
  - bar 1
  - bar 2:

$$x + y$$

  - bar 3
- foo 2
```
Or
```
- foo 1
  - bar 1
  - bar 2:

$$
x + y
$$

  - bar 3
- foo 2
```
However, prettier will reformat it like this (notice how `- bar 3` is moved):
```
- foo 1
  - bar 1
  - bar 2:

$$
x + y
$$

- bar 3
- foo 2
```
I tried to find a workaround, but I did not find any good ones, so I decided to accept it as a small drawback.