### PR TITLE
BUGFIX: Darknet state is not reset properly on prestige

### DIFF
--- a/src/DarkNet/effects/labyrinth.ts
+++ b/src/DarkNet/effects/labyrinth.ts
@@ -24,7 +24,7 @@ const PATH = " ";
 
 const MULTI_MAZE_THRESHOLD = 5;
 
-type labDetails = {
+type LabDetails = {
   name: string;
   depth: number;
   cha: number;
@@ -33,7 +33,7 @@ type labDetails = {
   manual: boolean;
 };
 
-export const labData: Record<string, labDetails> = {
+export const labData: Record<string, LabDetails> = {
   [SpecialServers.NormalLab]: {
     name: SpecialServers.NormalLab,
     depth: 7,

--- a/src/DarkNet/models/DarknetState.ts
+++ b/src/DarkNet/models/DarknetState.ts
@@ -22,6 +22,9 @@ export type LogEntry = {
   message: string | PasswordResponse;
 };
 
+/**
+ * If you add a new property to this global state, you must check if you need to reset it in prestigeDarknetState.
+ */
 export const DarknetState = {
   allowMutating: true,
   openServer: null as BaseServer | null,
@@ -56,6 +59,25 @@ export const DarknetState = {
   netViewTopScroll: 0,
   netViewLeftScroll: 0,
 };
+
+export function prestigeDarknetState(prestigeSourceFile: boolean): void {
+  DarknetState.allowMutating = true;
+  DarknetState.openServer = null;
+  DarknetState.storedCycles = 0;
+  if (prestigeSourceFile) {
+    DarknetState.hasUsedHeartbleed = false;
+  }
+  DarknetState.cyclesSinceLastMutation = 0;
+  DarknetState.Network = new Array(MAX_NET_DEPTH).fill(null).map(() => new Array<null>(NET_WIDTH).fill(null));
+  DarknetState.labyrinth = null;
+  DarknetState.labLocations = { "-1": [1, 1] };
+  DarknetState.lastPhishingCacheTime = new Date();
+  DarknetState.lastStormTime = new Date();
+  DarknetState.stockPromotions = {};
+  DarknetState.migrationInductionServers.clear();
+  DarknetState.serverState.clear();
+  DarknetState.offlineServers = [];
+}
 
 /**
  * Get the server state. It will initialize the state if it does not exist in DarknetState.serverState.

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -33,6 +33,7 @@ import { pendingUIShareJobIds } from "./NetworkShare/Share";
 import { getDarkscapeNavigator } from "./DarkNet/effects/effects";
 import { CodingContractEventEmitter } from "./CodingContract/CodingContractEventEmitter";
 import { showLiterature } from "./Literature/LiteratureHelpers";
+import { prestigeDarknetState } from "./DarkNet/models/DarknetState";
 
 const BitNode8StartingMoney = 250e6;
 function delayedDialog(message: string, canBeDismissedEasily = true) {
@@ -74,6 +75,8 @@ export function prestigeAugmentation(): void {
   const homeComp = Player.getHomeComputer();
   // Delete all servers except home computer
   prestigeAllServers();
+
+  prestigeDarknetState(false);
 
   // Reset home computer (only the programs) and add to AllServers
   AddToAllServers(homeComp);
@@ -224,6 +227,8 @@ export function prestigeSourceFile(isFlume: boolean): void {
 
   // Delete all servers except home computer
   prestigeAllServers(); // Must be done before initForeignServers()
+
+  prestigeDarknetState(true);
 
   // Reset home computer (only the programs) and add to AllServers
   AddToAllServers(homeComp);

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -11,8 +11,6 @@ import "../Script/RunningScript"; // For reviver side-effect
 import { assertObject } from "../utils/TypeAssertion";
 import { DarknetServer } from "./DarknetServer";
 import { applyRamBlocks } from "../DarkNet/effects/ramblock";
-import { DarknetState } from "../DarkNet/models/DarknetState";
-import { MAX_NET_DEPTH, NET_WIDTH } from "../DarkNet/Enums";
 
 /**
  * Map of all Servers that exist in the game
@@ -150,10 +148,6 @@ export const renameServer = (hostname: string, newName: string): void => {
 
 export function prestigeAllServers(): void {
   AllServers.clear();
-  // WIP: Check other properties in DarknetState as well, then improve validateDarknetNetwork.
-  DarknetState.Network = new Array(MAX_NET_DEPTH)
-    .fill(null)
-    .map(() => new Array<DarknetServer | null>(NET_WIDTH).fill(null));
 }
 
 export function loadAllServers(saveString: string): void {
@@ -166,9 +160,8 @@ export function loadAllServers(saveString: string): void {
   for (const [serverName, server] of Object.entries(allServersData)) {
     if (!(server instanceof Server) && !(server instanceof HacknetServer) && !(server instanceof DarknetServer)) {
       throw new Error(`Server ${serverName} is not an instance of Server or HacknetServer or DarknetServer.`);
-    } else {
-      AllServers.set(serverName, server);
     }
+    AllServers.set(serverName, server);
   }
 
   // Apply blocked ram for darknet servers

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -1298,6 +1298,12 @@ describe("lab location methods", () => {
   });
   test("dnet.labradar()", async () => {
     const ns = getNsOnServerNearLabyrinth();
+
+    // Make sure we are at the starting point.
+    const locationStatus = (await ns.dnet.labreport()) as LocationStatus;
+    expect(isLocationStatus(locationStatus)).toBe(true);
+    expect(locationStatus.coords).toStrictEqual([1, 1]);
+
     const response = (await ns.dnet.labradar()) as Result;
     assertNonNullish(response.message);
     const surroundingsString = response.message.split("\n");


### PR DESCRIPTION
How to reproduce this bug:
- Load a clean save.
- Check `DarknetState.hasUsedHeartbleed`. It should be false.
- Run `await ns.dnet.heartbleed("darkweb")`. `DarknetState.hasUsedHeartbleed` is true now.
- Soft-reset. `DarknetState.hasUsedHeartbleed` is still true.
- Bitflume. `DarknetState.hasUsedHeartbleed` is still true.

This means you will never get `CHALLENGE_BN15` after calling `heartbleed` once, even after prestige. This bug also affects other things. For example, after prestige, `labreport` and `labradar` may return wrong data due to stale data in `DarknetState.labLocations`.

I found this bug while fixing another bug in `setupBasicTestingEnvironment`. I'll open a PR for it later.