### PR TITLE
BUGFIX: Sleeves can earn exp and purchase augmentations when enabling disableSleeveExpAndAugmentation

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -56,6 +56,7 @@ import { throwIfReachable } from "../utils/helpers/throwIfReachable";
 import { loadActionIdentifier } from "./utils/loadActionIdentifier";
 import { pluralize } from "../utils/I18nUtils";
 import { calculateActionRankGain, calculateActionReputationGain } from "./Formulas";
+import { processWorkStats } from "../Work/Formulas";
 
 export const BladeburnerPromise: PromisePair<number> = { promise: null, resolve: null };
 
@@ -1204,7 +1205,8 @@ export class Bladeburner implements OperationTeam {
         const __a: never = action;
       }
     }
-    return retValue;
+
+    return processWorkStats(person, retValue);
   }
 
   infiltrateSynthoidCommunities(): void {

--- a/src/NetscriptFunctions/Sleeve.ts
+++ b/src/NetscriptFunctions/Sleeve.ts
@@ -245,16 +245,16 @@ export function NetscriptSleeve(): InternalAPI<NetscriptSleeve> {
       checkSleeveAPIAccess(ctx);
       checkSleeveNumber(ctx, sleeveNumber);
 
-      if (Player.sleeves[sleeveNumber].shock > 0) {
-        throw helpers.errorMessage(ctx, `Sleeve shock too high: Sleeve ${sleeveNumber}`);
-      }
-
       const aug = Augmentations[augName];
       if (!aug) {
         throw helpers.errorMessage(ctx, `Invalid aug: ${augName}`);
       }
 
-      return Player.sleeves[sleeveNumber].tryBuyAugmentation(aug);
+      const result = Player.sleeves[sleeveNumber].purchaseAugmentation(aug);
+      if (!result.success) {
+        helpers.log(ctx, () => result.message);
+      }
+      return result.success;
     },
     getSleeveAugmentationPrice: (ctx) => (_augName) => {
       checkSleeveAPIAccess(ctx);

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -7,7 +7,7 @@
  * Sleeves are unlocked in BitNode-10.
  */
 
-import type { SleevePerson } from "@nsdefs";
+import type { Result, SleevePerson } from "@nsdefs";
 import type { Augmentation } from "../../Augmentation/Augmentation";
 import type { SleeveWork } from "./Work/Work";
 
@@ -50,6 +50,7 @@ import { getFactionAugmentationsFiltered } from "../../Faction/FactionHelpers";
 import { Augmentations } from "../../Augmentation/Augmentations";
 import { getAugCost } from "../../Augmentation/AugmentationHelpers";
 import type { MoneySource } from "../../utils/MoneySourceTracker";
+import { formatMoney, formatSleeveShock } from "../../ui/formatNumber";
 
 export class Sleeve extends Person implements SleevePerson {
   currentWork: SleeveWork | null = null;
@@ -338,20 +339,62 @@ export class Sleeve extends Person implements SleevePerson {
     return true;
   }
 
-  tryBuyAugmentation(aug: Augmentation): boolean {
+  /**
+   * This function is only used in UI code for checking whether the "Manage Augmentations" button can be enabled. If you
+   * want to check if the player can purchase a specific augmentation, you need to call canPurchaseAugmentation.
+   */
+  checkPreconditionsOfPurchasingAugmentations(): Result {
+    if (Player.bitNodeOptions.disableSleeveExpAndAugmentation) {
+      return {
+        success: false,
+        message: `The "Disable Sleeves' experience and augmentation" option was enabled. You cannot purchase augmentations for your sleeves.`,
+      };
+    }
+
+    if (this.shock > 0) {
+      return {
+        success: false,
+        message: `You must reduce the sleeve shock to 0. The current shock is ${formatSleeveShock(this.shock)}.`,
+      };
+    }
+
+    return { success: true };
+  }
+
+  canPurchaseAugmentation(aug: Augmentation): Result {
+    const checkingPreconditions = this.checkPreconditionsOfPurchasingAugmentations();
+    if (!checkingPreconditions.success) {
+      return checkingPreconditions;
+    }
+
     if (!Player.canAfford(aug.baseCost)) {
-      return false;
+      return {
+        success: false,
+        message: `You must have at least ${formatMoney(aug.baseCost)}.`,
+      };
     }
 
     // Verify that this sleeve does not already have that augmentation.
-    if (this.hasAugmentation(aug.name)) return false;
+    if (this.hasAugmentation(aug.name)) {
+      return { success: false, message: `This sleeve already has "${aug.name}" augmentation.` };
+    }
 
     // Verify that the augmentation is available for purchase.
-    if (!this.findPurchasableAugs().includes(aug)) return false;
+    if (!this.findPurchasableAugs().includes(aug)) {
+      return { success: false, message: `"${aug.name}" is not in the list of purchasable augmentations.` };
+    }
 
+    return { success: true };
+  }
+
+  purchaseAugmentation(aug: Augmentation): Result {
+    const validationResult = this.canPurchaseAugmentation(aug);
+    if (!validationResult.success) {
+      return validationResult;
+    }
     Player.loseMoney(aug.baseCost, "sleeves");
     this.installAugmentation(aug);
-    return true;
+    return { success: true };
   }
 
   upgradeMemory(n: number): void {

--- a/src/PersonObjects/Sleeve/ui/SleeveAugmentationsModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveAugmentationsModal.tsx
@@ -1,10 +1,10 @@
 import { Container, Typography, Paper } from "@mui/material";
 import React from "react";
 import { PurchasableAugmentations } from "../../../Augmentation/ui/PurchasableAugmentations";
-import { Player } from "@player";
 import { Modal } from "../../../ui/React/Modal";
 import { Sleeve } from "../Sleeve";
 import { useRerender } from "../../../ui/React/hooks";
+import { dialogBoxCreate } from "../../../ui/React/DialogBox";
 
 interface IProps {
   open: boolean;
@@ -43,10 +43,14 @@ export function SleeveAugmentationsModal(props: IProps): React.ReactElement {
         augNames={availableAugs.map((aug) => aug.name)}
         ownedAugNames={ownedAugNames}
         canPurchase={(aug) => {
-          return Player.money >= aug.baseCost;
+          return props.sleeve.canPurchaseAugmentation(aug).success;
         }}
         purchaseAugmentation={(aug) => {
-          props.sleeve.tryBuyAugmentation(aug);
+          const result = props.sleeve.purchaseAugmentation(aug);
+          if (!result.success) {
+            dialogBoxCreate(result.message);
+            return;
+          }
           rerender();
         }}
         rerender={rerender}

--- a/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveElem.tsx
@@ -212,6 +212,7 @@ export function SleeveElem(props: SleeveElemProps): React.ReactElement {
     }
   }
   const desc = getWorkDescription(props.sleeve, progress);
+  const checkingPreconditionsResult = props.sleeve.checkPreconditionsOfPurchasingAugmentations();
   return (
     <>
       <Paper sx={{ p: 1, display: "grid", gridTemplateColumns: "1fr 1fr", width: "auto", gap: 1 }}>
@@ -231,12 +232,14 @@ export function SleeveElem(props: SleeveElemProps): React.ReactElement {
               </span>
             </Tooltip>
             <Tooltip
-              title={props.sleeve.shock > 0 ? <Typography>Unlocked when sleeve has fully recovered</Typography> : ""}
+              title={
+                !checkingPreconditionsResult.success && <Typography>{checkingPreconditionsResult.message}</Typography>
+              }
             >
               <span>
                 <Button
                   onClick={() => setAugmentationsOpen(true)}
-                  disabled={props.sleeve.shock > 0}
+                  disabled={!checkingPreconditionsResult.success}
                   sx={{ width: "100%", height: "100%" }}
                 >
                   Manage Augmentations

--- a/src/PersonObjects/Sleeve/ui/SleeveRoot.tsx
+++ b/src/PersonObjects/Sleeve/ui/SleeveRoot.tsx
@@ -7,6 +7,7 @@ import { Player } from "@player";
 import { SleeveElem } from "./SleeveElem";
 import { FAQModal } from "./FAQModal";
 import { useCycleRerender } from "../../../ui/React/hooks";
+import { Settings } from "../../../Settings/Settings";
 
 export function SleeveRoot(): React.ReactElement {
   const [FAQOpen, setFAQOpen] = useState(false);
@@ -25,6 +26,14 @@ export function SleeveRoot(): React.ReactElement {
           <br />
           <br />
         </Typography>
+        {Player.bitNodeOptions.disableSleeveExpAndAugmentation && (
+          <Typography color={Settings.theme.warning}>
+            You enabled the "Disable Sleeves' experience and augmentation" option. Your sleeves will not gain
+            experience, and they won't be able to install augmentations.
+            <br />
+            <br />
+          </Typography>
+        )}
       </Container>
 
       <Button onClick={() => setFAQOpen(true)}>FAQ</Button>

--- a/src/Work/Formulas.ts
+++ b/src/Work/Formulas.ts
@@ -21,7 +21,7 @@ import { CompanyPosition } from "../Company/CompanyPosition";
 import { isMember } from "../utils/EnumHelper";
 import { getMultiplierFromCharisma } from "../DarkNet/effects/effects";
 
-function processWorkStats(person: IPerson, workStats: WorkStats): WorkStats {
+export function processWorkStats(person: IPerson, workStats: WorkStats): WorkStats {
   // "person" can be a normal object that the player passes to NS APIs, so we cannot use `person instanceof Sleeve`.
   if (Player.bitNodeOptions.disableSleeveExpAndAugmentation && "shock" in person) {
     workStats.hackExp = 0;

--- a/test/jest/Netscript/Sleeve.test.ts
+++ b/test/jest/Netscript/Sleeve.test.ts
@@ -1,4 +1,4 @@
-import { FactionName } from "@enums";
+import { AugmentationName, FactionName } from "@enums";
 import { Player } from "@player";
 import { joinFaction } from "../../../src/Faction/FactionHelpers";
 import { Factions } from "../../../src/Faction/Factions";
@@ -7,7 +7,7 @@ import {
   MaxSleevesFromCovenant,
   recalculateNumberOfOwnedSleeves,
 } from "../../../src/PersonObjects/Sleeve/SleeveCovenantPurchases";
-import { getNS, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
+import { getNS, getWorkerScriptAndNS, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
 import { prestigeSourceFile } from "../../../src/Prestige";
 
 beforeAll(() => {
@@ -100,6 +100,15 @@ describe("Success", () => {
     expect(sleeve.memory).toStrictEqual(100);
     expect(Player.money).toStrictEqual(0);
   });
+  test("purchaseSleeveAug", () => {
+    const ns = getNS();
+    const augName = AugmentationName.BitWire;
+    Player.sleeves[0].shock = 0;
+    // CyberSec offers BitWire.
+    joinFaction(Factions.CyberSec);
+    Factions.CyberSec.playerReputation = 1e10;
+    expect(ns.sleeve.purchaseSleeveAug(0, augName)).toStrictEqual(true);
+  });
 });
 
 describe("Failure", () => {
@@ -168,5 +177,40 @@ describe("Failure", () => {
     result = ns.sleeve.upgradeMemory(0, 1);
     expect(result.success).toStrictEqual(false);
     expect(result.message).toContain("You must have at least");
+  });
+
+  test("purchaseSleeveAug", () => {
+    // Set BN10 and recalculate to get the first sleeve.
+    Player.bitNodeN = 10;
+    recalculateNumberOfOwnedSleeves();
+    const { ws, ns } = getWorkerScriptAndNS();
+    const augName = AugmentationName.BitWire;
+
+    // disableSleeveExpAndAugmentation = true
+    Player.bitNodeOptions.disableSleeveExpAndAugmentation = true;
+    expect(ns.sleeve.purchaseSleeveAug(0, augName)).toStrictEqual(false);
+    expect(ws.scriptRef.logs[0]).toMatch(`The "Disable Sleeves' experience and augmentation" option was enabled`);
+
+    // shock > 0
+    Player.bitNodeOptions.disableSleeveExpAndAugmentation = false;
+    expect(ns.sleeve.purchaseSleeveAug(0, augName)).toStrictEqual(false);
+    expect(ws.scriptRef.logs[1]).toMatch("You must reduce the sleeve shock to 0");
+
+    // Not enough money
+    Player.sleeves[0].shock = 0;
+    Player.money = 0;
+    expect(ns.sleeve.purchaseSleeveAug(0, augName)).toStrictEqual(false);
+    expect(ws.scriptRef.logs[2]).toMatch("You must have at least");
+
+    // Already have the augmentation
+    Player.money = 1e15;
+    Player.sleeves[0].augmentations.push({ name: augName, level: 1 });
+    expect(ns.sleeve.purchaseSleeveAug(0, augName)).toStrictEqual(false);
+    expect(ws.scriptRef.logs[3]).toMatch(`This sleeve already has "${augName}" augmentation`);
+
+    // Non-purchasable augmentation
+    Player.sleeves[0].augmentations = [];
+    expect(ns.sleeve.purchaseSleeveAug(0, augName)).toStrictEqual(false);
+    expect(ws.scriptRef.logs[4]).toMatch(`"${augName}" is not in the list of purchasable augmentations`);
   });
 });


### PR DESCRIPTION
How to reproduce:
- Bitflume and enable disableSleeveExpAndAugmentation.
- Join Bladeburner.
- Set a sleeve to Bladeburner's Training task. Check exp.
- Set shock to 0. Join a faction and get a bit of reputation, just enough to purchase an augmentation.
- Purchase that augmentation for the sleeve.

Fixing the exp bug is simple. We only need to call `processWorkStats`. Most functions in `src\Work\Formulas.ts` are also calling it. Fixing the aug bug requires a small refactor.

Note that there is a small behavior change here. `ns.sleeve.purchaseSleeveAug` previously threw an error when the sleeve's shock is greater than 0. Currently, it returns false instead of throwing. I don't think we need to mark this one as a breaking change. Technically, it is, but I doubt any reasonable code breaks due to it.

<img width="966" height="620" alt="Capture" src="https://github.com/user-attachments/assets/7e206a27-3e95-4d4e-966b-facf339ea83c" />
