### PR TITLE
UI: Change description of some script editor options

### DIFF
--- a/src/ScriptEditor/ui/OptionsModal.tsx
+++ b/src/ScriptEditor/ui/OptionsModal.tsx
@@ -108,7 +108,7 @@ export function OptionsModal(props: OptionsModalProps): ReactElement {
       </div>
 
       <div style={{ display: "flex", alignItems: "center" }}>
-        <Typography marginRight={"auto"}>Enable font ligatures: </Typography>
+        <Typography marginRight={"auto"}>Font ligatures: </Typography>
         <Switch
           onChange={(e) => props.onOptionChange("fontLigatures", e.target.checked)}
           checked={props.options.fontLigatures}
@@ -152,7 +152,7 @@ export function OptionsModal(props: OptionsModalProps): ReactElement {
       </div>
 
       <div style={{ display: "flex", alignItems: "center" }}>
-        <Typography marginRight={"auto"}>Enable Sticky Scroll: </Typography>
+        <Typography marginRight={"auto"}>Sticky Scroll: </Typography>
         <Switch
           onChange={(e) => props.onOptionChange("stickyScroll", { enabled: e.target.checked })}
           checked={props.options.stickyScroll?.enabled}
@@ -160,7 +160,7 @@ export function OptionsModal(props: OptionsModalProps): ReactElement {
       </div>
 
       <div style={{ display: "flex", alignItems: "center" }}>
-        <Typography marginRight={"auto"}>Enable Minimap: </Typography>
+        <Typography marginRight={"auto"}>Minimap: </Typography>
         <Switch
           onChange={(e) => props.onOptionChange("minimap", { enabled: e.target.checked })}
           checked={props.options.minimap?.enabled}


### PR DESCRIPTION
Some boolean options are prefixed with "Enable", while others are not. We should be consistent.

<img width="320" height="406" alt="Capture" src="https://github.com/user-attachments/assets/738a28aa-f322-432d-bb35-79407f9847fd" />
