### PR TITLE
UI: Add inline script RAM usage text to each active script

### DIFF
--- a/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
+++ b/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
@@ -4,7 +4,7 @@
  */
 import * as React from "react";
 
-import { formatExp, formatThreads, formatRam } from "../formatNumber";
+import { formatExp, formatThreads } from "../formatNumber";
 
 import Table from "@mui/material/Table";
 import TableCell from "@mui/material/TableCell";
@@ -33,6 +33,7 @@ import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFuncti
 import { arrayToString } from "../../utils/helpers/ArrayHelpers";
 import { Money } from "../React/Money";
 import { MoneyRate } from "../React/MoneyRate";
+import { roundToTwo } from "../../utils/helpers/roundToTwo";
 
 const useStyles = makeStyles()({
   noborder: {
@@ -69,7 +70,7 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
         <ListItemText
           primary={
             <Typography sx={{ overflowWrap: "break-word" }}>
-              └ {props.workerScript.name} {formatRam(scriptRef.ramUsage * scriptRef.threads)}{" "}
+              └ {props.workerScript.name} ({roundToTwo(scriptRef.ramUsage * scriptRef.threads)}GB){" "}
               {JSON.stringify(props.workerScript.args)}
             </Typography>
           }
@@ -87,7 +88,7 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
                 <TableCell className={classes.noborder}>
                   <Typography>
                     {formatThreads(scriptRef.threads)}{" "}
-                    {scriptRef.threads > 1 ? `(${formatRam(scriptRef.ramUsage)} each)` : ``}
+                    {scriptRef.threads > 1 ? `(${roundToTwo(scriptRef.ramUsage)}GB each)` : ``}
                   </Typography>
                 </TableCell>
               </TableRow>

--- a/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
+++ b/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
@@ -4,7 +4,7 @@
  */
 import * as React from "react";
 
-import { formatExp, formatThreads } from "../formatNumber";
+import { formatExp, formatThreads, formatRam } from "../formatNumber";
 
 import Table from "@mui/material/Table";
 import TableCell from "@mui/material/TableCell";
@@ -33,7 +33,6 @@ import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFuncti
 import { arrayToString } from "../../utils/helpers/ArrayHelpers";
 import { Money } from "../React/Money";
 import { MoneyRate } from "../React/MoneyRate";
-import { roundToTwo } from "../../utils/helpers/roundToTwo";
 
 const useStyles = makeStyles()({
   noborder: {
@@ -70,7 +69,7 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
         <ListItemText
           primary={
             <Typography sx={{ overflowWrap: "break-word" }}>
-              └ {props.workerScript.name} ({roundToTwo(scriptRef.ramUsage * scriptRef.threads)}GB){" "}
+              └ {props.workerScript.name} ({formatRam(scriptRef.ramUsage * scriptRef.threads)}){" "}
               {JSON.stringify(props.workerScript.args)}
             </Typography>
           }
@@ -87,8 +86,7 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
                 </TableCell>
                 <TableCell className={classes.noborder}>
                   <Typography>
-                    {formatThreads(scriptRef.threads)}{" "}
-                    {scriptRef.threads > 1 ? `(${roundToTwo(scriptRef.ramUsage)}GB each)` : ``}
+                    {formatThreads(scriptRef.threads)} {`(${formatRam(scriptRef.ramUsage)} each)`}
                   </Typography>
                 </TableCell>
               </TableRow>

--- a/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
+++ b/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
@@ -4,7 +4,7 @@
  */
 import * as React from "react";
 
-import { formatExp, formatThreads } from "../formatNumber";
+import { formatExp, formatThreads, formatRam } from "../formatNumber";
 
 import Table from "@mui/material/Table";
 import TableCell from "@mui/material/TableCell";
@@ -79,6 +79,14 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
         <Box mx={6}>
           <Table padding="none" size="small">
             <TableBody>
+              <TableRow>
+                <TableCell className={classes.noborder}>
+                  <Typography>└ RAM Usage:</Typography>
+                </TableCell>
+                <TableCell className={classes.noborder}>
+                  <Typography>{formatRam(props.workerScript.scriptRef.ramUsage)}</Typography>
+                </TableCell>
+              </TableRow>
               <TableRow>
                 <TableCell className={classes.noborder}>
                   <Typography>└ Threads:</Typography>

--- a/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
+++ b/src/ui/ActiveScripts/WorkerScriptAccordion.tsx
@@ -69,7 +69,8 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
         <ListItemText
           primary={
             <Typography sx={{ overflowWrap: "break-word" }}>
-              └ {props.workerScript.name} {JSON.stringify(props.workerScript.args)}
+              └ {props.workerScript.name} {formatRam(scriptRef.ramUsage * scriptRef.threads)}{" "}
+              {JSON.stringify(props.workerScript.args)}
             </Typography>
           }
         />
@@ -81,18 +82,13 @@ export function WorkerScriptAccordion(props: IProps): React.ReactElement {
             <TableBody>
               <TableRow>
                 <TableCell className={classes.noborder}>
-                  <Typography>└ RAM Usage:</Typography>
-                </TableCell>
-                <TableCell className={classes.noborder}>
-                  <Typography>{formatRam(props.workerScript.scriptRef.ramUsage)}</Typography>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className={classes.noborder}>
                   <Typography>└ Threads:</Typography>
                 </TableCell>
                 <TableCell className={classes.noborder}>
-                  <Typography>{formatThreads(props.workerScript.scriptRef.threads)}</Typography>
+                  <Typography>
+                    {formatThreads(scriptRef.threads)}{" "}
+                    {scriptRef.threads > 1 ? `(${formatRam(scriptRef.ramUsage)} each)` : ``}
+                  </Typography>
                 </TableCell>
               </TableRow>
               <TableRow>


### PR DESCRIPTION
(First time contributor, please let me know if I have missed something)
It can be hard to tell at a glance which scripts are eating up all your RAM, so I've slightly modified the Active Scripts page to include the total RAM used by a script (next to the script name), as well as the RAM usage of a single thread (shown next to thread count). 
<img width="736" height="435" alt="show-ram-inline" src="https://github.com/user-attachments/assets/7320bbf7-1d07-4ae3-a6e8-474185d583e8" />
Note that RAM used per thread is only displayed if threads > 1, so it's not shown at all for the first script.

✅ `npm run lint`
✅ `npm run format`
✅ `npm run test`