### PR TITLE
IPVGO: Fix scoring of very large open areas

### DIFF
--- a/src/Go/boardAnalysis/boardAnalysis.ts
+++ b/src/Go/boardAnalysis/boardAnalysis.ts
@@ -116,10 +116,10 @@ export function evaluateMoveResult(board: Board, x: number, y: number, player: G
 export function getControlledSpace(board: Board) {
   const chains = getAllChains(board);
   const length = board[0].length;
-  const whiteControlledEmptyNodes = getAllPotentialEyes(board, chains, GoColor.white, length * 2)
+  const whiteControlledEmptyNodes = getAllPotentialEyes(board, chains, GoColor.white, 99)
     .map((eye) => eye.chain)
     .flat();
-  const blackControlledEmptyNodes = getAllPotentialEyes(board, chains, GoColor.black, length * 2)
+  const blackControlledEmptyNodes = getAllPotentialEyes(board, chains, GoColor.black, 99)
     .map((eye) => eye.chain)
     .flat();
 

--- a/src/Go/boardAnalysis/scoring.ts
+++ b/src/Go/boardAnalysis/scoring.ts
@@ -141,9 +141,7 @@ function getColoredPieceCount(boardState: BoardState, color: GoColor) {
  * Finds all empty spaces fully surrounded by a single player's stones
  */
 function getTerritoryScores(board: Board) {
-  const emptyTerritoryChains = getAllChains(board).filter(
-    (chain) => chain?.[0]?.color === GoColor.empty && chain.length <= board.length * 2,
-  );
+  const emptyTerritoryChains = getAllChains(board).filter((chain) => chain?.[0]?.color === GoColor.empty);
 
   return emptyTerritoryChains.reduce(
     (scores, currentChain) => {


### PR DESCRIPTION
Previously, very large open areas were not scored as controlled territory in IPvGO, even if fully surrounded by one color. This rarely came up as those spaces were large enough to be worth invading, but some players did see problems in ending scores in some cases. This PR changes the calcs for both the score and node coloring to count an eye of any size.