### PR TITLE
UI: Prevent ending BNs through reuse of Bladeburner UI event handler

### DIFF
--- a/src/Bladeburner/ui/BlackOpPage.tsx
+++ b/src/Bladeburner/ui/BlackOpPage.tsx
@@ -9,6 +9,7 @@ import { Page } from "../../ui/Router";
 import { CorruptibleText } from "../../ui/React/CorruptibleText";
 import { blackOpsArray } from "../data/BlackOperations";
 import { finishBitNode } from "../../BitNode/BitNodeUtils";
+import { Player } from "@player";
 
 interface BlackOpPageProps {
   bladeburner: Bladeburner;
@@ -38,6 +39,9 @@ export function BlackOpPage({ bladeburner }: BlackOpPageProps): React.ReactEleme
         <Button
           sx={{ my: 1, p: 1 }}
           onClick={() => {
+            if (!Player.bladeburner || Player.bladeburner.numBlackOpsComplete < blackOpsArray.length) {
+              return;
+            }
             finishBitNode();
             Router.toPage(Page.BitVerse, { flume: false, quick: false });
           }}


### PR DESCRIPTION
Yichi mentioned this exploit a long time ago, but I have been too lazy to fix it. The UI code has many places that do not properly double-check conditions, so I'm sure there are still other exploits similar to this one.

Fixing this kind of exploit is also a bit silly because the exploit requires DOM manip, and once you do DOM manip, you are not far from prototype pollution and module raiding. Nonetheless, I think fixing it is still worthwhile, as long as it does not take too much effort.