### PR TITLE
UI: Tweak CSS/Position of Darknet Docs link

### DIFF
--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -318,7 +318,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
           <ZoomOut />
         </Button>
       </div>
-      <Box className={`${classes.inlineFlexBox}`}>
+      <Box className={`${classes.inlineFlexBox}`} style={{ justifyContent: "flex-start", gap: "10px" }}>
         <Typography component="div" display="flex">
           <Typography display="flex" alignItems="center" paddingRight="1em">
             {searchLabel}
@@ -339,8 +339,8 @@ export function NetworkDisplayWrapper(): React.ReactElement {
           style={{
             ...DWServerLogStyles,
             fontSize: "18px",
-            padding: "2px 20px",
-            backgroundColor: Settings.theme.button,
+            padding: "2px 15px",
+            backgroundColor: Settings.theme.well,
           }}
         >
           Darknet Docs


### PR DESCRIPTION
Per Discord discussion, the lower left seems to be more visible.

Old: <img width="1822" height="908" alt="image" src="https://github.com/user-attachments/assets/4f8d1480-d233-47ae-af79-b97b4e8fb90a" />
New: <img width="1812" height="873" alt="image" src="https://github.com/user-attachments/assets/7092d302-036d-49d2-8edd-f3bd5b1f3b82" />