### PR TITLE
API: Cancel sleeve's current task when calling ns.sleeve.travel()

### DIFF
--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -537,6 +537,14 @@ export class Sleeve extends Person implements SleevePerson {
     return false;
   }
 
+  travel(cityName: CityName): boolean {
+    if (!super.travel(cityName)) {
+      return false;
+    }
+    this.stopWork();
+    return true;
+  }
+
   travelCostMoneySource(): MoneySource {
     return "sleeves";
   }

--- a/src/PersonObjects/Sleeve/ui/TravelModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/TravelModal.tsx
@@ -22,7 +22,6 @@ export function TravelModal(props: TravelModalProps): React.ReactElement {
       dialogBoxCreate("You cannot afford to have this sleeve travel to another city");
       return;
     }
-    props.sleeve.stopWork();
     props.rerender();
     props.onClose();
   }

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -570,5 +570,10 @@ export const breakingChanges300: VersionBreakingChange = {
         "RAM cost. Now the hacknet namespace does not incur RAM cost, but each hacknet API incurs a 0.5GB RAM cost.",
       showWarning: false,
     },
+    {
+      brokenAPIs: [{ name: "ns.sleeve.travel" }],
+      info: "ns.sleeve.travel() did not cancel the sleeve's current task. It does now.",
+      showWarning: false,
+    },
   ],
 };

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -621,7 +621,7 @@ Error: ${e}`,
   if (ver < 45) {
     initDarkwebServer();
   }
-  if (ver < 46) {
+  if (ver < 47) {
     showAPIBreaks("3.0.0", breakingChanges300);
   }
 }


### PR DESCRIPTION
`ns.sleeve.travel()` does not cancel the current work of the specified sleeve. This is inconsistent with the Sleeve UI.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  Player.money = 1e10;
  ns.sleeve.travel(0, "Sector-12");
  ns.sleeve.setToCommitCrime(0, "Mug");
  console.log("before", ns.sleeve.getSleeve(0).city);
  console.log("before", ns.sleeve.getTask(0));
  ns.sleeve.travel(0, "Aevum");
  console.log("after", ns.sleeve.getSleeve(0).city);
  console.log("after", ns.sleeve.getTask(0));
}
```

Before:
```
before Sector-12
before {type: 'CRIME', crimeType: 'Mug', tasksCompleted: 0, cyclesWorked: 0, cyclesNeeded: 20}
after Aevum
after {type: 'CRIME', crimeType: 'Mug', tasksCompleted: 0, cyclesWorked: 0, cyclesNeeded: 20}
```

After:
```
before Sector-12
before {type: 'CRIME', crimeType: 'Mug', tasksCompleted: 0, cyclesWorked: 0, cyclesNeeded: 20}
after Aevum
after null
```

Log:
```
ns.sleeve.travel() did not cancel the sleeve's current task. It does now.

Usage of the following functions may have been affected:
ns.sleeve.travel

Potentially affected files on server home (with line numbers):
test.js: (Line numbers: 5, 9)
```