### PR TITLE
DOCUMENTATION: Use relative links instead of absolute links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ already been reported as an [Issue](https://github.com/bitburner-official/bitbur
 ## As a Developer
 
 Anyone is welcome to contribute to Bitburner code. However, please read
-the [license](https://github.com/bitburner-official/bitburner-src/blob/dev/license.txt)
-and the [readme](https://github.com/bitburner-official/bitburner-src/blob/dev/README.md)
+the [license](./license.txt)
+and the [readme](./README.md)
 before doing so.
 
 To contribute to Bitburner code, you will need to have

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ See the [frequently asked questions](/src/Documentation/doc/en/help/faq.md) for 
 
 There are 2 types of documentation:
 
-- In-game documentation: It can be found in the Documentation tab. This is the best place to get up-to-date information. You can also read the web version at https://github.com/bitburner-official/bitburner-src/blob/stable/src/Documentation/doc/index.md.
-- NS API documentation: It's generated from the [TypeScript definitions](./src/ScriptEditor/NetscriptDefinitions.d.ts). You can read it at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.md.
+- In-game documentation: It can be found in the Documentation tab. This is the best place to get up-to-date information. You can also read the web version at [Documentation](./src/Documentation/doc/en/index.md).
+- NS API documentation: It's generated from the [TypeScript definitions](./src/ScriptEditor/NetscriptDefinitions.d.ts). You can read it at [API Documentation](./markdown/bitburner.md).
 
 Anyone is welcome to contribute to the documentation by editing the [source
 files](/src/Documentation/doc/en) and then making a pull request with your contributions.

--- a/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
+++ b/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
@@ -32,12 +32,12 @@ Because of all the benefits this [BitNode](bitnodes.md) provides, it's definitel
 
 ## Depends on your priorities
 
-BN4 gives access to the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.singularity.md).
+BN4 gives access to the [Singularity API](../../../../../markdown/bitburner.singularity.md).
 This mechanic allows the automation of many actions directly affecting the player.
 If this appeals to you then you should prioritize this BitNode.
-Due to the [RAM](../basic/ram.md) cost, it's strongly recommended to complete BN4.3 before using the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.singularity.md) in other [BitNodes](bitnodes.md).
+Due to the [RAM](../basic/ram.md) cost, it's strongly recommended to complete BN4.3 before using the Singularity API in other [BitNodes](bitnodes.md).
 
-BN6 introduces the [Bladeburner](bladeburners.md) mechanic and its corresponding [Bladeburner API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.bladeburner.md).
+BN6 introduces the [Bladeburner](bladeburners.md) mechanic and its corresponding [Bladeburner API](../../../../../markdown/bitburner.bladeburner.md).
 Bladeburner is an alternative method to beat BitNodes which doesn't rely on money or hacking skill.
 [Sleeves](sleeves.md) help complete BN6 more quickly since they can share some Bladeburner tasks with the player but aren't a requirement.
 
@@ -70,7 +70,7 @@ It provides a variety of useful bonuses.
 
 ## Save these for later
 
-BN7 used to give access to the [Bladeburner API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.bladeburner.md), but now it doesn't.
+BN7 used to give access to the Bladeburner API, but now it doesn't.
 Because of that change this [BitNode](bitnodes.md) is relatively low priority and should definitely happen after BN6.
 The benefit for completing BN7.3 is an aug that lets the player perform [Bladeburner](bladeburners.md) and non-Bladeburner actions at the same time.
 

--- a/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
+++ b/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
@@ -70,7 +70,7 @@ It provides a variety of useful bonuses.
 
 ## Save these for later
 
-BN7 used to give access to the Bladeburner API, but now it doesn't.
+BN7 used to give access to the [Bladeburner API](../../../../../markdown/bitburner.bladeburner.md), but now it doesn't.
 Because of that change this [BitNode](bitnodes.md) is relatively low priority and should definitely happen after BN6.
 The benefit for completing BN7.3 is an aug that lets the player perform [Bladeburner](bladeburners.md) and non-Bladeburner actions at the same time.
 

--- a/src/Documentation/doc/en/advanced/bitnodes.md
+++ b/src/Documentation/doc/en/advanced/bitnodes.md
@@ -24,7 +24,7 @@ In this BitNode, most forms of income such as working at a [Company](../basic/co
 [Servers](../basic/servers.md) have less money on them and lowered growth rates, but it is easier to lower their security level using the `weaken` function.
 
 Furthermore, some BitNodes introduce new content and mechanics.
-For example, there is one BitNode that grants access to the [Singularity API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.singularity.md).
+For example, there is one BitNode that grants access to the [Singularity API](../../../../../markdown/bitburner.singularity.md).
 There is another BitNode in which you can manage a [Gang](gang.md) to earn money and [Reputation](../basic/reputation.md).
 
 ## How to destroy a BitNode

--- a/src/Documentation/doc/en/basic/augmentations.md
+++ b/src/Documentation/doc/en/basic/augmentations.md
@@ -46,7 +46,7 @@ Here is everything you will **KEEP** when you install an Augmentation:
 - Every Augmentation you have previously installed
 - [Scripts](scripts.md) on your home computer
 - [RAM](ram.md) / Core Upgrades on your home computer
-- [World Stock Exchange account](stockmarket.md) and [TIX API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.tix.md) Access
+- [World Stock Exchange account](stockmarket.md) and [TIX API](../../../../../markdown/bitburner.stock.md) Access
 
 ## Purchasing Multiple Augmentations
 

--- a/src/Documentation/doc/en/basic/autocomplete.md
+++ b/src/Documentation/doc/en/basic/autocomplete.md
@@ -29,7 +29,7 @@ Running this script from the terminal like `run script.js` or `./script.js` and 
 
 ## AutocompleteData
 
-To make this feature more useful, an [AutocompleteData](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.autocompletedata.md) object is provided to the autocomplete function that holds information commonly passed as arguments to scripts, such as server names and filenames.
+To make this feature more useful, an [AutocompleteData](../../../../../markdown/bitburner.autocompletedata.md) object is provided to the autocomplete function that holds information commonly passed as arguments to scripts, such as server names and filenames.
 
 AutocompleteData is an object with the following properties;
 

--- a/src/Documentation/doc/en/basic/codingcontracts.md
+++ b/src/Documentation/doc/en/basic/codingcontracts.md
@@ -3,7 +3,7 @@
 Coding Contracts are a mechanic that lets players earn rewards in exchange for solving programming problems.
 
 Coding Contracts are files with the `.cct` extension.
-They can be accessed through the [Terminal](terminal.md) or through [Scripts](scripts.md) using the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).
+They can be accessed through the [Terminal](terminal.md) or through [Scripts](scripts.md) using the [Coding Contract API](../../../../../markdown/bitburner.codingcontract.md).
 
 Each contract has a limited number of attempts.
 If you provide the wrong answer too many times and exceed the number of attempts, the contract will self destruct (delete itself).
@@ -22,21 +22,21 @@ The popup will display the contract's problem, the number of attempts remaining,
 
 ## Interacting through Scripts
 
-See the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).
+See the [Coding Contract API](../../../../../markdown/bitburner.codingcontract.md).
 Interacting with Coding Contracts via the [Terminal](terminal.md) can be tedious the more contracts you solve.
-Consider using the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) to automate various aspects of your solution.
+Consider using the APIs to automate various aspects of your solution.
 For example, some contracts have long solutions while others have even longer solutions.
-You might want to use the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) to automate the process of submitting your solution rather than copy and paste a long solution into an answer box.
-The [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) can also be used to find out useful information about a contract including the number of attempts you have left, the type of contract and its difficulty.
-It can also be used to test your algorithm for a specific contract type by [spawning dummy contracts](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.createdummycontract.md).
+You might want to use the APIs to automate the process of submitting your solution rather than copy and paste a long solution into an answer box.
+The APIs can also be used to find out useful information about a contract including the number of attempts you have left, the type of contract and its difficulty.
+It can also be used to test your algorithm for a specific contract type by [spawning dummy contracts](../../../../../markdown/bitburner.codingcontract.createdummycontract.md).
 
-However, using the [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) comes at a cost.
-Like most functions in other APIs, almost all of the functions in the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) have a RAM cost.
+However, using the APIs comes at a cost.
+Like most functions in other APIs, almost all of the functions in the APIs have a RAM cost.
 
-Depending on which function you use, the initial [RAM](ram.md) on your home server might not be enough to allow you to use various [API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md) functions.
-Plan on upgrading the [RAM](ram.md) on your home server if you want to use the [Coding Contract API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.md).
+Depending on which function you use, the initial [RAM](ram.md) on your home server might not be enough to allow you to use various API functions.
+Plan on upgrading the [RAM](ram.md) on your home server if you want to use the APIs.
 
-The [`getContractTypes`](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.codingcontract.getcontracttypes.md) function is free, and returns a list of all of the contract types currently in the game.
+The [`getContractTypes`](../../../../../markdown/bitburner.codingcontract.getcontracttypes.md) function is free, and returns a list of all of the contract types currently in the game.
 
 ## Submitting Solutions
 

--- a/src/Documentation/doc/en/basic/scripts.md
+++ b/src/Documentation/doc/en/basic/scripts.md
@@ -47,7 +47,7 @@ For details on references in terminal commands, see [Terminal](terminal.md).
 
 ## Script Arguments
 
-When running a script, you can use [flags](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.flags.md) and [arguments](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.args.md), which the script's logic can access and act on, allowing flexibility in your script designs. For example allowing you to get different results or attack different targets without re-writing your code:
+When running a script, you can use [flags](../../../../../markdown/bitburner.ns.flags.md) and [arguments](../../../../../markdown/bitburner.ns.args.md), which the script's logic can access and act on, allowing flexibility in your script designs. For example allowing you to get different results or attack different targets without re-writing your code:
 
     $ run hack.js "harakiri-sushi"
     $ run hack.js "silver-helix"
@@ -60,7 +60,7 @@ For example, if a script run with 1 thread is able to hack \$10,000, then runnin
 
 [Note -- Scripts will not actually become multithreaded in the real-world sense - Javascript is a "single-threaded" coding language.]
 
-When "multithreading" a script, the total [RAM](ram.md) cost can be calculated by simply multiplying the [RAM](ram.md) cost of a single instance of your script by the number of threads you will use. [See [`ns.getScriptRam()`](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.getscriptram.md) or the `mem` terminal command detailed below]
+When "multithreading" a script, the total [RAM](ram.md) cost can be calculated by simply multiplying the [RAM](ram.md) cost of a single instance of your script by the number of threads you will use. [See [`ns.getScriptRam()`](../../../../../markdown/bitburner.ns.getscriptram.md) or the `mem` terminal command detailed below]
 
 ## Never-ending scripts
 

--- a/src/Documentation/doc/en/basic/servers.md
+++ b/src/Documentation/doc/en/basic/servers.md
@@ -41,7 +41,7 @@ The player's home computer is special for a variety of reasons:
   (you will, however, lose programs and messages on your home computer).
 
 The player can also purchase access to additional cloud servers for their use. These are virtual machines hosted remotely that the player has access to.
-This can be done by visiting certain locations in the [World](world.md), or it can be done automatically through a script using the `purchaseServer` function in the [Cloud API](<(https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.cloud.md)>).
+This can be done by visiting certain locations in the [World](world.md), or it can be done automatically through a script using the `purchaseServer` function in the [Cloud API](../../../../../markdown/bitburner.cloud.md).
 The advantage of cloud servers is that, in terms of [RAM](ram.md), they are cheaper than upgrading your home computer.
 The disadvantage is that access to your cloud servers is lost when you install [Augmentations](augmentations.md), and you will need to purchase access again.
 

--- a/src/Documentation/doc/en/basic/stockmarket.md
+++ b/src/Documentation/doc/en/basic/stockmarket.md
@@ -157,7 +157,7 @@ The potency of this effect is based on how effective you are when you work (i.e.
 ## Automating the Stock Market
 
 You can write scripts to perform automatic and algorithmic trading on the Stock Market.
-See [TIX API](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.tix.md) for more details.
+See [Stock API](../../../../../markdown/bitburner.stock.md) for more details.
 
 ## Under the Hood
 

--- a/src/Documentation/doc/en/changelog-v1.md
+++ b/src/Documentation/doc/en/changelog-v1.md
@@ -553,10 +553,7 @@ Stanek Gift
 
 ** Documentation **
 
-- The new documentation for the netscript API is available at
-  https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md
-  This documentation is used in-game to validate the code, in-editor to autocomplete, and
-  for users to reference. This is a huge quality of life improvements for me.
+- The new documentation for the netscript API is available [here](../../../../markdown/bitburner.ns.md). This documentation is used in-game to validate the code, in-editor to autocomplete, and for users to reference. This is a huge quality of life improvements for me.
 
 ** Reputation **
 

--- a/src/Documentation/doc/en/changelog-v2.md
+++ b/src/Documentation/doc/en/changelog-v2.md
@@ -526,7 +526,7 @@
 - (Corporation) Add a missing check on exportMaterial (@catloversg)
 - (Corporation) Add ns.corporation.sellDivision (@catloversg)
 - (Formulas) Add ns.formulas.hacking.growAmount (@d0sboots)
-- (Go) Some changes to the Go API, including some minor breaking changes. Please refer to the API documentation in the script editor or at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.go.md (@ficocelliguy)
+- (Go) Some changes to the Go API, including some minor breaking changes. Please refer to the [IPvGO API documentation](../../../../markdown/bitburner.go.md) (@ficocelliguy)
 - (Go) Added ns.go.analysis.getStats (@ficocelliguy)
 - (Go) Fix a bug that allowed facing secret opponent early or with wrong board size (@ficoccelliguy)
 - (Infiltration) More information is provided on ns.infiltration.getInfiltration (@catloversg)
@@ -1176,8 +1176,8 @@ GRAFTING:
 DOCUMENTATION
 
 - Many documentation updates (@Mughur, @d0sboots, @Snarling, @teauxfu).
-- Official non-markdown docs are at https://github.com/bitburner-official/bitburner-src/tree/dev/src/Documentation/doc
-- Official dev version markdown docs are at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md
+- Official dev version non-markdown docs are at https://github.com/bitburner-official/bitburner-src/tree/dev/src/Documentation/doc/en
+- Official dev version markdown docs are at https://github.com/bitburner-official/bitburner-src/blob/dev/markdown/bitburner.ns.md
 - Official stable version markdown docs are at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md
 - Dev version documentation is now kept up to date as changes are made. (@Snarling)
 
@@ -1202,7 +1202,7 @@ Hotfix / bugfix:
 - Fixed an issue with sleeve HP calculation
 - Possible fix for MathJax "Typesetting Failed" errors
 - There was an issue with Corporations decaying their employees to 0 stats, even though the minimum was supposed to be 5. Moved the variable storing the min decay value to corporation constants, and raised it to 10.
-- Regenerated documentation at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md due to corporation changes related to min decay stats.
+- Regenerated [documentation](../../../../markdown/bitburner.ns.md) due to corporation changes related to min decay stats.
 - Faction XP was unintentionally providing 20x the experience gain as it did prior to v2.0. This caused faction work to exceed gym/university as the optimal way to gain experience. Values have been reduced to only about 2x what they were prior to v2.0, and they are no longer better than gym/university.
 - Fixed an issue where the overview skill bars could be displayed inaccurately based on player multipliers.
 

--- a/src/Documentation/doc/en/help/getting_started.md
+++ b/src/Documentation/doc/en/help/getting_started.md
@@ -348,7 +348,7 @@ Next, we're going to create a [Script](../basic/scripts.md) that automatically p
 These cloud [Servers](../basic/servers.md) will be used to run many [Scripts](../basic/scripts.md).
 Running this [Script](../basic/scripts.md) will initially be very expensive since purchasing a cloud [Server](../basic/servers.md) costs money, but it will pay off in the long run.
 
-In order to create this [Script](../basic/scripts.md), you should familiarize yourself with the following functions, some of which are in the [Cloud API](<(https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.cloud.md)>):
+In order to create this [Script](../basic/scripts.md), you should familiarize yourself with the following functions, some of which are in the [Cloud API](../../../../../markdown/bitburner.cloud.md):
 
 - `cloud.purchaseServer()`
 - `cloud.getServerCost()`

--- a/src/Documentation/doc/en/index.md
+++ b/src/Documentation/doc/en/index.md
@@ -47,7 +47,7 @@
 
 ## Resources
 
-- [NS API documentation](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md)
+- [NS API documentation](../../../../markdown/bitburner.ns.md)
 - [Learn to program](programming/learn.md)
 - [Remote API](programming/remote_api.md)
 - [Game frozen or stuck?](programming/game_frozen.md)

--- a/src/Documentation/doc/en/programming/game_frozen.md
+++ b/src/Documentation/doc/en/programming/game_frozen.md
@@ -58,4 +58,4 @@ To prevent this from happening make sure to multithread the scripts as much as p
 ## Bug
 
 Otherwise, the game is probably frozen/stuck due to a bug.
-To report a bug, follow the guidelines [here](https://github.com/bitburner-official/bitburner-src/blob/stable/CONTRIBUTING.md#reporting-bugs).
+To report a bug, follow the guidelines [here](../../../../../CONTRIBUTING.md#reporting-bugs).

--- a/src/Documentation/doc/en/programming/go_algorithms.md
+++ b/src/Documentation/doc/en/programming/go_algorithms.md
@@ -4,7 +4,7 @@ IPvGO is a strategic territory control minigame accessible from DefComm in New T
 
 For basic instructions, go to DefComm or CIA to access the current subnet, and look through the "How to Play" section. This document is specifically focused on building scripts to automate subnet takeover, which will be more applicable you have played a few subnets.
 
-For a full list of all IpvGO methods and their descriptions and documentation, you can use the game's [API documentation page](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.go.md).
+For a full list of all IPvGO methods and their descriptions and documentation, you can use the game's [IPvGO API documentation page](../../../../../markdown/bitburner.go.md).
 
 &nbsp;
 

--- a/src/Documentation/doc/en/programming/hackingalgorithms.md
+++ b/src/Documentation/doc/en/programming/hackingalgorithms.md
@@ -111,7 +111,7 @@ This means we must implement a delay into the scripts.
 
 In older versions of the game, this required using `sleep` or `asleep` functions, which have a RAM cost of zero.
 However, due to JavaScript limitations, the delay duration is not millisecond-precise and can cause the functions to finish out of order.
-Instead, the hack, grow and weaken functions have a special [option](https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.basichgwoptions.md) called `additionalMsec` that allows more precise delays.
+Instead, the hack, grow and weaken functions have a special [option](../../../../../markdown/bitburner.basichgwoptions.md) called `additionalMsec` that allows more precise delays.
 
 As well as the run time for each function, we also need information on the impact of a hack, grow or weaken thread on the target's security and/or money to optimise the thread ratios between the functions.
 This information can come from `formulas.exe` and use of the `getPlayer` and `getServer` functions, but cheaper functions such as `hackAnalyze`, `hackAnalyzeSecurity`, `getHackTime`, `growthAnalyze` and `growthAnalyzeSecurity` can still be used.

--- a/src/ui/MD/a.tsx
+++ b/src/ui/MD/a.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "@mui/material";
-import { defaultNsApiPage, externalUrlOfNsApiPage, useNavigator } from "../React/Documentation";
+import { relativeUrlOfNsApiPage, useNavigator } from "../React/Documentation";
 import { CorruptibleText } from "../React/CorruptibleText";
 import { Player } from "@player";
 import { Settings } from "../../Settings/Settings";
@@ -10,26 +10,6 @@ export const isSpoiler = (title: string): boolean => title.includes("advanced/")
 export const A = (props: React.PropsWithChildren<{ href?: string }>): React.ReactElement => {
   const navigator = useNavigator();
   const href = props.href ?? "";
-
-  const onClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    navigator.navigate(href, event.ctrlKey);
-  };
-  if (href === externalUrlOfNsApiPage) {
-    return (
-      <Link
-        onClick={(event) => {
-          navigator.navigate(defaultNsApiPage, event.ctrlKey);
-        }}
-        color={Settings.theme.info}
-        sx={{
-          textDecorationThickness: "3px",
-          textUnderlineOffset: "5px",
-        }}
-      >
-        {props.children}
-      </Link>
-    );
-  }
 
   if (isSpoiler(href)) {
     return (
@@ -43,8 +23,19 @@ export const A = (props: React.PropsWithChildren<{ href?: string }>): React.Reac
       </span>
     );
   }
+
+  const onClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    navigator.navigate(href, event.ctrlKey);
+  };
+  const sx = href.includes(relativeUrlOfNsApiPage)
+    ? {
+        textDecorationThickness: "3px",
+        textUnderlineOffset: "5px",
+        color: Settings.theme.info,
+      }
+    : {};
   return (
-    <Link onClick={onClick} component="button" variant="body1" fontSize="inherit">
+    <Link onClick={onClick} component="button" variant="body1" fontSize="inherit" sx={sx}>
       {props.children}
     </Link>
   );

--- a/src/ui/MD/a.tsx
+++ b/src/ui/MD/a.tsx
@@ -27,13 +27,17 @@ export const A = (props: React.PropsWithChildren<{ href?: string }>): React.Reac
   const onClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     navigator.navigate(href, event.ctrlKey);
   };
-  const sx = href.includes(relativeUrlOfNsApiPage)
-    ? {
-        textDecorationThickness: "3px",
-        textUnderlineOffset: "5px",
-        color: Settings.theme.info,
-      }
-    : {};
+  // In the in-game doc viewer, links are highlighted with an underline, but the color is the same as the normal text.
+  // In order to improve the discoverability of NS API documentation and external links, we change the text color and
+  // make the underline stand out a bit more.
+  const sx =
+    href.includes(relativeUrlOfNsApiPage) || href.startsWith("https://") || href.startsWith("http://")
+      ? {
+          textDecorationThickness: "3px",
+          textUnderlineOffset: "5px",
+          color: Settings.theme.info,
+        }
+      : {};
   return (
     <Link onClick={onClick} component="button" variant="body1" fontSize="inherit" sx={sx}>
       {props.children}

--- a/src/ui/React/Documentation.tsx
+++ b/src/ui/React/Documentation.tsx
@@ -27,9 +27,7 @@ export const defaultNsApiPage = asFilePath("nsDoc/bitburner.ns.md");
  * If we move or rename "bitburner.ns.md", we must update this constant, "defaultNsApiPage", "openDocExternally", and
  * the URL in src/Documentation/doc/en/index.md.
  */
-export const externalUrlOfNsApiPage =
-  "https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md";
-export const prefixOfHttpUrlOfNsDocs = "https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/";
+export const relativeUrlOfNsApiPage = "../../../../markdown/bitburner.ns.md";
 
 const prefixOfRelativeUrlOfNSDoc = "../../../../markdown/bitburner.";
 
@@ -120,11 +118,7 @@ export function openDocExternally(path: string): void {
  * - Relative URL from NS docs to other NS docs (e.g., click the links in NS docs viewer): Open "./bitburner.ns.cloud.md" from "nsDoc/bitburner.ns.md"
  * - Internal NS docs (e.g., choose a dropdown option in DocumentationAutocomplete): nsDoc/bitburner.ns.md
  * - Internal non-NS docs: help/getting_started.md
- * - HTTP URL:
- *   - Point to NS docs. Some non-NS docs pages include links to NS docs. For example: basic/scripts.md has a
- * link to https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.flags.md. In
- * these cases, the link always points to a file at https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/
- *   - Point to other places.
+ * - HTTP URL: Point to other places.
  */
 export function convertNavigatorHref(
   href: string,
@@ -150,15 +144,8 @@ export function convertNavigatorHref(
     // Internal NS docs
     path = asFilePath(href);
   } else if (href.startsWith("https://") || href.startsWith("http://")) {
-    // TODO: Remove this case after converting all these links to relative links.
-    // HTTP URL pointing to NS docs.
-    // Convert https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.foo.md to nsDoc/bitburner.foo.md
-    if (href.startsWith(prefixOfHttpUrlOfNsDocs)) {
-      path = asFilePath(`nsDoc/${href.replace(prefixOfHttpUrlOfNsDocs, "")}`);
-    } else {
-      // HTTP URL pointing to other places.
-      return { path: href, forceOpenExternally: true };
-    }
+    // HTTP URL pointing to other places.
+    return { path: href, forceOpenExternally: true };
   } else {
     // Internal non-NS docs
     path = resolveFilePath("./" + href, currentPage);

--- a/src/ui/React/Documentation.tsx
+++ b/src/ui/React/Documentation.tsx
@@ -118,7 +118,7 @@ export function openDocExternally(path: string): void {
  * - Relative URL from NS docs to other NS docs (e.g., click the links in NS docs viewer): Open "./bitburner.ns.cloud.md" from "nsDoc/bitburner.ns.md"
  * - Internal NS docs (e.g., choose a dropdown option in DocumentationAutocomplete): nsDoc/bitburner.ns.md
  * - Internal non-NS docs: help/getting_started.md
- * - HTTP URL: Point to other places.
+ * - HTTP URL
  */
 export function convertNavigatorHref(
   href: string,
@@ -144,7 +144,11 @@ export function convertNavigatorHref(
     // Internal NS docs
     path = asFilePath(href);
   } else if (href.startsWith("https://") || href.startsWith("http://")) {
-    // HTTP URL pointing to other places.
+    // There are 2 types of HTTP URLs:
+    // - URL pointing to NS docs (e.g., https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.foo.md)
+    // - URL pointing to other places (e.g., https://github.com/bitburner-official/bitburner-src, MDN, other websites)
+    // Most URLs pointing to NS docs were converted to relative links. There are rare/historical usages of links
+    // pointing to our own docs that still use this format, and we're OK with them being external links.
     return { path: href, forceOpenExternally: true };
   } else {
     // Internal non-NS docs

--- a/test/jest/ui/DocumentationNavigator.test.ts
+++ b/test/jest/ui/DocumentationNavigator.test.ts
@@ -47,15 +47,7 @@ describe("convertNavigatorHref", () => {
       expect(forceOpenExternally).toStrictEqual(false);
     });
 
-    test("HTTP/HTTPS URL - Point to NS docs", () => {
-      const { path, forceOpenExternally } = convertNavigatorHref(
-        "https://github.com/bitburner-official/bitburner-src/blob/stable/markdown/bitburner.ns.md",
-        defaultPage,
-      );
-      expect(path).toStrictEqual("nsDoc/bitburner.ns.md");
-      expect(forceOpenExternally).toStrictEqual(false);
-    });
-    test("HTTP/HTTPS URL - Point to other places", () => {
+    test("HTTP/HTTPS URL", () => {
       const { path, forceOpenExternally } = convertNavigatorHref("https://bitburner-official.github.io", defaultPage);
       expect(path).toStrictEqual("https://bitburner-official.github.io");
       expect(forceOpenExternally).toStrictEqual(true);


### PR DESCRIPTION
Using absolute links pointing to a specific branch is problematic when there are differences between branches. For example, let's say we add `foo.md` which has a link pointing to `bar.md`, and both of them are only available on dev. If the absolute link points to the stable branch, the URL is invalid.

Note:
- I don't change the link (`https://github.com/bitburner-official/bitburner-src/blob/stable/src/Themes/README.md`) in `src\Themes\ui\ThemeCollaborate.tsx`.
- I sometimes delete unnecessary links. We tend to use too many links in our doc. To be honest, this is ridiculous, IMO. You can see some examples in `src\Documentation\doc\en\basic\codingcontracts.md` or `src\Documentation\doc\en\help\getting_started.md`. For example:
```
To briefly summarize: Each [Server](../basic/servers.md) has a security level that affects how difficult it is to hack.
Each [Server](../basic/servers.md) also has a certain amount of money, as well as a maximum amount of money it can hold.
[Hacking](../basic/hacking.md) a [Server](../basic/servers.md) steals a percentage of that [Server](../basic/servers.md)'s money.
The `hack()` function is used to hack a [Server](../basic/servers.md).
The `grow()` function is used to increase the amount of money available on a [Server](../basic/servers.md).
The `weaken()` function is used to decrease a [Server](../basic/servers.md)'s security level.
```
In a very short paragraph, we added 7 links pointing to a single page.