### PR TITLE
DOCUMENTATION: Fix typo in rewards of BN7

### DIFF
--- a/src/Documentation/doc/advanced/bitnodes.md
+++ b/src/Documentation/doc/advanced/bitnodes.md
@@ -138,7 +138,7 @@ Destroying this BitNode will give you Source-File 7, or if you already have this
 
 - Level 1: 8%
 - Level 2: 12%
-- Level 3: Level 3: 14% and immediately receive "The Blade's Simulacrum" augmentation after joining the Bladeburner division
+- Level 3: 14% and immediately receive "The Blade's Simulacrum" augmentation after joining the Bladeburner division
 
 ### BitNode 8: Ghost of Wall Street
 


### PR DESCRIPTION
BN7 Level 3 had "Level 3:" twice in a row, which was inconsistent with every other BN/level description - I removed the error