### PR TITLE
MISC: Rework faction rumor

### DIFF
--- a/src/Faction/FactionHelpers.tsx
+++ b/src/Faction/FactionHelpers.tsx
@@ -41,16 +41,14 @@ export function joinFaction(faction: Faction): void {
   // Add this faction to player's faction list, keeping it in standard order
   Player.factions = getRecordKeys(Factions).filter((facName) => Factions[facName].isMember);
 
-  // Ban player from this faction's enemies
+  // Ban player from joining this faction's enemies
   for (const enemy of faction.getInfo().enemies) {
     if (Factions[enemy]) Factions[enemy].isBanned = true;
-    Player.factionRumors.delete(enemy);
   }
-  // Remove invalid invites and rumors
+  // Remove invalid invites
   Player.factionInvitations = Player.factionInvitations.filter((factionName) => {
     return !Factions[factionName].isMember && !Factions[factionName].isBanned;
   });
-  Player.factionRumors.delete(faction.name);
 }
 
 //Returns a boolean indicating whether the player has the prerequisites for the

--- a/src/Faction/ui/FactionInvitationManager.tsx
+++ b/src/Faction/ui/FactionInvitationManager.tsx
@@ -52,7 +52,7 @@ export function FactionInvitationManager({ hidden }: { hidden: boolean }): React
   const enemies = faction?.getInfo().enemies ?? [];
 
   function join(): void {
-    if (faction === null || !faction.alreadyInvited || faction.isBanned) {
+    if (faction === null || !faction.alreadyInvited) {
       return;
     }
     joinFaction(faction);

--- a/src/Faction/ui/FactionInvitationManager.tsx
+++ b/src/Faction/ui/FactionInvitationManager.tsx
@@ -52,7 +52,7 @@ export function FactionInvitationManager({ hidden }: { hidden: boolean }): React
   const enemies = faction?.getInfo().enemies ?? [];
 
   function join(): void {
-    if (faction === null || !faction.alreadyInvited) {
+    if (faction === null || !faction.alreadyInvited || faction.isBanned) {
       return;
     }
     joinFaction(faction);

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -85,11 +85,9 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
     Router.toPage(Page.FactionAugmentations, { faction });
   }
 
-  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, faction: Faction): void {
-    if (!event.isTrusted || !faction.alreadyInvited || faction.isBanned) {
-      return;
-    }
-    joinFaction(faction);
+  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, faction: FactionName): void {
+    if (!event.isTrusted) return;
+    joinFaction(Factions[faction]);
     props.rerender();
   }
 
@@ -118,7 +116,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
             <Button onClick={() => openFactionAugPage(props.faction)}>Augments</Button>
           </Box>
         ) : props.faction.alreadyInvited ? (
-          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction)}>
+          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction.name)}>
             Join!
           </Button>
         ) : null}

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -121,7 +121,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
               alignItems: "center",
             }}
           >
-            {props.faction.discovery == FactionDiscovery.known ? (
+            {props.faction.discovery === FactionDiscovery.known ? (
               <Tooltip
                 title={
                   <>
@@ -130,13 +130,27 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
                   </>
                 }
               >
-                <span style={{ overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
+                <span
+                  style={{
+                    overflow: "hidden",
+                    whiteSpace: "nowrap",
+                    textOverflow: "ellipsis",
+                    textDecorationLine: Factions[props.faction.name].isBanned ? "line-through" : "none",
+                  }}
+                >
                   {props.faction.name}
                 </span>
               </Tooltip>
             ) : (
               <Tooltip title={"Rumored Faction"}>
-                <span style={{ overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
+                <span
+                  style={{
+                    overflow: "hidden",
+                    whiteSpace: "nowrap",
+                    textOverflow: "ellipsis",
+                    textDecorationLine: Factions[props.faction.name].isBanned ? "line-through" : "none",
+                  }}
+                >
                   <CorruptibleText content={props.faction.name} spoiler={false} />
                 </span>
               </Tooltip>
@@ -217,7 +231,9 @@ export function FactionsRoot(): React.ReactElement {
   const joinedFactions = Object.values(Factions).filter((faction) => faction.isMember);
   // Display invitations and rumors in the order they were received
   const invitedFactions = Player.factionInvitations.map((facName) => Factions[facName]).filter((faction) => !!faction);
-  const rumoredFactions = [...Player.factionRumors].map((facName) => Factions[facName]).filter((faction) => !!faction);
+  const rumoredFactions = [...Player.factionRumors]
+    .map((facName) => Factions[facName])
+    .filter((faction) => !!faction && !faction.isMember && !faction.alreadyInvited);
 
   return (
     <Container disableGutters maxWidth="lg" sx={{ mx: 0, mb: 10 }}>

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -85,9 +85,11 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
     Router.toPage(Page.FactionAugmentations, { faction });
   }
 
-  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, faction: FactionName): void {
-    if (!event.isTrusted) return;
-    joinFaction(Factions[faction]);
+  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, faction: Faction): void {
+    if (!event.isTrusted || !faction.alreadyInvited || faction.isBanned) {
+      return;
+    }
+    joinFaction(faction);
     props.rerender();
   }
 
@@ -116,7 +118,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
             <Button onClick={() => openFactionAugPage(props.faction)}>Augments</Button>
           </Box>
         ) : props.faction.alreadyInvited ? (
-          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction.name)}>
+          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction)}>
             Join!
           </Button>
         ) : null}

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -58,6 +58,16 @@ const JoinChecklist = (props: { faction: Faction }): React.ReactElement => {
   );
 };
 
+function getStylesForFactionName(faction: Faction) {
+  return {
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    color: faction.isBanned ? Settings.theme.error : "inherit",
+    textDecorationLine: faction.isBanned ? "line-through" : "none",
+  };
+}
+
 interface FactionElementProps {
   faction: Faction;
   /** Rerender function to force the entire FactionsRoot to rerender */
@@ -130,29 +140,11 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
                   </>
                 }
               >
-                <span
-                  style={{
-                    overflow: "hidden",
-                    whiteSpace: "nowrap",
-                    textOverflow: "ellipsis",
-                    color: Factions[props.faction.name].isBanned ? Settings.theme.error : "inherit",
-                    textDecorationLine: Factions[props.faction.name].isBanned ? "line-through" : "none",
-                  }}
-                >
-                  {props.faction.name}
-                </span>
+                <span style={getStylesForFactionName(props.faction)}>{props.faction.name}</span>
               </Tooltip>
             ) : (
               <Tooltip title={"Rumored Faction"}>
-                <span
-                  style={{
-                    overflow: "hidden",
-                    whiteSpace: "nowrap",
-                    textOverflow: "ellipsis",
-                    color: Factions[props.faction.name].isBanned ? Settings.theme.error : "inherit",
-                    textDecorationLine: Factions[props.faction.name].isBanned ? "line-through" : "none",
-                  }}
-                >
+                <span style={getStylesForFactionName(props.faction)}>
                   <CorruptibleText content={props.faction.name} spoiler={false} />
                 </span>
               </Tooltip>

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -135,6 +135,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
                     overflow: "hidden",
                     whiteSpace: "nowrap",
                     textOverflow: "ellipsis",
+                    color: Factions[props.faction.name].isBanned ? Settings.theme.error : "inherit",
                     textDecorationLine: Factions[props.faction.name].isBanned ? "line-through" : "none",
                   }}
                 >
@@ -148,6 +149,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
                     overflow: "hidden",
                     whiteSpace: "nowrap",
                     textOverflow: "ellipsis",
+                    color: Factions[props.faction.name].isBanned ? Settings.theme.error : "inherit",
                     textDecorationLine: Factions[props.faction.name].isBanned ? "line-through" : "none",
                   }}
                 >

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -140,7 +140,6 @@ export function prestigeAugmentation(this: PlayerObject): void {
 export function prestigeSourceFile(this: PlayerObject): void {
   this.entropy = 0;
   this.prestigeAugmentation();
-  this.factionRumors.clear();
   this.karma = 0;
   // Duplicate sleeves are reset to level 1 every Bit Node (but the number of sleeves you have persists)
   this.sleeves.forEach((sleeve) => sleeve.prestige());

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -110,7 +110,6 @@ export function prestigeAugmentation(this: PlayerObject): void {
 
   this.factions = [];
   this.factionInvitations = [];
-  this.factionRumors.clear();
   // Clear any pending invitation modals
   FactionInvitationEvents.emit({ type: "ClearAll" });
 
@@ -141,6 +140,7 @@ export function prestigeAugmentation(this: PlayerObject): void {
 export function prestigeSourceFile(this: PlayerObject): void {
   this.entropy = 0;
   this.prestigeAugmentation();
+  this.factionRumors.clear();
   this.karma = 0;
   // Duplicate sleeves are reset to level 1 every Bit Node (but the number of sleeves you have persists)
   this.sleeves.forEach((sleeve) => sleeve.prestige());
@@ -174,17 +174,22 @@ export function prestigeSourceFile(this: PlayerObject): void {
 
 export function receiveInvite(this: PlayerObject, factionName: FactionName): void {
   const faction = Factions[factionName];
-  if (this.factionInvitations.includes(factionName) || faction.alreadyInvited || faction.isMember || faction.isBanned)
+  if (this.factionInvitations.includes(factionName) || faction.alreadyInvited || faction.isMember || faction.isBanned) {
     return;
+  }
   this.factionInvitations.push(factionName);
-  this.factionRumors.delete(factionName);
   faction.discovery = FactionDiscovery.known;
 }
 
 export function receiveRumor(this: PlayerObject, factionName: FactionName): void {
   const faction = Factions[factionName];
-  if (faction.discovery === FactionDiscovery.unknown) faction.discovery = FactionDiscovery.rumored;
-  if (this.factionRumors.has(factionName) || faction.isMember || faction.isBanned || faction.alreadyInvited) return;
+  if (faction.discovery === FactionDiscovery.unknown) {
+    faction.discovery = FactionDiscovery.rumored;
+  }
+  if (this.factionRumors.has(factionName) || faction.isMember || faction.alreadyInvited) {
+    return;
+  }
+
   this.factionRumors.add(factionName);
 }
 
@@ -446,12 +451,11 @@ export function reapplyAllSourceFiles(this: PlayerObject): void {
 export function checkForFactionInvitations(this: PlayerObject): Faction[] {
   const invitedFactions = [];
   for (const faction of Object.values(Factions)) {
-    if (faction.isBanned) continue;
     if (faction.isMember) continue;
     if (faction.alreadyInvited) continue;
     // Handle invites
     const { inviteReqs, rumorReqs } = faction.getInfo();
-    if (inviteReqs.isSatisfied(this)) invitedFactions.push(faction);
+    if (!faction.isBanned && inviteReqs.isSatisfied(this)) invitedFactions.push(faction);
     // Handle rumors
     if (this.factionRumors.has(faction.name)) continue;
     if (rumorReqs.isSatisfied(this)) this.receiveRumor(faction.name);

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -58,14 +58,11 @@ export function prestigeAugmentation(): void {
 
   initBitNodeMultipliers();
 
-  // Maintain invites to factions with the 'keepOnInstall' flag, and rumors about others
+  // Maintain invites to factions with the 'keepOnInstall' flag
   const maintainInvites = new Set<FactionName>();
-  const maintainRumors = new Set<FactionName>();
   for (const facName of [...Player.factions, ...Player.factionInvitations]) {
     if (Factions[facName].getInfo().keep) {
       maintainInvites.add(facName);
-    } else {
-      maintainRumors.add(facName);
     }
   }
 
@@ -192,9 +189,6 @@ export function prestigeAugmentation(): void {
       Factions[FactionName.ChurchOfTheMachineGod].isBanned = true;
     }
   }
-
-  // Hear rumors after all invites/bans
-  for (const factionName of maintainRumors) Player.receiveRumor(factionName);
 
   resetPidCounter();
   ProgramsSeen.clear();

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -157,6 +157,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
   const canOpenFactions =
     Player.factionInvitations.length > 0 ||
     Player.factions.length > 0 ||
+    Player.factionRumors.size > 0 ||
     Player.augmentations.length > 0 ||
     Player.queuedAugmentations.length > 0 ||
     knowAboutBitverse();

--- a/src/utils/SaveDataMigrationUtils.ts
+++ b/src/utils/SaveDataMigrationUtils.ts
@@ -622,6 +622,9 @@ Error: ${e}`,
     initDarkwebServer();
   }
   if (ver < 47) {
+    for (const faction of [...Player.factions, ...Player.factionInvitations]) {
+      Player.factionRumors.add(faction);
+    }
     showAPIBreaks("3.0.0", breakingChanges300);
   }
 }


### PR DESCRIPTION
The rumor feature was added in #888. We discussed the following behaviors on Discord:
- After joining a faction, the rumors of its enemy factions are removed.
- You get rumors of factions that you were in or invited to in the immediately previous reset.

Suggestions:
- Instead of removing rumors of enemy factions, we mark that faction rumor as an "inaccessible" one.
- Make rumors persistent across BNs.

This PR makes these changes:
- Never reset `Player.factionRumors`.
- Never delete items in `Player.factionRumors`. When showing the rumors in the UI, we filter out those belonging to factions that the player is in or invited.
- Allow receiving rumors of banned factions.
- Show the "Factions" tab if there is at least one rumor.

"Inaccessible" rumors:

<img width="978" height="615" alt="Capture" src="https://github.com/user-attachments/assets/5cc6a6ed-95f0-4038-a495-dac8503a0e24" />

Close #2507.