### PR TITLE
REFACTOR: Make getPlayer 10x faster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "prettier": "^2.8.8",
         "react-refresh": "^0.18.0",
         "style-loader": "^4.0.0",
+        "tinybench": "^6.0.0",
         "typescript": "^5.9.3",
         "webpack": "^5.100.2",
         "webpack-cli": "^6.0.1",
@@ -17779,6 +17780,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "node_modules/tinybench": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.0.0.tgz",
+      "integrity": "sha512-BWlWpVbbZXaYjRV0twGLNQO00Zj4HA/sjLOQP2IvzQqGwRGp+2kh7UU3ijyJ3ywFRogYDRbiHDMrUOfaMnN56g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/tldts": {
       "version": "6.1.86",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "prettier": "^2.8.8",
     "react-refresh": "^0.18.0",
     "style-loader": "^4.0.0",
+    "tinybench": "^6.0.0",
     "typescript": "^5.9.3",
     "webpack": "^5.100.2",
     "webpack-cli": "^6.0.1",

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1422,17 +1422,17 @@ export const ns: InternalAPI<NSFull> = {
   getPlayer: () => () => {
     const data = {
       // Person
-      hp: structuredClone(Player.hp),
-      skills: structuredClone(Player.skills),
-      exp: structuredClone(Player.exp),
-      mults: structuredClone(Player.mults),
+      hp: { ...Player.hp },
+      skills: { ...Player.skills },
+      exp: { ...Player.exp },
+      mults: { ...Player.mults },
       city: Player.city,
       // Player-specific
       numPeopleKilled: Player.numPeopleKilled,
       money: Player.money,
       location: Player.location,
       totalPlaytime: Player.totalPlaytime,
-      jobs: structuredClone(Player.jobs),
+      jobs: { ...Player.jobs },
       factions: Player.factions.slice(),
       entropy: Player.entropy,
       karma: Player.karma,

--- a/test/jest/Netscript/GetPlayer.test.ts
+++ b/test/jest/Netscript/GetPlayer.test.ts
@@ -1,0 +1,37 @@
+import { Bench } from "tinybench";
+import { initGameEnvironment, setupBasicTestingEnvironment, getWorkerScriptAndNS } from "../Utilities";
+import { Player } from "@player";
+
+initGameEnvironment();
+
+beforeEach(() => {
+  setupBasicTestingEnvironment();
+});
+
+test("getPlayer", () => {
+  const { ns } = getWorkerScriptAndNS();
+  const props = [
+    "hp",
+    "skills",
+    "exp",
+    "mults",
+    "city",
+    "numPeopleKilled",
+    "money",
+    "location",
+    "totalPlaytime",
+    "jobs",
+    "factions",
+    "entropy",
+    "karma",
+  ];
+  const expected = Object.fromEntries(props.map((k) => [k, (Player as unknown as { [key: string]: unknown })[k]]));
+  expect(ns.getPlayer()).toEqual(expected);
+});
+// Benchmarks shouldn't waste time on every test run. Un-skip this when evaluating changes.
+test.skip("Benchmark getPlayer", async () => {
+  const { ns } = getWorkerScriptAndNS();
+  const bench = new Bench().add("getPlayer", () => ns.getPlayer());
+  await bench.run();
+  console.table(bench.table());
+});

--- a/test/jest/Netscript/GetPlayer.test.ts
+++ b/test/jest/Netscript/GetPlayer.test.ts
@@ -24,8 +24,8 @@ test("getPlayer", () => {
     "factions",
     "entropy",
     "karma",
-  ];
-  const expected = Object.fromEntries(props.map((k) => [k, (Player as unknown as { [key: string]: unknown })[k]]));
+  ] as const;
+  const expected = Object.fromEntries(props.map((k) => [k, Player[k]]));
   expect(ns.getPlayer()).toEqual(expected);
 });
 // Benchmarks shouldn't waste time on every test run. Un-skip this when evaluating changes.


### PR DESCRIPTION
Added a test and a benchmark for proof

Running the benchmark, on my machine before:
 ``` 
┌─────────┬─────────────┬──────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name   │ Latency avg (ns) │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼─────────────┼──────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'getPlayer' │ '8344.8 ± 0.45%' │ '8109.0 ± 101.00' │ '121823 ± 0.03%'       │ '123320 ± 1540'        │ 119836  │
└─────────┴─────────────┴──────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
```

After:
``` 
┌─────────┬─────────────┬──────────────────┬──────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name   │ Latency avg (ns) │ Latency med (ns) │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼─────────────┼──────────────────┼──────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'getPlayer' │ '609.65 ± 5.97%' │ '405.00 ± 65.00' │ '2317715 ± 0.04%'      │ '2469136 ± 454841'     │ 1640298 │
└─────────┴─────────────┴──────────────────┴──────────────────┴────────────────────────┴────────────────────────┴─────────┘
```