### PR TITLE
ELECTRON: Add UI menus and CLI flags to change log levels

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -30,8 +30,11 @@ const path = require("path");
 const { realpathSync } = require("fs");
 const { fileURLToPath, format } = require("url");
 
-log.transports.file.level = store.get("file-log-level", "info");
-log.transports.console.level = store.get("console-log-level", "debug");
+utils.initializeLogLevelConfig();
+
+// Apply config of log levels.
+log.transports.file.level = store.get("file-log-level");
+log.transports.console.level = store.get("console-log-level");
 
 log.info(`Started app: ${JSON.stringify(process.argv)}`);
 

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -7,6 +7,30 @@ const storage = require("./storage");
 const store = new Store();
 const { steamworksClient } = require("./steamworksUtils");
 
+/** @import {LogLevel} from "electron-log" */
+/**
+ * @param {*} window
+ * @param {"file-log-level" | "console-log-level"} configKey
+ * @param {LogLevel} logLevel
+ * @returns {*}
+ */
+function createLogLevelMenuItem(window, configKey, logLevel) {
+  return {
+    label: logLevel,
+    type: "checkbox",
+    checked: store.get(configKey) === logLevel,
+    click: () => {
+      if (configKey === "file-log-level") {
+        log.transports.file.level = logLevel;
+      } else {
+        log.transports.console.level = logLevel;
+      }
+      store.set(configKey, logLevel);
+      refreshMenu(window);
+    },
+  };
+}
+
 function getMenu(window) {
   const canZoomIn = utils.getZoomFactor() <= 2;
   const zoomIn = () => {
@@ -299,6 +323,31 @@ function getMenu(window) {
     {
       label: "Debug",
       submenu: [
+        {
+          label: "File Log Level",
+          submenu: [
+            createLogLevelMenuItem(window, "file-log-level", "error"),
+            createLogLevelMenuItem(window, "file-log-level", "warn"),
+            createLogLevelMenuItem(window, "file-log-level", "info"),
+            createLogLevelMenuItem(window, "file-log-level", "verbose"),
+            createLogLevelMenuItem(window, "file-log-level", "debug"),
+            createLogLevelMenuItem(window, "file-log-level", "silly"),
+          ],
+        },
+        {
+          label: "Console Log Level",
+          submenu: [
+            createLogLevelMenuItem(window, "console-log-level", "error"),
+            createLogLevelMenuItem(window, "console-log-level", "warn"),
+            createLogLevelMenuItem(window, "console-log-level", "info"),
+            createLogLevelMenuItem(window, "console-log-level", "verbose"),
+            createLogLevelMenuItem(window, "console-log-level", "debug"),
+            createLogLevelMenuItem(window, "console-log-level", "silly"),
+          ],
+        },
+        {
+          type: "separator",
+        },
         {
           label: "Activate",
           accelerator: "f12",

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "dependencies": {
         "@catloversg/steamworks.js": "0.0.2",
+        "arg": "^5.0.2",
         "electron-log": "^4.4.8",
         "electron-store": "^8.1.0",
         "lodash": "^4.17.21"
@@ -65,6 +66,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/atomically": {
       "version": "1.7.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@catloversg/steamworks.js": "0.0.2",
+    "arg": "^5.0.2",
     "electron-log": "^4.4.8",
     "electron-store": "^8.1.0",
     "lodash": "^4.17.21"

--- a/electron/utils.js
+++ b/electron/utils.js
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { dialog } = require("electron");
 const log = require("electron-log");
-
 const Store = require("electron-store");
 const store = new Store();
+const arg = require("arg");
 
 function reloadAndKill(window, killScripts) {
   log.info("Reloading & Killing all scripts...");
@@ -105,6 +105,47 @@ function setZoomFactor(window, zoom = null) {
   window.webContents.setZoomFactor(zoom);
 }
 
+function initializeLogLevelConfig() {
+  /**
+   * @type {{
+   *  ["--file-log-level"]?: string,
+   *  ["--console-log-level"]?: string,
+   * }}
+   */
+  let args = {};
+  try {
+    args = arg(
+      {
+        "--file-log-level": String,
+        "--console-log-level": String,
+      },
+      { permissive: true, argv: process.argv.slice(1) },
+    );
+  } catch (error) {
+    log.error("Cannot parse arguments", process.argv, error);
+  }
+
+  // Set default log levels if no stored config exists.
+  if (store.get("file-log-level") === undefined) {
+    store.set("file-log-level", "info");
+  }
+  if (store.get("console-log-level") === undefined) {
+    store.set("console-log-level", "debug");
+  }
+
+  const validLogLevels = ["error", "warn", "info", "verbose", "debug", "silly"];
+
+  // Override log levels if relevant arguments are provided.
+  const parsedFileLogLevel = args["--file-log-level"];
+  if (parsedFileLogLevel !== undefined && validLogLevels.includes(parsedFileLogLevel)) {
+    store.set("file-log-level", parsedFileLogLevel);
+  }
+  const parsedConsoleLogLevel = args["--console-log-level"];
+  if (parsedConsoleLogLevel !== undefined && validLogLevels.includes(parsedConsoleLogLevel)) {
+    store.set("console-log-level", parsedConsoleLogLevel);
+  }
+}
+
 module.exports = {
   reloadAndKill,
   showErrorBox,
@@ -115,4 +156,5 @@ module.exports = {
   writeToast,
   getZoomFactor,
   setZoomFactor,
+  initializeLogLevelConfig,
 };


### PR DESCRIPTION
Every time I troubleshoot Electron-related errors with players, I have to instruct them to manually change the code to adjust the log level. This PR allows them to do that without touching the code.

<img width="488" height="222" alt="Capture" src="https://github.com/user-attachments/assets/27d76640-ac96-4fe5-875c-03a2f6e35df5" />
