### PR TITLE
UI: Use font family setting when rendering MUI Link component

### DIFF
--- a/src/Themes/ui/Theme.tsx
+++ b/src/Themes/ui/Theme.tsx
@@ -416,6 +416,13 @@ export function refreshTheme(): void {
           },
         },
       },
+      MuiLink: {
+        styleOverrides: {
+          root: {
+            fontFamily: Settings.styles.fontFamily,
+          },
+        },
+      },
     },
   });
 


### PR DESCRIPTION
When using the Link component, we need to put it in a Typography component. For example, in `src\ui\React\RecoveryRoot.tsx`:

```typescript
      <Box>
        <Typography>It is recommended to alert a developer.</Typography>
        <Typography>
          <Link href={crashReport?.issueUrl ?? newIssueUrl} target="_blank">
            File an issue on github
          </Link>
        </Typography>
        <Typography>
          <Link href="https://discord.gg/TFc3hKD" target="_blank">
            Post in the #bug-report channel on Discord.
          </Link>
        </Typography>
        <Typography>
          <Link href="https://www.reddit.com/r/Bitburner/" target="_blank">
            Make a reddit post
          </Link>
        </Typography>
        <Typography variant="h4" color={Settings.theme.warning}>
          Please include your save file and the crash report.
        </Typography>
      </Box>
```

This is unnecessarily bothersome. There are no places in our codebase that the Link component needs to *not* use `Settings.styles.fontFamily`.

Before:

<img width="553" height="151" alt="before" src="https://github.com/user-attachments/assets/acb4e5ad-a092-4c80-b5d7-29168d3db7e3" />

After:

<img width="552" height="151" alt="after" src="https://github.com/user-attachments/assets/27a80a1c-603b-4d9f-be71-9cd30efc2ff4" />
