### PR TITLE
DARKNET: Prevent blocked ram on the "darkweb" server

### DIFF
--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -71,9 +71,11 @@ export function initDarkwebServer(): void {
     leftOffset: -1,
     depth: -1,
     difficulty: 0,
+    name: SpecialServers.DarkWeb,
+    preventBlockedRam: true,
   };
 
-  const darkweb = DnetServerBuilder(data, SpecialServers.DarkWeb, false);
+  const darkweb = DnetServerBuilder(data);
   darkweb.isStationary = true;
   darkweb.hasAdminRights = true;
   darkweb.blockedRam = 0;

--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -73,7 +73,7 @@ export function initDarkwebServer(): void {
     difficulty: 0,
   };
 
-  const darkweb = DnetServerBuilder(data, SpecialServers.DarkWeb);
+  const darkweb = DnetServerBuilder(data, SpecialServers.DarkWeb, false);
   darkweb.isStationary = true;
   darkweb.hasAdminRights = true;
   darkweb.blockedRam = 0;

--- a/src/DarkNet/models/DarknetServerOptions.ts
+++ b/src/DarkNet/models/DarknetServerOptions.ts
@@ -54,9 +54,13 @@ export type DarknetServerOptions = {
   leftOffset: number;
 };
 
-export const DnetServerBuilder = (options: DarknetServerOptions, name = generateDarknetServerName()): DarknetServer => {
+export const DnetServerBuilder = (
+  options: DarknetServerOptions,
+  name = generateDarknetServerName(),
+  allowBlockedRam = true,
+): DarknetServer => {
   const maxRam = 16 * 2 ** Math.floor(options.difficulty / 4);
-  const ramBlock = getRamBlock(maxRam);
+  const ramBlock = allowBlockedRam ? getRamBlock(maxRam) : 0;
 
   const labDetails = getLabyrinthDetails();
   const labDifficulty = labDetails.cha;

--- a/src/DarkNet/models/DarknetServerOptions.ts
+++ b/src/DarkNet/models/DarknetServerOptions.ts
@@ -52,15 +52,14 @@ export type DarknetServerOptions = {
   difficulty: number;
   depth: number;
   leftOffset: number;
+  name?: string;
+  preventBlockedRam?: boolean;
 };
 
-export const DnetServerBuilder = (
-  options: DarknetServerOptions,
-  name = generateDarknetServerName(),
-  allowBlockedRam = true,
-): DarknetServer => {
+export const DnetServerBuilder = (options: DarknetServerOptions): DarknetServer => {
   const maxRam = 16 * 2 ** Math.floor(options.difficulty / 4);
-  const ramBlock = allowBlockedRam ? getRamBlock(maxRam) : 0;
+  const ramBlock = options.preventBlockedRam ? 0 : getRamBlock(maxRam);
+  const name = options.name ?? generateDarknetServerName();
 
   const labDetails = getLabyrinthDetails();
   const labDifficulty = labDetails.cha;


### PR DESCRIPTION
As discussed on discord.
in order to make the transition into darknet as easy as possible for new players, this prevents the "darkweb" server from having any ram blocked to start.