### PR TITLE
UI: Prevent joining banned factions via UI

### DIFF
--- a/src/Faction/ui/FactionInvitationManager.tsx
+++ b/src/Faction/ui/FactionInvitationManager.tsx
@@ -44,7 +44,7 @@ export function FactionInvitationManager({ hidden }: { hidden: boolean }): React
 
   function close(): void {
     setFactions((currentFactions) => {
-      return currentFactions.slice(1);
+      return currentFactions.slice(1).filter((name) => !Factions[name].isBanned);
     });
   }
 
@@ -52,7 +52,7 @@ export function FactionInvitationManager({ hidden }: { hidden: boolean }): React
   const enemies = faction?.getInfo().enemies ?? [];
 
   function join(): void {
-    if (faction === null || !faction.alreadyInvited) {
+    if (faction === null || !faction.alreadyInvited || faction.isBanned) {
       return;
     }
     joinFaction(faction);

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -75,11 +75,11 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
     Router.toPage(Page.FactionAugmentations, { faction });
   }
 
-  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, faction: Faction): void {
-    if (!event.isTrusted || !faction.alreadyInvited || faction.isBanned) {
+  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, factionName: FactionName): void {
+    if (!event.isTrusted || !Factions[factionName].alreadyInvited || Factions[factionName].isBanned) {
       return;
     }
-    joinFaction(faction);
+    joinFaction(Factions[factionName]);
     props.rerender();
   }
 
@@ -108,7 +108,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
             <Button onClick={() => openFactionAugPage(props.faction)}>Augments</Button>
           </Box>
         ) : props.faction.alreadyInvited ? (
-          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction)}>
+          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction.name)}>
             Join!
           </Button>
         ) : null}

--- a/src/Faction/ui/FactionsRoot.tsx
+++ b/src/Faction/ui/FactionsRoot.tsx
@@ -75,9 +75,11 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
     Router.toPage(Page.FactionAugmentations, { faction });
   }
 
-  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, faction: FactionName): void {
-    if (!event.isTrusted) return;
-    joinFaction(Factions[faction]);
+  function acceptInvitation(event: React.MouseEvent<HTMLButtonElement>, faction: Faction): void {
+    if (!event.isTrusted || !faction.alreadyInvited || faction.isBanned) {
+      return;
+    }
+    joinFaction(faction);
     props.rerender();
   }
 
@@ -106,7 +108,7 @@ const FactionElement = (props: FactionElementProps): React.ReactElement => {
             <Button onClick={() => openFactionAugPage(props.faction)}>Augments</Button>
           </Box>
         ) : props.faction.alreadyInvited ? (
-          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction.name)}>
+          <Button sx={{ height: "48px", mr: 1 }} onClick={(e) => acceptInvitation(e, props.faction)}>
             Join!
           </Button>
         ) : null}


### PR DESCRIPTION
It's just as the title said. The fix is in the `close` function. I also update the conditions before calling `joinFaction` in other places.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  Player.money = 1e100;
  ns.singularity.travelToCity("Sector-12");
  ns.singularity.checkFactionInvitations();
  ns.singularity.travelToCity("Chongqing");
  ns.singularity.checkFactionInvitations();
}
```

Before:

https://github.com/user-attachments/assets/2cba4b84-3c0c-4530-9be3-63342754b5e5

After:

https://github.com/user-attachments/assets/02daf5c3-459b-409d-9bbb-35cf59ddff37
