### PR TITLE
BLADEBURNER: Adjusted team bonus computation to make one member help

### DIFF
--- a/src/Bladeburner/Actions/Operation.ts
+++ b/src/Bladeburner/Actions/Operation.ts
@@ -96,7 +96,7 @@ export const operationSkillSuccessBonus = (inst: Bladeburner) => {
 export function operationTeamSuccessBonus(this: Operation | BlackOperation, inst: Bladeburner) {
   if (this.teamCount && this.teamCount > 0) {
     this.teamCount = Math.min(this.teamCount, inst.teamSize);
-    const teamMultiplier = Math.pow(this.teamCount, 0.05);
+    const teamMultiplier = Math.pow(this.teamCount + 1, 0.05);
     return teamMultiplier;
   }
 

--- a/src/Bladeburner/Actions/Operation.ts
+++ b/src/Bladeburner/Actions/Operation.ts
@@ -93,12 +93,6 @@ export const operationSkillSuccessBonus = (inst: Bladeburner) => {
   return inst.getSkillMult(BladeburnerMultName.SuccessChanceOperation);
 };
 
-export function operationTeamSuccessBonus(this: Operation | BlackOperation, inst: Bladeburner) {
-  if (this.teamCount && this.teamCount > 0) {
-    this.teamCount = Math.min(this.teamCount, inst.teamSize);
-    const teamMultiplier = Math.pow(this.teamCount + 1, 0.05);
-    return teamMultiplier;
-  }
-
-  return 1;
+export function operationTeamSuccessBonus(this: Operation | BlackOperation) {
+  return Math.pow(this.teamCount + 1, 0.05);
 }


### PR DESCRIPTION
Fixed bug where there was no benefit to having a team size of 1 for a Bladeburner operation/black op

Testing: I ran the script provided in the issue on my current save file and got the following output
<img width="554" height="178" alt="image" src="https://github.com/user-attachments/assets/663d834e-147d-444c-a5a8-b9967e2c58d2" />


fixes #2540