### PR TITLE
BUGFIX: Fixed typo/whitespace issue in sector-12-crime.lit

### DIFF
--- a/src/Literature/Literatures.tsx
+++ b/src/Literature/Literatures.tsx
@@ -409,7 +409,7 @@ export const Literatures: Record<LiteratureName, Literature> = {
         CIA director David Glarow says it's too early to know whether these figures indicate the beginning of a
         sustained increase in crime rates, or whether the year was just an unfortunate outlier. He states that many
         intelligence and law enforcement agents have noticed an increase in organized crime activities, and believes
-        that these figures may be the result of an uprising from criminal organizations such as{" "}
+        that these figures may be the result of an uprising from criminal organizations such as {" "}
         {FactionName.TheSyndicate} or the {FactionName.SlumSnakes}.
       </Typography>
     ),

--- a/src/Literature/Literatures.tsx
+++ b/src/Literature/Literatures.tsx
@@ -400,7 +400,7 @@ export const Literatures: Record<LiteratureName, Literature> = {
     factionRumors: [FactionName.TheSyndicate, FactionName.SlumSnakes],
     text: (
       <Typography>
-        A recent study by analytics company Wilson Inc. shows a significant rise in criminal activity in{" "}
+        A recent study by analytics company Wilson Inc. shows a significant rise in criminal activity in {" "}
         {CityName.Sector12}. Perhaps the most alarming part of the statistic is that most of the rise is in violent
         crime such as homicide and assault. According to the study, the city saw a total of 21,406 reported homicides in
         2076, which is over a 20% increase compared to 2075.


### PR DESCRIPTION
Adds missing spaces in the text.

Fixes issue #2552 