### PR TITLE
GITHUB: Update format created by "build artifacts" workflow

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm run electron-win
       - name: Zip
         shell: bash
-        run: cd .build; for i in bitburner-*; do 7z a "$i.zip" "$i"; done; cd ../;
+        run: cd .build; 7z a "bitburner-win32-x64.zip" "bitburner-win32-x64/*"; cd ../;
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -54,7 +54,7 @@ jobs:
       - name: Build the Electron app
         run: npm run electron-linux
       - name: Zip
-        run: cd .build; for i in bitburner-*; do zip -r "$i.zip" "$i"; done; cd ../;
+        run: cd .build; zip -r "bitburner-linux-x64.zip" "bitburner-linux-x64/*"; cd ../;
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -80,7 +80,7 @@ jobs:
       - name: Build the Electron app
         run: npm run electron-mac
       - name: Zip
-        run: cd .build; for i in bitburner-*; do zip -r "$i.zip" "$i"; done; cd ../;
+        run: cd .build; zip -r "bitburner-darwin-universal.zip" "bitburner-darwin-universal/*"; cd ../;
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Build the Electron app
         shell: bash
         run: npm run electron-win
-      - name: Upload artifact
+      - name: Upload x64 artifact
         uses: actions/upload-artifact@v4
         with:
           name: bitburner-win32-x64
           include-hidden-files: true
           path: .build/bitburner-win32-x64/*
           if-no-files-found: error
-      - name: Upload arm artifact
+      - name: Upload arm64 artifact
         uses: actions/upload-artifact@v4
         with:
           name: bitburner-win32-arm64
@@ -57,14 +57,14 @@ jobs:
         run: npm run build
       - name: Build the Electron app
         run: npm run electron-linux
-      - name: Upload artifact
+      - name: Upload x64 artifact
         uses: actions/upload-artifact@v4
         with:
           name: bitburner-linux-x64
           include-hidden-files: true
           path: .build/bitburner-linux-x64/*
           if-no-files-found: error
-      - name: Upload arm artifact
+      - name: Upload arm64 artifact
         uses: actions/upload-artifact@v4
         with:
           name: bitburner-linux-arm64
@@ -88,7 +88,7 @@ jobs:
         run: npm run build
       - name: Build the Electron app
         run: npm run electron-mac
-      - name: Upload artifact
+      - name: Upload darwin-universal artifact
         uses: actions/upload-artifact@v4
         with:
           name: bitburner-darwin-universal

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -26,15 +26,12 @@ jobs:
       - name: Build the Electron app
         shell: bash
         run: npm run electron-win
-      - name: Zip
-        shell: bash
-        run: cd .build; 7z a "bitburner-win32-x64.zip" "bitburner-win32-x64/*"; cd ../;
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts-win
           include-hidden-files: true
-          path: .build/*.zip
+          path: .build/bitburner-win32-x64/*
           if-no-files-found: error
 
   build-linux:
@@ -53,14 +50,12 @@ jobs:
         run: npm run build
       - name: Build the Electron app
         run: npm run electron-linux
-      - name: Zip
-        run: cd .build; zip -r "bitburner-linux-x64.zip" "bitburner-linux-x64/*"; cd ../;
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts-linux
           include-hidden-files: true
-          path: .build/*.zip
+          path: .build/bitburner-linux-x64/*
           if-no-files-found: error
 
   build-mac:
@@ -79,12 +74,10 @@ jobs:
         run: npm run build
       - name: Build the Electron app
         run: npm run electron-mac
-      - name: Zip
-        run: cd .build; zip -r "bitburner-darwin-universal.zip" "bitburner-darwin-universal/*"; cd ../;
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts-mac
           include-hidden-files: true
-          path: .build/*.zip
+          path: .build/bitburner-darwin-universal/*
           if-no-files-found: error

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Upload arm artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bitburner-win32-arm
+          name: bitburner-win32-arm64
           include-hidden-files: true
-          path: .build/bitburner-win32-arm/*
+          path: .build/bitburner-win32-arm64/*
           if-no-files-found: error
 
   build-linux:
@@ -67,9 +67,9 @@ jobs:
       - name: Upload arm artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bitburner-linux-arm
+          name: bitburner-linux-arm64
           include-hidden-files: true
-          path: .build/bitburner-linux-arm/*
+          path: .build/bitburner-linux-arm64/*
           if-no-files-found: error
 
   build-mac:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -29,9 +29,16 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-win
+          name: bitburner-win32-x64
           include-hidden-files: true
           path: .build/bitburner-win32-x64/*
+          if-no-files-found: error
+      - name: Upload arm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bitburner-win32-arm
+          include-hidden-files: true
+          path: .build/bitburner-win32-arm/*
           if-no-files-found: error
 
   build-linux:
@@ -53,9 +60,16 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-linux
+          name: bitburner-linux-x64
           include-hidden-files: true
           path: .build/bitburner-linux-x64/*
+          if-no-files-found: error
+      - name: Upload arm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bitburner-linux-arm
+          include-hidden-files: true
+          path: .build/bitburner-linux-arm/*
           if-no-files-found: error
 
   build-mac:
@@ -77,7 +91,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-mac
+          name: bitburner-darwin-universal
           include-hidden-files: true
           path: .build/bitburner-darwin-universal/*
           if-no-files-found: error

--- a/.github/workflows/build-upload-artifacts.yml
+++ b/.github/workflows/build-upload-artifacts.yml
@@ -20,19 +20,19 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: "npm"
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: .build
-          pattern: build-artifacts-*
-          merge-multiple: true
+          pattern: bitburner-*
+          merge-multiple: false
       - name: List files
         run: ls -la .build
+      - name: Zip
+        run: cd .build; for i in bitburner-*; do zip -r "$i.zip" "$i"; done; cd ../;
+      - name: List files
+        run: |
+          ls -la .build
       - name: Upload to release
         env:
           GH_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/build-upload-artifacts.yml
+++ b/.github/workflows/build-upload-artifacts.yml
@@ -29,7 +29,7 @@ jobs:
       - name: List files
         run: ls -la .build
       - name: Zip
-        run: cd .build; for i in bitburner-*; do zip -r "$i.zip" "$i"; done; cd ../;
+        run: cd .build; for i in bitburner-*; do cd "$i"; zip -r "../$i.zip" *; cd ../; done; cd ../;
       - name: List files
         run: |
           ls -la .build


### PR DESCRIPTION
The original format was not conducive to easily uploading to steam for version updates - previous format was a zip of built artifacts, which contained one or more zips of platform builds, and those platform build zips contained a directory which contained the game content.

Steam expects the uploaded zip to directly contain the game content, so I updated the workflow to produce this. Steam didn't need the arm builds, but these have been maintained for manual downloads. See https://github.com/bitburner-official/bitburner-src/actions/runs/21675942464 for sample run.