### PR TITLE
DARKNET: Improve documentation; remove requirement that getBlockedRam and getDepth be called on a darknet server

### DIFF
--- a/markdown/bitburner.darknet.getblockedram.md
+++ b/markdown/bitburner.darknet.getblockedram.md
@@ -4,7 +4,7 @@
 
 ## Darknet.getBlockedRam() method
 
-Gets the amount of RAM blocked by the server owner's processes. This ram can be freed for use using memoryReallocation().
+Gets the amount of RAM blocked by the server owner's processes. This ram can be freed for use using dnet.memoryReallocation() .
 
 **Signature:**
 

--- a/markdown/bitburner.darknet.induceservermigration.md
+++ b/markdown/bitburner.darknet.induceservermigration.md
@@ -4,7 +4,7 @@
 
 ## Darknet.induceServerMigration() method
 
-Increases the chance that target connected server will move to other parts of the darknet, by overloading the connections between it and the current server. Cannot target the current server. Must be run from a darknet server.
+Increases the chance that the target server will move to other parts of the darknet, by overloading the connections between it and the current server. The target must be a connected, non-stationary, darknet server - scripts cannot target the server they are running on.
 
 Effect scales with threads and charisma level.
 

--- a/markdown/bitburner.darknet.isdarknetserver.md
+++ b/markdown/bitburner.darknet.isdarknetserver.md
@@ -6,7 +6,7 @@
 
 Returns whether the server is a darknet server.
 
-Returns false if the server does not exist or has gone offline recently. This function does not DarkscapeNavigator.exe.
+Returns false if the server does not exist or has gone offline recently. This function does not require DarkscapeNavigator.exe.
 
 **Signature:**
 

--- a/markdown/bitburner.darknet.md
+++ b/markdown/bitburner.darknet.md
@@ -60,7 +60,7 @@ If unsuccessful, more detail may be able to be gathered by using heartbleed() to
 
 </td><td>
 
-Gets the amount of RAM blocked by the server owner's processes. This ram can be freed for use using memoryReallocation().
+Gets the amount of RAM blocked by the server owner's processes. This ram can be freed for use using dnet.memoryReallocation() .
 
 
 </td></tr>
@@ -156,7 +156,7 @@ The speed of capture scales with the number of threads used. See formulas.dnet.g
 
 </td><td>
 
-Increases the chance that target connected server will move to other parts of the darknet, by overloading the connections between it and the current server. Cannot target the current server. Must be run from a darknet server.
+Increases the chance that the target server will move to other parts of the darknet, by overloading the connections between it and the current server. The target must be a connected, non-stationary, darknet server - scripts cannot target the server they are running on.
 
 Effect scales with threads and charisma level.
 
@@ -171,7 +171,7 @@ Effect scales with threads and charisma level.
 
 Returns whether the server is a darknet server.
 
-Returns false if the server does not exist or has gone offline recently. This function does not DarkscapeNavigator.exe.
+Returns false if the server does not exist or has gone offline recently. This function does not require DarkscapeNavigator.exe.
 
 
 </td></tr>

--- a/src/DarkNet/effects/ramblock.ts
+++ b/src/DarkNet/effects/ramblock.ts
@@ -19,9 +19,6 @@ import { isLabyrinthServer } from "./labyrinth";
 export const handleRamBlockRemoved = (ctx: NetscriptContext, server: DarknetServer) => {
   const threads = ctx.workerScript.scriptRef.threads;
   const difficulty = server.difficulty + 1;
-  const xpGained =
-    Player.mults.charisma_exp * threads * 10 * 1.1 ** difficulty * ((200 + Player.skills.charisma) / 200);
-  Player.gainCharismaExp(xpGained);
 
   const ramBlockRemoved = getRamBlockRemoved(server, threads);
   server.blockedRam -= ramBlockRemoved;
@@ -30,6 +27,9 @@ export const handleRamBlockRemoved = (ctx: NetscriptContext, server: DarknetServ
   if (server.blockedRam <= 0) {
     handleRamBlockClearedRewards(server);
   }
+  const xpGained =
+    Player.mults.charisma_exp * threads * 10 * 1.1 ** difficulty * ((200 + Player.skills.charisma) / 200);
+  Player.gainCharismaExp(xpGained);
 
   const result = `Liberated ${formatNumber(
     ramBlockRemoved,

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -595,7 +595,6 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
       (ctx) =>
       (_host): number => {
         const targetHost = helpers.string(ctx, "host", _host ?? ctx.workerScript.hostname);
-        expectRunningOnDarknetServer(ctx);
         const onlineConnectionCheck = getFailureResult(ctx, targetHost);
         if (!onlineConnectionCheck.success) {
           return 0;
@@ -606,7 +605,6 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
       (ctx) =>
       (_host): number => {
         const targetHost = helpers.string(ctx, "host", _host ?? ctx.workerScript.hostname);
-        expectRunningOnDarknetServer(ctx);
         const onlineConnectionCheck = getFailureResult(ctx, targetHost);
         if (!onlineConnectionCheck.success) {
           return -1;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4593,8 +4593,8 @@ export interface Darknet {
   packetCapture(host: string): Promise<DarknetResult & { data: string }>;
 
   /**
-   * Increases the chance that target connected server will move to other parts of the darknet, by overloading the connections between it and the current server.
-   * Cannot target the current server. Must be run from a darknet server.
+   * Increases the chance that the target server will move to other parts of the darknet, by overloading the connections between it and the current server.
+   * The target must be a connected, non-stationary, darknet server - scripts cannot target the server they are running on.
    *
    * Effect scales with threads and charisma level.
    *
@@ -4621,7 +4621,7 @@ export interface Darknet {
   /**
    * Returns whether the server is a darknet server.
    *
-   * Returns false if the server does not exist or has gone offline recently. This function does not DarkscapeNavigator.exe.
+   * Returns false if the server does not exist or has gone offline recently. This function does not require DarkscapeNavigator.exe.
    *
    * @remarks
    * RAM cost: 0.1 GB
@@ -4646,7 +4646,7 @@ export interface Darknet {
   memoryReallocation(host?: string): Promise<DarknetResult>;
 
   /**
-   * Gets the amount of RAM blocked by the server owner's processes. This ram can be freed for use using memoryReallocation().
+   * Gets the amount of RAM blocked by the server owner's processes. This ram can be freed for use using dnet.memoryReallocation() .
    *
    * @remarks
    * RAM cost: 0 GB

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -225,11 +225,11 @@ describe("home", () => {
   });
   test("getBlockedRam", () => {
     const ns = getNsOnHome();
-    expect(() => ns.dnet.getBlockedRam()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getBlockedRam()).toThrow("home is not a darknet server");
   });
   test("getDepth", () => {
     const ns = getNsOnHome();
-    expect(() => ns.dnet.getDepth()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getDepth()).toThrow("home is not a darknet server");
   });
   test("promoteStock", async () => {
     const ns = getNsOnHome();
@@ -401,11 +401,11 @@ describe("Normal NPC server", () => {
   });
   test("getBlockedRam", () => {
     const ns = getNS(SpecialServers.CyberSecServer);
-    expect(() => ns.dnet.getBlockedRam()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getBlockedRam()).toThrow("CSEC is not a darknet server");
   });
   test("getDepth", () => {
     const ns = getNS(SpecialServers.CyberSecServer);
-    expect(() => ns.dnet.getDepth()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getDepth()).toThrow("CSEC is not a darknet server");
   });
   test("promoteStock", async () => {
     const ns = getNS(SpecialServers.CyberSecServer);
@@ -495,11 +495,11 @@ describe("Private server", () => {
   });
   test("getBlockedRam", () => {
     const ns = getNS("test-server-1");
-    expect(() => ns.dnet.getBlockedRam()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getBlockedRam()).toThrow("test-server-1 is not a darknet server");
   });
   test("getDepth", () => {
     const ns = getNS("test-server-1");
-    expect(() => ns.dnet.getDepth()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getDepth()).toThrow("test-server-1 is not a darknet server");
   });
   test("promoteStock", async () => {
     const ns = getNS("test-server-1");
@@ -589,11 +589,11 @@ describe("Hashnet server", () => {
   });
   test("getBlockedRam", () => {
     const ns = getNS("hacknet-server-0");
-    expect(() => ns.dnet.getBlockedRam()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getBlockedRam()).toThrow("hacknet-server-0 is not a darknet server");
   });
   test("getDepth", () => {
     const ns = getNS("hacknet-server-0");
-    expect(() => ns.dnet.getDepth()).toThrow("This API can only be used on a darknet server");
+    expect(() => ns.dnet.getDepth()).toThrow("hacknet-server-0 is not a darknet server");
   });
   test("promoteStock", async () => {
     const ns = getNS("hacknet-server-0");


### PR DESCRIPTION
Feedback from today's user testing.

- Fix typo in isDarknetServer description
- Fixed misleading requirements in induceServerMigration docs
- removed requirement that getDepth and getBlockedRam be only run on darknet servers
- fixed order of actions on getExpectedRamBlockRemoved so that xp is only gained after the effect is complete