### PR TITLE
WORKFLOW: Fix wrong instruction of generating docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
         run: npm run doc
       - name: Check generated docs
         run: |
-          test -z "$(git status --porcelain)" || (echo "::error title=Documentation is outdated::You need to run 'run npm doc'";exit 1;)
+          test -z "$(git status --porcelain)" || (echo "::error title=Documentation is outdated::You need to run 'npm run doc'";exit 1;)


### PR DESCRIPTION
It's `npm run doc`, not `run npm doc`.