### PR TITLE
API: Add minimum width/height constraints to ns.ui.resizeTail

### DIFF
--- a/markdown/bitburner.userinterface.resizetail.md
+++ b/markdown/bitburner.userinterface.resizetail.md
@@ -42,7 +42,7 @@ number
 
 </td><td>
 
-Width of the window.
+Width of the window. The minimum value is 150.
 
 
 </td></tr>
@@ -58,7 +58,7 @@ number
 
 </td><td>
 
-Height of the window.
+Height of the window. The minimum value is 30.
 
 
 </td></tr>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6744,8 +6744,8 @@ interface UserInterface {
    *
    * Resize a tail window. Size are in pixel.
    *
-   * @param width - Width of the window.
-   * @param height - Height of the window.
+   * @param width - Width of the window. The minimum value is 150.
+   * @param height - Height of the window. The minimum value is 30.
    * @param pid - Optional. PID of the script having its tail resized. If omitted, the current script is used.
    */
   resizeTail(width: number, height: number, pid?: number): void;

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -27,11 +27,16 @@ import { useRerender } from "./hooks";
 import { dialogBoxCreate } from "./DialogBox";
 import { makeStyles } from "tss-react/mui";
 import { logBoxBaseZIndex } from "./Constants";
+import { clampNumber } from "../../utils/helpers/clampNumber";
+
 let layerCounter = 0;
 
 export const LogBoxEvents = new EventEmitter<[RunningScript]>();
 export const LogBoxCloserEvents = new EventEmitter<[number]>();
 export const LogBoxClearEvents = new EventEmitter<[]>();
+
+// Min width/height of a log window
+const minWindowSize: [number, number] = [150, 33];
 
 // Dynamic properties (size, position) bound to a specific rendered instance of a LogBox
 export class LogBoxProperties {
@@ -64,8 +69,8 @@ export class LogBoxProperties {
   }
 
   setSize(width: number, height: number): void {
-    this.width = width;
-    this.height = height;
+    this.width = clampNumber(width, minWindowSize[0]);
+    this.height = clampNumber(height, minWindowSize[1]);
     this.rerender();
   }
 
@@ -330,9 +335,6 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
     }
   };
 
-  // Max [width, height]
-  const minConstraints: [number, number] = [150, 33];
-
   return (
     <Draggable handle=".drag" onDrag={onDrag} ref={rootRef} onMouseDown={updateLayer}>
       <Box
@@ -341,8 +343,8 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
           flexFlow: "column",
           position: "fixed",
           zIndex: 1400,
-          minWidth: `${minConstraints[0]}px`,
-          minHeight: `${minConstraints[1]}px`,
+          minWidth: `${minWindowSize[0]}px`,
+          minHeight: `${minWindowSize[1]}px`,
           ...(minimized
             ? {
                 border: "none",
@@ -360,7 +362,7 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
           width={propsRef.current.width}
           height={propsRef.current.height}
           onResize={onResize}
-          minConstraints={minConstraints}
+          minConstraints={minWindowSize}
           handle={
             <span
               style={{
@@ -379,7 +381,7 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
             <Paper className="drag" sx={{ display: "flex", alignItems: "center", cursor: "grab" }} ref={draggableRef}>
               {title()}
 
-              <span style={{ minWidth: "fit-content", height: `${minConstraints[1]}px` }}>
+              <span style={{ minWidth: "fit-content", height: `${minWindowSize[1]}px` }}>
                 {!workerScripts.has(script.pid) ? (
                   <IconButton title="Re-run script" className={classes.titleButton} onClick={run} onTouchEnd={run}>
                     <PlayCircleIcon />
@@ -405,7 +407,7 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
 
             <Paper
               className={classes.logs}
-              style={{ height: `calc(100% - ${minConstraints[1]}px)`, display: minimized ? "none" : "flex" }}
+              style={{ height: `calc(100% - ${minWindowSize[1]}px)`, display: minimized ? "none" : "flex" }}
               tabIndex={-1}
               ref={textArea}
               onKeyDown={textAreaKeyDown}


### PR DESCRIPTION
These constraints are already enforced in the UI when you resize the window by dragging. However, if you use the API, it looks like this:

<img width="404" height="355" alt="Capture" src="https://github.com/user-attachments/assets/3081377d-4a74-4feb-97f5-4f841a19f3c0" />
