### PR TITLE
BUGFIX: Fix webstorm by using a mutationLock

### DIFF
--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -133,7 +133,7 @@ export const clearDarknet = () => {
   DarknetState.zoomIndex = 7;
   DarknetState.netViewLeftScroll = 0;
   DarknetState.netViewTopScroll = 0;
-  DarknetState.allowMutating = true;
+  DarknetState.mutationLock?.();
   DarknetState.openServer = null;
   DarknetState.stockPromotions = {};
   DarknetState.migrationInductionServers = new Map();

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -43,7 +43,7 @@ export const processDarknet = (cycles: number): void => {
 };
 
 export const mutateDarknet = (): void => {
-  if (!DarknetState.allowMutating) {
+  if (DarknetState.mutationLock) {
     return;
   }
   const servers = getAllMovableDarknetServers();

--- a/src/DarkNet/effects/webstorm.ts
+++ b/src/DarkNet/effects/webstorm.ts
@@ -20,42 +20,62 @@ const validateDarknetNetworkAndEmitDarknetEvent = (): void => {
   DarknetEvents.emit();
 };
 
+const cancelled = Symbol("cancelled");
+
 export const launchWebstorm = async (suppressToast = false) => {
-  DarknetState.allowMutating = false;
-  if (!suppressToast) {
-    SnackbarEvents.emit(`DARKNET WEBSTORM APPROACHING`, ToastVariant.ERROR, 5000);
+  if (DarknetState.mutationLock) {
+    return;
   }
-  await sleep(5000);
+  try {
+    const cancelPromise = new Promise((res, rej) => {
+      DarknetState.mutationLock = () => {
+        rej(cancelled);
+        DarknetState.mutationLock = null;
+      };
+    });
+    const cancellableSleep = (ms: number) => Promise.race([sleep(ms), cancelPromise]);
 
-  const serversToDelete = getAllMovableDarknetServers().length * 0.6 + (Math.random() * getNetDepth() - 6);
-  deleteRandomDarknetServers(serversToDelete);
-  moveRandomDarknetServers((getAllMovableDarknetServers().length - serversToDelete) * 0.6);
-  restartAllDarknetServers();
-  validateDarknetNetworkAndEmitDarknetEvent();
-  triggerNextUpdate();
+    if (!suppressToast) {
+      SnackbarEvents.emit(`DARKNET WEBSTORM APPROACHING`, ToastVariant.ERROR, 5000);
+    }
+    await cancellableSleep(5000);
 
-  await sleep(4000);
-  addRandomDarknetServers(NET_WIDTH);
-  validateDarknetNetworkAndEmitDarknetEvent();
-  triggerNextUpdate();
+    const serversToDelete = getAllMovableDarknetServers().length * 0.6 + (Math.random() * getNetDepth() - 6);
+    deleteRandomDarknetServers(serversToDelete);
+    moveRandomDarknetServers((getAllMovableDarknetServers().length - serversToDelete) * 0.6);
+    restartAllDarknetServers();
+    validateDarknetNetworkAndEmitDarknetEvent();
+    triggerNextUpdate();
 
-  await sleep(4000);
-  addRandomDarknetServers(NET_WIDTH * 2);
-  validateDarknetNetworkAndEmitDarknetEvent();
-  triggerNextUpdate();
+    await cancellableSleep(4000);
+    addRandomDarknetServers(NET_WIDTH);
+    validateDarknetNetworkAndEmitDarknetEvent();
+    triggerNextUpdate();
 
-  await sleep(4000);
-  addRandomDarknetServers(NET_WIDTH * 2);
-  validateDarknetNetworkAndEmitDarknetEvent();
-  triggerNextUpdate();
+    await cancellableSleep(4000);
+    addRandomDarknetServers(NET_WIDTH * 2);
+    validateDarknetNetworkAndEmitDarknetEvent();
+    triggerNextUpdate();
 
-  await sleep(8000);
-  balanceDarknetServers();
-  validateDarknetNetworkAndEmitDarknetEvent();
-  triggerNextUpdate();
+    await cancellableSleep(4000);
+    addRandomDarknetServers(NET_WIDTH * 2);
+    validateDarknetNetworkAndEmitDarknetEvent();
+    triggerNextUpdate();
 
-  await sleep(5000);
-  DarknetState.allowMutating = true;
+    await cancellableSleep(8000);
+    balanceDarknetServers();
+    validateDarknetNetworkAndEmitDarknetEvent();
+    triggerNextUpdate();
+
+    await cancellableSleep(5000);
+  } catch (ex) {
+    if (ex !== cancelled) throw ex;
+  } finally {
+    // Maybe a future TypeScript will remove the need for this...
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const dumb = DarknetState.mutationLock!;
+    dumb?.();
+  }
 };
 
 export const handleStormSeed = (server: BaseServer) => {

--- a/src/DarkNet/models/DarknetServerOptions.ts
+++ b/src/DarkNet/models/DarknetServerOptions.ts
@@ -151,7 +151,7 @@ const decorateName = (name: string): string => {
       // Just in case we hit a lot of the same name mutations, or if the player
       // messes with Math.random(), prevent an infinite loop
       updatedName += `/T${Date.now()}`;
-      break;
+      continue;
     }
 
     const connector = connectors[Math.floor(Math.random() * connectors.length)];

--- a/src/DarkNet/models/DarknetState.ts
+++ b/src/DarkNet/models/DarknetState.ts
@@ -9,7 +9,7 @@ import type { PasswordResponse } from "./DarknetServerOptions";
 import { assertFiniteNumber, assertNonNullish } from "../../utils/TypeAssertion";
 
 /** Event emitter to allow the UI to subscribe to Darknet gameplay updates in order to trigger rerenders properly */
-export const DarknetEvents = new EventEmitter();
+export const DarknetEvents = new EventEmitter<[]>();
 
 export type ServerState = {
   lastLogTime?: Date;
@@ -26,7 +26,10 @@ export type LogEntry = {
  * If you add a new property to this global state, you must check if you need to reset it in prestigeDarknetState.
  */
 export const DarknetState = {
-  allowMutating: true,
+  // If this is null, network mutation is allowed. If this is a function,
+  // mutation is frozen and calling the function releases the lock.
+  // *Only* the lock function may reset this to null.
+  mutationLock: null as (() => void) | null,
   openServer: null as BaseServer | null,
   nextMutation: Promise.resolve(),
   nextMutationResolver: null as (() => void) | null,
@@ -77,7 +80,7 @@ export const DarknetState = {
 };
 
 export function prestigeDarknetState(prestigeSourceFile: boolean): void {
-  DarknetState.allowMutating = true;
+  DarknetState.mutationLock?.();
   DarknetState.openServer = null;
   DarknetState.storedCycles = 0;
   if (prestigeSourceFile) {

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -243,7 +243,11 @@ export function NetworkDisplayWrapper(): React.ReactElement {
       ) : (
         ""
       )}
-      {DarknetState.allowMutating ? (
+      {DarknetState.mutationLock ? (
+        <Typography variant={"h6"} className={classes.gold}>
+          [WEBSTORM WARNING]
+        </Typography>
+      ) : (
         <Box className={`${classes.inlineFlexBox}`}>
           <Typography variant={"h5"} sx={{ fontWeight: "bold" }}>
             Dark Net
@@ -265,10 +269,6 @@ export function NetworkDisplayWrapper(): React.ReactElement {
             </Tooltip>
           )}
         </Box>
-      ) : (
-        <Typography variant={"h6"} className={classes.gold}>
-          [WEBSTORM WARNING]
-        </Typography>
       )}
 
       <div

--- a/src/DarkNet/ui/PasswordPrompt.tsx
+++ b/src/DarkNet/ui/PasswordPrompt.tsx
@@ -67,7 +67,7 @@ export const PasswordPrompt = ({ server, onClose }: PasswordPromptProps): React.
     setLastDarknetResultFromAuth(authResult.result);
 
     if (authResult.result.success) {
-      DarknetEvents.emit("server-unlocked", server);
+      DarknetEvents.emit();
     } else {
       // This selects the text inside the password input field so that the player can immediately start typing a new
       // guess without needing to clear out the old one.

--- a/src/utils/IPAddress.ts
+++ b/src/utils/IPAddress.ts
@@ -7,10 +7,12 @@ import type { IPAddress } from "../Types/strings";
 export const createRandomIp = (): IPAddress => {
   // Credit goes to yichizhng on BitBurner discord
   // Generates a number like 0.c8f0a07f1d47e8
-  const ip = Math.random().toString(16);
+  // The extra zeros are to catch numbers like 0 and 0.5 that have a shorter
+  // exact representation.
+  const ip = Math.random().toString(16) + "000000000";
   // uses regex to match every 2 characters. [0.][c8][f0][a0][7f][1d][47][e8]
   // we only want #1 through #4
-  const matchResult = ip.match(/../g);
+  const matchResult = ip.match(/..?/g);
   if (!matchResult) {
     // This case should never happen.
     throw new Error(`Unexpected regex matching bug in createRandomIp. ip: ${ip}`);

--- a/test/jest/Darknet/Darknet.test.ts
+++ b/test/jest/Darknet/Darknet.test.ts
@@ -723,10 +723,10 @@ describe("mutateDarknet and webstorm", () => {
     try {
       jest.useFakeTimers();
       const promise = launchWebstorm();
-      expect(DarknetState.allowMutating).toBe(false);
+      expect(DarknetState.mutationLock).toBeTruthy();
 
       await jest.advanceTimersByTimeAsync(10000);
-      expect(DarknetState.allowMutating).toBe(false);
+      expect(DarknetState.mutationLock).toBeTruthy();
 
       const initialServers = serverSnapshot();
       // Low rolls cause stuff to happen, we want deterministic testing.
@@ -739,7 +739,7 @@ describe("mutateDarknet and webstorm", () => {
 
       await jest.runAllTimersAsync();
       await promise; // Should immediately finish
-      expect(DarknetState.allowMutating).toBe(true);
+      expect(DarknetState.mutationLock).toBeNull();
 
       mutateDarknet();
       expect(serverSnapshot()).not.toEqual(initialServers);
@@ -753,12 +753,12 @@ describe("mutateDarknet and webstorm", () => {
       jest.useFakeTimers();
       const promise = launchWebstorm();
       await jest.advanceTimersByTimeAsync(0); // Finish any promises
-      expect(DarknetState.allowMutating).toBe(false);
+      expect(DarknetState.mutationLock).toBeTruthy();
 
       const beforePrestige = serverSnapshot();
       prestigeAugmentation();
 
-      expect(DarknetState.allowMutating).toBe(true);
+      expect(DarknetState.mutationLock).toBeNull();
       const initialServers = serverSnapshot();
       // Validate that prestige changed the network
       expect(initialServers).not.toEqual(beforePrestige);
@@ -766,7 +766,7 @@ describe("mutateDarknet and webstorm", () => {
       await jest.runAllTimersAsync();
       await promise; // Should immediately finish
 
-      expect(DarknetState.allowMutating).toBe(true);
+      expect(DarknetState.mutationLock).toBeNull();
       // Webstorm should not have changed anything
       expect(serverSnapshot()).toEqual(initialServers);
     } finally {

--- a/test/jest/Darknet/Darknet.test.ts
+++ b/test/jest/Darknet/Darknet.test.ts
@@ -62,6 +62,8 @@ import { isDirectoryPath } from "../../../src/Paths/Directory";
 import { isFilePath } from "../../../src/Paths/FilePath";
 import { LAB_CACHE_NAME } from "../../../src/DarkNet/effects/labyrinth";
 import { generateCacheFilename } from "../../../src/DarkNet/effects/cacheFiles";
+import { getAllDarknetServers } from "../../../src/DarkNet/utils/darknetNetworkUtils";
+import { prestigeAugmentation } from "../../../src/Prestige";
 
 beforeAll(() => {
   initGameEnvironment();
@@ -691,6 +693,11 @@ describe("Password Tests", () => {
   });
 });
 
+const serverSnapshot = () =>
+  getAllDarknetServers()
+    .map((s) => ({ hostname: s.hostname, depth: s.depth, leftOffset: s.leftOffset }))
+    .sort((a, b) => (a.hostname < b.hostname ? -1 : a.hostname === b.hostname ? 0 : 1));
+
 describe("mutateDarknet and webstorm", () => {
   test("mutateDarknet", () => {
     const spiedExceptionAlert = jest.spyOn(exceptionAlertModule, "exceptionAlert");
@@ -710,6 +717,61 @@ describe("mutateDarknet and webstorm", () => {
     }
     expect(spiedExceptionAlert).not.toHaveBeenCalled();
     expect(spiedConsoleError).not.toHaveBeenCalled();
+  });
+  test("mutation during webstorm", async () => {
+    const realRandom = Math.random;
+    try {
+      jest.useFakeTimers();
+      const promise = launchWebstorm();
+      expect(DarknetState.allowMutating).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(10000);
+      expect(DarknetState.allowMutating).toBe(false);
+
+      const initialServers = serverSnapshot();
+      // Low rolls cause stuff to happen, we want deterministic testing.
+      // Jest spies keep state, make our own mock so it doesn't eat memory in
+      // case something goes wrong.
+      let count = 0;
+      Math.random = () => count++ * (Number.EPSILON * 1024);
+      mutateDarknet();
+      expect(serverSnapshot()).toEqual(initialServers);
+
+      await jest.runAllTimersAsync();
+      await promise; // Should immediately finish
+      expect(DarknetState.allowMutating).toBe(true);
+
+      mutateDarknet();
+      expect(serverSnapshot()).not.toEqual(initialServers);
+    } finally {
+      jest.useRealTimers();
+      Math.random = realRandom;
+    }
+  });
+  test("prestige during webstorm", async () => {
+    try {
+      jest.useFakeTimers();
+      const promise = launchWebstorm();
+      await jest.advanceTimersByTimeAsync(0); // Finish any promises
+      expect(DarknetState.allowMutating).toBe(false);
+
+      const beforePrestige = serverSnapshot();
+      prestigeAugmentation();
+
+      expect(DarknetState.allowMutating).toBe(true);
+      const initialServers = serverSnapshot();
+      // Validate that prestige changed the network
+      expect(initialServers).not.toEqual(beforePrestige);
+
+      await jest.runAllTimersAsync();
+      await promise; // Should immediately finish
+
+      expect(DarknetState.allowMutating).toBe(true);
+      // Webstorm should not have changed anything
+      expect(serverSnapshot()).toEqual(initialServers);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -116,11 +116,11 @@ describe("Common APIs", () => {
     const ns = getNsOnNonDarkwebDarknetServer();
     const result1 = ns.dnet.unleashStormSeed();
     expect(result1.success).toStrictEqual(false);
-    expect(DarknetState.allowMutating).toStrictEqual(true);
+    expect(DarknetState.mutationLock).toBeNull();
     getDarknetServerOrThrow(ns.getHostname()).programs.push(CompletedProgramName.stormSeed);
     const result2 = ns.dnet.unleashStormSeed();
     expect(result2.success).toStrictEqual(true);
-    expect(DarknetState.allowMutating).toStrictEqual(false);
+    expect(DarknetState.mutationLock).toBeTruthy();
   });
   test("getDarknetInstability", () => {
     const ns = getNsOnDarkWeb();


### PR DESCRIPTION
This is an alternative implementation to #2538

Hats off to CatLover for the hard work of running down the flakiness and getting to root cause. When I looked at that fix, I had lingering concerns about how `allowMutating` was used (in general), which led to creating this alternate design.

This approach is focused on guaranteeing safety by ensuring that only one place (the mutationLock) owns the responsibility of setting mutationLock to null, so that anything that needs to be cancelled will be properly notified (by construction).

I didn't reproduce the manual testing, but I added Darknet tests for webstorm concurrency.

This also fixes some incidental bugs found when forcing Math.random to small values for testing.