### PR TITLE
BUGFIX: Import save comparison popup shows wrong BN level

### DIFF
--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -429,7 +429,7 @@ class BitburnerSaveObject implements BitburnerSaveObjectType {
       achievements: importedPlayer.achievements?.length ?? 0,
 
       bitNode: importedPlayer.bitNodeN,
-      bitNodeLevel: importedPlayer.sourceFileLvl(Player.bitNodeN) + 1,
+      bitNodeLevel: importedPlayer.sourceFileLvl(importedPlayer.bitNodeN) + 1,
       sourceFiles: [...importedPlayer.sourceFiles].reduce<number>((total, [__bn, lvl]) => (total += lvl), 0),
       exploits: importedPlayer.exploits.length,
 


### PR DESCRIPTION
How to reproduce this issue:
- Load `foo.gz`
- Options => Import Game => Choose `bar.gz` => Compare Save
- Check "BitNode" row. It's 3-4 instead of 3-1.

Save files:
[foo.gz](https://github.com/user-attachments/files/26174787/foo.gz)
[bar.gz](https://github.com/user-attachments/files/26174785/bar.gz)

The fix is trivial.

Tested manually.