### PR TITLE
CODEBASE: Update NodeJS to v24

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -68,10 +68,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/build-upload-artifacts.yml
+++ b/.github/workflows/build-upload-artifacts.yml
@@ -20,10 +20,10 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -42,10 +42,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install NPM dependencies for version updater
         working-directory: ./tools/bump-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
       - env:
           ENABLE_DEV_MODE: ${{ github.event.inputs.enable_dev_mode }}

--- a/.github/workflows/fetch-changes.yml
+++ b/.github/workflows/fetch-changes.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
       - name: Install NPM dependencies
         working-directory: ./tools/fetch-changelog

--- a/.github/workflows/steamDev.yml
+++ b/.github/workflows/steamDev.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Build and deploy
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ upstream/master
 
 Install
 
-- `npm` (maybe via `nvm`)
+- NodeJS (maybe via `nvm`). When installing NodeJS, you also get a tool called `npm`. You can update `npm` to the latest version by running `npm install -g npm@latest`.
 - Github Desktop (Windows only)
 - Visual Studio Code (optional)
 
@@ -169,7 +169,7 @@ Saving a file will reload the game automatically.
 
 ### How to build the electron app
 
-Tested on Node v20.11.1 (LTS) on Windows.
+Tested on Node 24.13.0 (LTS) on Windows.
 These steps only work in a Bash-like environment, like MinGW for Windows.
 
 ```sh
@@ -220,10 +220,6 @@ the following rules:
 ### Unrelated changes in `package-lock.json`
 
 After running `npm install`, if you do not change anything in `package.json` and `package-lock.json` is still changed, you need to update `npm` to the latest version. After that, discard the changes in `package-lock.json`, delete the `node_modules` folder, and run `npm install` again.
-
-### Unrelated failed Jest tests
-
-Some Jest tests fail to run in Node 24. Those tests show a small difference between the expected value ("Snapshot") and the actual value ("Received"). If you do not change anything related to those tests, you can ignore them. This is not a problem with earlier Node versions.
 
 ## As a Documenter
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,10 @@ the following rules:
 
 After running `npm install`, if you do not change anything in `package.json` and `package-lock.json` is still changed, you need to update `npm` to the latest version. After that, discard the changes in `package-lock.json`, delete the `node_modules` folder, and run `npm install` again.
 
+### Unrelated failed Jest tests
+
+Some Jest tests fail to run in Node versions older than v24. On those versions, these tests show a small difference between the expected value ("Snapshot") and the actual value ("Received"). You need to use Node v24+ to run these tests.
+
 ## As a Documenter
 
 To contribute to and view your changes to the BitBurner documentation in-game, you will

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "xml-formatter": "^3.6.7"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     }
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "homepage": "https://bitburner-official.github.io/",
   "repository": {

--- a/test/jest/Netscript/Sleeve.test.ts
+++ b/test/jest/Netscript/Sleeve.test.ts
@@ -51,7 +51,7 @@ describe("Cost", () => {
     expect(Player.sleeves[0].getMemoryUpgradeCost(0)).toStrictEqual(0);
     expect(Player.sleeves[0].getMemoryUpgradeCost(1)).toStrictEqual(1e12);
     expect(Player.sleeves[0].getMemoryUpgradeCost(10)).toStrictEqual(1.0949720999737857e13);
-    expect(Player.sleeves[0].getMemoryUpgradeCost(99)).toStrictEqual(3.051297116790363e14);
+    expect(Player.sleeves[0].getMemoryUpgradeCost(99)).toStrictEqual(3.051297116790364e14);
     Player.sleeves[0].memory = 50;
     expect(Player.sleeves[0].getMemoryUpgradeCost(0)).toStrictEqual(0);
     expect(Player.sleeves[0].getMemoryUpgradeCost(1)).toStrictEqual(2.6388117932094194e12);

--- a/test/jest/__snapshots__/Corporation.test.ts.snap
+++ b/test/jest/__snapshots__/Corporation.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 0 to 2 1`] = `2069999999.9999986`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 0 to 3 1`] = `3214900000.000002`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 0 to 3 1`] = `3214899999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 0 to 4 1`] = `4439942999.999999`;
 
@@ -12,21 +12,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 1 to 2 1`] = `2214899999.999999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 1 to 3 1`] = `3439943000.0000024`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 1 to 3 1`] = `3439942999.999999`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 1 to 4 1`] = `4750739010`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 1 to 5 1`] = `6153290740.700001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 2 to 3 1`] = `3680739010.000002`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 2 to 3 1`] = `3680739009.999998`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 2 to 4 1`] = `5083290740.7`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 2 to 5 1`] = `6584021092.549001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 3 to 4 1`] = `5439121092.549`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 3 to 4 1`] = `5439121092.548999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 3 to 5 1`] = `7044902569.027432`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 3 to 5 1`] = `7044902569.027431`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: ABC SalesBots: from 4 to 5 1`] = `7538045748.859352`;
 
@@ -34,7 +34,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Foc
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 0 to 2 1`] = `2060000000.0000007`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 0 to 3 1`] = `3183600000.000002`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 0 to 3 1`] = `3183599999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 0 to 4 1`] = `4374616000.000002`;
 
@@ -42,21 +42,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Foc
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 1 to 2 1`] = `2183600000.000001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 1 to 3 1`] = `3374616000.0000024`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 1 to 3 1`] = `3374615999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 1 to 4 1`] = `4637092960.000001`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 1 to 5 1`] = `5975318537.599999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 2 to 3 1`] = `3577092960.0000033`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 2 to 3 1`] = `3577092959.999999`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 2 to 4 1`] = `4915318537.600002`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 2 to 5 1`] = `6333837649.856001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 3 to 4 1`] = `5210237649.856003`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 3 to 4 1`] = `5210237649.856002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 3 to 5 1`] = `6713867908.847361`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 3 to 5 1`] = `6713867908.84736`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: FocusWires: from 4 to 5 1`] = `7116699983.378202`;
 
@@ -64,7 +64,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neu
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 0 to 2 1`] = `2060000000.0000007`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 0 to 3 1`] = `3183600000.000002`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 0 to 3 1`] = `3183599999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 0 to 4 1`] = `4374616000.000002`;
 
@@ -72,21 +72,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neu
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 1 to 2 1`] = `2183600000.000001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 1 to 3 1`] = `3374616000.0000024`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 1 to 3 1`] = `3374615999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 1 to 4 1`] = `4637092960.000001`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 1 to 5 1`] = `5975318537.599999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 2 to 3 1`] = `3577092960.0000033`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 2 to 3 1`] = `3577092959.999999`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 2 to 4 1`] = `4915318537.600002`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 2 to 5 1`] = `6333837649.856001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 3 to 4 1`] = `5210237649.856003`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 3 to 4 1`] = `5210237649.856002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 3 to 5 1`] = `6713867908.847361`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 3 to 5 1`] = `6713867908.84736`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Neural Accelerators: from 4 to 5 1`] = `7116699983.378202`;
 
@@ -94,7 +94,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuo
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 0 to 2 1`] = `2060000000.0000007`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 0 to 3 1`] = `3183600000.000002`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 0 to 3 1`] = `3183599999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 0 to 4 1`] = `4374616000.000002`;
 
@@ -102,21 +102,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuo
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 1 to 2 1`] = `2183600000.000001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 1 to 3 1`] = `3374616000.0000024`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 1 to 3 1`] = `3374615999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 1 to 4 1`] = `4637092960.000001`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 1 to 5 1`] = `5975318537.599999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 2 to 3 1`] = `3577092960.0000033`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 2 to 3 1`] = `3577092959.999999`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 2 to 4 1`] = `4915318537.600002`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 2 to 5 1`] = `6333837649.856001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 3 to 4 1`] = `5210237649.856003`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 3 to 4 1`] = `5210237649.856002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 3 to 5 1`] = `6713867908.847361`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 3 to 5 1`] = `6713867908.84736`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Nuoptimal Nootropic Injector Implants: from 4 to 5 1`] = `7116699983.378202`;
 
@@ -124,7 +124,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Pro
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 0 to 2 1`] = `10349999999.999992`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 0 to 3 1`] = `16074500000.00001`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 0 to 3 1`] = `16074499999.999992`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 0 to 4 1`] = `22199714999.999996`;
 
@@ -132,21 +132,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Pro
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 1 to 2 1`] = `11074499999.999992`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 1 to 3 1`] = `17199715000.000008`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 1 to 3 1`] = `17199714999.999992`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 1 to 4 1`] = `23753695049.999996`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 1 to 5 1`] = `30766453703.500004`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 2 to 3 1`] = `18403695050.00001`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 2 to 3 1`] = `18403695049.999992`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 2 to 4 1`] = `25416453703.499996`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 2 to 5 1`] = `32920105462.745003`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 3 to 4 1`] = `27195605462.745007`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 3 to 4 1`] = `27195605462.745003`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 3 to 5 1`] = `35224512845.13716`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 3 to 5 1`] = `35224512845.13715`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Project Insight: from 4 to 5 1`] = `37690228744.29675`;
 
@@ -154,7 +154,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Sma
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 0 to 2 1`] = `4120000000.0000014`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 0 to 3 1`] = `6367200000.000004`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 0 to 3 1`] = `6367199999.999997`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 0 to 4 1`] = `8749232000.000004`;
 
@@ -162,21 +162,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Sma
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 1 to 2 1`] = `4367200000.000002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 1 to 3 1`] = `6749232000.000005`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 1 to 3 1`] = `6749231999.999997`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 1 to 4 1`] = `9274185920.000002`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 1 to 5 1`] = `11950637075.199999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 2 to 3 1`] = `7154185920.000007`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 2 to 3 1`] = `7154185919.999998`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 2 to 4 1`] = `9830637075.200005`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 2 to 5 1`] = `12667675299.712002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 3 to 4 1`] = `10420475299.712006`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 3 to 4 1`] = `10420475299.712004`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 3 to 5 1`] = `13427735817.694721`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 3 to 5 1`] = `13427735817.69472`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Factories: from 4 to 5 1`] = `14233399966.756405`;
 
@@ -184,7 +184,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Sma
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 0 to 2 1`] = `4120000000.0000014`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 0 to 3 1`] = `6367200000.000004`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 0 to 3 1`] = `6367199999.999997`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 0 to 4 1`] = `8749232000.000004`;
 
@@ -192,21 +192,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Sma
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 1 to 2 1`] = `4367200000.000002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 1 to 3 1`] = `6749232000.000005`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 1 to 3 1`] = `6749231999.999997`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 1 to 4 1`] = `9274185920.000002`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 1 to 5 1`] = `11950637075.199999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 2 to 3 1`] = `7154185920.000007`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 2 to 3 1`] = `7154185919.999998`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 2 to 4 1`] = `9830637075.200005`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 2 to 5 1`] = `12667675299.712002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 3 to 4 1`] = `10420475299.712006`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 3 to 4 1`] = `10420475299.712004`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 3 to 5 1`] = `13427735817.694721`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 3 to 5 1`] = `13427735817.69472`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Smart Storage: from 4 to 5 1`] = `14233399966.756405`;
 
@@ -214,7 +214,7 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Spe
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 0 to 2 1`] = `2060000000.0000007`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 0 to 3 1`] = `3183600000.000002`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 0 to 3 1`] = `3183599999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 0 to 4 1`] = `4374616000.000002`;
 
@@ -222,21 +222,21 @@ exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Spe
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 1 to 2 1`] = `2183600000.000001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 1 to 3 1`] = `3374616000.0000024`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 1 to 3 1`] = `3374615999.9999986`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 1 to 4 1`] = `4637092960.000001`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 1 to 5 1`] = `5975318537.599999`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 2 to 3 1`] = `3577092960.0000033`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 2 to 3 1`] = `3577092959.999999`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 2 to 4 1`] = `4915318537.600002`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 2 to 5 1`] = `6333837649.856001`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 3 to 4 1`] = `5210237649.856003`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 3 to 4 1`] = `5210237649.856002`;
 
-exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 3 to 5 1`] = `6713867908.847361`;
+exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 3 to 5 1`] = `6713867908.84736`;
 
 exports[`Corporation helpers.calculateUpgradeCost should have fixed formula: Speech Processor Implants: from 4 to 5 1`] = `7116699983.378202`;
 


### PR DESCRIPTION
When running Jest tests with v24+, some tests fail due to a change related to floating-point operations in V8. For more information, please check https://discord.com/channels/415207508303544321/459097632896188436/1419898835320442901. Therefore, we need to use v22 and add a note to `CONTRIBUTING.md` about this known issue.

V22 is fairly old at this point, and according to my survey on Discord, most people are using v24+. It's time to update our requirement.
