### PR TITLE
MISC: Allow parsing unknown options with data.flags in autocomplete

### DIFF
--- a/src/Documentation/doc/en/basic/autocomplete.md
+++ b/src/Documentation/doc/en/basic/autocomplete.md
@@ -35,15 +35,15 @@ AutocompleteData is an object with the following properties;
 
 ```javascript
   {
-    command:    // the command being run, as seen on the terminal.
-    enums:      // the ns.enums object with various in-game strings.
-    filename:   // the name of the script file containing the autocomplete function.
-    hostname:   // the name of the host server the script would be running on.
-    processes:  // list of all processes running on the current server.
-    servers:    // list of all servers in the game. Some servers are hidden until you satisfy their requirements. This array does not contain those servers if you do not satisfy their requirements.
-    txts:       // list of all text files on the current server.
-    scripts:    // list of all scripts on the current server.
-    flags:      // the same flags function as passed with ns. Calling this function adds all the flags as autocomplete arguments.
+    command:    // The command being run, as seen on the terminal.
+    enums:      // The ns.enums object with various in-game strings.
+    filename:   // The name of the script file containing the autocomplete function.
+    hostname:   // The name of the host server the script would be running on.
+    processes:  // List of all processes running on the current server.
+    servers:    // List of all servers in the game. Some servers are hidden until you satisfy their requirements. This array does not contain those servers if you do not satisfy their requirements.
+    txts:       // List of all text files on the current server.
+    scripts:    // List of all scripts on the current server.
+    flags:      // A function similar to ns.flags(). Calling this function adds all the flags as autocomplete arguments.
   }
 ```
 
@@ -66,9 +66,33 @@ export function autocomplete(data, args) {
 }
 ```
 
+## args
+
+The args array is also passed to the autocomplete function as a second parameter. Similar to ns.args passed to `main` in normal scripts, this array contains the arguments currently inputted into the terminal.
+
+This can be used to remove already passed arguments from the autocomplete suggestions.
+
+For example;
+
+```javascript
+/**
+ * @param {AutocompleteData} data - context about the game, useful when autocompleting
+ * @param {string[]} args - current arguments, not including "run script.js"
+ * @returns {string[]} - the array of possible autocomplete options
+ */
+export function autocomplete(data, args) {
+  const servers = data.servers;
+  const serversWithArgsRemoved = servers.filter((server) => !args.includes(server));
+
+  return serversWithArgsRemoved;
+}
+```
+
+In that example typing `run script.js` and pressing tab would initially suggest every server for autocomplete. Then if "n00dles" is added to the arguments and tab is pressed again, "n00dles" would no longer be suggested in subsequent autocomplete calls.
+
 ## data.flags
 
-This is a function that works nearly identical to `ns.flags()`. The only difference is that it allows unknown options. For example:
+This is a function that works nearly identically to `ns.flags()`. The only difference is that it allows unknown options. For example:
 
 ```js
 export function autocomplete(data, args) {
@@ -94,30 +118,6 @@ ArgError: unknown or unexpected option: --f
 ```
 
 This is because `f` is not defined in the schema, and `ns.flags` does not allow unknown options.
-
-## args
-
-The args array is also passed to the autocomplete function as a second parameter. Similar to ns.args passed to `main` in normal scripts, this array contains the arguments currently inputted into the terminal.
-
-This can be used to remove already passed arguments from the autocomplete suggestions.
-
-For example;
-
-```javascript
-/**
- * @param {AutocompleteData} data - context about the game, useful when autocompleting
- * @param {string[]} args - current arguments, not including "run script.js"
- * @returns {string[]} - the array of possible autocomplete options
- */
-export function autocomplete(data, args) {
-  const servers = data.servers;
-  const serversWithArgsRemoved = servers.filter((server) => !args.includes(server));
-
-  return serversWithArgsRemoved;
-}
-```
-
-In that example typing `run script.js` and pressing tab would initially suggest every server for autocomplete. Then if "n00dles" is added to the arguments and tab is pressed again, "n00dles" would no longer be suggested in subsequent autocomplete calls.
 
 # Notes
 

--- a/src/Documentation/doc/en/basic/autocomplete.md
+++ b/src/Documentation/doc/en/basic/autocomplete.md
@@ -66,6 +66,35 @@ export function autocomplete(data, args) {
 }
 ```
 
+## data.flags
+
+This is a function that works nearly identical to `ns.flags()`. The only difference is that it allows unknown options. For example:
+
+```js
+export function autocomplete(data, args) {
+  const parsedFlags = data.flags([["foo", true]]);
+  return [];
+}
+
+/** @param {NS} ns */
+export async function main(ns) {
+  const parsedFlags = ns.flags([["foo", true]]);
+}
+```
+
+If you type `run a.js --f` in the terminal and press tab, `parsedFlags` in `autocomplete` is `{_: ["--f"], foo: true}`.
+
+- `f` is not defined in the schema, so it's added to `_`.
+- The command does not specify `foo`, so `foo` is set to the default value.
+
+If you type `run a.js --f` in the terminal and press enter, an error will be thrown:
+
+```
+ArgError: unknown or unexpected option: --f
+```
+
+This is because `f` is not defined in the schema, and `ns.flags` does not allow unknown options.
+
 ## args
 
 The args array is also passed to the autocomplete function as a second parameter. Similar to ns.args passed to `main` in normal scripts, this array contains the arguments currently inputted into the terminal.

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1524,7 +1524,7 @@ export const ns: InternalAPI<NSFull> = {
     //Script **must** be a script at this point
     return compile(script as Script, server.scripts);
   },
-  flags: Flags,
+  flags: (ctx) => Flags(ctx, false),
   heart: { break: () => () => Player.karma },
   ...NetscriptExtra(),
 };

--- a/src/NetscriptFunctions/Flags.ts
+++ b/src/NetscriptFunctions/Flags.ts
@@ -6,7 +6,7 @@ import { NetscriptContext } from "../Netscript/APIWrapper";
 export type Schema = [string, string | number | boolean | string[]][];
 type FlagType = StringConstructor | NumberConstructor | BooleanConstructor | StringConstructor[];
 type FlagsRet = Record<string, ScriptArg | string[]>;
-export function Flags(ctx: NetscriptContext | string[]): (data: unknown) => FlagsRet {
+export function Flags(ctx: NetscriptContext | string[], permissive: boolean): (data: unknown) => FlagsRet {
   const vargs = Array.isArray(ctx) ? ctx : ctx.workerScript.args;
   return (schema: unknown): FlagsRet => {
     schema = toNative(schema);
@@ -26,7 +26,7 @@ export function Flags(ctx: NetscriptContext | string[]): (data: unknown) => Flag
       args["-".repeat(numDashes) + d[0]] = t;
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-    const ret: FlagsRet = libarg(args, { argv: vargs });
+    const ret: FlagsRet = libarg(args, { argv: vargs, permissive });
     for (const d of schema as Schema) {
       if (!Object.hasOwn(ret, "--" + d[0]) || !Object.hasOwn(ret, "-" + d[0])) ret[d[0]] = d[1];
     }

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -355,7 +355,25 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
         try {
           return flagFunc(schema);
         } catch (error) {
-          throw new Error("Cannot parse the schema passed to AutocompleteData.flags", { cause: error });
+          // Let's say the autocomplete function is defined like this:
+          // export function autocomplete(data, args) {
+          //   data.flags([
+          //     ["foo", true],
+          //   ]);
+          //   return [];
+          // }
+          // If the command is "run test.js --f[tab]", the expected behavior is "--foo" being shown in the autocomplete
+          // result. However, the schema defines "foo", not "f", so the arg library throws the ARG_UNKNOWN_OPTION error.
+          // This is the expected behavior of this library, but when it happens in the autocomplete function, it makes
+          // data.flags become useless. We should suppress the error in this case.
+          // Note that it means we also suppress legit error cases like "run test.js --bar[tab]" ("bar" is not defined
+          // in the schema). Handling all these cases is possible, but it's unnecessarily complicated.
+          if (error instanceof Error && "code" in error && error.code === "ARG_UNKNOWN_OPTION") {
+            return {};
+          }
+          throw new Error("Cannot parse the arguments with the schema passed to AutocompleteData.flags", {
+            cause: error,
+          });
         }
       },
       hostname: currServ.hostname,

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -325,7 +325,7 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
        */
       console.warn(error);
     }
-    const flagFunc = Flags(flags._);
+    const flagFunc = Flags(flags._, true);
     const autocompleteData: AutocompleteData = {
       servers: GetAllServers()
         .filter((server) => server.serversOnNetwork.length !== 0)
@@ -355,22 +355,6 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
         try {
           return flagFunc(schema);
         } catch (error) {
-          // Let's say the autocomplete function is defined like this:
-          // export function autocomplete(data, args) {
-          //   data.flags([
-          //     ["foo", true],
-          //   ]);
-          //   return [];
-          // }
-          // If the command is "run test.js --f[tab]", the expected behavior is "--foo" being shown in the autocomplete
-          // result. However, the schema defines "foo", not "f", so the arg library throws the ARG_UNKNOWN_OPTION error.
-          // This is the expected behavior of this library, but when it happens in the autocomplete function, it makes
-          // data.flags become useless. We should suppress the error in this case.
-          // Note that it means we also suppress legit error cases like "run test.js --bar[tab]" ("bar" is not defined
-          // in the schema). Handling all these cases is possible, but it's unnecessarily complicated.
-          if (error instanceof Error && "code" in error && error.code === "ARG_UNKNOWN_OPTION") {
-            return {};
-          }
           throw new Error("Cannot parse the arguments with the schema passed to AutocompleteData.flags", {
             cause: error,
           });


### PR DESCRIPTION
Let's say the autocomplete function is defined like this:
```
export function autocomplete(data, args) {
  data.flags([
    ["foo", true],
  ]);
  return [];
}
```
If the command is "run test.js --f[tab]", the expected behavior is "--foo" being shown in the autocomplete
result. However, the schema defines "foo", not "f", so the arg library throws the ARG_UNKNOWN_OPTION error.
This is the expected behavior of this library, but when it happens in the autocomplete function, it makes
data.flags become useless. We should suppress the error in this case.
Note that it means we also suppress legit error cases like "run test.js --bar[tab]" ("bar" is not defined
in the schema). Handling all these cases is possible, but it's unnecessarily complicated.

Closes #2536.

Alternative: The `arg` library supports an option that works similarly (https://www.npmjs.com/package/arg#permissive), but it slightly changes the behavior of `data.flags`.
```js
export function autocomplete(data, args) {
  console.log("before", args);
  console.log(data.flags([
    ["foo", true],
  ]));
  console.log("after", args);
  return [];
}
```
Now:
```
before ['--f']
{}
after ['--f']
```
With `permissive`:
```
before ['--f']
{foo:true, _: ['--f']}
after ['--f']
```
The behavior of `permissive` makes sense to me, and I think it's more "correct" if we allow unknown options, but I'm not sure if we should do that.

Edit: I changed my mind. The alternative is better.