### PR TITLE
UI: Show karma in Stats page and explain what it is in documentation

### DIFF
--- a/src/Documentation/doc/en/advanced/gang.md
+++ b/src/Documentation/doc/en/advanced/gang.md
@@ -6,7 +6,9 @@ Seen by most of the population as nihilistic, murderous and vile, occasional rum
 
 ## Starting and Recruiting
 
-Outside of [BitNode-2](bitnodes.md) gangs require much more crime and heartbreak to create, but can still be a great help. Creating a Gang in other [BitNodes](bitnodes.md) will offer more [Augmentations](../basic/augmentations.md) than other [Factions](../basic/factions.md), but they will not be a way to destroy the [BitNode](bitnodes.md) alone.
+Outside of [BitNode-2](bitnodes.md), you need to have -54000 karma or lower to create a Gang. It takes a long time to reduce your karma, but Gang is a great help. If you have access to [Sleeves](sleeves.md), you can make them commit crimes and "farm karma" for you.
+
+Creating a Gang in other [BitNodes](bitnodes.md) will offer more [Augmentations](../basic/augmentations.md) than other [Factions](../basic/factions.md), but they will not be a way to destroy the [BitNode](bitnodes.md) alone.
 
 After creating a gang, you will be able to start recruiting, adding members to your gang as you gain Respect. While in a BitNode, your gang and gang member stats will not reset if you install augmentations.
 

--- a/src/Documentation/doc/en/basic/crimes.md
+++ b/src/Documentation/doc/en/basic/crimes.md
@@ -1,6 +1,7 @@
 # Crimes
 
-Committing crimes is an active gameplay mechanic that allows the player to train their [Stats](stats.md) and potentially earn money.
+Committing crimes is an active gameplay mechanic that allows the player to train their [Stats](stats.md) and potentially earn money. It also reduces your karma, and having low karma is a requirement of some factions.
+
 The player can attempt to commit crimes by visiting `The Slums` through the `City` tab (Alt + w).
 `The Slums` is available in every city.
 

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -284,6 +284,7 @@ export function CharacterStats(): React.ReactElement {
                 color={Settings.theme.primary}
                 data={{ content: String(Player.augmentations.length) }}
               />
+              <StatsRow name="Karma" color={Settings.theme.primary} data={{ content: formatNumber(Player.karma, 3) }} />
             </TableBody>
           </Table>
         </Paper>


### PR DESCRIPTION
A long time ago, karma was (kind of) a "mysterious" feature of Bitburner. There was no page displaying it in the UI. The only API to check its value was an (intentionally?) hidden one. It had not been even mentioned anywhere in the doc until we added `faction_list.md` (only says how much karma is required for each faction) and `bitnodes.md` (only says gang needs karma without any further explanation).

I was not here back then, so I don't know why karma was "mysterious" like that. However, nowadays, karma is much more "normal". We have `faction_list.md` that shows the requirements, a documented API (`ns.getPlayer().karma`), and BN recommendation guides that mention karma. I think it's time to show it in the UI and explain what it is in documentation.

<img width="979" height="231" alt="Capture" src="https://github.com/user-attachments/assets/e6c2691f-5dd9-4913-8c1b-56ea3da97c22" />
