### PR TITLE
API: Make ns.cloud.purchaseServer() and ns.cloud.deleteServer() use hostname as provided

### DIFF
--- a/src/Locations/ui/PurchaseServerModal.tsx
+++ b/src/Locations/ui/PurchaseServerModal.tsx
@@ -30,7 +30,9 @@ export function PurchaseServerModal(props: IProps): React.ReactElement {
   }
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>): void {
-    setHostname(event.target.value);
+    // Players may accidentally include whitespace in the hostname and later wonder why they cannot use the cloud APIs.
+    // For example, they intend the hostname to be "foobar", but type "foobar " or "foo bar" instead.
+    setHostname(event.target.value.replace(/\s+/g, ""));
   }
 
   return (

--- a/src/NetscriptFunctions/Cloud.ts
+++ b/src/NetscriptFunctions/Cloud.ts
@@ -33,9 +33,8 @@ export function NetscriptCloud(): InternalAPI<Cloud> {
       return cost;
     },
     purchaseServer: (ctx) => (_hostname, _ram) => {
-      let hostname = helpers.string(ctx, "hostname", _hostname);
+      const hostname = helpers.string(ctx, "hostname", _hostname);
       const ram = helpers.number(ctx, "ram", _ram);
-      hostname = hostname.replace(/\s+/g, "");
       if (hostname === "") {
         helpers.log(ctx, () => `Invalid argument: hostname='${hostname}' is an empty string.`);
         return "";
@@ -126,8 +125,7 @@ export function NetscriptCloud(): InternalAPI<Cloud> {
     },
 
     deleteServer: (ctx) => (_name) => {
-      let host = helpers.string(ctx, "name", _name);
-      host = host.replace(/\s\s+/g, "");
+      const host = helpers.string(ctx, "name", _name);
       const server = helpers.getNormalServer(ctx, host);
       const hostname = server.hostname;
 

--- a/src/Server/ServerHelpers.ts
+++ b/src/Server/ServerHelpers.ts
@@ -40,7 +40,7 @@ export enum ServerOwnershipType {
  * does not have a duplicate hostname/ip.
  */
 export function safelyCreateUniqueServer(params: StandardServerConstructorParams): Server {
-  let hostname: string = params.hostname.replace(/ /g, `-`);
+  let hostname = params.hostname;
 
   if (params.ip != null && ipExists(params.ip)) {
     params.ip = createUniqueRandomIp();

--- a/src/utils/APIBreaks/3.0.0.ts
+++ b/src/utils/APIBreaks/3.0.0.ts
@@ -575,5 +575,12 @@ export const breakingChanges300: VersionBreakingChange = {
       info: "ns.sleeve.travel() did not cancel the sleeve's current task. It does now.",
       showWarning: false,
     },
+    {
+      brokenAPIs: [{ name: "ns.cloud.purchaseServer" }, { name: "ns.cloud.deleteServer" }],
+      info:
+        "ns.cloud.purchaseServer() and ns.cloud.deleteServer() previously removed whitespace from the provided hostname inconsistently.\n" +
+        "They now use the hostname as provided.",
+      showWarning: false,
+    },
   ],
 };


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/pull/2367#issuecomment-3503711089

Note: This PR also reverts part of https://github.com/danielyxie/bitburner/pull/2010. I'm not sure what issue hydroflame was referring to in https://github.com/danielyxie/bitburner/issues/1999.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  Player.money = 1e100;
  // for (const s of ns.cloud.getServerNames()) {
  //   ns.cloud.deleteServer(s);
  // }
  ns.cloud.purchaseServer("foo bar", 2);
  ns.cloud.purchaseServer("foo bar", 2);
  ns.cloud.purchaseServer("foo bar", 2);
}
```

Before:
```
cloud.purchaseServer: Purchased new cloud server with hostname 'foobar' for $110.000k
cloud.purchaseServer: Purchased new cloud server with hostname 'foobar-0' for $110.000k
cloud.purchaseServer: Purchased new cloud server with hostname 'foobar-1' for $110.000k
```

After:
```
cloud.purchaseServer: Purchased new cloud server with hostname 'foo bar' for $110.000k
cloud.purchaseServer: Purchased new cloud server with hostname 'foo bar-0' for $110.000k
cloud.purchaseServer: Purchased new cloud server with hostname 'foo bar-1' for $110.000k
```