### PR TITLE
BLADEBURNER: Rebalance charisma exp gain of Recruitment action

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -1116,9 +1116,14 @@ export class Bladeburner implements OperationTeam {
             break;
           }
           case BladeburnerGeneralActionName.Recruitment: {
-            const actionTime = action.getActionTime(this, person) * 1000;
+            const actionTime = action.getActionTime(this, person);
+            // Without dnet, the best way to gain charisma in the early part of a BN run is to take uni course at zb.
+            // With only SF1.3, the "Leadership" course gives ~20.5exp/s. With this exponential saturation curve, the
+            // action gives worse exp than the course at first, but it becomes better later while never being
+            // overpowered. The gain rate is soft-capped at ~60exp/s, which is ~3x the uni course.
+            const charismaGainRate = clampNumber(60 * (1 - Math.exp(-Math.pow(person.exp.charisma / 216000, 1.3))), 1);
             if (action.attempt(this, person)) {
-              const expGain = 2 * BladeburnerConstants.BaseStatGain * actionTime;
+              const expGain = charismaGainRate * actionTime;
               retValue.chaExp = expGain;
               ++this.teamSize;
               if (this.logging.general) {
@@ -1130,7 +1135,7 @@ export class Bladeburner implements OperationTeam {
                 );
               }
             } else {
-              const expGain = BladeburnerConstants.BaseStatGain * actionTime;
+              const expGain = (charismaGainRate * actionTime) / 2;
               retValue.chaExp = expGain;
               if (this.logging.general) {
                 this.log(


### PR DESCRIPTION
Context: #295.

Except for the very niche use of `Diplomacy` (get 100k charisma to one-shot chaos), charisma has been useless. With dnet, it's time to acknowledge this issue. Currently, `Recruitment` gives 2000 cha/s, which is 100x the "Leadership" uni course in zb. The simplest way to fix this issue is to remove the x1000 as suggested in #295. However, nerfing it to 2 cha/s may be too harsh. Recruitment is already almost useless due to how bad the team mechanic is, so having 2 cha/s looks like a joke. I'm fine with it, but I want to try a different approach.

In this PR, I tune the formula with these conditions in mind:
- Soft-capped at a multiple of uni course cha/s.
- Gain rate depends on the current cha exp.
  - Without a reasonable amount of current cha exp, it's very low. This forces the player to gain some exp before using this action. They cannot use it with 0 exp and expect the level to jump to 300-500 immediately.
  - With some cha exp, the gain rate increases smoothly until it hits the softcap. And the softcap is relatively decent (3x uni course, which is really high without dnet).
- Not affect dnet balance.

I know tuning the gain rate like this is useless if we compare it with dnet. However, it's nice to *not* nerf this feature to a meme-ish level.

Desmos link: https://www.desmos.com/calculator/piiyxamulx

Some numbers (you should fiddle with my simulator to see more):

With 0 cha exp and never do uni course:
- Cha/s stucks at 1 cha/s even after 2 hours.
- 9 cha/s after 5 hours.
- Hit softcap after ~ 9 hours.

Do 30 minutes of uni course before using this action:
- Hit 20 cha/s (equal uni course) after 1.5 hour.
- Hit softcap after 4 hours.

Do 30 minutes of uni course, then keep doing uni course while using this action:
- Hit 20 cha/s (equal uni course) after 37 minutes.
- Hit softcap after 3 hours.

Simulator:
```js
/** @param {NS} ns */
export async function main(ns) {
  console.clear();
  const expMult = 1.28128; // SF1.3
  const skillMult = expMult;
  const uniCourseExpGainRate = 5 * 4 * 0.8 * expMult;
  console.log(uniCourseExpGainRate);
  let currentExp = uniCourseExpGainRate * 60 * 30;
  let currentSkill = calculateSkill(currentExp, skillMult);
  let totalTime = 0;
  let uniCourse = true;
  // uniCourse = false;
  console.log("start", currentSkill, currentExp);
  for (let i = 0; i < 70; ++i) {
    const time = getActionTime(currentSkill);
    totalTime += time;
    if (uniCourse) {
      currentExp += uniCourseExpGainRate * time;
    }
    // const charismaGainRate = 2000;
    const charismaGainRate = clampNumber(
      60 * (1 - Math.exp(-Math.pow(currentExp / 216000, 1.3))),
      1,
    );
    const expGain = charismaGainRate * time;
    const effectiveExpGain = expGain * expMult;
    currentExp += effectiveExpGain;
    currentSkill = calculateSkill(currentExp, skillMult);
    console.log(ns.format.time(totalTime * 1000), currentSkill, currentExp, charismaGainRate);
  }
}

function getActionTime(charismaLevel) {
  // Assume that skillMult from BB skills is 1
  const effCharisma = charismaLevel;
  const charismaFactor = Math.pow(effCharisma, 0.81) + effCharisma / 90;
  return Math.max(10, Math.round(300 - charismaFactor));
}

function calculateSkill(exp, mult) {
  const value = Math.floor(mult * (32 * Math.log(exp + 534.6) - 200));
  return clampNumber(value, 1);
}

function clampNumber(value, min = -Number.MAX_VALUE, max = Number.MAX_VALUE) {
  return Math.max(Math.min(value, max), min);
}
```