### PR TITLE
BLADEBURNER: Always show Black Operations list

### DIFF
--- a/src/Bladeburner/ui/BlackOpPage.tsx
+++ b/src/Bladeburner/ui/BlackOpPage.tsx
@@ -35,7 +35,8 @@ export function BlackOpPage({ bladeburner }: BlackOpPageProps): React.ReactEleme
         losses. Black Ops success significantly affected by combat stats. Many Ops benefit from Hacking skill.
         Unaffected by Charisma.
       </Typography>
-      {bladeburner.numBlackOpsComplete >= blackOpsArray.length ? (
+
+      {bladeburner.numBlackOpsComplete >= blackOpsArray.length && (
         <Button
           sx={{ my: 1, p: 1 }}
           onClick={() => {
@@ -48,13 +49,11 @@ export function BlackOpPage({ bladeburner }: BlackOpPageProps): React.ReactEleme
         >
           <CorruptibleText content="Destroy w0r1d_d43m0n" spoiler={false}></CorruptibleText>
         </Button>
-      ) : (
-        <>
-          {blackOperations.map((blackOperation) => (
-            <BlackOpElem key={blackOperation.name} bladeburner={bladeburner} action={blackOperation} />
-          ))}
-        </>
       )}
+
+      {blackOperations.map((blackOperation) => (
+        <BlackOpElem key={blackOperation.name} bladeburner={bladeburner} action={blackOperation} />
+      ))}
     </>
   );
 }


### PR DESCRIPTION
A player wanted to view BlackOps missions' descriptions even after completing all of them.

Before:

<img width="1130" height="321" alt="before" src="https://github.com/user-attachments/assets/5e504450-5b9b-42a9-b6f3-c9e4aae36d54" />

After:

<img width="1125" height="400" alt="after" src="https://github.com/user-attachments/assets/da767159-3510-44cf-b71c-a2e433df623b" />
