### PR TITLE
API: Print error message when calling ns.ui.closeTail with nonexistent pid or pid of stopped scripts

### DIFF
--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -70,7 +70,12 @@ export function NetscriptUserInterface(): InternalAPI<IUserInterface> {
       (ctx) =>
       (_pid = ctx.workerScript.scriptRef.pid) => {
         const pid = helpers.number(ctx, "pid", _pid);
-        //Emit an event to tell the game to close the tail window if it exists
+        const runningScriptObj = helpers.getRunningScript(ctx, pid);
+        if (runningScriptObj == null) {
+          helpers.log(ctx, () => helpers.getCannotFindRunningScriptErrorMessage(pid));
+          return;
+        }
+        // Emit an event to tell the game to close the tail window if it exists.
         LogBoxCloserEvents.emit(pid);
       },
 


### PR DESCRIPTION
This is the standard behavior of all other tail-related APIs.

<img width="448" height="253" alt="Capture" src="https://github.com/user-attachments/assets/c3d92bcb-6988-4b83-bc6b-951812e76c44" />
