### PR TITLE
ELECTRON: Allow opening dev tools via CLI arguments

### DIFF
--- a/electron/gameWindow.js
+++ b/electron/gameWindow.js
@@ -7,7 +7,7 @@ const path = require("path");
 const { windowTracker } = require("./windowTracker");
 const storage = require("./storage");
 
-const debug = process.argv.includes("--debug");
+const openDevtools = process.argv.includes("--dev");
 
 async function createWindow(killall) {
   const setStopProcessHandler = global.app_handlers.stopProcess;
@@ -49,7 +49,7 @@ async function createWindow(killall) {
     utils.setZoomFactor(window, utils.getZoomFactor());
   });
   window.show();
-  if (debug) window.webContents.openDevTools();
+  if (openDevtools) window.webContents.openDevTools();
 
   window.webContents.setWindowOpenHandler(({ url }) => {
     // File protocol is allowed because it will use the file protocol intercept from main.js


### PR DESCRIPTION
This is an old feature that does not work due to the `--debug` flag. Ref: https://github.com/microsoft/vscode/issues/159011#issuecomment-1225292255

I'm fine with `--dev-tool` or any other option. I chose `--dev` because it's short.