### PR TITLE
UI: Update toolbar of in-game editor

### DIFF
--- a/src/Documentation/ui/DocumentationAutocomplete.tsx
+++ b/src/Documentation/ui/DocumentationAutocomplete.tsx
@@ -19,9 +19,10 @@ type DocumentationAutocompleteProps = {
    * "path" is always "nsDoc/filename.md"
    */
   onChange: (path: string, external: boolean) => void;
+  width?: number;
 };
 
-export function DocumentationAutocomplete({ sx, onChange }: DocumentationAutocompleteProps) {
+export function DocumentationAutocomplete({ sx, onChange, width }: DocumentationAutocompleteProps) {
   return (
     <AutoCompleteSearchBox
       sx={sx}
@@ -45,6 +46,7 @@ export function DocumentationAutocomplete({ sx, onChange }: DocumentationAutocom
           onChange(`nsDoc/${path}`, external);
         }
       }}
+      width={width}
     />
   );
 }

--- a/src/ScriptEditor/ui/Toolbar.tsx
+++ b/src/ScriptEditor/ui/Toolbar.tsx
@@ -69,7 +69,11 @@ export function Toolbar({ editor, onSave, onRun, onBeautify }: IProps) {
         >
           Beautify
         </Button>
-        <Button color={isUpdatingRAM ? "secondary" : "primary"} sx={{ mx: 1 }} onClick={openRAMInfo}>
+        <Button
+          color={isUpdatingRAM ? "secondary" : "primary"}
+          sx={{ mx: 1, whiteSpace: "nowrap" }}
+          onClick={openRAMInfo}
+        >
           {ram}
         </Button>
         <Tooltip title={parseKeyCombinationsToString(CurrentKeyBindings[ScriptEditorAction.Save])}>
@@ -105,6 +109,7 @@ export function Toolbar({ editor, onSave, onRun, onBeautify }: IProps) {
             }
             openDocumentationPopUp(path);
           }}
+          width={350}
         />
         <Typography>
           <DocumentationLink


### PR DESCRIPTION
From Discord: When the screen width is small, the RAM button is displayed on 2 lines. Now it's always on the same line.

I also reduced the width of the autocomplete search box.

Before:

<img width="854" height="77" alt="before" src="https://github.com/user-attachments/assets/afa34cef-3948-4b3a-9bdf-ef04c55bfb8e" />

After:

<img width="848" height="69" alt="after" src="https://github.com/user-attachments/assets/f765080a-9ce6-4ab7-9d8c-a282e1e0831b" />
