### PR TITLE
DOCUMENTATION: Update BitNode recommendation short guide

### DIFF
--- a/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
+++ b/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
@@ -41,8 +41,8 @@ BN6 introduces the [Bladeburner](bladeburners.md) mechanic and its corresponding
 Bladeburner is an alternative method to beat BitNodes which doesn't rely on money or hacking skill.
 [Sleeves](sleeves.md) help complete BN6 more quickly since they can share some Bladeburner tasks with the player but aren't a requirement.
 
-BN7 unlocks Bladeburner and gives access to the Bladeburner APIs like BN6, but it's a bit harder than BN6 while giving more Bladeburner-specific rewards.
-Source-File 7 buffs Bladeburner's multipliers, and Source-File 7.3 gives free access to an augmentation that lets you perform Bladeburner and non-Bladeburner actions at the same time.
+BN7 also unlocks Bladeburner like BN6, but it's a bit harder than BN6 while giving more Bladeburner-specific rewards,
+such as an augmentation that lets you perform Bladeburner and non-Bladeburner actions at the same time.
 
 BN10 unlocks two new mechanics: [Sleeves](sleeves.md) and [Grafting](grafting.md).
 [Sleeves](sleeves.md) act as additional players and can perform tasks like studying, training, committing crime and working for factions independently of the player.

--- a/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
+++ b/src/Documentation/doc/en/advanced/bitnode_recommendation_short_guide.md
@@ -41,8 +41,11 @@ BN6 introduces the [Bladeburner](bladeburners.md) mechanic and its corresponding
 Bladeburner is an alternative method to beat BitNodes which doesn't rely on money or hacking skill.
 [Sleeves](sleeves.md) help complete BN6 more quickly since they can share some Bladeburner tasks with the player but aren't a requirement.
 
+BN7 unlocks Bladeburner and gives access to the Bladeburner APIs like BN6, but it's a bit harder than BN6 while giving more Bladeburner-specific rewards.
+Source-File 7 buffs Bladeburner's multipliers, and Source-File 7.3 gives free access to an augmentation that lets you perform Bladeburner and non-Bladeburner actions at the same time.
+
 BN10 unlocks two new mechanics: [Sleeves](sleeves.md) and [Grafting](grafting.md).
-[Sleeves](sleeves.md) act as additional players and can perform tasks like studying, training, crime and working for factions independently of the player.
+[Sleeves](sleeves.md) act as additional players and can perform tasks like studying, training, committing crime and working for factions independently of the player.
 [Grafting](grafting.md) installs augmentations without a soft reset.
 Both are very useful to have but require large amounts of money to use to their fullest extent.
 Each [Source-File](sourcefiles.md) grants an additional sleeve and up to five additional sleeves may be purchased from a faction only in this BitNode.
@@ -56,7 +59,7 @@ Overall, this [BitNode](bitnodes.md) is considered an advanced one even if there
 
 BN9 introduces the [Hacknet Server](hacknetservers.md) mechanic to replace the [Hacknet Nodes](../basic/hacknet_nodes.md) mechanic.
 [Hacknet Servers](hacknetservers.md) generate hashes instead of money directly and these hashes can be traded for various benefits.
-Players who find [RAM](../basic/ram.md) tight at the beginning of a [BitNode](bitnodes.md) will find BN9.2's bonus to start with 128GiB in their home machine.
+Players who find [RAM](../basic/ram.md) tight at the beginning of a [BitNode](bitnodes.md) will find BN9.2's bonus to start with 128GiB in their home machine useful.
 
 BN13 introduces [Stanek's Gift](stanek.md), a powerful augmentation that can provide bonuses to skills, [hacknet](../basic/hacknet_nodes.md) production and costs, working and [crime](../basic/crimes.md) gains, and [hacking](../basic/hacking.md) power and speed.
 These bonuses are versatile but not enough to offset the challenge of the BitNode itself.
@@ -69,10 +72,6 @@ It encourages solving a number of practical problems (e.g. passing data around b
 It provides a variety of useful bonuses.
 
 ## Save these for later
-
-BN7 used to give access to the [Bladeburner API](../../../../../markdown/bitburner.bladeburner.md), but now it doesn't.
-Because of that change this [BitNode](bitnodes.md) is relatively low priority and should definitely happen after BN6.
-The benefit for completing BN7.3 is an aug that lets the player perform [Bladeburner](bladeburners.md) and non-Bladeburner actions at the same time.
 
 BN8 focuses on the stock market to the point that there's no other way to make money.
 Completing at least BN10.1 is highly recommended in order to have [Grafting](grafting.md).


### PR DESCRIPTION
While converting links in #2521, I noticed the paragraph of BN7 gives questionable information.

> BN7 used to give access to the Bladeburner API, but now it doesn't.

I think the OP of this guide wanted to say BN7 is not the only BN that gives access to Bladeburner API now. However, the phrasing here actually means BN7 does *not* give access to Bladeburner API, which is wrong.

> Because of that change this [BitNode](bitnodes.md) is relatively low priority and should definitely happen after BN6.

I don't think this is good advice, especially when it's in the "Save these for later" part. We usually see 4 groups of players:
- Do not like/need Bladeburner: Ignore both BN6 and BN7.
- Really like/need Bladeburner: Beat both BN6 and BN7, then use Bladeburner to beat other BNs.
- Somewhat like/need Bladeburner, but do not want to waste too much time to beat both:
  - Beat only BN7 to unlock Bladeburner and get as many Bladeburner-specific rewards as possible.
  - Beat only BN6 to unlock Bladeburner and save their time (BN6 is easier than BN7).

Based on my experience, the last group is the minority. Most people are in the first two groups (beat both BNs or none). If you must choose between 2 BNs, BN7 is actually the better choice, IMO. BN6 is only good if you want to unlock Bladeburner ASAP, but that sounds like something for speedrunning, and Bladeburner is a terrible choice for speedrunning.

I have not seen anyone beating BN6, using Bladeburner in other BNs, and then beating BN7 later.