### PR TITLE
WORKFLOW: Update NodeJS used in CI workflows to v25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
+      - name: Use Node.js 25
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 25
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
+      - name: Use Node.js 25
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 25
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
+      - name: Use Node.js 25
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 25
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
+      - name: Use Node.js 25
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 25
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
+      - name: Use Node.js 25
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 25
           cache: "npm"
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
The test failed in #2583 because Node24 does not support `Uint8Array.toBase64`. Setting up Jest to polyfill it properly in the test environment is not worth the effort.

To keep the changes minimal, I only update NodeJS in CI workflows. I'll update it in other workflows if requested.