### PR TITLE
BUGFIX: Hacknet server UI shows NaN hash rate when 100% RAM is being used

### DIFF
--- a/src/Hacknet/ui/HacknetServerElem.tsx
+++ b/src/Hacknet/ui/HacknetServerElem.tsx
@@ -267,9 +267,13 @@ export function HacknetServerElem(props: IProps): React.ReactElement {
                     <br />
                     <span style={{ opacity: 0.5 }}>
                       <HashRate
-                        hashes={
-                          node.maxRam > node.ramUsed ? (node.hashRate * node.maxRam) / (node.maxRam - node.ramUsed) : 0
-                        }
+                        hashes={calculateHashGainRate(
+                          node.level,
+                          0,
+                          node.maxRam,
+                          node.cores,
+                          Player.mults.hacknet_node_money,
+                        )}
                       />
                     </span>{" "}
                     max production rate. (achieved when 100% RAM is allocated to it)

--- a/src/Hacknet/ui/HacknetServerElem.tsx
+++ b/src/Hacknet/ui/HacknetServerElem.tsx
@@ -266,7 +266,11 @@ export function HacknetServerElem(props: IProps): React.ReactElement {
                     <HashRate hashes={node.hashRate} /> current production rate.
                     <br />
                     <span style={{ opacity: 0.5 }}>
-                      <HashRate hashes={(node.hashRate * node.maxRam) / (node.maxRam - node.ramUsed)} />
+                      <HashRate
+                        hashes={
+                          node.maxRam > node.ramUsed ? (node.hashRate * node.maxRam) / (node.maxRam - node.ramUsed) : 0
+                        }
+                      />
                     </span>{" "}
                     max production rate. (achieved when 100% RAM is allocated to it)
                     <br />


### PR DESCRIPTION
How to reproduce this bug: Run a script that takes 100% RAM of a hacknet server, then hover the mouse over the "Production" line.

Before:

<img width="606" height="188" alt="before" src="https://github.com/user-attachments/assets/21489bd1-3f7a-4082-b4e4-c4180c746a5c" />

After:

<img width="658" height="181" alt="after" src="https://github.com/user-attachments/assets/8f5dcf7f-498f-4143-a11e-bd780d52283a" />