### PR TITLE
BUGFIX: Monaco shows wrong TSDoc of APIs that have "export" word

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -42,7 +42,7 @@ export function Editor({ onMount, onChange, onUnmount }: EditorProps) {
      * check: https://github.com/microsoft/monaco-editor/issues/3580 and https://github.com/microsoft/monaco-editor/pull/4544.
      */
     monaco.editor.createModel(
-      netscriptDefinitions.replace(/export /g, ""),
+      netscriptDefinitions.replace(/^export /gm, ""),
       "typescript",
       monaco.Uri.file("netscript.d.ts"),
     );


### PR DESCRIPTION
How to reproduce: Hover the mouse over `ns.corporation.exportMaterial` in the in-game editor. It shows `Set material data` instead of `Set material export data`. Our regex mistakenly deletes all instances of "export " instead of ones of "export interface" and "export type".

I use `replaceAll("export interface", "interface").replaceAll("export type", "type")` in my tool, but using regex is okay too.

Before:

<img width="604" height="218" alt="before" src="https://github.com/user-attachments/assets/c45acc7e-85f5-489b-a4f0-c845256d8d6e" />

After:

<img width="598" height="211" alt="after" src="https://github.com/user-attachments/assets/00e9a050-415c-4213-90f0-5bbd0c4411f0" />
