### PR TITLE
BUGFIX: hacknetNodeCost formula API throws when using documented optional parameter

### DIFF
--- a/markdown/bitburner.hacknetnodesformulas.hacknetnodecost.md
+++ b/markdown/bitburner.hacknetnodesformulas.hacknetnodecost.md
@@ -9,7 +9,7 @@ Calculate the cost of a hacknet node.
 **Signature:**
 
 ```typescript
-hacknetNodeCost(n: number, mult: number): number;
+hacknetNodeCost(n: number, mult?: number): number;
 ```
 
 ## Parameters
@@ -58,7 +58,7 @@ number
 
 </td><td>
 
-player cost reduction (defaults to 1)
+_(Optional)_ player cost reduction (defaults to 1)
 
 
 </td></tr>

--- a/src/NetscriptFunctions/Formulas.ts
+++ b/src/NetscriptFunctions/Formulas.ts
@@ -274,12 +274,14 @@ export function NetscriptFormulas(): InternalAPI<IFormulas> {
           checkFormulasAccess(ctx);
           return calculateCoreUpgradeCost(startingCore, extraCores, costMult);
         },
-      hacknetNodeCost: (ctx) => (_n, _mult) => {
-        const n = helpers.number(ctx, "n", _n);
-        const mult = helpers.number(ctx, "mult", _mult);
-        checkFormulasAccess(ctx);
-        return calculateNodeCost(n, mult);
-      },
+      hacknetNodeCost:
+        (ctx) =>
+        (_n, _mult = 1) => {
+          const n = helpers.number(ctx, "n", _n);
+          const mult = helpers.number(ctx, "mult", _mult);
+          checkFormulasAccess(ctx);
+          return calculateNodeCost(n, mult);
+        },
       constants: (ctx) => () => {
         checkFormulasAccess(ctx);
         return Object.assign({}, HacknetNodeConstants);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6328,7 +6328,7 @@ interface HacknetNodesFormulas {
    * @param mult - player cost reduction (defaults to 1)
    * @returns The calculated cost.
    */
-  hacknetNodeCost(n: number, mult: number): number;
+  hacknetNodeCost(n: number, mult?: number): number;
   /**
    * All constants used by the game.
    * @returns An object with all hacknet node constants used by the game.


### PR DESCRIPTION
The TSDoc says it defaults to 1, but it's actually not an optional parameter.

There is no need to add a breaking change notice for this change.