### PR TITLE
CODEBASE: Create monaco editor instance with null model

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -51,7 +51,7 @@ export function Editor({ onMount, onChange, onUnmount }: EditorProps) {
 
     // Initialize monaco editor
     editorRef.current = monaco.editor.create(containerDiv.current, {
-      value: "",
+      model: null,
       automaticLayout: true,
       language: "javascript",
       ...options,


### PR DESCRIPTION
Video:

https://github.com/user-attachments/assets/ff7ad969-6363-4183-bffd-bdb870b86b76

Stack trace:
```
Uncaught Error: Cannot read properties of undefined (reading '0')

TypeError: Cannot read properties of undefined (reading '0')
    at Emitter._deliverQueue (event.js:894:36)
    at Emitter.fire (event.js:904:18)
    at TextModel.dispose (textModel.js:286:29)
    at StandaloneEditor._postDetachModelCleanup (standaloneCodeEditor.js:271:27)
    at StandaloneEditor.setModel (codeEditorWidget.js:441:18)
    at UniqueContainer.eval [as value] (codeEditorWidget.js:1322:63)
    at Emitter._deliver (event.js:883:22)
    at Emitter._deliverQueue (event.js:894:18)
    at Emitter.fire (event.js:915:18)
    at TextModel.dispose (textModel.js:286:29)
    at Emitter._deliverQueue (event.js:894:36)
    at Emitter.fire (event.js:904:18)
    at TextModel.dispose (textModel.js:286:29)
    at StandaloneEditor._postDetachModelCleanup (standaloneCodeEditor.js:271:27)
    at StandaloneEditor.setModel (codeEditorWidget.js:441:18)
    at UniqueContainer.eval [as value] (codeEditorWidget.js:1322:63)
    at Emitter._deliver (event.js:883:22)
    at Emitter._deliverQueue (event.js:894:18)
    at Emitter.fire (event.js:915:18)
    at TextModel.dispose (textModel.js:286:29)
    at eval (errors.js:29:27)
```
After upgrading monaco, I started seeing this error when rapidly switching tabs between the editor and other tabs.

After creating the monaco editor instance, there are 5 models created (`monaco.editor.getModels()`). 4 of them are: `netscript.d.ts`, `react.d.ts`, `react-dom.d.ts`, and `lib.dom.d.ts`. The fifth model is the initial model created by specifying `value` when calling `monaco.editor.create`.

This issue stops occurring if I set the editor to use a null model.