### PR TITLE
BUGFIX: Fix issues with RFA auto-reconnecting feature

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -21,6 +21,10 @@ declare interface Document {
   achievements: string[];
 }
 
+declare interface WebSocket {
+  intentionallyClosed?: boolean;
+}
+
 declare global {
   /**
    * "loader" is not exposed in the public API.

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -6,11 +6,11 @@ import { Settings } from "../Settings/Settings";
 import { EventEmitter } from "../utils/EventEmitter";
 import type { getRemoteFileApiConnectionStatus } from "./RemoteFileAPI";
 
+const timeOutIds = new Set<number>();
+
 function showErrorMessage(address: string, detail: string) {
   SnackbarEvents.emit(`Error with websocket ${address}, details: ${detail}`, ToastVariant.ERROR, 5000);
 }
-
-const eventCodeWhenIntentionallyStoppingConnection = 3000;
 
 export const RemoteFileApiConnectionEvents = new EventEmitter<[ReturnType<typeof getRemoteFileApiConnectionStatus>]>();
 
@@ -26,7 +26,15 @@ export class Remote {
   }
 
   public stopConnection(): void {
-    this.connection?.close(eventCodeWhenIntentionallyStoppingConnection);
+    // Cancel all pending retries immediately. This function is only called when we intentionally close the current
+    // connection before starting a new one. The new connection will retry on its own if needed.
+    timeOutIds.forEach((id) => window.clearTimeout(id));
+    timeOutIds.clear();
+
+    if (this.connection) {
+      this.connection.intentionallyClosed = true;
+    }
+    this.connection?.close();
     RemoteFileApiConnectionEvents.emit("Offline");
   }
 
@@ -62,6 +70,9 @@ export class Remote {
       );
       RemoteFileApiConnectionEvents.emit("Online");
     });
+    // "Capture" this.connection to use in its event handler later. this.connection will be assigned a new value when
+    // startConnection is called.
+    const thisConnection = this.connection;
     this.connection.addEventListener("close", (event) => {
       /**
        * On Bitburner side, we may intentionally close the connection. For example, we do that before starting a new
@@ -69,7 +80,7 @@ export class Remote {
        * unexpectedly (e.g., show a warning, reconnect after a delay), so we need to check whether the close event is
        * unexpected.
        */
-      if (event.code === eventCodeWhenIntentionallyStoppingConnection) {
+      if (thisConnection.intentionallyClosed) {
         return;
       }
 
@@ -83,7 +94,8 @@ export class Remote {
 
       if (Settings.RemoteFileApiReconnectionDelay > 0) {
         this.reconnecting = true;
-        setTimeout(() => {
+        const timeOutId = window.setTimeout(() => {
+          timeOutIds.delete(timeOutId);
           if (autoConnectAttempt === 1) {
             SnackbarEvents.emit(`Attempting to auto connect Remote API`, ToastVariant.WARNING, 2000);
           }
@@ -93,6 +105,7 @@ export class Remote {
 
           this.startConnection(attempts);
         }, Settings.RemoteFileApiReconnectionDelay * 1000);
+        timeOutIds.add(timeOutId);
         RemoteFileApiConnectionEvents.emit("Reconnecting");
       } else {
         this.reconnecting = false;

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -70,9 +70,6 @@ export class Remote {
       );
       RemoteFileApiConnectionEvents.emit("Online");
     });
-    // "Capture" this.connection to use in its event handler later. this.connection will be assigned a new value when
-    // startConnection is called.
-    const thisConnection = this.connection;
     this.connection.addEventListener("close", (event) => {
       /**
        * On Bitburner side, we may intentionally close the connection. For example, we do that before starting a new
@@ -80,7 +77,7 @@ export class Remote {
        * unexpectedly (e.g., show a warning, reconnect after a delay), so we need to check whether the close event is
        * unexpected.
        */
-      if (thisConnection.intentionallyClosed) {
+      if (event.currentTarget instanceof WebSocket && event.currentTarget.intentionallyClosed) {
         return;
       }
 


### PR DESCRIPTION
Bug 1:

https://github.com/user-attachments/assets/ef597f80-e900-4e52-b309-61f7ce1f100a

When we intentionally close the current connection before starting a new one, we call `close()` with a custom error code and check this code later in the event handler. This works with `ws` (https://www.npmjs.com/package/ws) and Deno's websocket server but does not work with Bun's websocket server and `websocket` (https://www.npmjs.com/package/websocket). When using the latter packages, the event code is not our custom error code.

Bug 2:

https://github.com/user-attachments/assets/30c04031-74fb-48e0-b753-d78e99d1a415

When clicking on the "Connect" button multiple times and there is no running RFA server, many retry attempts are scheduled, and many connections will be spawned and hit the RFA server at the same time later.