### PR TITLE
CODEBASE: Update comment of LoadingScreen of ComplexPage enum

### DIFF
--- a/src/ui/Enums.ts
+++ b/src/ui/Enums.ts
@@ -11,7 +11,6 @@ export enum ToastVariant {
  * transition to. You can use setPage() with these.
  */
 export enum SimplePage {
-  LoadingScreen = "Loading Screen",
   ActiveScripts = "Active Scripts",
   RecentlyKilledScripts = "Recently Killed Scripts",
   RecentErrors = "Recent Errors",
@@ -53,4 +52,8 @@ export enum ComplexPage {
   Location = "Location",
   ImportSave = "Import Save",
   Documentation = "Documentation",
+  // LoadingScreen is a special state that should never be returned to after the initial game load. To enforce this, it
+  // is constructed as a ComplexPage with no PageContext, and thus toPage() cannot be used (since no overload will fit
+  // it).
+  LoadingScreen = "Loading Screen",
 }

--- a/src/ui/Enums.ts
+++ b/src/ui/Enums.ts
@@ -12,6 +12,7 @@ export enum ToastVariant {
  * transition to. You can use setPage() with these.
  */
 export enum SimplePage {
+  LoadingScreen = "Loading Screen",
   ActiveScripts = "Active Scripts",
   RecentlyKilledScripts = "Recently Killed Scripts",
   RecentErrors = "Recent Errors",
@@ -53,5 +54,4 @@ export enum ComplexPage {
   Location = "Location",
   ImportSave = "Import Save",
   Documentation = "Documentation",
-  LoadingScreen = "Loading Screen", // Has no PageContext, and thus toPage() cannot be used
 }

--- a/src/ui/Enums.ts
+++ b/src/ui/Enums.ts
@@ -5,7 +5,6 @@ export enum ToastVariant {
   INFO = "info",
 }
 
-// This enum doesn't need enum helper support for now
 /**
  * The full-screen page the player is currently be on.
  * These are "simple" pages that don't require any extra parameters to

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -34,7 +34,6 @@ export type PageWithContext =
   | ({ page: ComplexPage.Location } & PageContext<ComplexPage.Location>)
   | ({ page: ComplexPage.ImportSave } & PageContext<ComplexPage.ImportSave>)
   | ({ page: ComplexPage.Documentation } & PageContext<ComplexPage.Documentation>)
-  | { page: ComplexPage.LoadingScreen }
   | { page: SimplePage };
 
 export interface ScriptEditorRouteOptions {

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -34,6 +34,7 @@ export type PageWithContext =
   | ({ page: ComplexPage.Location } & PageContext<ComplexPage.Location>)
   | ({ page: ComplexPage.ImportSave } & PageContext<ComplexPage.ImportSave>)
   | ({ page: ComplexPage.Documentation } & PageContext<ComplexPage.Documentation>)
+  | { page: ComplexPage.LoadingScreen }
   | { page: SimplePage };
 
 export interface ScriptEditorRouteOptions {


### PR DESCRIPTION
`LoadingScreen` was added in #1474. After checking that PR, the comment (`Has no PageContext, and thus toPage() cannot be used`), and its current callers, I still don't understand why it's in `ComplexPage` instead of `SimplePage` (I don't get what that comment says).

I briefly tested the UI, and I didn't see any problems.