### PR TITLE
API: Reduce RAM cost of inGang and inBladeburner APIs

### DIFF
--- a/markdown/bitburner.bladeburner.inbladeburner.md
+++ b/markdown/bitburner.bladeburner.inbladeburner.md
@@ -19,5 +19,5 @@ whether player is a member of Bladeburner division.
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 

--- a/markdown/bitburner.gang.ingang.md
+++ b/markdown/bitburner.gang.ingang.md
@@ -4,7 +4,7 @@
 
 ## Gang.inGang() method
 
-Check if you're in a gang.
+Check if you're in a gang. Does not require API access.
 
 **Signature:**
 
@@ -19,5 +19,5 @@ True if you're in a gang, false otherwise.
 
 ## Remarks
 
-RAM cost: 1GB
+RAM cost: 0GB
 

--- a/markdown/bitburner.gang.md
+++ b/markdown/bitburner.gang.md
@@ -234,7 +234,7 @@ Get stats of a task.
 
 </td><td>
 
-Check if you're in a gang.
+Check if you're in a gang. Does not require API access.
 
 
 </td></tr>

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -272,7 +272,7 @@ const format = {
 // Gang API
 const gang = {
   createGang: RamCostConstants.GangApiBase / 4,
-  inGang: RamCostConstants.GangApiBase / 4,
+  inGang: 0,
   getMemberNames: RamCostConstants.GangApiBase / 4,
   renameMember: 0,
   getGangInformation: RamCostConstants.GangApiBase / 2,
@@ -334,7 +334,7 @@ const go = {
 
 // Bladeburner API
 const bladeburner = {
-  inBladeburner: RamCostConstants.BladeburnerApiBase / 4,
+  inBladeburner: 0,
   getContractNames: 0,
   getOperationNames: 0,
   getBlackOpNames: 0,

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -3988,9 +3988,10 @@ export interface Bladeburner {
    */
   nextUpdate(): Promise<number>;
 
-  /** Returns whether player is a member of Bladeburner division. Does not require API access.
+  /**
+   * Returns whether player is a member of Bladeburner division. Does not require API access.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * @returns whether player is a member of Bladeburner division. */
   inBladeburner(): boolean;
@@ -4833,9 +4834,10 @@ export interface Gang {
   createGang(faction: FactionName): boolean;
 
   /**
-   * Check if you're in a gang.
+   * Check if you're in a gang. Does not require API access.
    * @remarks
-   * RAM cost: 1GB
+   * RAM cost: 0GB
+   *
    * @returns True if you're in a gang, false otherwise.
    */
   inGang(): boolean;


### PR DESCRIPTION
The original suggestion on Discord was to make the RAM cost of `inGang`, `inBladeburner`, and `hasCorporation` consistent. It doesn’t seem particularly important to me, but I’m fine with making the change.

We can either increase the cost of `hasCorporation` or reduce the cost of the other two. I'm fine either way.