### PR TITLE
CCT: Change contract reward fallback priorities

### DIFF
--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -179,13 +179,14 @@ function sanitizeRewardType(rewardType: CodingContractRewardType): CodingContrac
       return false;
     }
   });
+  if (type === CodingContractRewardType.CompanyReputation && Object.keys(Player.jobs).length === 0) {
+    type =
+      Math.random() < 0.5 ? CodingContractRewardType.FactionReputation : CodingContractRewardType.FactionReputationAll;
+  }
   if (type === CodingContractRewardType.FactionReputation && factionsThatAllowHacking.length === 0) {
-    type = CodingContractRewardType.CompanyReputation;
+    type = CodingContractRewardType.Money;
   }
   if (type === CodingContractRewardType.FactionReputationAll && factionsThatAllowHacking.length === 0) {
-    type = CodingContractRewardType.CompanyReputation;
-  }
-  if (type === CodingContractRewardType.CompanyReputation && Object.keys(Player.jobs).length === 0) {
     type = CodingContractRewardType.Money;
   }
 


### PR DESCRIPTION
Contracts can reward company (job) rep, faction rep, faction rep for all factions or money. If the chosen option isn't available, the contract generator picks a default back up option.

Currently, both faction reps default to company rep, and company rep defaults to money. In practice this means 75% of generated contracts give company rep if there's no valid factions (e.g. start of BN).

This is [generally unpopular](https://discord.com/channels/415207508303544321/923282733332054126/1417254490091950230) (or a "noob trap") as company rep is probably the least useful of the 4 rewards, with faction rep generally being the rate determining step for progression.

This PR switches the order so that company rep is no longer the fallback if faction options fall through, and instead 75% of rolls land on money. With no job it goes from 50:50 faction rep:money to 75% faction rep (of various forms).

I considered removing the `try {} catch {}` in `sanitizeRewardType` as it seems superfluous, but then looking at `getRandomServer` there's a fair few aspects of this file that could be cleaner and that's probably a separate PR - unless I'm advised otherwise, and I'll try and clean it up now.