### PR TITLE
UI: Show errors if using nano/vim with patterns that do not match any files

### DIFF
--- a/src/Terminal/commands/common/editor.ts
+++ b/src/Terminal/commands/common/editor.ts
@@ -46,7 +46,12 @@ export function commonEditor(
 
     // Glob of existing files
     if (pattern.includes("*") || pattern.includes("?")) {
-      for (const [path, file] of getGlobbedFileMap(pattern, server, Terminal.currDir)) {
+      const globbedFileMap = getGlobbedFileMap(pattern, server, Terminal.currDir);
+      if (globbedFileMap.size === 0) {
+        Terminal.error(`No files matching ${pattern}`);
+        return;
+      }
+      for (const [path, file] of globbedFileMap) {
         if (isLegacyScript(path)) {
           hasLegacyScript = true;
         }


### PR DESCRIPTION
When using nano/vim with patterns that do not match any files, we open the editor without any files. This may be confusing, especially when the player does not know what "glob" means.

There is a small behavior change here. When a pattern does not match any files, now we print an error and exit immediately. For example, `nano a*.js bar.js` does not open `bar.js`. This is consistent with the non-glob cases (e.g., `nano foo".js bar.js` also does not open `bar.js`).

<img width="261" height="232" alt="Capture" src="https://github.com/user-attachments/assets/d4fad13b-cc80-48fd-8557-39da5ff6f1a6" />
