### PR TITLE
UI: Remove BitNode's difficulty in BitNode selection popup

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -22,13 +22,7 @@ class BitNode {
   // BitNode number
   number: number;
 
-  constructor(
-    n: number,
-    name: string,
-    tagline = "",
-    description: JSX.Element,
-    sfDescription: JSX.Element,
-  ) {
+  constructor(n: number, name: string, tagline = "", description: JSX.Element, sfDescription: JSX.Element) {
     this.number = n;
     this.name = name;
     this.tagline = tagline;

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -22,18 +22,14 @@ class BitNode {
   // BitNode number
   number: number;
 
-  difficulty: 0 | 1 | 2;
-
   constructor(
     n: number,
-    difficulty: 0 | 1 | 2,
     name: string,
     tagline = "",
     description: JSX.Element,
     sfDescription: JSX.Element,
   ) {
     this.number = n;
-    this.difficulty = difficulty;
     this.name = name;
     this.tagline = tagline;
     this.description = description;
@@ -50,7 +46,6 @@ export const BitNodes: Record<string, BitNode> = {};
 export function initBitNodes() {
   BitNodes.BitNode1 = new BitNode(
     1,
-    0,
     "Source Genesis",
     "The original BitNode",
     (
@@ -80,7 +75,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode2 = new BitNode(
     2,
-    0,
     "Rise of the Underworld",
     "From the shadows, they rose",
     (
@@ -115,7 +109,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode3 = new BitNode(
     3,
-    2,
     "Corporatocracy",
     "The Price of Civilization",
     (
@@ -151,7 +144,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode4 = new BitNode(
     4,
-    1,
     "The Singularity",
     "The Man and the Machine",
     (
@@ -183,7 +175,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode5 = new BitNode(
     5,
-    1,
     "Artificial Intelligence",
     "Posthuman",
     (
@@ -225,7 +216,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode6 = new BitNode(
     6,
-    1,
     FactionName.Bladeburners,
     "Like Tears in Rain",
     (
@@ -259,7 +249,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode7 = new BitNode(
     7,
-    2,
     `${FactionName.Bladeburners} 2079`,
     "More human than humans",
     (
@@ -296,7 +285,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode8 = new BitNode(
     8,
-    2,
     "Ghost of Wall Street",
     "Money never sleeps",
     (
@@ -333,7 +321,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode9 = new BitNode(
     9,
-    2,
     "Hacktocracy",
     "Hacknet Unleashed",
     (
@@ -375,7 +362,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode10 = new BitNode(
     10,
-    2,
     "Digital Carbon",
     "Your body is not who you are",
     (
@@ -410,7 +396,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode11 = new BitNode(
     11,
-    1,
     "The Big Crash",
     "Okay. Sell it all.",
     (
@@ -452,7 +437,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode12 = new BitNode(
     12,
-    0,
     "The Recursion",
     "Repeat.",
     (
@@ -469,7 +453,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode13 = new BitNode(
     13,
-    2,
     "They're lunatics",
     "1 step back, 2 steps forward",
     (
@@ -501,7 +484,6 @@ export function initBitNodes() {
   );
   BitNodes.BitNode14 = new BitNode(
     14,
-    1,
     "IPvGO Subnet Takeover",
     "Territory exists only in the 'net",
     (

--- a/src/BitNode/ui/PortalModal.tsx
+++ b/src/BitNode/ui/PortalModal.tsx
@@ -101,8 +101,6 @@ export function PortalModal(props: IProps): React.ReactElement {
         Source-File Level: {props.level} / {maxSourceFileLevel}
       </Typography>
       <br />
-      <Typography> Difficulty: {["easy", "normal", "hard"][bitNode.difficulty]}</Typography>
-      <br />
       <br />
       <Typography component="div">{bitNode.info}</Typography>
       <BitNodeMultiplierDescription n={props.n} level={newLevel} hideMultsIfCannotAccessFeature={false} />

--- a/src/Documentation/doc/en/advanced/bitnode_recommendation_comprehensive_guide.md
+++ b/src/Documentation/doc/en/advanced/bitnode_recommendation_comprehensive_guide.md
@@ -38,7 +38,7 @@ Some mechanics synergize well with other mechanics. For example, in order to cre
 
 Some mechanics have peculiarities that you should know beforehand. For example, enabling territory clashes too soon will make the player lose all territory and ruin their gang.
 
-All BitNodes have a unique set of multipliers that affect the difficulty of that BitNode. You can see these multipliers when choosing a BitNode in the BitVerse. [Source-File](./sourcefiles.md) 5 gives you access to these multipliers when you are already in a BitNode. Some BitNodes are much harder than others. It's recommended to unlock other Source-Files before trying to beat these hard BitNodes. Note that the "Difficulty" value of a BitNode in the BitVerse may be a bit misleading in some cases. Understanding the difficulty of a BitNode is much harder than just choosing between "easy", "normal" and "hard".
+All BitNodes have a unique set of multipliers that affect the difficulty of that BitNode. You can see these multipliers when choosing a BitNode in the BitVerse. [Source-File](./sourcefiles.md) 5 gives you access to these multipliers when you are already in a BitNode. Some BitNodes are much harder than others. It's recommended to unlock other Source-Files before trying to beat these hard BitNodes.
 
 # BitNode analysis
 


### PR DESCRIPTION
This description usually does more harm than good. It classifies BN into 3 "tiers" of difficulty: easy, normal, and hard. However, due to how complicated BitNodes are, this tends to mislead new players. For example:
- Both BN7 and BN9 are classified as "hard", but BN9 is actually much more difficult than BN7.
- BN3 is classified as "hard", but it's not really hard. The hard thing is the mechanic that it unlocks. If you don't care about corp and just want to beat BN3, it's not hard at all.

With our new in-game guides for BN recommendations, we don't need this (misleading) way of classification.

Before:

<img width="1228" height="522" alt="before" src="https://github.com/user-attachments/assets/ef96a7f7-277e-4180-aa6b-137bde9f1247" />

After:

<img width="1226" height="489" alt="after" src="https://github.com/user-attachments/assets/f3b86ade-52f0-4b4e-9ce9-b7482228d1e3" />
