### PR TITLE
API: Allow ns.read to read .msg and .lit files

### DIFF
--- a/markdown/bitburner.ns.read.md
+++ b/markdown/bitburner.ns.read.md
@@ -58,7 +58,9 @@ Data in the specified text file.
 
 RAM cost: 0 GB
 
-This function is used to read data from a text file (.txt, .json, .css) or script (.js, .jsx, .ts, .tsx).
+This function is used to read data from a text file (.txt, .json, .css), a script (.js, .jsx, .ts, .tsx), a literature file (.lit), or a message (.msg).
 
 This function will return the data in the specified file. If the file does not exist, an empty string will be returned.
+
+With literature files, the returned data is a raw HTML string.
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -109,6 +109,9 @@ import { compile } from "./NetscriptJSEvaluator";
 import { Script } from "./Script/Script";
 import { NetscriptFormat } from "./NetscriptFunctions/Format";
 import { FragmentTypeEnum } from "./CotMG/FragmentType";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Literatures } from "./Literature/Literatures";
+import { Messages } from "./Message/MessageHelpers";
 
 export const enums: NSEnums = {
   CityName,
@@ -1083,8 +1086,23 @@ export const ns: InternalAPI<NSFull> = {
   },
   read: (ctx) => (_filename) => {
     const path = helpers.filePath(ctx, "filename", _filename);
-    if (!hasScriptExtension(path) && !hasTextExtension(path)) return "";
     const server = ctx.workerScript.getServer();
+    const isLiterature = path.endsWith(".lit");
+    const isMessage = path.endsWith(".msg");
+    if (isLiterature || isMessage) {
+      if (!server.messages.includes(path as LiteratureName | MessageFilename)) {
+        helpers.log(ctx, () => `${path} does not exist on ${server.hostname}.`);
+        return "";
+      }
+      return isLiterature
+        ? renderToStaticMarkup(Literatures[path as LiteratureName].text)
+        : Messages[path as MessageFilename].msg;
+    }
+
+    if (!hasScriptExtension(path) && !hasTextExtension(path)) {
+      helpers.log(ctx, () => `${path} does not exist on ${server.hostname}.`);
+      return "";
+    }
     return server.getContentFile(path)?.content ?? "";
   },
   getFileMetadata: (ctx) => (_filename) => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7862,10 +7862,13 @@ export interface NS {
    * @remarks
    * RAM cost: 0 GB
    *
-   * This function is used to read data from a text file (.txt, .json, .css) or script (.js, .jsx, .ts, .tsx).
+   * This function is used to read data from a text file (.txt, .json, .css), a script (.js, .jsx, .ts, .tsx), a
+   * literature file (.lit), or a message (.msg).
    *
-   * This function will return the data in the specified file.
-   * If the file does not exist, an empty string will be returned.
+   * This function will return the data in the specified file. If the file does not exist, an empty string will be
+   * returned.
+   *
+   * With literature files, the returned data is a raw HTML string.
    *
    * @param filename - Name of the file to be read.
    * @returns Data in the specified text file.


### PR DESCRIPTION
Players often ask us why they cannot move .msg and .lit files with `ns.mv` but can copy them with `ns.scp`. The reason is a technical one. These files' data does not exist in the internal server object (we only store the filename), so those files must be on the root of the server. This means `mv` cannot be used. `scp` is fine because you cannot specify a custom path for the destination.

A common use case is to copy these files from NPC's servers and then move them to a subdirectory to avoid cluttering the home folder. This can be done by reading the file content, saving it to a txt file, and then moving that txt file. However, `ns.read` cannot read these files. This PR solves this issue.

The content of .lit files is written in JSX, so we need to use a library to parse it to a string. I decided to use React built-in functions in `react-dom/server`. The bundle size only increases a bit.

Before:

<img width="530" height="479" alt="before" src="https://github.com/user-attachments/assets/c6099f45-903b-4e09-a8c7-abba22cfde93" />

After:

<img width="542" height="515" alt="after" src="https://github.com/user-attachments/assets/d6f94c14-14de-48ef-854e-f718bbcfbc23" />

Reports:

[report-after.html](https://github.com/user-attachments/files/24834714/report-after.html)

[report-before.html](https://github.com/user-attachments/files/24834715/report-before.html)

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  ns.print(ns.read("j0.msg"));
  ns.print(ns.read("hackers-starting-handbook.lit"));
}
```

Output:
```
I know you can sense it. I know you're searching for it. It's why you spend night after night at your computer. 

It's real, I've seen it. And I can help you find it. But not right now. You're not ready yet.

Use this program to track your progress

The fl1ght.exe program was added to your home computer

-jump3R
<p class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root">When starting out, hacking is the most profitable way to earn money and progress. This is a brief collection of tips/pointers on how to make the most out of your hacking scripts.<br/><br/>-hack() and grow() both work by percentages. hack() steals a certain percentage of the money on a server, and grow() increases the amount of money on a server by some percentage (multiplicatively)<br/><br/>-Because hack() and grow() work by percentages, they are more effective if the target server has a high amount of money. Therefore, you should try to increase the amount of money on a server (using grow()) to a certain amount before hacking it. Two important Netscript functions for this are getServerMoneyAvailable() and getServerMaxMoney()<br/><br/>-Keep security level low. Security level affects everything when hacking. Two important Netscript functions for this are getServerSecurityLevel() and getServerMinSecurityLevel()<br/><br/>-Purchase additional cloud servers by visiting &quot;Alpha Enterprises&quot; in the city. They are relatively cheap and give you valuable RAM to run more scripts early in the game<br/><br/>-Prioritize upgrading the RAM on your home computer. This can also be done at &quot;Alpha Enterprises&quot;<br/><br/>-Many low level servers have free RAM. You can use this RAM to run your scripts. Use the scp Terminal or Netscript command to copy your scripts onto these servers and then run them.</p>
```