### PR TITLE
UI: Show "undefined" instead of -1 as pid in error popup when catching promise errors

### DIFF
--- a/src/ErrorHandling/DisplayError.ts
+++ b/src/ErrorHandling/DisplayError.ts
@@ -9,7 +9,7 @@ let currentId = 0;
 export const DisplayError = (message: string, errorType: string, ws: WorkerScript | null = null) => {
   const scriptName = ws?.scriptRef?.filename ?? "";
   const hostname = ws?.hostname ?? "";
-  const pid = ws?.pid ?? -1;
+  const pid = ws?.pid;
   const parsedMessage = ws ? parseBlobUrlInMessage(ws, message) : message;
   const errorPageOpen = Router.page() === SimplePage.RecentErrors;
   if (!errorPageOpen) {
@@ -19,7 +19,7 @@ export const DisplayError = (message: string, errorType: string, ws: WorkerScrip
   if (prior) {
     prior.occurrences++;
     prior.time = new Date();
-    if (pid !== -1) {
+    if (pid !== undefined) {
       prior.pid = pid;
     }
     prior.server = hostname;
@@ -37,6 +37,7 @@ export const DisplayError = (message: string, errorType: string, ws: WorkerScrip
       occurrences: 1,
       time: new Date(),
       unread: !errorPageOpen,
+      force: false,
     });
     while (ErrorState.Errors.length > 100) {
       ErrorState.Errors.pop();

--- a/src/ErrorHandling/ErrorModal.tsx
+++ b/src/ErrorHandling/ErrorModal.tsx
@@ -73,7 +73,7 @@ export function ErrorModal(): React.ReactElement {
             <p>
               Script: {error.scriptName}
               <br />
-              PID: {error.pid}
+              PID: {error.pid ?? "Unknown"}
             </p>
             {!Settings.SuppressErrorModals && (
               <OptionSwitch
@@ -92,7 +92,7 @@ export function ErrorModal(): React.ReactElement {
           <Box className={classes.inlineFlexBox}>
             <Button onClick={() => onClose()}>Close</Button>
             <div>
-              <Button disabled={error.pid === -1} onClick={viewLogs}>
+              <Button disabled={error.pid === undefined} onClick={viewLogs}>
                 View Script Logs
               </Button>
               <Button onClick={goToErrorPage}>Errors Page</Button>

--- a/src/ErrorHandling/ErrorModal.tsx
+++ b/src/ErrorHandling/ErrorModal.tsx
@@ -73,7 +73,7 @@ export function ErrorModal(): React.ReactElement {
             <p>
               Script: {error.scriptName}
               <br />
-              PID: {error.pid ?? "Unknown"}
+              PID: {error.pid ?? "undefined"}
             </p>
             {!Settings.SuppressErrorModals && (
               <OptionSwitch

--- a/src/ErrorHandling/ErrorModal.tsx
+++ b/src/ErrorHandling/ErrorModal.tsx
@@ -73,7 +73,7 @@ export function ErrorModal(): React.ReactElement {
             <p>
               Script: {error.scriptName}
               <br />
-              PID: {error.pid ?? "undefined"}
+              PID: {String(error.pid)}
             </p>
             {!Settings.SuppressErrorModals && (
               <OptionSwitch

--- a/src/ErrorHandling/ErrorState.tsx
+++ b/src/ErrorHandling/ErrorState.tsx
@@ -6,11 +6,11 @@ export type ErrorRecord = {
   errorType: string;
   message: string;
   scriptName: string;
-  pid: number;
+  pid?: number;
   occurrences: number;
   time: Date;
   unread: boolean;
-  force?: boolean;
+  force: boolean;
 };
 
 export const ErrorState = {


### PR DESCRIPTION
Edit: It will show "undefined".

Jeek asked why the pid was -1. I guess showing "Unknown" pid is less confusing.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.asleep(0).then(() => {
    throw new Error("foo");
  });
}
```

Before:

<img width="315" height="334" alt="before" src="https://github.com/user-attachments/assets/ddd553c9-7880-4e56-8d2c-4bd31960ebf0" />

After:

<img width="298" height="310" alt="after" src="https://github.com/user-attachments/assets/b8065151-aec6-4a68-9f6f-7e06505e2433" />