### PR TITLE
DARKNET: Tune 2G_cellular timing attack puzzle

### DIFF
--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -105,7 +105,7 @@ export const calculateAuthenticationTime = (
   // Add extra time for timing attack server, per correct character
   const sharedChars =
     darknetServerData.modelId === ModelIds.TimingAttack ? getSharedChars(password, attemptedPassword) : 0;
-  const sharedCharsExtraTime = sharedChars * 50;
+  const sharedCharsExtraTime = sharedChars * 50 * threadsFactor;
 
   return time * calculateIntelligenceBonus(person.skills.intelligence, 0.25) + sharedCharsExtraTime;
 };


### PR DESCRIPTION
This PR makes the bonus runtime speed from threads during authentication also apply to the extra time added per correct character, to make sure the puzzle isn't too much of an outlier compared to others at high difficulty