### PR TITLE
DNET: Adjust balance from player feedback

### DIFF
--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -1922,7 +1922,7 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       hacking: 1.1,
       company_rep: 1.05,
       isSpecial: true,
-      prereqs: [AugmentationName.TheHammer],
+      prereqs: [AugmentationName.TheStaff],
       factions: [],
     },
     [AugmentationName.TheSword]: {

--- a/src/Augmentation/Augmentations.ts
+++ b/src/Augmentation/Augmentations.ts
@@ -1895,6 +1895,20 @@ export const Augmentations: Record<AugmentationName, Augmentation> = (() => {
       prereqs: [AugmentationName.TheBoots],
       factions: [],
     },
+    [AugmentationName.TheStaff]: {
+      repCost: 1e4,
+      moneyCost: 1e6,
+      info:
+        "This skeletal augmentation greatly enhances the users durability and health. Inspired by the original Staff of Medicine that is said to " +
+        "have been given to Daedalus as a reward for the completion of the Labyrinth, which all modern augments are a descendant of. ",
+      stats:
+        "This augmentation increases the stasis link limit by one, and raises charisma xp by 20% and defense by 30%.",
+      charisma_exp: 1.2,
+      defense: 1.3,
+      isSpecial: true,
+      prereqs: [AugmentationName.TheHammer],
+      factions: [],
+    },
     [AugmentationName.TheLaw]: {
       repCost: 1e4,
       moneyCost: 1e6,

--- a/src/Augmentation/Enums.ts
+++ b/src/Augmentation/Enums.ts
@@ -130,6 +130,7 @@ export enum AugmentationName {
   // Darknet lab augs (in order of acquisition)
   TheBrokenWings = "The W1ngs of Icarus",
   TheBoots = "The B00ts of Perseus",
+  TheStaff = "The St4ff of Asclepius",
   TheHammer = "The H4mmer of Daedalus",
   TheLaw = "The L4w of Bayes",
   TheSword = "The B1ade of Solomonoff",

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -305,7 +305,7 @@ export const restartServer = (server: DarknetServer): void => {
   killServerScripts(server, "Server restarted.");
   const serverState = getServerState(server.hostname);
   serverState.authenticatedPIDs = [];
-  serverState.serverLogs = [{ pid: -1, message: "Server restarted." }];
+  serverState.serverLogs = [{ pid: -1, message: "Server restarting, terminating scripts..." }];
   server.backdoorInstalled = false;
   disconnectServer(server);
   addGuaranteedConnection(server);

--- a/src/DarkNet/effects/cacheFiles.ts
+++ b/src/DarkNet/effects/cacheFiles.ts
@@ -67,7 +67,10 @@ export const getCCTReward = (difficulty: number): string => {
     return getMoneyReward(difficulty);
   }
 
-  const contractCount = [1, 1, 2][Math.floor(Math.random() * 3)];
+  const contractCount = Math.floor(Math.min(20, difficulty) * 0.2 - 1.5 + Math.random() * 3);
+  if (contractCount <= 0) {
+    return getMoneyReward(difficulty);
+  }
   tryGeneratingRandomContract(contractCount);
   return `New coding contracts are now available on the network!`;
 };

--- a/src/DarkNet/effects/cacheFiles.ts
+++ b/src/DarkNet/effects/cacheFiles.ts
@@ -62,8 +62,12 @@ export const getRewardFromCache = (server: DarknetServer, cacheName: string, sup
   };
 };
 
-export const getCCTReward = (): string => {
-  const contractCount = [2, 3, 4][Math.floor(Math.random() * 3)];
+export const getCCTReward = (difficulty: number): string => {
+  if (Math.random() < difficulty * 0.2) {
+    return getMoneyReward(difficulty);
+  }
+
+  const contractCount = [1, 1, 2][Math.floor(Math.random() * 3)];
   tryGeneratingRandomContract(contractCount);
   return `New coding contracts are now available on the network!`;
 };

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -41,12 +41,11 @@ export const handleSuccessfulAuth = (server: DarknetServer, threads: number, pid
   server.hasAdminRights = true;
   addClue(server);
 
-  // TODO: balance coding contract chance
-  if (Math.random() < 0.1 && server.difficulty > 2) {
+  const cctChance = Math.min(0.1, 0.02 * (server.difficulty - 1));
+  if (Math.random() < cctChance) {
     generateContract({ server: server.hostname });
   }
 
-  // TODO: balance cache chance
   const chance = 0.1 * 1.05 ** server?.difficulty;
   if (Math.random() < chance && !isLabyrinthServer(server.hostname)) {
     addCacheToServer(server);
@@ -231,7 +230,8 @@ export const scaleDarknetVolatilityIncreases = (scalar: number) => {
 export const getStasisLinkLimit = (): number => {
   const brokenWingLimitIncrease = Player.hasAugmentation(AugmentationName.TheBrokenWings) ? 1 : 0;
   const hammerLimitIncrease = Player.hasAugmentation(AugmentationName.TheHammer) ? 1 : 0;
-  return 1 + brokenWingLimitIncrease + hammerLimitIncrease;
+  const staffLimitIncrease = Player.hasAugmentation(AugmentationName.TheStaff) ? 1 : 0;
+  return 1 + brokenWingLimitIncrease + hammerLimitIncrease + staffLimitIncrease;
 };
 
 export const getSetStasisLinkDuration = (): number => {

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -41,7 +41,7 @@ export const handleSuccessfulAuth = (server: DarknetServer, threads: number, pid
   server.hasAdminRights = true;
   addClue(server);
 
-  const cctChance = Math.min(0.1, 0.02 * (server.difficulty - 1));
+  const cctChance = Math.min(0.12, 0.02 * (server.difficulty - 1));
   if (Math.random() < cctChance) {
     generateContract({ server: server.hostname });
   }

--- a/src/DarkNet/effects/labyrinth.ts
+++ b/src/DarkNet/effects/labyrinth.ts
@@ -69,23 +69,31 @@ export const labData: Record<string, LabDetails> = {
   [SpecialServers.EternalLab]: {
     name: SpecialServers.EternalLab,
     depth: 29,
-    cha: 2800,
+    cha: 3000,
+    mazeWidth: 60,
+    mazeHeight: 40,
+    manual: false,
+  },
+  [SpecialServers.EndlessLab]: {
+    name: SpecialServers.EndlessLab,
+    depth: 31,
+    cha: 3500,
     mazeWidth: 60,
     mazeHeight: 40,
     manual: false,
   },
   [SpecialServers.FinalLab]: {
     name: SpecialServers.FinalLab,
-    depth: 31,
-    cha: 3200,
+    depth: 36,
+    cha: 4000,
     mazeWidth: 60,
     mazeHeight: 40,
     manual: false,
   },
   [SpecialServers.BonusLab]: {
     name: SpecialServers.BonusLab,
-    depth: 31,
-    cha: 3200,
+    depth: 36,
+    cha: 4000,
     mazeWidth: 60,
     mazeHeight: 40,
     manual: false,
@@ -373,6 +381,7 @@ export const getLabAugReward = (): AugmentationName => {
     AugmentationName.TheBrokenWings,
     AugmentationName.TheBoots,
     AugmentationName.TheHammer,
+    AugmentationName.TheStaff,
     AugmentationName.TheLaw,
     AugmentationName.TheSword,
   ];
@@ -409,12 +418,15 @@ const getCurrentLabName = () => {
   if (!hasAugment(AugmentationName.TheHammer)) {
     return SpecialServers.MercilessLab;
   }
+  if (!hasAugment(AugmentationName.TheStaff)) {
+    return SpecialServers.UberLab;
+  }
   if (Player.bitNodeN === 15) {
     if (!hasAugment(AugmentationName.TheRedPill)) {
-      return SpecialServers.UberLab;
+      return SpecialServers.EternalLab;
     }
     if (!hasAugment(AugmentationName.TheLaw)) {
-      return SpecialServers.EternalLab;
+      return SpecialServers.EndlessLab;
     }
     if (!hasAugment(AugmentationName.TheSword)) {
       return SpecialServers.FinalLab;
@@ -423,10 +435,10 @@ const getCurrentLabName = () => {
   }
 
   if (!hasAugment(AugmentationName.TheLaw)) {
-    return SpecialServers.UberLab;
+    return SpecialServers.EternalLab;
   }
   if (!hasAugment(AugmentationName.TheSword)) {
-    return SpecialServers.EternalLab;
+    return SpecialServers.EndlessLab;
   }
   if (allowTRP && !hasAugment(AugmentationName.TheRedPill)) {
     return SpecialServers.FinalLab;

--- a/src/DarkNet/effects/phishing.ts
+++ b/src/DarkNet/effects/phishing.ts
@@ -36,11 +36,13 @@ export const handlePhishingAttack = (ctx: NetscriptContext, server: DarknetServe
   } else if (Math.random() < moneyRewardChance) {
     const randomFactor = Math.random() * 0.3 + 0.9;
     const bonusTimeFactor = hasDarknetBonusTime() ? 1.3 : 1;
+    const depthFactor = 0.1 + server.depth * 0.05;
     const moneyReward =
-      1e4 *
+      2000 *
       Player.mults.crime_money *
+      depthFactor *
       threads *
-      ((50 + Player.skills.charisma) / 50) *
+      ((200 + Player.skills.charisma) / 200) *
       bonusTimeFactor *
       randomFactor *
       currentNodeMults.DarknetMoneyMultiplier;

--- a/src/Server/data/SpecialServers.ts
+++ b/src/Server/data/SpecialServers.ts
@@ -15,6 +15,7 @@ export const SpecialServers = {
   MercilessLab: "m3rc1l3ss_l4byr1nth",
   UberLab: "ub3r_l4byr1nth",
   EternalLab: "et3rn4l_l4byr1nth",
+  EndlessLab: "end13ss_l4byr1nth",
   FinalLab: "f1n4l_l4byr1nth",
   BonusLab: "b0nus_l4byr1nth",
 } as const;

--- a/test/jest/Darknet/Labyrinth.test.ts
+++ b/test/jest/Darknet/Labyrinth.test.ts
@@ -33,6 +33,7 @@ const setupBN15Environment = (labAugCount: number) => {
     AugmentationName.TheBrokenWings,
     AugmentationName.TheBoots,
     AugmentationName.TheHammer,
+    AugmentationName.TheStaff,
     AugmentationName.TheRedPill,
     AugmentationName.TheLaw,
     AugmentationName.TheSword,
@@ -54,6 +55,7 @@ const setupNonBN15Environment = (labAugCount: number, hasSf15 = false, allowTRPI
     AugmentationName.TheBrokenWings,
     AugmentationName.TheBoots,
     AugmentationName.TheHammer,
+    AugmentationName.TheStaff,
     AugmentationName.TheLaw,
     AugmentationName.TheSword,
     AugmentationName.TheRedPill,
@@ -200,7 +202,7 @@ describe("Labyrinth Tests", () => {
       expect(labDetails.name).toEqual(SpecialServers.UberLab);
       expect(labDetails.lab?.hostname).toEqual(SpecialServers.UberLab);
       expect(labDetails.lab?.requiredCharismaSkill).toEqual(labData[SpecialServers.UberLab].cha);
-      expect(getLabAugReward()).toEqual(AugmentationName.TheLaw);
+      expect(getLabAugReward()).toEqual(AugmentationName.TheStaff);
     });
     it("should attach eternal lab if the player has SF15 access and uber lab aug", () => {
       setupNonBN15Environment(4, true);
@@ -209,10 +211,19 @@ describe("Labyrinth Tests", () => {
       expect(labDetails.name).toEqual(SpecialServers.EternalLab);
       expect(labDetails.lab?.hostname).toEqual(SpecialServers.EternalLab);
       expect(labDetails.lab?.requiredCharismaSkill).toEqual(labData[SpecialServers.EternalLab].cha);
+      expect(getLabAugReward()).toEqual(AugmentationName.TheLaw);
+    });
+    it("should attach endless lab if the player has SF15 access and endless lab aug", () => {
+      setupNonBN15Environment(5, true);
+      const labDetails = getLabyrinthDetails();
+
+      expect(labDetails.name).toEqual(SpecialServers.EndlessLab);
+      expect(labDetails.lab?.hostname).toEqual(SpecialServers.EndlessLab);
+      expect(labDetails.lab?.requiredCharismaSkill).toEqual(labData[SpecialServers.EndlessLab].cha);
       expect(getLabAugReward()).toEqual(AugmentationName.TheSword);
     });
     it("should attach bonus lab, but not offer TRP, if the player has SF15 access and eternal lab aug, but the bitnode disables TRP in lab", () => {
-      setupNonBN15Environment(5, true, false);
+      setupNonBN15Environment(6, true, false);
       const labDetails = getLabyrinthDetails();
 
       expect(labDetails.name).toEqual(SpecialServers.BonusLab);
@@ -221,7 +232,7 @@ describe("Labyrinth Tests", () => {
       expect(getLabAugReward()).toEqual(AugmentationName.NeuroFluxGovernor);
     });
     it("should attach bonus lab if the player has SF15 access and final lab aug", () => {
-      setupNonBN15Environment(5, true, true);
+      setupNonBN15Environment(6, true, true);
       const labDetails = getLabyrinthDetails();
 
       expect(labDetails.name).toEqual(SpecialServers.FinalLab);
@@ -230,7 +241,7 @@ describe("Labyrinth Tests", () => {
       expect(getLabAugReward()).toEqual(AugmentationName.TheRedPill);
     });
     it("should attach bonus lab if the player has SF15 access and final lab aug", () => {
-      setupNonBN15Environment(6, true, true);
+      setupNonBN15Environment(7, true, true);
       const labDetails = getLabyrinthDetails();
 
       expect(labDetails.name).toEqual(SpecialServers.BonusLab);
@@ -275,7 +286,7 @@ describe("Labyrinth Tests", () => {
       expect(labDetails.name).toEqual(SpecialServers.UberLab);
       expect(labDetails.lab?.hostname).toEqual(SpecialServers.UberLab);
       expect(labDetails.lab?.requiredCharismaSkill).toEqual(labData[SpecialServers.UberLab].cha);
-      expect(getLabAugReward()).toEqual(AugmentationName.TheRedPill);
+      expect(getLabAugReward()).toEqual(AugmentationName.TheStaff);
     });
     it("should attach eternal lab if the player has SF15 access and uber lab aug", () => {
       setupBN15Environment(4);
@@ -284,10 +295,19 @@ describe("Labyrinth Tests", () => {
       expect(labDetails.name).toEqual(SpecialServers.EternalLab);
       expect(labDetails.lab?.hostname).toEqual(SpecialServers.EternalLab);
       expect(labDetails.lab?.requiredCharismaSkill).toEqual(labData[SpecialServers.EternalLab].cha);
+      expect(getLabAugReward()).toEqual(AugmentationName.TheRedPill);
+    });
+    it("should attach endless lab if the player has SF15 access and endless lab aug", () => {
+      setupBN15Environment(5);
+      const labDetails = getLabyrinthDetails();
+
+      expect(labDetails.name).toEqual(SpecialServers.EndlessLab);
+      expect(labDetails.lab?.hostname).toEqual(SpecialServers.EndlessLab);
+      expect(labDetails.lab?.requiredCharismaSkill).toEqual(labData[SpecialServers.EndlessLab].cha);
       expect(getLabAugReward()).toEqual(AugmentationName.TheLaw);
     });
     it("should attach final lab if the player has SF15 access and eternal lab aug", () => {
-      setupBN15Environment(5);
+      setupBN15Environment(6);
       const labDetails = getLabyrinthDetails();
 
       expect(labDetails.name).toEqual(SpecialServers.FinalLab);
@@ -296,7 +316,7 @@ describe("Labyrinth Tests", () => {
       expect(getLabAugReward()).toEqual(AugmentationName.TheSword);
     });
     it("should attach bonus lab if the player has SF15 access and final lab aug", () => {
-      setupBN15Environment(6);
+      setupBN15Environment(7);
       const labDetails = getLabyrinthDetails();
 
       expect(labDetails.name).toEqual(SpecialServers.BonusLab);


### PR DESCRIPTION
- Reduce the base money from phishing attacks
- Reduce the money from phishing on lower-level servers

- Reduced the chance of .ccts spawning from authentication or from cache rewards on low-level servers

- Add another lab to the chain, requiring 5 total labs & installs on BN15, and 7 on other nodes
- Increased the cha requirement of the TRP lab on BN15 to 3000, and the final one (for TRP outside of BN15) to 4000

These can all be adjusted further as needed.