### PR TITLE
DARKNET: Add extra hint to sorted echo puzzle at high levels

### DIFF
--- a/src/DarkNet/effects/authentication.ts
+++ b/src/DarkNet/effects/authentication.ts
@@ -124,6 +124,23 @@ export const checkPassword = (
         `${altitude}`,
       );
     }
+    case ModelIds.SortedEchoVuln: {
+      if (server.password.length < 5 || attemptedPassword.length !== server.password.length) {
+        return getFailureResponse(attemptedPassword, server.staticPasswordHint, server.passwordHintData);
+      }
+      let squaredError = 0;
+      for (let i = 0; i < attemptedPassword.length; i++) {
+        const attempted = Number(attemptedPassword[i]);
+        const actual = Number(server.password[i]);
+        if (isNaN(attempted) || isNaN(actual)) {
+          return getFailureResponse(attemptedPassword, server.staticPasswordHint, server.passwordHintData);
+        }
+        squaredError += (attempted - actual) ** 2;
+      }
+      const rmsd = Math.sqrt(squaredError / attemptedPassword.length);
+      const rmsdMessage = `${server.passwordHintData};RMS Deviation:${rmsd.toFixed(3)}`;
+      return getFailureResponse(attemptedPassword, server.staticPasswordHint, rmsdMessage);
+    }
     default:
       return getFailureResponse(attemptedPassword, server.staticPasswordHint, server.passwordHintData);
   }

--- a/src/DarkNet/effects/authentication.ts
+++ b/src/DarkNet/effects/authentication.ts
@@ -132,7 +132,7 @@ export const checkPassword = (
       for (let i = 0; i < attemptedPassword.length; i++) {
         const attempted = Number(attemptedPassword[i]);
         const actual = Number(server.password[i]);
-        if (isNaN(attempted) || isNaN(actual)) {
+        if (!isFinite(attempted)) {
           return getFailureResponse(attemptedPassword, server.staticPasswordHint, server.passwordHintData);
         }
         squaredError += (attempted - actual) ** 2;

--- a/src/DarkNet/effects/authentication.ts
+++ b/src/DarkNet/effects/authentication.ts
@@ -138,7 +138,7 @@ export const checkPassword = (
         squaredError += (attempted - actual) ** 2;
       }
       const rmsd = Math.sqrt(squaredError / attemptedPassword.length);
-      const rmsdMessage = `${server.passwordHintData};RMS Deviation:${rmsd.toFixed(3)}`;
+      const rmsdMessage = `${server.passwordHintData}; RMS Deviation:${rmsd.toFixed(3)}`;
       return getFailureResponse(attemptedPassword, server.staticPasswordHint, rmsdMessage);
     }
     default:

--- a/src/DarkNet/effects/authentication.ts
+++ b/src/DarkNet/effects/authentication.ts
@@ -132,7 +132,7 @@ export const checkPassword = (
       for (let i = 0; i < attemptedPassword.length; i++) {
         const attempted = Number(attemptedPassword[i]);
         const actual = Number(server.password[i]);
-        if (!isFinite(attempted)) {
+        if (!Number.isFinite(attempted)) {
           return getFailureResponse(attemptedPassword, server.staticPasswordHint, server.passwordHintData);
         }
         squaredError += (attempted - actual) ** 2;

--- a/test/jest/Darknet/Darknet.test.ts
+++ b/test/jest/Darknet/Darknet.test.ts
@@ -626,17 +626,17 @@ describe("Password Tests", () => {
     const failedAttemptResponse = getAuthResult(sortedEchoVulnServer, "23456", 1);
     expect(failedAttemptResponse.result.code).toBe(ResponseCodeEnum.AuthFailure);
     const logs1 = getMostRecentAuthLog(sortedEchoVulnServer.hostname);
-    expect(logs1?.data).toBe(`${sortedEchoVulnServer.passwordHintData};RMS Deviation:1.000`);
+    expect(logs1?.data).toBe(`${sortedEchoVulnServer.passwordHintData}; RMS Deviation:1.000`);
 
     getAuthResult(sortedEchoVulnServer, "23579", 1);
     expect(failedAttemptResponse.result.code).toBe(ResponseCodeEnum.AuthFailure);
     const logs2 = getMostRecentAuthLog(sortedEchoVulnServer.hostname);
-    expect(logs2?.data).toBe(`${sortedEchoVulnServer.passwordHintData};RMS Deviation:2.490`);
+    expect(logs2?.data).toBe(`${sortedEchoVulnServer.passwordHintData}; RMS Deviation:2.490`);
 
     getAuthResult(sortedEchoVulnServer, "12355", 1);
     expect(failedAttemptResponse.result.code).toBe(ResponseCodeEnum.AuthFailure);
     const logs3 = getMostRecentAuthLog(sortedEchoVulnServer.hostname);
-    expect(logs3?.data).toBe(`${sortedEchoVulnServer.passwordHintData};RMS Deviation:0.447`);
+    expect(logs3?.data).toBe(`${sortedEchoVulnServer.passwordHintData}; RMS Deviation:0.447`);
 
     expect(getAuthResult(sortedEchoVulnServer, sortedEchoVulnServer.password, 1).result.code).toBe(
       ResponseCodeEnum.Success,

--- a/test/jest/Darknet/Darknet.test.ts
+++ b/test/jest/Darknet/Darknet.test.ts
@@ -26,6 +26,7 @@ import {
   getXorMaskEncryptedPasswordConfig,
   getTripleModuloConfig,
   getKingOfTheHillConfig,
+  getSortedEchoVulnConfig,
 } from "../../../src/DarkNet/controllers/ServerGenerator";
 import {
   commonPasswordDictionary,
@@ -614,6 +615,33 @@ describe("Password Tests", () => {
 
     const successResult = getAuthResult(bufferOverflowServer, "A".repeat(passwordLength * 2), 1);
     expect(successResult.response.code).toBe(ResponseCodeEnum.Success);
+  });
+
+  test("sortedEchoVuln creates a valid password and hint", () => {
+    const sortedEchoVulnServer = serverFactory(getSortedEchoVulnConfig, 20, 0, 0);
+    sortedEchoVulnServer.password = "12345";
+    sortedEchoVulnServer.passwordHintData = "41532";
+
+    expect(sortedEchoVulnServer).toBeDefined();
+    const failedAttemptResponse = getAuthResult(sortedEchoVulnServer, "23456", 1);
+    expect(failedAttemptResponse.result.code).toBe(ResponseCodeEnum.AuthFailure);
+    const logs1 = getMostRecentAuthLog(sortedEchoVulnServer.hostname);
+    expect(logs1?.data).toBe(`${sortedEchoVulnServer.passwordHintData};RMS Deviation:1.000`);
+
+    getAuthResult(sortedEchoVulnServer, "23579", 1);
+    expect(failedAttemptResponse.result.code).toBe(ResponseCodeEnum.AuthFailure);
+    const logs2 = getMostRecentAuthLog(sortedEchoVulnServer.hostname);
+    expect(logs2?.data).toBe(`${sortedEchoVulnServer.passwordHintData};RMS Deviation:2.490`);
+
+    getAuthResult(sortedEchoVulnServer, "12355", 1);
+    expect(failedAttemptResponse.result.code).toBe(ResponseCodeEnum.AuthFailure);
+    const logs3 = getMostRecentAuthLog(sortedEchoVulnServer.hostname);
+    expect(logs3?.data).toBe(`${sortedEchoVulnServer.passwordHintData};RMS Deviation:0.447`);
+
+    expect(getAuthResult(sortedEchoVulnServer, sortedEchoVulnServer.password, 1).result.code).toBe(
+      ResponseCodeEnum.Success,
+    );
+    expect(sortedEchoVulnServer.hasAdminRights).toBe(true);
   });
 
   test("kingOfTheHill server creates a valid password and hint", () => {


### PR DESCRIPTION
The darknet sorted echo vulnerability puzzle currently just asks players to try all permutations. This PR adds an extra hint to add more opportunities to optimize the higher-level versions of the puzzle, to avoid the higher-difficulty variants from feeling too brute-force. Specifically, it provides the root mean square deviation of the attempted password vs the correct one when each digit is considered individually. 