### PR TITLE
CODEBASE: Fix React warning in IPvGO scoring explanation popup

### DIFF
--- a/src/Go/ui/GoScoreExplanation.tsx
+++ b/src/Go/ui/GoScoreExplanation.tsx
@@ -16,7 +16,7 @@ export const GoScoreExplanation = ({ open, onClose }: Props): React.ReactElement
     <Modal open={open} onClose={onClose}>
       <>
         <div className={classes.scoreExplanationModal}>
-          <Typography>
+          <Typography component="div">
             <h2>IPvGO Scoring Explanation</h2>
             IPvGO uses one of the oldest scoring systems in Go, "area scoring", rather than "territory scoring" later
             popularized by Japan. All stones are alive unless captured, chains that could be dead are not automatically


### PR DESCRIPTION
It's just as the title said.

Unrelated story:
Making this kind of PR was too boring, so I tried a fun experiment. I asked GitHub copilot to find this type of issue. I gave it an explanation of this issue, some instructions, then tweaked the prompt every time it found a false positive.

After a while, it concluded that the codebase did not have this issue. However, when I told it to specifically check `src\Go\ui\GoScoreExplanation.tsx`, it suddenly found the issue. Then, after I forced it to rescan the entire repository, it reported again that there were no issues besides that file. I hope it's right this time.