### PR TITLE
BLADEBURNER: Stop randomizing action difficulty

### DIFF
--- a/src/Bladeburner/Actions/Action.ts
+++ b/src/Bladeburner/Actions/Action.ts
@@ -3,7 +3,6 @@ import type { Person } from "../../PersonObjects/Person";
 import type { Availability, SuccessChanceParams } from "../Types";
 import type { Skills as PersonSkills } from "../../PersonObjects/Skills";
 
-import { addOffset } from "../../utils/helpers/addOffset";
 import { BladeburnerConstants } from "../data/Constants";
 import { calculateIntelligenceBonus } from "../../PersonObjects/formulas/intelligence";
 import { BladeburnerMultName } from "../Enums";
@@ -67,7 +66,7 @@ export abstract class ActionClass {
     this.desc = params.desc;
     if (params.warning) this.warning = params.warning;
     if (params.successScaling) this.successScaling = params.successScaling;
-    if (params.baseDifficulty) this.baseDifficulty = addOffset(params.baseDifficulty, 10);
+    if (params.baseDifficulty) this.baseDifficulty = params.baseDifficulty;
 
     if (params.rankGain) this.rankGain = params.rankGain;
     if (params.rankLoss) this.rankLoss = params.rankLoss;

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -157,7 +157,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Contract",
             "data": {
               "autoLevel": true,
-              "count": 105,
+              "count": 97,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -168,7 +168,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Contract",
             "data": {
               "autoLevel": true,
-              "count": 113,
+              "count": 101,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -179,7 +179,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Contract",
             "data": {
               "autoLevel": true,
-              "count": 105,
+              "count": 101,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -204,7 +204,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Operation",
             "data": {
               "autoLevel": true,
-              "count": 11,
+              "count": 124,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -216,7 +216,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Operation",
             "data": {
               "autoLevel": true,
-              "count": 80,
+              "count": 69,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -228,7 +228,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Operation",
             "data": {
               "autoLevel": true,
-              "count": 144,
+              "count": 116,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -240,7 +240,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Operation",
             "data": {
               "autoLevel": true,
-              "count": 3,
+              "count": 120,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -252,7 +252,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Operation",
             "data": {
               "autoLevel": true,
-              "count": 136,
+              "count": 112,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,
@@ -264,7 +264,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
             "ctor": "Operation",
             "data": {
               "autoLevel": true,
-              "count": 86,
+              "count": 72,
               "failures": 0,
               "level": 1,
               "maxLevel": 1,


### PR DESCRIPTION
Each action has a difficulty that affects action time, reward, success chance, etc. This difficulty is based on `baseDifficulty` and a small randomized offset that changes every time the player loads the game. This offset does not have any real benefit, and it confuses the player when they see the action time/success chance changes. This PR removes this offset.

@d0sboots Besides this usage in the action's constructor, we also randomize the rank gain, rank loss, and damage. What do you think about removing them as well?