### PR TITLE
DNET: More fixes and feedback

### DIFF
--- a/markdown/bitburner.darknet.authenticate.md
+++ b/markdown/bitburner.darknet.authenticate.md
@@ -8,6 +8,8 @@ Sends a network request to try to authenticate on a darkweb server. The target s
 
 If successful, grants the script a session, allowing it to exec() scripts on that server, or scp() files to it. (scp() \*from\* the server is always allowed.)
 
+Note that the charisma level on a server is not a requirement for authentication, but authentication takes longer if the player's charisma is below the server's charisma level.
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.darknet.heartbleed.md
+++ b/markdown/bitburner.darknet.heartbleed.md
@@ -8,7 +8,7 @@ Uses an exploit to extract log data from a server by sending a malformed heartbe
 
 Servers will periodically produce logs themselves, as well, which sometimes are useful, but most times are not.
 
-The speed of capture scales with the number of threads used. See formulas.dnet.getHeartbleedTime for more information.
+The speed of capture scales with the number of threads used. See formulas.dnet.getHeartbleedTime for more information. Note that you cannot scrape logs from servers whose required charisma is higher than your charisma level.
 
 **Signature:**
 

--- a/markdown/bitburner.darknet.md
+++ b/markdown/bitburner.darknet.md
@@ -36,6 +36,8 @@ Sends a network request to try to authenticate on a darkweb server. The target s
 
 If successful, grants the script a session, allowing it to exec() scripts on that server, or scp() files to it. (scp() \*from\* the server is always allowed.)
 
+Note that the charisma level on a server is not a requirement for authentication, but authentication takes longer if the player's charisma is below the server's charisma level.
+
 
 </td></tr>
 <tr><td>
@@ -145,7 +147,7 @@ Uses an exploit to extract log data from a server by sending a malformed heartbe
 
 Servers will periodically produce logs themselves, as well, which sometimes are useful, but most times are not.
 
-The speed of capture scales with the number of threads used. See formulas.dnet.getHeartbleedTime for more information.
+The speed of capture scales with the number of threads used. See formulas.dnet.getHeartbleedTime for more information. Note that you cannot scrape logs from servers whose required charisma is higher than your charisma level.
 
 
 </td></tr>

--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -94,7 +94,7 @@ export const populateDarknet = () => {
     return;
   }
 
-  clearDarknet(true);
+  clearDarknet();
   addLabyrinth();
   addRandomDarknetServers(getNetDepth() * NET_WIDTH * SERVER_DENSITY - 10);
   addRandomDarknetServers(5 - DarknetState.Network[0].length);
@@ -108,13 +108,13 @@ export const populateDarknet = () => {
   }
 };
 
-export const clearDarknet = (force = false) => {
+export const clearDarknet = () => {
   movePlayerIfNeeded();
   for (let i = 0; i < MAX_NET_DEPTH; i++) {
     for (let j = 0; j < NET_WIDTH; j++) {
       const server = DarknetState.Network[i]?.[j];
       if (!server) continue;
-      deleteDarknetServer(server, force);
+      deleteDarknetServer(server, true);
       DarknetState.Network[i][j] = null;
     }
   }

--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -35,6 +35,7 @@ import {
 } from "../Enums";
 import { DarknetServerOptions, DnetServerBuilder } from "../models/DarknetServerOptions";
 import {
+  getAllDarknetServers,
   getAllMovableDarknetServers,
   getNeighborsOnRow,
   getServersOnRowAbove,
@@ -156,9 +157,9 @@ export const loadDarknet = () => {
     return;
   }
 
-  const darkNetServers = getAllMovableDarknetServers();
+  const darkNetServers = getAllDarknetServers();
   for (const server of darkNetServers) {
-    if (isLabyrinthServer(server.hostname)) {
+    if (isLabyrinthServer(server.hostname) || server.hostname === SpecialServers.DarkWeb) {
       continue;
     }
     disconnectServer(server, true);

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -203,6 +203,7 @@ export const addLowLevelServersIfNeeded = (): void => {
   const serversConnectedToDarkweb = getAllDarknetServers().filter((s) => s.depth === 0);
   if (serversConnectedToDarkweb.length <= 3) {
     addRandomDarknetServers(2, 0, true);
+    addLowLevelServersIfNeeded();
   }
   if (lowLevelServers.length / (4 * NET_WIDTH) < LOW_LEVEL_SERVER_DENSITY) {
     addRandomDarknetServers(2, Math.floor(Math.random() * 4));

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -79,10 +79,9 @@ export const calculateAuthenticationTime = (
 
   const threadsFactor = 1 / (1 + 0.2 * (threads - 1));
   const skillFactor = (diffFactor * chaRequired + baseDiff) / (person.skills.charisma + 100);
-  const noobFactor = Math.min(0.5 + difficulty / 4, 1);
   const backdoorFactor = getBackdoorAuthTimeDebuff();
-  const underleveledFactor =
-    person.skills.charisma >= chaRequired ? 1 : 1.5 + (chaRequired + 50) / (person.skills.charisma + 50);
+  const applyUnderleveledFactor = person.skills.charisma <= chaRequired && darknetServerData.depth > 1;
+  const underleveledFactor = applyUnderleveledFactor ? 1.5 + (chaRequired + 50) / (person.skills.charisma + 50) : 1;
   const hasBootsFactor = Player.hasAugmentation(AugmentationName.TheBoots) ? 0.8 : 1;
   const hasSf15_2Factor = Player.activeSourceFileLvl(15) > 2 ? 0.8 : 1;
   const bonusTimeFactor = hasDarknetBonusTime() ? 0.75 : 1;
@@ -90,7 +89,6 @@ export const calculateAuthenticationTime = (
   const time =
     baseTime *
     skillFactor *
-    noobFactor *
     backdoorFactor *
     underleveledFactor *
     hasBootsFactor *

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -58,27 +58,6 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     [draggableBackground],
   );
 
-  const isWithinScreen = useCallback(
-    (server: DarknetServer) => {
-      const { left, top } = getPixelPosition(server, true);
-      const background = draggableBackground.current;
-      const buffer = 600;
-      const visibleAreaLeftEdge = (background?.scrollLeft ?? 0) / zoomOptions[zoomIndex];
-      const visibleAreaTopEdge = (background?.scrollTop ?? 0) / zoomOptions[zoomIndex];
-      const visibleAreaRightEdge =
-        visibleAreaLeftEdge + ((background?.clientWidth ?? 0) / zoomOptions[zoomIndex] ** 2 || window.innerWidth);
-      const visibleAreaBottomEdge =
-        visibleAreaTopEdge + ((background?.clientHeight ?? 0) / zoomOptions[zoomIndex] ** 2 || window.innerHeight);
-      return (
-        left >= visibleAreaLeftEdge - buffer &&
-        left <= visibleAreaRightEdge + buffer &&
-        top >= visibleAreaTopEdge - buffer &&
-        top <= visibleAreaBottomEdge + buffer
-      );
-    },
-    [zoomIndex, zoomOptions],
-  );
-
   const updateDisplay = useCallback(() => {
     if (!canvas.current) {
       return;
@@ -87,8 +66,8 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     setNetDisplayDepth(getDeepestServerDepth() + visibilityMargin);
 
     rerender();
-    drawOnCanvas(canvas.current, isWithinScreen);
-  }, [isWithinScreen, rerender]);
+    drawOnCanvas(canvas.current);
+  }, [rerender]);
 
   useEffect(() => {
     const clearSubscription = DarknetEvents.subscribe(() => updateDisplay());
@@ -99,7 +78,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     return () => {
       clearSubscription();
     };
-  }, [isWithinScreen, updateDisplay, rerender, scrollTo]);
+  }, [updateDisplay, rerender, scrollTo]);
 
   const getDeepestServerDepth = () => {
     const lab = getLabyrinthDetails().lab;
@@ -327,8 +306,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
           {DarknetState.Network.slice(0, netDisplayDepth).map((row, i) =>
             row.map(
               (server, j) =>
-                server &&
-                isWithinScreen(server) && (
+                server && (
                   <ServerStatusBox
                     server={server}
                     key={getServerKey(server, i, j)}

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -58,36 +58,57 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     [draggableBackground],
   );
 
-  useEffect(() => {
-    const clearSubscription = DarknetEvents.subscribe(() => {
-      if (canvas.current) {
-        const lab = getLabyrinthDetails().lab;
-        const startingDepth = lab && getServerLogs(lab, 1, true).length ? lab.depth : 0;
-        const deepestServer = DarknetState.Network.flat().reduce((deepest, server) => {
-          if (server?.hasAdminRights && server.depth > deepest) {
-            return server.depth;
-          }
-          return deepest;
-        }, startingDepth);
-        const visibilityMargin = DarknetState.showFullNetwork ? 99 : 3;
-        setNetDisplayDepth(deepestServer + visibilityMargin);
+  const isWithinScreen = useCallback(
+    (server: DarknetServer) => {
+      const { left, top } = getPixelPosition(server, true);
+      const background = draggableBackground.current;
+      const buffer = 600;
+      const visibleAreaLeftEdge = (background?.scrollLeft ?? 0) / zoomOptions[zoomIndex];
+      const visibleAreaTopEdge = (background?.scrollTop ?? 0) / zoomOptions[zoomIndex];
+      const visibleAreaRightEdge =
+        visibleAreaLeftEdge + ((background?.clientWidth ?? 0) / zoomOptions[zoomIndex] ** 2 || window.innerWidth);
+      const visibleAreaBottomEdge =
+        visibleAreaTopEdge + ((background?.clientHeight ?? 0) / zoomOptions[zoomIndex] ** 2 || window.innerHeight);
+      return (
+        left >= visibleAreaLeftEdge - buffer &&
+        left <= visibleAreaRightEdge + buffer &&
+        top >= visibleAreaTopEdge - buffer &&
+        top <= visibleAreaBottomEdge + buffer
+      );
+    },
+    [zoomIndex, zoomOptions],
+  );
 
-        rerender();
-        drawOnCanvas(canvas.current);
-      }
-    });
-    canvas.current && drawOnCanvas(canvas.current);
+  const updateDisplay = useCallback(() => {
+    if (!canvas.current) {
+      return;
+    }
+    const visibilityMargin = DarknetState.showFullNetwork ? 99 : 3;
+    setNetDisplayDepth(getDeepestServerDepth() + visibilityMargin);
+
+    rerender();
+    drawOnCanvas(canvas.current, isWithinScreen);
+  }, [isWithinScreen, rerender]);
+
+  useEffect(() => {
+    const clearSubscription = DarknetEvents.subscribe(() => updateDisplay());
     draggableBackground.current?.addEventListener("wheel", (e) => e.preventDefault());
     scrollTo(DarknetState.netViewTopScroll, DarknetState.netViewLeftScroll);
+    updateDisplay();
 
     return () => {
       clearSubscription();
     };
-  }, [rerender, scrollTo]);
+  }, [isWithinScreen, updateDisplay, rerender, scrollTo]);
 
-  useEffect(() => {
-    DarknetEvents.emit();
-  }, []);
+  const getDeepestServerDepth = () => {
+    const lab = getLabyrinthDetails().lab;
+    const startingDepth = lab && getServerLogs(lab, 1, true).length ? lab.depth : 0;
+    return DarknetState.Network.flat().reduce(
+      (deepest, server) => (server?.hasAdminRights && server.depth > deepest ? server.depth : deepest),
+      startingDepth,
+    );
+  };
 
   const allowAuth = (server: DarknetServer | null) =>
     !!server &&
@@ -189,24 +210,6 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     throttledZoom(wheelEvent as unknown as WheelEvent);
   };
 
-  const isWithinScreen = (server: DarknetServer) => {
-    const { left, top } = getPixelPosition(server, true);
-    const background = draggableBackground.current;
-    const buffer = 600;
-    const visibleAreaLeftEdge = (background?.scrollLeft ?? 0) / zoomOptions[zoomIndex];
-    const visibleAreaTopEdge = (background?.scrollTop ?? 0) / zoomOptions[zoomIndex];
-    const visibleAreaRightEdge =
-      visibleAreaLeftEdge + ((background?.clientWidth ?? 0) / zoomOptions[zoomIndex] ** 2 || window.innerWidth);
-    const visibleAreaBottomEdge =
-      visibleAreaTopEdge + ((background?.clientHeight ?? 0) / zoomOptions[zoomIndex] ** 2 || window.innerHeight);
-    return (
-      left >= visibleAreaLeftEdge - buffer &&
-      left <= visibleAreaRightEdge + buffer &&
-      top >= visibleAreaTopEdge - buffer &&
-      top <= visibleAreaBottomEdge + buffer
-    );
-  };
-
   const search = (selection: string, options: string[], searchTerm: string) => {
     if (searchTerm.length === 1) {
       return;
@@ -250,6 +253,10 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     }
 
     return servers;
+  };
+
+  const getServerKey = (server: DarknetServer, x: number, y: number) => {
+    return `${x} ${y} ${server.hostname} ${server.hasAdminRights}`;
   };
 
   return (
@@ -322,7 +329,12 @@ export function NetworkDisplayWrapper(): React.ReactElement {
               (server, j) =>
                 server &&
                 isWithinScreen(server) && (
-                  <ServerStatusBox server={server} key={`${i},${j}`} enableAuth={allowAuth(server)} classes={classes} />
+                  <ServerStatusBox
+                    server={server}
+                    key={getServerKey(server, i, j)}
+                    enableAuth={allowAuth(server)}
+                    classes={classes}
+                  />
                 ),
             ),
           )}

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -63,7 +63,13 @@ export function NetworkDisplayWrapper(): React.ReactElement {
       return;
     }
     const visibilityMargin = DarknetState.showFullNetwork ? 99 : 3;
-    setNetDisplayDepth(getDeepestServerDepth() + visibilityMargin);
+    const lab = getLabyrinthDetails().lab;
+    const startingDepth = lab && getServerLogs(lab, 1, true).length ? lab.depth : 0;
+    const deepestServerDepth = DarknetState.Network.flat().reduce(
+      (deepest, server) => (server?.hasAdminRights && server.depth > deepest ? server.depth : deepest),
+      startingDepth,
+    );
+    setNetDisplayDepth(deepestServerDepth + visibilityMargin);
 
     rerender();
     drawOnCanvas(canvas.current);
@@ -79,15 +85,6 @@ export function NetworkDisplayWrapper(): React.ReactElement {
       clearSubscription();
     };
   }, [updateDisplay, rerender, scrollTo]);
-
-  const getDeepestServerDepth = () => {
-    const lab = getLabyrinthDetails().lab;
-    const startingDepth = lab && getServerLogs(lab, 1, true).length ? lab.depth : 0;
-    return DarknetState.Network.flat().reduce(
-      (deepest, server) => (server?.hasAdminRights && server.depth > deepest ? server.depth : deepest),
-      startingDepth,
-    );
-  };
 
   const allowAuth = (server: DarknetServer | null) =>
     !!server &&
@@ -234,10 +231,6 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     return servers;
   };
 
-  const getServerKey = (server: DarknetServer, x: number, y: number) => {
-    return `${x} ${y} ${server.hostname} ${server.hasAdminRights}`;
-  };
-
   return (
     <Container maxWidth={false} disableGutters>
       {serverOpened ? (
@@ -303,16 +296,11 @@ export function NetworkDisplayWrapper(): React.ReactElement {
             style={{ position: "absolute", zIndex: -1 }}
           ></canvas>
           {darkWebRoot && <ServerStatusBox server={darkWebRoot} enableAuth={true} classes={classes} />}
-          {DarknetState.Network.slice(0, netDisplayDepth).map((row, i) =>
+          {DarknetState.Network.slice(0, netDisplayDepth).map((row) =>
             row.map(
-              (server, j) =>
+              (server) =>
                 server && (
-                  <ServerStatusBox
-                    server={server}
-                    key={getServerKey(server, i, j)}
-                    enableAuth={allowAuth(server)}
-                    classes={classes}
-                  />
+                  <ServerStatusBox server={server} key={server.ip} enableAuth={allowAuth(server)} classes={classes} />
                 ),
             ),
           )}

--- a/src/DarkNet/ui/ServerSummary.tsx
+++ b/src/DarkNet/ui/ServerSummary.tsx
@@ -48,6 +48,9 @@ export function ServerSummary({
           runningScriptNames.length > 3 ? ` +${runningScriptNames.length - 3}` : ""
         }`
       : "No running scripts on server";
+  const dataCacheTooltip = `Reward caches on server: ${server.caches.slice(0, 3).join(", ")}${
+    server.caches.length > 3 ? ` +${server.caches.length - 3}` : ""
+  }`;
   const hasStormSeed = server.programs.includes(CompletedProgramName.stormSeed);
   const hasBackdoor = server.backdoorInstalled && !server.hasStasisLink;
   const ramBlockedDetails = formatToMaxDigits(server.blockedRam, 2) + "GB";
@@ -65,7 +68,7 @@ export function ServerSummary({
   const components = [];
   if (cacheCount) {
     components.push(
-      <Tooltip key="cache" title={<>Reward cache count: {cacheCount}</>}>
+      <Tooltip key="cache" title={<>{dataCacheTooltip}</>}>
         <Typography>
           <SvgIcon component={Inventory2} className={`${classes.gold} ${classes.serverStatusIcon}`} />
           {cacheCount}

--- a/src/DarkNet/ui/networkCanvas.ts
+++ b/src/DarkNet/ui/networkCanvas.ts
@@ -10,7 +10,7 @@ import { SpecialServers } from "../../Server/data/SpecialServers";
 import { getNetDepth, isLabyrinthServer } from "../effects/labyrinth";
 import { NET_WIDTH } from "../Enums";
 import type { DarknetServer } from "../../Server/DarknetServer";
-import { getDarknetServer } from "../utils/darknetServerUtils";
+import { getDarknetServerOrThrow } from "../utils/darknetServerUtils";
 
 export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
   const ctx = canvas?.getContext("2d");
@@ -23,18 +23,18 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
   for (const server of DarknetState.Network.flat()) {
     if (
       !server ||
-      (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServer(s)?.hasAdminRights))
+      (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServerOrThrow(s)?.hasAdminRights))
     ) {
       continue;
     }
 
     // draw a line between each server and its connected servers
     for (const connectedServerName of server.serversOnNetwork) {
-      const connectedServer = getDarknetServer(connectedServerName);
+      const connectedServer = getDarknetServerOrThrow(connectedServerName);
       if (
         !connectedServer ||
         (!connectedServer.hasAdminRights &&
-          !connectedServer.serversOnNetwork.find((s) => getDarknetServer(s)?.hasAdminRights))
+          !connectedServer.serversOnNetwork.find((s) => getDarknetServerOrThrow(s)?.hasAdminRights))
       ) {
         continue;
       }

--- a/src/DarkNet/ui/networkCanvas.ts
+++ b/src/DarkNet/ui/networkCanvas.ts
@@ -23,7 +23,7 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
   for (const server of DarknetState.Network.flat()) {
     if (
       !server ||
-      (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServerOrThrow(s)?.hasAdminRights))
+      (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights))
     ) {
       continue;
     }
@@ -34,7 +34,7 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
       if (
         !connectedServer ||
         (!connectedServer.hasAdminRights &&
-          !connectedServer.serversOnNetwork.find((s) => getDarknetServerOrThrow(s)?.hasAdminRights))
+          !connectedServer.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights))
       ) {
         continue;
       }

--- a/src/DarkNet/ui/networkCanvas.ts
+++ b/src/DarkNet/ui/networkCanvas.ts
@@ -12,7 +12,7 @@ import { NET_WIDTH } from "../Enums";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { getDarknetServer } from "../utils/darknetServerUtils";
 
-export const drawOnCanvas = (canvas: HTMLCanvasElement, isWithinScreen: (server: DarknetServer) => boolean) => {
+export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
   const ctx = canvas?.getContext("2d");
   if (!ctx || !canvas) {
     console.error("Could not get canvas context");
@@ -23,7 +23,6 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement, isWithinScreen: (server:
   for (const server of DarknetState.Network.flat()) {
     if (
       !server ||
-      !isWithinScreen(server) ||
       (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServer(s)?.hasAdminRights))
     ) {
       continue;

--- a/src/DarkNet/ui/networkCanvas.ts
+++ b/src/DarkNet/ui/networkCanvas.ts
@@ -10,9 +10,9 @@ import { SpecialServers } from "../../Server/data/SpecialServers";
 import { getNetDepth, isLabyrinthServer } from "../effects/labyrinth";
 import { NET_WIDTH } from "../Enums";
 import type { DarknetServer } from "../../Server/DarknetServer";
-import { getDarknetServerOrThrow } from "../utils/darknetServerUtils";
+import { getDarknetServer } from "../utils/darknetServerUtils";
 
-export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
+export const drawOnCanvas = (canvas: HTMLCanvasElement, isWithinScreen: (server: DarknetServer) => boolean) => {
   const ctx = canvas?.getContext("2d");
   if (!ctx || !canvas) {
     console.error("Could not get canvas context");
@@ -23,17 +23,19 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
   for (const server of DarknetState.Network.flat()) {
     if (
       !server ||
-      (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights))
+      !isWithinScreen(server) ||
+      (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServer(s)?.hasAdminRights))
     ) {
       continue;
     }
 
     // draw a line between each server and its connected servers
     for (const connectedServerName of server.serversOnNetwork) {
-      const connectedServer = getDarknetServerOrThrow(connectedServerName);
+      const connectedServer = getDarknetServer(connectedServerName);
       if (
-        !connectedServer.hasAdminRights &&
-        !connectedServer.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights)
+        !connectedServer ||
+        (!connectedServer.hasAdminRights &&
+          !connectedServer.serversOnNetwork.find((s) => getDarknetServer(s)?.hasAdminRights))
       ) {
         continue;
       }

--- a/src/DevMenu/ui/DarknetDev.tsx
+++ b/src/DevMenu/ui/DarknetDev.tsx
@@ -191,7 +191,7 @@ export function DarknetDev(): React.ReactElement {
           <Tooltip title={<Typography>Create a new darkweb network.</Typography>}>
             <Button
               onClick={() => {
-                clearDarknet(true);
+                clearDarknet();
                 populateDarknet();
                 SnackbarEvents.emit("New dark network generated", ToastVariant.SUCCESS, 2000);
               }}

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4450,6 +4450,9 @@ export interface Darknet {
    *
    * If successful, grants the script a session, allowing it to exec() scripts on that server, or scp() files to it. (scp() *from* the server is always allowed.)
    *
+   * Note that the charisma level on a server is not a requirement for authentication, but authentication takes longer
+   * if the player's charisma is below the server's charisma level.
+   *
    * @remarks
    * RAM cost: 0.6 GB
    *
@@ -4489,6 +4492,7 @@ export interface Darknet {
    * Servers will periodically produce logs themselves, as well, which sometimes are useful, but most times are not.
    *
    * The speed of capture scales with the number of threads used. See formulas.dnet.getHeartbleedTime for more information.
+   * Note that you cannot scrape logs from servers whose required charisma is higher than your charisma level.
    *
    * @remarks
    * RAM cost: 0.6 GB

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -71,7 +71,7 @@ function getNsOnServerNearLabyrinth() {
       (hostname) => hostname !== SpecialServers.Home && hostname !== SpecialServers.DarkWeb,
     );
     if (!server) {
-      clearDarknet(true);
+      clearDarknet();
       populateDarknet();
     }
   }


### PR DESCRIPTION
- make darknet background canvas only draw connections for servers that are on the screen
- base the server component key on a more robust set of properties to re-render when details change
- removed noobfactor from auth time; removed underlevelled debuff for very shallow servers
- add clearer docs around server charisma level for authenticate and heartbleed

