### PR TITLE
BUGFIX: Fix recursive alias detection causing infinite recursion

### DIFF
--- a/src/Alias.ts
+++ b/src/Alias.ts
@@ -93,7 +93,7 @@ function applyAliases(origCommand: string, depth = 0, currentlyProcessingAliases
   // First get non-global aliases, and recursively apply them
   // (unless there are any reference loops or the reference chain is too deep)
   const localAlias = Aliases.get(commandArray[0]);
-  if (localAlias && !currentlyProcessingAliases.includes(localAlias)) {
+  if (localAlias && !currentlyProcessingAliases.includes(commandArray[0])) {
     const appliedAlias = applyAliases(localAlias, depth + 1, [commandArray[0], ...currentlyProcessingAliases]);
     commandArray.splice(0, 1, ...appliedAlias.split(" "));
   }
@@ -101,7 +101,7 @@ function applyAliases(origCommand: string, depth = 0, currentlyProcessingAliases
   // Once local aliasing is complete (or if none are present) handle any global aliases
   const processedCommands = commandArray.reduce((resolvedCommandArray: string[], command) => {
     const globalAlias = GlobalAliases.get(command);
-    if (globalAlias && !currentlyProcessingAliases.includes(globalAlias)) {
+    if (globalAlias && !currentlyProcessingAliases.includes(command)) {
       const appliedAlias = applyAliases(globalAlias, depth + 1, [command, ...currentlyProcessingAliases]);
       resolvedCommandArray.push(appliedAlias);
     } else {

--- a/test/jest/Alias/Alias.test.ts
+++ b/test/jest/Alias/Alias.test.ts
@@ -1,5 +1,22 @@
-import { substituteAliases, parseAliasDeclaration } from "../../../src/Alias";
+import { Aliases, GlobalAliases, substituteAliases, parseAliasDeclaration } from "../../../src/Alias";
 describe("substituteAliases Tests", () => {
+  beforeEach(() => {
+    Aliases.clear();
+    GlobalAliases.clear();
+  });
+
+  it("Should not infinitely recurse when alias value contains the alias name", () => {
+    parseAliasDeclaration("buy=buy -l");
+    const result = substituteAliases("buy");
+    expect(result).toEqual("buy -l");
+  });
+
+  it("Should not infinitely recurse when global alias value contains the alias name", () => {
+    parseAliasDeclaration("scan=scan -d 5", true);
+    const result = substituteAliases("scan");
+    expect(result).toEqual("scan -d 5");
+  });
+
   it("Should gracefully handle recursive local aliases", () => {
     parseAliasDeclaration("recursiveAlias=b");
     parseAliasDeclaration("b=c");
@@ -7,7 +24,7 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=recursiveAlias");
 
     const result = substituteAliases("recursiveAlias");
-    expect(result).toEqual("d");
+    expect(result).toEqual("recursiveAlias");
   });
 
   it("Should only change local aliases if they are the start of the command", () => {
@@ -27,7 +44,7 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=a", true);
 
     const result = substituteAliases("a b c d");
-    expect(result).toEqual("d a b c");
+    expect(result).toEqual("a b c d");
   });
 
   it("Should gracefully handle recursive mixed local and global aliases", () => {
@@ -37,7 +54,7 @@ describe("substituteAliases Tests", () => {
     parseAliasDeclaration("d=recursiveAlias", false);
 
     const result = substituteAliases("recursiveAlias");
-    expect(result).toEqual("d");
+    expect(result).toEqual("recursiveAlias");
   });
 
   it("Should replace chained aliases", () => {


### PR DESCRIPTION
## Summary

Fixes #1647

Self-referencing aliases like `alias buy="buy -l"` cause a `RangeError: too much recursion` because the recursion guard in `applyAliases()` never fires.

## Root Cause

The recursion guard compares alias **values** against a list of alias **names**:

- Line 96: `!currentlyProcessingAliases.includes(localAlias)` — `localAlias` is the value `"buy -l"`, but the processing list contains names like `"buy"`. These never match.
- Line 104: Same bug for global aliases.

## Fix

Two-line change: compare the alias **name** (the command being expanded) instead of the alias value.

- Line 96: `localAlias` → `commandArray[0]`
- Line 104: `globalAlias` → `command`

This matches POSIX alias semantics where expansion stops when a name that has already been expanded is encountered again.

## Behavior Change for Circular Chains

Circular alias chains (e.g., `a→b→c→d→a`) previously resolved to an intermediate value due to the same value-vs-name comparison bug coincidentally stopping early. With the fix, circular chains now correctly resolve back to the original command (consistent with POSIX behavior). Non-circular chains (e.g., `a→b→c→d→e`) are unaffected.

## Test

Added two new tests that reproduce the exact bug (self-referencing local and global aliases). Updated three existing circular-chain test expectations to match the corrected recursion detection behavior. Added `beforeEach` cleanup to prevent alias leakage between tests.

## Note

PR #1649 addressed the same issue (open since Sept 2024). This PR takes a simpler approach — fixing the comparison directly rather than reworking the tracking data structure.

## Checklist

- [x] Branched from `dev`
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run test` passes (51 suites, 4393 tests)
- [x] No bundled files or index.html included
- [x] Test added that reproduces the bug