### PR TITLE
CODEBASE: Update SaveData type to be compatible with TS 5.9 and upgrade TS

### DIFF
--- a/electron/saveDataBinaryFormat.d.ts
+++ b/electron/saveDataBinaryFormat.d.ts
@@ -1,1 +1,1 @@
-export declare const isBinaryFormat: (saveData: string | Uint8Array) => boolean;
+export declare const isBinaryFormat: (saveData: string | Uint8Array<ArrayBuffer>) => boolean;

--- a/markdown/bitburner.singularity.getsavedata.md
+++ b/markdown/bitburner.singularity.getsavedata.md
@@ -9,11 +9,11 @@ This function returns the save data.
 **Signature:**
 
 ```typescript
-getSaveData(): Promise<Uint8Array>;
+getSaveData(): Promise<Uint8Array<ArrayBuffer>>;
 ```
 **Returns:**
 
-Promise&lt;Uint8Array&gt;
+Promise&lt;Uint8Array&lt;ArrayBuffer&gt;&gt;
 
 ## Remarks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "prettier": "^2.8.8",
         "react-refresh": "^0.18.0",
         "style-loader": "^4.0.0",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.3",
         "webpack": "^5.100.2",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2",
@@ -18081,9 +18081,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "prettier": "^2.8.8",
     "react-refresh": "^0.18.0",
     "style-loader": "^4.0.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.3",
     "webpack": "^5.100.2",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2",

--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -10,6 +10,7 @@ import { exportScripts } from "./Terminal/commands/download";
 import { CONSTANTS } from "./Constants";
 import { commitHash } from "./utils/helpers/commitHash";
 import { handleGetSaveDataInfoError } from "./utils/ErrorHandler";
+import { assertSaveData } from "./utils/TypeAssertion";
 
 interface IReturnWebStatus extends IReturnStatus {
   data?: Record<string, unknown>;
@@ -122,9 +123,7 @@ function initElectronBridge(): void {
       });
   });
   bridge.receive("get-save-info-request", (saveData: unknown) => {
-    if (typeof saveData !== "string" && !(saveData instanceof Uint8Array)) {
-      throw new Error("Error while trying to get save info");
-    }
+    assertSaveData(saveData);
     window.appSaveFns
       .getSaveInfo(saveData)
       .then((saveInfo) => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1879,7 +1879,7 @@ export interface Singularity {
    * @remarks
    * RAM cost: 1 GB * 16/4/1
    */
-  getSaveData(): Promise<Uint8Array>;
+  getSaveData(): Promise<Uint8Array<ArrayBuffer>>;
 
   /**
    * Backup game save.

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,4 +46,4 @@ export interface IMinMaxRange {
 }
 
 // Type of save data. The base64 format is string, the binary format is Uint8Array.
-export type SaveData = string | Uint8Array;
+export type SaveData = string | Uint8Array<ArrayBuffer>;

--- a/src/utils/SaveDataUtils.ts
+++ b/src/utils/SaveDataUtils.ts
@@ -15,12 +15,12 @@ export function canUseBinaryFormat(): boolean {
   return "CompressionStream" in globalThis;
 }
 
-async function compress(dataString: string): Promise<Uint8Array> {
+async function compress(dataString: string): Promise<Uint8Array<ArrayBuffer>> {
   const compressedReadableStream = new Blob([dataString]).stream().pipeThrough(new CompressionStream("gzip"));
   return new Uint8Array(await new Response(compressedReadableStream).arrayBuffer());
 }
 
-async function decompress(binaryData: Uint8Array): Promise<string> {
+async function decompress(binaryData: Uint8Array<ArrayBuffer>): Promise<string> {
   const decompressedReadableStream = new Blob([binaryData]).stream().pipeThrough(new DecompressionStream("gzip"));
   const reader = decompressedReadableStream.pipeThrough(new TextDecoderStream("utf-8", { fatal: true })).getReader();
   let result = "";

--- a/src/utils/TypeAssertion.ts
+++ b/src/utils/TypeAssertion.ts
@@ -1,4 +1,4 @@
-import type { Unknownify } from "../types";
+import type { SaveData, Unknownify } from "../types";
 
 // This function is empty because Unknownify<T> is a typesafe assertion on any object with no runtime checks needed.
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -87,5 +87,16 @@ export function assertNumberArray(unknownData: unknown, assertFinite = false): a
         throw new Error(`${value} is not a number.`);
       }
     }
+  }
+}
+
+export function assertSaveData(unknownData: unknown): asserts unknownData is SaveData {
+  if (typeof unknownData !== "string" && !(unknownData instanceof Uint8Array)) {
+    console.error(unknownData);
+    throw new Error(`Invalid save data. Its type is ${getFriendlyType(unknownData)}.`);
+  }
+  if (unknownData instanceof Uint8Array && !(unknownData.buffer instanceof ArrayBuffer)) {
+    console.error(unknownData);
+    throw new Error("Invalid save data. It's Uint8Array, but its buffer is not ArrayBuffer.");
   }
 }


### PR DESCRIPTION
I'm (slowly) working on a PR that updates eslint to the latest version. We are using a very old version of eslint, and it does not catch some fairly obvious errors. This will take a while, though. New lint rules trigger too many errors in our codebase. Some are false positives, but some are worth looking into.

When upgrading eslint, we will also upgrade TypeScript, and TS 5.9 has a change that makes the generic `Uint8Array` (without specifying the type of its buffer) not compatible with `BlobPart`. For more information, please check:
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#libdts-changes
- https://github.com/microsoft/TypeScript/issues/62546#issuecomment-3374526284
- https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/2113#issuecomment-3166485333

Let's update TS beforehand and see if there are any other issues. I tested on latest Chrome and our current Electron version.