### PR TITLE
BUGFIX: Global states are not reset properly between each Jest test

### DIFF
--- a/src/DarkNet/effects/labyrinth.ts
+++ b/src/DarkNet/effects/labyrinth.ts
@@ -24,7 +24,7 @@ const PATH = " ";
 
 const MULTI_MAZE_THRESHOLD = 5;
 
-type labDetails = {
+type LabDetails = {
   name: string;
   depth: number;
   cha: number;
@@ -33,7 +33,7 @@ type labDetails = {
   manual: boolean;
 };
 
-export const labData: Record<string, labDetails> = {
+export const labData: Record<string, LabDetails> = {
   [SpecialServers.NormalLab]: {
     name: SpecialServers.NormalLab,
     depth: 7,

--- a/src/DarkNet/models/DarknetState.ts
+++ b/src/DarkNet/models/DarknetState.ts
@@ -22,6 +22,9 @@ export type LogEntry = {
   message: string | PasswordResponse;
 };
 
+/**
+ * If you add a new property to this global state, you must check if you need to reset it in prestigeDarknetState.
+ */
 export const DarknetState = {
   allowMutating: true,
   openServer: null as BaseServer | null,
@@ -56,6 +59,25 @@ export const DarknetState = {
   netViewTopScroll: 0,
   netViewLeftScroll: 0,
 };
+
+export function prestigeDarknetState(prestigeSourceFile: boolean): void {
+  DarknetState.allowMutating = true;
+  DarknetState.openServer = null;
+  DarknetState.storedCycles = 0;
+  if (prestigeSourceFile) {
+    DarknetState.hasUsedHeartbleed = false;
+  }
+  DarknetState.cyclesSinceLastMutation = 0;
+  DarknetState.Network = new Array(MAX_NET_DEPTH).fill(null).map(() => new Array<null>(NET_WIDTH).fill(null));
+  DarknetState.labyrinth = null;
+  DarknetState.labLocations = { "-1": [1, 1] };
+  DarknetState.lastPhishingCacheTime = new Date();
+  DarknetState.lastStormTime = new Date();
+  DarknetState.stockPromotions = {};
+  DarknetState.migrationInductionServers.clear();
+  DarknetState.serverState.clear();
+  DarknetState.offlineServers = [];
+}
 
 /**
  * Get the server state. It will initialize the state if it does not exist in DarknetState.serverState.

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -33,6 +33,7 @@ import { pendingUIShareJobIds } from "./NetworkShare/Share";
 import { getDarkscapeNavigator } from "./DarkNet/effects/effects";
 import { CodingContractEventEmitter } from "./CodingContract/CodingContractEventEmitter";
 import { showLiterature } from "./Literature/LiteratureHelpers";
+import { prestigeDarknetState } from "./DarkNet/models/DarknetState";
 
 const BitNode8StartingMoney = 250e6;
 function delayedDialog(message: string, canBeDismissedEasily = true) {
@@ -74,6 +75,8 @@ export function prestigeAugmentation(): void {
   const homeComp = Player.getHomeComputer();
   // Delete all servers except home computer
   prestigeAllServers();
+
+  prestigeDarknetState(false);
 
   // Reset home computer (only the programs) and add to AllServers
   AddToAllServers(homeComp);
@@ -224,6 +227,8 @@ export function prestigeSourceFile(isFlume: boolean): void {
 
   // Delete all servers except home computer
   prestigeAllServers(); // Must be done before initForeignServers()
+
+  prestigeDarknetState(true);
 
   // Reset home computer (only the programs) and add to AllServers
   AddToAllServers(homeComp);

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -11,8 +11,6 @@ import "../Script/RunningScript"; // For reviver side-effect
 import { assertObject } from "../utils/TypeAssertion";
 import { DarknetServer } from "./DarknetServer";
 import { applyRamBlocks } from "../DarkNet/effects/ramblock";
-import { DarknetState } from "../DarkNet/models/DarknetState";
-import { MAX_NET_DEPTH, NET_WIDTH } from "../DarkNet/Enums";
 
 /**
  * Map of all Servers that exist in the game
@@ -150,10 +148,6 @@ export const renameServer = (hostname: string, newName: string): void => {
 
 export function prestigeAllServers(): void {
   AllServers.clear();
-  // WIP: Check other properties in DarknetState as well, then improve validateDarknetNetwork.
-  DarknetState.Network = new Array(MAX_NET_DEPTH)
-    .fill(null)
-    .map(() => new Array<DarknetServer | null>(NET_WIDTH).fill(null));
 }
 
 export function loadAllServers(saveString: string): void {
@@ -166,9 +160,8 @@ export function loadAllServers(saveString: string): void {
   for (const [serverName, server] of Object.entries(allServersData)) {
     if (!(server instanceof Server) && !(server instanceof HacknetServer) && !(server instanceof DarknetServer)) {
       throw new Error(`Server ${serverName} is not an instance of Server or HacknetServer or DarknetServer.`);
-    } else {
-      AllServers.set(serverName, server);
     }
+    AllServers.set(serverName, server);
   }
 
   // Apply blocked ram for darknet servers

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -1298,6 +1298,12 @@ describe("lab location methods", () => {
   });
   test("dnet.labradar()", async () => {
     const ns = getNsOnServerNearLabyrinth();
+
+    // Make sure we are at the starting point.
+    const locationStatus = (await ns.dnet.labreport()) as LocationStatus;
+    expect(isLocationStatus(locationStatus)).toBe(true);
+    expect(locationStatus.coords).toStrictEqual([1, 1]);
+
     const response = (await ns.dnet.labradar()) as Result;
     assertNonNullish(response.message);
     const surroundingsString = response.message.split("\n");

--- a/test/jest/Utilities.ts
+++ b/test/jest/Utilities.ts
@@ -15,6 +15,10 @@ import { purchaseServer } from "../../src/Server/ServerPurchases";
 import { purchaseHacknet } from "../../src/Hacknet/HacknetHelpers";
 import { initForeignServers } from "../../src/Server/ServerHelpers";
 import { generateNextPid } from "../../src/Netscript/Pid";
+import { initBitNodeMultipliers } from "../../src/BitNode/BitNode";
+import { resetGoPromises } from "../../src/Go/boardAnalysis/goAI";
+import { enterBitNode } from "../../src/RedPill";
+import { getDefaultBitNodeOptions } from "../../src/BitNode/BitNodeUtils";
 
 declare const importActual: (typeof config)["doImport"];
 
@@ -54,12 +58,26 @@ export function initGameEnvironment() {
 export function setupBasicTestingEnvironment(
   { purchaseHacknetServer, purchasePServer } = { purchasePServer: false, purchaseHacknetServer: false },
 ): void {
+  // We need to delete all servers before calling initForeignServers.
   prestigeAllServers();
   setPlayer(new PlayerObject());
+
+  // Basic steps of initializing a new save file. These are the steps that we do in Engine.load() when there is no save
+  // data.
+  initBitNodeMultipliers();
   Player.init();
-  Player.sourceFiles.set(4, 3);
-  Player.money = 1e15;
   initForeignServers(Player.getHomeComputer());
+  Player.reapplyAllAugmentations();
+  resetGoPromises();
+
+  // Grant SF4 for conveniently using Singularity APIs in tests.
+  Player.sourceFiles.set(4, 3);
+  // Simulate bitflume. This step is very important. It ensures all global states (e.g., Factions, Companies, BN mults)
+  // are reset.
+  enterBitNode(true, Player.bitNodeN, 1, getDefaultBitNodeOptions());
+  // Get some money.
+  Player.money = 1e15;
+
   if (purchasePServer) {
     purchaseServer("test-server-1", 2);
   }


### PR DESCRIPTION
Note: This PR depends on #2486. Please review and merge that PR before this one.

With #2486, due to the stale data issue I said in that PR, `dnet.labradar()` test will be failed. After "dnet.labreport" test, pid 2 is at [3, 1], and this position is stored in `DarknetState.labLocations`. When `dnet.labradar` runs, the pid of `ns` is also 2, but the location should be [1, 1] because we bitflume between each test (the change in this PR). However, the actual location of pid 2 is [3, 1] due to the stale data in `DarknetState.labLocations`.

Run this Jest test:
```ts
import { Player } from "@player";
import { currentNodeMults } from "../../src/BitNode/BitNodeMultipliers";
import { initGameEnvironment, setupBasicTestingEnvironment } from "./Utilities";
import { prestigeSourceFile } from "../../src/Prestige";
import { joinFaction } from "../../src/Faction/FactionHelpers";
import { FactionName } from "../../src/Enums";
import { Factions } from "../../src/Faction/Factions";

beforeAll(() => {
  initGameEnvironment();
});

beforeEach(() => {
  setupBasicTestingEnvironment();
});

describe("test", () => {
  test("test 1", () => {
    console.log(
      "test 1 - before",
      Player.bitNodeN,
      currentNodeMults.CodingContractMoney,
      Player.factions,
      Factions[FactionName.CyberSec].isMember,
    );
    Player.bitNodeN = 8;
    prestigeSourceFile(true);
    joinFaction(Factions[FactionName.CyberSec]);
    console.log(
      "test 1 - after",
      Player.bitNodeN,
      currentNodeMults.CodingContractMoney,
      Player.factions,
      Factions[FactionName.CyberSec].isMember,
    );
  });
  test("test 2", () => {
    console.log(
      "test 2",
      Player.bitNodeN,
      currentNodeMults.CodingContractMoney,
      Player.factions,
      Factions[FactionName.CyberSec].isMember,
    );
  });
});
```

Before:
```
  console.log
    test 1 - before 1 1 [] false

      at Object.log (test/jest/CodingContract/test.ts:19:13)

  console.log
    test 1 - after 8 0 [ 'CyberSec' ] true

      at Object.log (test/jest/CodingContract/test.ts:29:13)

  console.log
    test 2 1 0 [] true

      at Object.log (test/jest/CodingContract/test.ts:38:13)
```

After:
```
  console.log
    test 1 - before 1 1 [] false

      at Object.log (test/jest/CodingContract/test.ts:19:13)

  console.log
    test 1 - after 8 0 [ 'CyberSec' ] true

      at Object.log (test/jest/CodingContract/test.ts:29:13)

  console.log
    test 2 1 1 [] false

      at Object.log (test/jest/CodingContract/test.ts:38:13)
```

Notice the wrong values of `currentNodeMults.CodingContractMoney` and `Factions[FactionName.CyberSec].isMember` in "test 2".