### PR TITLE
BUGFIX: Intelligence skill is not overridden in some calculations

### DIFF
--- a/src/Bladeburner/Actions/Action.ts
+++ b/src/Bladeburner/Actions/Action.ts
@@ -172,7 +172,7 @@ export abstract class ActionClass {
     for (const stat of getRecordKeys(person.skills)) {
       competence += this.weights[stat] * Math.pow(inst.getEffectiveSkillLevel(person, stat), this.decays[stat]);
     }
-    competence *= calculateIntelligenceBonus(person.skills.intelligence, 0.75);
+    competence *= calculateIntelligenceBonus(person, 0.75);
     competence *= inst.calculateStaminaPenalty();
 
     competence *= this.getTeamSuccessBonus(inst);

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -57,6 +57,7 @@ import { loadActionIdentifier } from "./utils/loadActionIdentifier";
 import { pluralize } from "../utils/I18nUtils";
 import { calculateActionRankGain, calculateActionReputationGain } from "./Formulas";
 import { processWorkStats } from "../Work/Formulas";
+import { getEffectiveIntelligence } from "../PersonObjects/formulas/intelligence";
 
 export const BladeburnerPromise: PromisePair<number> = { promise: null, resolve: null };
 
@@ -1089,7 +1090,7 @@ export class Bladeburner implements OperationTeam {
             // Does not use stamina. Effectiveness depends on hacking, int, and cha
             let eff =
               0.04 * Math.pow(person.skills.hacking, 0.3) +
-              0.04 * Math.pow(person.skills.intelligence, 0.9) +
+              0.04 * Math.pow(getEffectiveIntelligence(person), 0.9) +
               0.02 * Math.pow(person.skills.charisma, 0.3);
             eff *= person.mults.bladeburner_analysis;
             if (isNaN(eff) || eff < 0) {

--- a/src/Company/CompanyPosition.ts
+++ b/src/Company/CompanyPosition.ts
@@ -2,6 +2,7 @@ import { Person as IPerson } from "@nsdefs";
 import { CONSTANTS } from "../Constants";
 import { JobName, JobField } from "@enums";
 import type { Skills } from "../PersonObjects/Skills";
+import { getEffectiveIntelligence } from "../PersonObjects/formulas/intelligence";
 
 export interface CompanyPositionCtorParams {
   nextPosition: JobName | null;
@@ -167,7 +168,7 @@ export class CompanyPosition {
       console.error("Company reputation gain calculated to be NaN");
       reputationGain = 0;
     }
-    reputationGain += worker.skills.intelligence / CONSTANTS.MaxSkillLevel;
+    reputationGain += getEffectiveIntelligence(worker) / CONSTANTS.MaxSkillLevel;
     return reputationGain;
   }
 }

--- a/src/Crime/Crime.ts
+++ b/src/Crime/Crime.ts
@@ -4,7 +4,7 @@ import { Person as IPerson } from "@nsdefs";
 import { WorkerScript } from "../Netscript/WorkerScript";
 import { CrimeType } from "@enums";
 import { CrimeWork } from "../Work/CrimeWork";
-import { calculateIntelligenceBonus } from "../PersonObjects/formulas/intelligence";
+import { calculateIntelligenceBonus, getEffectiveIntelligence } from "../PersonObjects/formulas/intelligence";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 
 interface IConstructorParams {
@@ -125,12 +125,12 @@ export class Crime {
       this.dexterity_success_weight * p.skills.dexterity +
       this.agility_success_weight * p.skills.agility +
       this.charisma_success_weight * p.skills.charisma +
-      CONSTANTS.IntelligenceCrimeWeight * p.skills.intelligence;
+      CONSTANTS.IntelligenceCrimeWeight * getEffectiveIntelligence(p);
     chance /= CONSTANTS.MaxSkillLevel;
     chance /= this.difficulty;
     chance *= p.mults.crime_success;
     chance *= currentNodeMults.CrimeSuccessRate;
-    chance *= calculateIntelligenceBonus(p.skills.intelligence, 1);
+    chance *= calculateIntelligenceBonus(p, 1);
 
     return Math.min(chance, 1);
   }

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -106,7 +106,7 @@ export const calculateAuthenticationTime = (
     darknetServerData.modelId === ModelIds.TimingAttack ? getSharedChars(password, attemptedPassword) : 0;
   const sharedCharsExtraTime = sharedChars * 50 * threadsFactor;
 
-  return time * calculateIntelligenceBonus(person.skills.intelligence, 0.25) + sharedCharsExtraTime;
+  return time * calculateIntelligenceBonus(person, 0.25) + sharedCharsExtraTime;
 };
 
 export const getBackdoorAuthTimeDebuff = () => {

--- a/src/Hacking.ts
+++ b/src/Hacking.ts
@@ -15,11 +15,7 @@ export function calculateHackingChance(server: IServer, person: IPerson): number
   const difficultyMult = (100 - hackDifficulty) / 100;
   const skillMult = clampNumber(hackFactor * person.skills.hacking, 1);
   const skillChance = (skillMult - requiredHackingSkill) / skillMult;
-  const chance =
-    skillChance *
-    difficultyMult *
-    person.mults.hacking_chance *
-    calculateIntelligenceBonus(person.skills.intelligence, 1);
+  const chance = skillChance * difficultyMult * person.mults.hacking_chance * calculateIntelligenceBonus(person, 1);
   return clampNumber(chance, 0, 1);
 }
 
@@ -72,9 +68,7 @@ export function calculateHackingTime(server: IServer, person: IPerson): number {
   const hackTimeMultiplier = 5;
   const hackingTime =
     (hackTimeMultiplier * skillFactor) /
-    (person.mults.hacking_speed *
-      currentNodeMults.HackingSpeedMultiplier *
-      calculateIntelligenceBonus(person.skills.intelligence, 1));
+    (person.mults.hacking_speed * currentNodeMults.HackingSpeedMultiplier * calculateIntelligenceBonus(person, 1));
 
   return hackingTime;
 }

--- a/src/Infiltration/formulas/game.ts
+++ b/src/Infiltration/formulas/game.ts
@@ -1,5 +1,6 @@
 import { Player } from "@player";
 import { clampNumber } from "../../utils/helpers/clampNumber";
+import { getEffectiveIntelligence } from "../../PersonObjects/formulas/intelligence";
 
 export const MaxDifficultyForInfiltration = 3.5;
 // This value is typically denoted "lambda," and is the instantaneous rate of decay.
@@ -39,7 +40,7 @@ export function decreaseMarketDemandMultiplier(timestamp: number, floors: number
 }
 
 function calculateRawDiff(stats: number, startingDifficulty: number): number {
-  return clampNumber(startingDifficulty - Math.pow(stats, 0.9) / 250 - Player.skills.intelligence / 1600, 0);
+  return clampNumber(startingDifficulty - Math.pow(stats, 0.9) / 250 - getEffectiveIntelligence(Player) / 1600, 0);
 }
 
 export function calculateDifficulty(startingSecurityLevel: number): number {

--- a/src/NetworkShare/Share.ts
+++ b/src/NetworkShare/Share.ts
@@ -21,7 +21,7 @@ export const pendingUIShareJobIds: number[] = [];
 
 export function calculateEffectiveSharedThreads(threads: number, cpuCores: number): number {
   const coreBonus = getCoreBonus(cpuCores);
-  return threads * calculateIntelligenceBonus(Player.skills.intelligence, 2) * coreBonus;
+  return threads * calculateIntelligenceBonus(Player, 2) * coreBonus;
 }
 
 export function startSharing(threads: number, cpuCores: number): () => void {

--- a/src/PersonObjects/Grafting/GraftingHelpers.ts
+++ b/src/PersonObjects/Grafting/GraftingHelpers.ts
@@ -21,7 +21,7 @@ export const getGraftingAvailableAugs = (): AugmentationName[] => {
 };
 
 export const graftingIntBonus = (): number => {
-  return calculateIntelligenceBonus(Player.skills.intelligence, 1);
+  return calculateIntelligenceBonus(Player, 1);
 };
 
 export const calculateGraftingTimeWithBonus = (aug: GraftableAugmentation): number => {

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -264,10 +264,7 @@ export class Sleeve extends Person implements SleevePerson {
     this.storedCycles += numCycles;
     if (this.storedCycles < CyclesPerSecond || !this.currentWork) return;
     const cyclesUsed = Math.min(this.storedCycles, 15);
-    this.shock = Math.max(
-      0,
-      this.shock - 0.0001 * calculateIntelligenceBonus(this.skills.intelligence, 0.75) * cyclesUsed,
-    );
+    this.shock = Math.max(0, this.shock - 0.0001 * calculateIntelligenceBonus(this, 0.75) * cyclesUsed);
     this.currentWork.process(this, cyclesUsed);
     this.storedCycles -= cyclesUsed;
   }

--- a/src/PersonObjects/Sleeve/Work/SleeveRecoveryWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveRecoveryWork.ts
@@ -10,10 +10,7 @@ export class SleeveRecoveryWork extends SleeveWorkClass {
   type: SleeveWorkType.RECOVERY = SleeveWorkType.RECOVERY;
 
   process(sleeve: Sleeve, cycles: number) {
-    sleeve.shock = Math.max(
-      0,
-      sleeve.shock - 0.0002 * calculateIntelligenceBonus(sleeve.skills.intelligence, 0.75) * cycles,
-    );
+    sleeve.shock = Math.max(0, sleeve.shock - 0.0002 * calculateIntelligenceBonus(sleeve, 0.75) * cycles);
     if (sleeve.shock <= 0) sleeve.stopWork();
   }
 

--- a/src/PersonObjects/Sleeve/Work/SleeveSynchroWork.ts
+++ b/src/PersonObjects/Sleeve/Work/SleeveSynchroWork.ts
@@ -11,10 +11,7 @@ export class SleeveSynchroWork extends SleeveWorkClass {
   type: SleeveWorkType.SYNCHRO = SleeveWorkType.SYNCHRO;
 
   process(sleeve: Sleeve, cycles: number) {
-    sleeve.sync = Math.min(
-      100,
-      sleeve.sync + calculateIntelligenceBonus(Player.skills.intelligence, 0.5) * 0.0002 * cycles,
-    );
+    sleeve.sync = Math.min(100, sleeve.sync + calculateIntelligenceBonus(Player, 0.5) * 0.0002 * cycles);
     if (sleeve.sync >= 100) sleeve.stopWork();
   }
 

--- a/src/PersonObjects/formulas/intelligence.ts
+++ b/src/PersonObjects/formulas/intelligence.ts
@@ -1,12 +1,13 @@
 import type { Person as IPerson } from "@nsdefs";
 import { Player } from "@player";
+import { Person } from "../Person";
 
 export function calculateIntelligenceBonus(person: IPerson, weight = 1): number {
   return 1 + (weight * Math.pow(getEffectiveIntelligence(person), 0.8)) / 600;
 }
 
 export function getEffectiveIntelligence(person: IPerson): number {
-  if (person !== Player || Player.bitNodeOptions.intelligenceOverride === undefined) {
+  if (!(person instanceof Person) || Player.bitNodeOptions.intelligenceOverride === undefined) {
     return person.skills.intelligence;
   }
   return Math.min(Player.bitNodeOptions.intelligenceOverride, person.skills.intelligence);

--- a/src/PersonObjects/formulas/intelligence.ts
+++ b/src/PersonObjects/formulas/intelligence.ts
@@ -1,13 +1,13 @@
 import type { Person as IPerson } from "@nsdefs";
-import { PlayerObject } from "../Player/PlayerObject";
+import { Player } from "@player";
 
 export function calculateIntelligenceBonus(person: IPerson, weight = 1): number {
   return 1 + (weight * Math.pow(getEffectiveIntelligence(person), 0.8)) / 600;
 }
 
 export function getEffectiveIntelligence(person: IPerson): number {
-  if (!(person instanceof PlayerObject) || person.bitNodeOptions.intelligenceOverride === undefined) {
+  if (person !== Player || Player.bitNodeOptions.intelligenceOverride === undefined) {
     return person.skills.intelligence;
   }
-  return Math.min(person.bitNodeOptions.intelligenceOverride, person.skills.intelligence);
+  return Math.min(Player.bitNodeOptions.intelligenceOverride, person.skills.intelligence);
 }

--- a/src/PersonObjects/formulas/intelligence.ts
+++ b/src/PersonObjects/formulas/intelligence.ts
@@ -1,9 +1,13 @@
-import { Player } from "@player";
+import type { Person as IPerson } from "@nsdefs";
+import { PlayerObject } from "../Player/PlayerObject";
 
-export function calculateIntelligenceBonus(intelligence: number, weight = 1): number {
-  const effectiveIntelligence =
-    Player.bitNodeOptions.intelligenceOverride !== undefined
-      ? Math.min(Player.bitNodeOptions.intelligenceOverride, intelligence)
-      : intelligence;
-  return 1 + (weight * Math.pow(effectiveIntelligence, 0.8)) / 600;
+export function calculateIntelligenceBonus(person: IPerson, weight = 1): number {
+  return 1 + (weight * Math.pow(getEffectiveIntelligence(person), 0.8)) / 600;
+}
+
+export function getEffectiveIntelligence(person: IPerson): number {
+  if (!(person instanceof PlayerObject) || person.bitNodeOptions.intelligenceOverride === undefined) {
+    return person.skills.intelligence;
+  }
+  return Math.min(person.bitNodeOptions.intelligenceOverride, person.skills.intelligence);
 }

--- a/src/PersonObjects/formulas/reputation.ts
+++ b/src/PersonObjects/formulas/reputation.ts
@@ -2,7 +2,7 @@ import { CONSTANTS } from "../../Constants";
 import { currentNodeMults } from "../../BitNode/BitNodeMultipliers";
 import { calculateCurrentShareBonus } from "../../NetworkShare/Share";
 import { Person as IPerson } from "@nsdefs";
-import { calculateIntelligenceBonus } from "./intelligence";
+import { calculateIntelligenceBonus, getEffectiveIntelligence } from "./intelligence";
 import { Player } from "@player";
 
 function mult(favor: number): number {
@@ -15,9 +15,10 @@ function mult(favor: number): number {
 
 export function getHackingWorkRepGain(p: IPerson, favor: number): number {
   return (
-    ((p.skills.hacking + p.skills.intelligence + getDarknetCharismaBonus(p, 0.15) / 3) / CONSTANTS.MaxSkillLevel) *
+    ((p.skills.hacking + getEffectiveIntelligence(p) + getDarknetCharismaBonus(p, 0.15) / 3) /
+      CONSTANTS.MaxSkillLevel) *
     p.mults.faction_rep *
-    calculateIntelligenceBonus(p.skills.intelligence, 1) *
+    calculateIntelligenceBonus(p, 1) *
     mult(favor) *
     calculateCurrentShareBonus()
   );
@@ -30,10 +31,11 @@ export function getFactionSecurityWorkRepGain(p: IPerson, favor: number): number
         p.skills.defense +
         p.skills.dexterity +
         p.skills.agility +
-        (p.skills.hacking + p.skills.intelligence + getDarknetCharismaBonus(p, 0.3)) * calculateCurrentShareBonus())) /
+        (p.skills.hacking + getEffectiveIntelligence(p) + getDarknetCharismaBonus(p, 0.3)) *
+          calculateCurrentShareBonus())) /
     CONSTANTS.MaxSkillLevel /
     4.5;
-  return t * p.mults.faction_rep * mult(favor) * calculateIntelligenceBonus(p.skills.intelligence, 1);
+  return t * p.mults.faction_rep * mult(favor) * calculateIntelligenceBonus(p, 1);
 }
 
 export function getFactionFieldWorkRepGain(p: IPerson, favor: number): number {
@@ -44,10 +46,11 @@ export function getFactionFieldWorkRepGain(p: IPerson, favor: number): number {
         p.skills.dexterity +
         p.skills.agility +
         p.skills.charisma +
-        (p.skills.hacking + p.skills.intelligence + getDarknetCharismaBonus(p, 0.3)) * calculateCurrentShareBonus())) /
+        (p.skills.hacking + getEffectiveIntelligence(p) + getDarknetCharismaBonus(p, 0.3)) *
+          calculateCurrentShareBonus())) /
     CONSTANTS.MaxSkillLevel /
     5.5;
-  return t * p.mults.faction_rep * mult(favor) * calculateIntelligenceBonus(p.skills.intelligence, 1);
+  return t * p.mults.faction_rep * mult(favor) * calculateIntelligenceBonus(p, 1);
 }
 
 function getDarknetCharismaBonus(p: IPerson, scalar: number = 1): number {

--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -16,6 +16,7 @@ import { Page } from "../ui/Router";
 import { knowAboutBitverse } from "../BitNode/BitNodeUtils";
 import { handleStormSeed } from "../DarkNet/effects/webstorm";
 import { clampNumber } from "../utils/helpers/clampNumber";
+import { getEffectiveIntelligence } from "../PersonObjects/formulas/intelligence";
 
 function requireHackingLevel(lvl: number) {
   return function () {
@@ -24,7 +25,7 @@ function requireHackingLevel(lvl: number) {
 }
 
 export function getEffectiveHackingLevelRequirement(level: number): number {
-  return clampNumber(level - Player.skills.intelligence / 2, 1);
+  return clampNumber(level - getEffectiveIntelligence(Player) / 2, 1);
 }
 
 function bitFlumeRequirements() {

--- a/src/Programs/ui/ProgramsRoot.tsx
+++ b/src/Programs/ui/ProgramsRoot.tsx
@@ -12,6 +12,7 @@ import { Settings } from "../../Settings/Settings";
 import { Programs } from "../Programs";
 import { CreateProgramWork, isCreateProgramWork } from "../../Work/CreateProgramWork";
 import { useCycleRerender } from "../../ui/React/hooks";
+import { getEffectiveIntelligence } from "../../PersonObjects/formulas/intelligence";
 
 export const ProgramsSeen = new Set<string>();
 
@@ -40,7 +41,7 @@ export function ProgramsRoot(): React.ReactElement {
   });
 
   const getHackingLevelRemaining = (lvl: number): number => {
-    return Math.ceil(Math.max(lvl - (Player.skills.hacking + Player.skills.intelligence / 2), 0));
+    return Math.ceil(Math.max(lvl - (Player.skills.hacking + getEffectiveIntelligence(Player) / 2), 0));
   };
 
   const getProgCompletion = (name: string): number => {

--- a/src/Work/CreateProgramWork.ts
+++ b/src/Work/CreateProgramWork.ts
@@ -59,7 +59,7 @@ export class CreateProgramWork extends Work {
     const focusBonus = Player.focusPenalty();
     //Higher hacking skill will allow you to create programs faster
     const reqLvl = this.getProgram().create?.level ?? 0;
-    let skillMult = (Player.skills.hacking / reqLvl) * calculateIntelligenceBonus(Player.skills.intelligence, 3); //This should always be greater than 1;
+    let skillMult = (Player.skills.hacking / reqLvl) * calculateIntelligenceBonus(Player, 3); //This should always be greater than 1;
     skillMult = 1 + (skillMult - 1) / 5; //The divider constant can be adjusted as necessary
     skillMult *= focusBonus;
     //Skill multiplier directly applied to "time worked"


### PR DESCRIPTION
How to reproduce this bug: Set int level to 10k, override it with 1 when bitfluming, then do hacking work for a faction and observe the rep gain.

Tested: Manual testing.