### PR TITLE
JEST: Add tests for checking getAnswer and solver of coding contracts

### DIFF
--- a/test/jest/CodingContract/ContractGenerator.test.ts
+++ b/test/jest/CodingContract/ContractGenerator.test.ts
@@ -17,6 +17,8 @@ import { CodingContractRewardType } from "../../../src/CodingContract/Contract";
 import { joinFaction } from "../../../src/Faction/FactionHelpers";
 import { Factions } from "../../../src/Faction/Factions";
 import { Companies } from "../../../src/Company/Companies";
+import { CodingContractTypes } from "../../../src/CodingContract/ContractTypes";
+import { getRecordEntries } from "../../../src/Types/Record";
 
 beforeAll(() => {
   initGameEnvironment();
@@ -200,4 +202,23 @@ describe("Receive fallback reward", () => {
     ns.codingcontract.attempt(contract.getAnswer(), contract.fn);
     expect(Factions.CyberSec.playerReputation).toBeGreaterThan(0);
   });
+});
+
+describe("Check getAnswer and solver", () => {
+  // These contracts do not give a way to generate the answer.
+  const skippedContractTypes = [
+    CodingContractName.Proper2ColoringOfAGraph,
+    CodingContractName.ShortestPathInAGrid,
+    CodingContractName.SquareRoot,
+  ];
+  for (const [name, cct] of getRecordEntries(CodingContractTypes)) {
+    if (skippedContractTypes.includes(name)) {
+      continue;
+    }
+    const state = cct.generate();
+    const data = cct.getData ? cct.getData(state) : state;
+    const answer = cct.getAnswer(data);
+    expect(answer).not.toBeNull();
+    expect(cct.solver(state, answer)).toStrictEqual(true);
+  }
 });


### PR DESCRIPTION
While reviewing #2440, I caught an error: https://github.com/bitburner-official/bitburner-src/pull/2440#discussion_r2665964378. Back then, I manually checked all changes. This new Jest test will catch this kind of error automatically.