### PR TITLE
DARKNET: Cancel webstorm on prestige

### DIFF
--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -130,7 +130,7 @@ export const mutateDarknet = (): void => {
     balanceDarknetServers();
   }
   validateDarknetNetwork();
-  DarknetEvents.emit();
+  DarknetEvents.emit("RefreshUI");
 };
 
 export const restartAllDarknetServers = (): void => {

--- a/src/DarkNet/effects/webstorm.ts
+++ b/src/DarkNet/effects/webstorm.ts
@@ -17,15 +17,31 @@ import { getAllMovableDarknetServers } from "../utils/darknetNetworkUtils";
 
 const validateDarknetNetworkAndEmitDarknetEvent = (): void => {
   validateDarknetNetwork();
-  DarknetEvents.emit();
+  DarknetEvents.emit("RefreshUI");
 };
 
 export const launchWebstorm = async (suppressToast = false) => {
+  if (!DarknetState.allowMutating) {
+    return;
+  }
+  // Exit immediately if receivedPrestigeEvent is true. There is no need to set DarknetState.allowMutating to true in
+  // that case. That will be done in prestigeDarknetState.
+  let receivedPrestigeEvent = false;
+  const unsubscribe = DarknetEvents.subscribe((eventType) => {
+    if (eventType !== "Prestige") {
+      return;
+    }
+    receivedPrestigeEvent = true;
+  });
   DarknetState.allowMutating = false;
   if (!suppressToast) {
     SnackbarEvents.emit(`DARKNET WEBSTORM APPROACHING`, ToastVariant.ERROR, 5000);
   }
   await sleep(5000);
+  if (receivedPrestigeEvent) {
+    unsubscribe();
+    return;
+  }
 
   const serversToDelete = getAllMovableDarknetServers().length * 0.6 + (Math.random() * getNetDepth() - 6);
   deleteRandomDarknetServers(serversToDelete);
@@ -35,26 +51,43 @@ export const launchWebstorm = async (suppressToast = false) => {
   triggerNextUpdate();
 
   await sleep(4000);
+  if (receivedPrestigeEvent) {
+    unsubscribe();
+    return;
+  }
   addRandomDarknetServers(NET_WIDTH);
   validateDarknetNetworkAndEmitDarknetEvent();
   triggerNextUpdate();
 
   await sleep(4000);
+  if (receivedPrestigeEvent) {
+    unsubscribe();
+    return;
+  }
   addRandomDarknetServers(NET_WIDTH * 2);
   validateDarknetNetworkAndEmitDarknetEvent();
   triggerNextUpdate();
 
   await sleep(4000);
+  if (receivedPrestigeEvent) {
+    unsubscribe();
+    return;
+  }
   addRandomDarknetServers(NET_WIDTH * 2);
   validateDarknetNetworkAndEmitDarknetEvent();
   triggerNextUpdate();
 
   await sleep(8000);
+  if (receivedPrestigeEvent) {
+    unsubscribe();
+    return;
+  }
   balanceDarknetServers();
   validateDarknetNetworkAndEmitDarknetEvent();
   triggerNextUpdate();
 
   await sleep(5000);
+  unsubscribe();
   DarknetState.allowMutating = true;
 };
 

--- a/src/DarkNet/models/DarknetState.ts
+++ b/src/DarkNet/models/DarknetState.ts
@@ -8,8 +8,11 @@ import { getDarknetCyclesPerMutation } from "../utils/darknetNetworkUtils";
 import type { PasswordResponse } from "./DarknetServerOptions";
 import { assertFiniteNumber, assertNonNullish } from "../../utils/TypeAssertion";
 
-/** Event emitter to allow the UI to subscribe to Darknet gameplay updates in order to trigger rerenders properly */
-export const DarknetEvents = new EventEmitter();
+/**
+ * - Trigger UI rerender when there are Darknet updates.
+ * - Cancel webstorm on prestige.
+ */
+export const DarknetEvents = new EventEmitter<["RefreshUI" | "Prestige"]>();
 
 export type ServerState = {
   lastLogTime?: Date;
@@ -77,6 +80,7 @@ export const DarknetState = {
 };
 
 export function prestigeDarknetState(prestigeSourceFile: boolean): void {
+  DarknetEvents.emit("Prestige");
   DarknetState.allowMutating = true;
   DarknetState.openServer = null;
   DarknetState.storedCycles = 0;

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -76,7 +76,12 @@ export function NetworkDisplayWrapper(): React.ReactElement {
   }, [rerender]);
 
   useEffect(() => {
-    const clearSubscription = DarknetEvents.subscribe(() => updateDisplay());
+    const clearSubscription = DarknetEvents.subscribe((eventType) => {
+      if (eventType !== "RefreshUI") {
+        return;
+      }
+      updateDisplay();
+    });
     draggableBackground.current?.addEventListener("wheel", (e) => e.preventDefault());
     scrollTo(DarknetState.netViewTopScroll, DarknetState.netViewLeftScroll);
     updateDisplay();
@@ -110,7 +115,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     if (target.id === "draggableBackgroundTarget") {
       background?.releasePointerCapture(pointerEvent.pointerId);
     }
-    DarknetEvents.emit();
+    DarknetEvents.emit("RefreshUI");
   };
 
   const handleDrag: PointerEventHandler<HTMLDivElement> = (pointerEvent) => {

--- a/src/DarkNet/ui/PasswordPrompt.tsx
+++ b/src/DarkNet/ui/PasswordPrompt.tsx
@@ -67,7 +67,7 @@ export const PasswordPrompt = ({ server, onClose }: PasswordPromptProps): React.
     setLastDarknetResultFromAuth(authResult.result);
 
     if (authResult.result.success) {
-      DarknetEvents.emit("server-unlocked", server);
+      DarknetEvents.emit("RefreshUI");
     } else {
       // This selects the text inside the password input field so that the player can immediately start typing a new
       // guess without needing to clear out the old one.
@@ -75,7 +75,7 @@ export const PasswordPrompt = ({ server, onClose }: PasswordPromptProps): React.
       // passwordInput.current may become null unexpectedly. Using the optional chaining operator for accessing
       // passwordInput.current is specifically for the case in which somebody mistakenly moves this line.
       passwordInput.current?.querySelector("input")?.select();
-      DarknetEvents.emit();
+      DarknetEvents.emit("RefreshUI");
     }
   }
 

--- a/src/DevMenu/ui/DarknetDev.tsx
+++ b/src/DevMenu/ui/DarknetDev.tsx
@@ -69,7 +69,7 @@ export function DarknetDev(): React.ReactElement {
 
   const toggleShowFullNetwork = (newValue: boolean): void => {
     DarknetState.showFullNetwork = newValue;
-    DarknetEvents.emit();
+    DarknetEvents.emit("RefreshUI");
   };
 
   const changeSelectedServerType = (event: SelectChangeEvent<string>): void => {


### PR DESCRIPTION
There is a flaky test in dnet. While investigating it, I found out the root cause is the webstorm not being cancelled on prestige, so the network can be mutated unexpectedly. For example, if the player runs webstorm and flume, in the new BN, dnet will be mutated at any point (when the current sleep in `launchWebstorm` finishes).

You can check how to reproduce the flaky tests in https://github.com/catloversg/bitburner-src/tree/test-flaky-test. Sample log: https://github.com/catloversg/bitburner-src/actions/runs/22448333429.