### PR TITLE
DEPS: Update Electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "babel-plugin-transform-barrels": "^1.0.17",
         "css-loader": "^7.1.2",
         "csstype": "3.1.3",
-        "electron": "^38.4.0",
+        "electron": "^41.0.3",
         "eslint": "^8.52.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -5276,13 +5276,13 @@
       "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
     },
     "node_modules/@types/node": {
-      "version": "22.13.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -8304,15 +8304,15 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "38.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.4.0.tgz",
-      "integrity": "sha512-9CsXKbGf2qpofVe2pQYSgom2E//zLDJO2rGLLbxgy9tkdTOs7000Gte+d/PUtzLjI/DS95jDK0ojYAeqjLvpYg==",
+      "version": "41.0.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.0.3.tgz",
+      "integrity": "sha512-IDjx8liW1q+r7+MOip5W1Eo1eMwJzVObmYrd9yz2dPCkS7XlgLq3qPVMR80TpiROFp73iY30kTzMdpA6fEVs3A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -18014,9 +18014,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "babel-plugin-transform-barrels": "^1.0.17",
     "css-loader": "^7.1.2",
     "csstype": "3.1.3",
-    "electron": "^38.4.0",
+    "electron": "^41.0.3",
     "eslint": "^8.52.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",


### PR DESCRIPTION
To avoid regressions from new Electron versions, I've been holding off on updating Electron and waiting for the v3 release, but the v3 development cycle is taking longer than I expected.

We're going to release some fixes for the cloud feature in the next beta version, including a fix for the multiple cloud files issue (I'm currently testing it), so I think it's a good time to update Electron and test everything together. I haven't seen any breaking changes that would affect us in the Electron release notes.

I've briefly tested this version on Windows and will test on Linux after I finish the fix mentioned above.

Edit: It seems "Reload & Kill All Scripts" does not work properly on Windows. The cause was reported at https://github.com/electron/electron/issues/48661. Back then, this issue only affected Linux, but now it also affects Windows.