### PR TITLE
DOCUMENTATION: Fix invalid links in ns.sleep and ns.asleep

### DIFF
--- a/markdown/bitburner.ns.asleep.md
+++ b/markdown/bitburner.ns.asleep.md
@@ -58,5 +58,5 @@ A promise that resolves to true when the sleep is completed.
 
 RAM cost: 0 GB
 
-Note that the actual delay may be longer than intended. For more information, please check https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout\#delay.
+Note that the actual delay may be longer than intended. For more information, please check [https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout\#delay](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay)<!-- -->.
 

--- a/markdown/bitburner.ns.sleep.md
+++ b/markdown/bitburner.ns.sleep.md
@@ -58,7 +58,7 @@ A promise that resolves to true when the sleep is completed.
 
 RAM cost: 0 GB
 
-Note that the actual delay may be longer than intended. For more information, please check https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout\#delay.
+Note that the actual delay may be longer than intended. For more information, please check [https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout\#delay](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay)<!-- -->.
 
 ## Example
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7287,7 +7287,7 @@ export interface NS {
    * RAM cost: 0 GB
    *
    * Note that the actual delay may be longer than intended. For more information, please check
-   * https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay.
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay}.
    *
    * @param millis - Number of milliseconds to sleep. Default to 0.
    * @example
@@ -7308,7 +7308,7 @@ export interface NS {
    * RAM cost: 0 GB
    *
    * Note that the actual delay may be longer than intended. For more information, please check
-   * https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay.
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#delay}.
    *
    * @param millis - Number of milliseconds to sleep. Default to 0.
    * @returns A promise that resolves to true when the sleep is completed.


### PR DESCRIPTION
Without `@link`, the URL is generated as `https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout\#delay` (notice `\#`) in the md file. When opening that URL with Ctrl+Click, it's encoded as `https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout%5C#delay`, which is invalid.