### PR TITLE
CODEBASE: Configure Babel to use core-js polyfills

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,23 @@
 module.exports = {
-  presets: ["@babel/preset-react", "@babel/preset-env", "@babel/preset-typescript"],
+  // The default value of sourceType is "module", so we can omit this config. We can also specify "unambiguous" to let
+  // Babel infer the source type and avoid explicitly setting it for saveDataBinaryFormat.js. However, being explicit is
+  // preferable, since we know all of our modules use ES modules except for those in the Electron folder.
+  sourceType: "module",
+  presets: [
+    "@babel/preset-react",
+    [
+      "@babel/preset-env",
+      {
+        useBuiltIns: "usage",
+        corejs: "3.49",
+      },
+    ],
+    "@babel/preset-typescript",
+  ],
+  overrides: [
+    {
+      test: ["./electron/saveDataBinaryFormat.js"],
+      sourceType: "commonjs",
+    },
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "bcryptjs": "^2.4.3",
         "clsx": "^1.2.1",
         "convert-source-map": "^2.0.0",
+        "core-js": "^3.49.0",
         "date-fns": "^2.30.0",
         "fast-dice-coefficient": "1.0.3",
         "hast-util-from-dom": "^5.0.1",
@@ -7522,6 +7523,17 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bcryptjs": "^2.4.3",
     "clsx": "^1.2.1",
     "convert-source-map": "^2.0.0",
+    "core-js": "^3.49.0",
     "date-fns": "^2.30.0",
     "fast-dice-coefficient": "1.0.3",
     "hast-util-from-dom": "^5.0.1",


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/pull/2583#discussion_r2963758755

By default, Babel only transpiles syntax. It needs to be configured to provide polyfills.

Webpack bundle analyzer report: 
[report.html](https://github.com/user-attachments/files/26144565/report.html)

Build log:
[build-log.txt](https://github.com/user-attachments/files/26144615/build-log.txt)

Tested: Add `console.log(new Uint8Array([0x1f, 0x8b, 0x08]).toBase64());` to `electron\saveDataBinaryFormat.js`. Tested on Chromium 130 via Electron 33.3.1.

Edit: This PR is not needed now due to https://github.com/bitburner-official/bitburner-src/pull/2586#issuecomment-4103256305 and https://github.com/bitburner-official/bitburner-src/pull/2583/commits/703605c7912b9c957ea2dcf49c1df55b29dd8d7a.