### PR TITLE
API: Add warning when installing backdoor on backdoored server with Singularity API

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -529,6 +529,14 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         throw helpers.errorMessage(ctx, canHack.msg || "");
       }
 
+      if (server.backdoorInstalled) {
+        helpers.log(
+          ctx,
+          () =>
+            "You have already installed a backdoor on this server. You can check if the server has a backdoor installed " +
+            "with ns.getServer().backdoorInstalled.",
+        );
+      }
       helpers.log(
         ctx,
         () => `Installing backdoor on '${server.hostname}' in ${convertTimeMsToTimeElapsedString(installTime, true)}`,


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/issues/1702#issuecomment-3809805872

I'm not sure if we should conditionally hide the current messages ("Installing backdoor on" and "Successfully installed backdoor on"). I'm neutral on that.