### PR TITLE
DOCS: Fix some IPvGO docs that do not reflect winstreak rep converted to favor

### DIFF
--- a/src/Go/Go.ts
+++ b/src/Go/Go.ts
@@ -1,10 +1,13 @@
 import type { BoardState, OpponentStats } from "./Types";
 
-import type { GoOpponent } from "@enums";
+import { GoOpponent } from "@enums";
 import { getRecordKeys, PartialRecord } from "../Types/Record";
 import { resetGoPromises } from "./boardAnalysis/goAI";
 import { getNewBoardState } from "./boardState/boardState";
 import { EventEmitter } from "../utils/EventEmitter";
+import { Player } from "@player";
+import { AugmentationName } from "@enums";
+import { newOpponentStats } from "./Constants";
 
 export const getEmptyHighlightedPoints = (size: number = 7) => {
   return Array.from({ length: size }, () => Array.from({ length: size }, () => null));
@@ -20,6 +23,15 @@ export class GoObject {
   moveOrCheatViaApi = false;
 
   prestigeAugmentation() {
+    if (
+      Player.bitNodeN === 14 &&
+      Player.hasAugmentation(AugmentationName.TheRedPill) &&
+      !Go.stats[GoOpponent.w0r1d_d43m0n]
+    ) {
+      // Show the secret opponent on the go stats page in BN14 if the player has TRP
+      Go.stats[GoOpponent.w0r1d_d43m0n] = newOpponentStats();
+    }
+    // Clear out stats except for reputation as favor from winstreaks on prestige
     for (const opponent of getRecordKeys(Go.stats)) {
       const stats = Go.stats[opponent];
       if (!stats) {

--- a/src/Go/ui/GoHistoryPage.tsx
+++ b/src/Go/ui/GoHistoryPage.tsx
@@ -125,10 +125,29 @@ export const GoHistoryPage = (): React.ReactElement => {
                     }
                   >
                     <TableRow>
-                      <TableCell className={classes.cellNone}>Reputation from winstreaks:</TableCell>
-                      <TableCell className={classes.cellNone}>
-                        {data.rep ?? 0} {data.rep === getMaxRep() ? "(max)" : ""}
-                      </TableCell>
+                      <Tooltip
+                        title={
+                          <>
+                            Two wins in a row against an opponent will give you {getMaxRep() / 200} reputation converted
+                            to favor with that faction (up to a max of {getMaxRep()} reputation), if you are a member of
+                            that faction.
+                            <br />
+                            The reputation is immediately applied as favor, meaning it will increase reputation gain
+                            right away without needing an install.
+                          </>
+                        }
+                      >
+                        <>
+                          <TableCell className={classes.cellNone}>
+                            Rep converted to favor
+                            <br />
+                            from winstreaks:
+                          </TableCell>
+                          <TableCell className={classes.cellNone}>
+                            {data.rep ?? 0} {data.rep === getMaxRep() ? "(max)" : ""}
+                          </TableCell>
+                        </>
+                      </Tooltip>
                     </TableRow>
                   </Tooltip>
                 </TableBody>

--- a/src/Go/ui/GoInstructionsPage.tsx
+++ b/src/Go/ui/GoInstructionsPage.tsx
@@ -144,7 +144,7 @@ export const GoInstructionsPage = (): React.ReactElement => {
               <br />
               <br />
               Two wins in a row against an opponent will give you {getMaxRep() / 200} rep converted to favor with that
-              faction (up to a max of {getMaxRep()} favor), if you are a member of that faction.
+              faction (up to a max of {getMaxRep()} reputation), if you are a member of that faction.
               <br />
               The rep is immediately applied as favor, meaning it will increase reputation gain right away without
               needing an install.

--- a/src/Go/ui/GoScorePowerSummary.tsx
+++ b/src/Go/ui/GoScorePowerSummary.tsx
@@ -100,7 +100,7 @@ export const GoScorePowerSummary = ({ finalScore, opponent }: Props) => {
           title={
             <>
               Two wins in a row against an opponent will give you {getMaxRep() / 200} rep converted to favor with that
-              faction (up to a max of {getMaxRep()} favor), if you are a member of that faction.
+              faction (up to a max of {getMaxRep()} reputation), if you are a member of that faction.
               <br />
               The rep is immediately applied as favor, meaning it will increase reputation gain right away without
               needing an install.
@@ -109,9 +109,7 @@ export const GoScorePowerSummary = ({ finalScore, opponent }: Props) => {
         >
           <Typography className={`${classes.inlineFlexBox} ${classes.keyText}`}>
             <span>Winstreak Bonus: </span>
-            <span>
-              {getMaxRep() / 200} reputation converted to favor with {opponent}
-            </span>
+            <span>{getMaxRep() / 200} reputation converted to favor</span>
           </Typography>
         </Tooltip>
       ) : (

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -565,7 +565,7 @@ export function CharacterStats(): React.ReactElement {
                     value: Player.activeSourceFileLvl(14) ? 2 * currentNodeMults.GoPower : currentNodeMults.GoPower,
                   },
                   {
-                    mult: "IPvGO Max Favor",
+                    mult: "IPvGO Max Rep Converted to Favor",
                     value: getMaxRep(),
                     isNumber: true,
                   },


### PR DESCRIPTION
- Fix some outdated docs referring to favor gained directly from winstreaks instead of rep
- Tweaked some verbiage to better fit in the UI
- Added more tooltips explaining how winstreak reputation works
- If the player is in BN14 and has TRP, adds the secret opponent as a line item on the stats page to aid in discovery