### PR TITLE
BUGFIX: Fix skillMaxUpgradeCount returning 1 at extreme skill levels

### DIFF
--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -81,6 +81,9 @@ export class Skill {
   }
 
   calculateMaxUpgradeCount(currentLevel: number, cost: PositiveNumber): number {
+    // At extreme levels, floating-point precision loss makes currentLevel + 1 === currentLevel,
+    // causing calculateCost to return 0. No upgrade is possible in this case.
+    if (this.calculateCost(currentLevel, 1 as PositiveInteger) <= 0) return 0;
     /**
      * Define:
      * - x = count

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -1,0 +1,36 @@
+import { BladeburnerMultName, BladeburnerSkillName } from "@enums";
+import { Skill } from "../../../src/Bladeburner/Skill";
+import { PositiveNumber } from "../../../src/types";
+
+const hyperdrive = new Skill({
+  name: BladeburnerSkillName.Hyperdrive,
+  desc: "test",
+  baseCost: 1,
+  costInc: 2.5,
+  mults: { [BladeburnerMultName.ExpGain]: 10 },
+});
+
+describe("Bladeburner Skill", () => {
+  describe("calculateMaxUpgradeCount", () => {
+    it("should return 0 when currentLevel is too high for floating-point precision", () => {
+      // At level 1e50, adding 1 is below float64 precision: 1e50 + 1 === 1e50
+      // So calculateCost returns 0 for any count, and no upgrade is possible
+      const result = hyperdrive.calculateMaxUpgradeCount(1e50, 1 as PositiveNumber);
+      expect(result).toBe(0);
+    });
+
+    it("should return correct count at normal levels", () => {
+      // At level 0 with cost 1, baseCost 1, costInc 2.5:
+      // cost of 1 level = round(1 * 1 * (1 + 2.5 * (0 + 0/2))) = round(1) = 1
+      const result = hyperdrive.calculateMaxUpgradeCount(0, 1 as PositiveNumber);
+      expect(result).toBe(1);
+    });
+
+    it("should return 0 when cost is less than the price of one level", () => {
+      // At level 10: cost of 1 level = round(1 * 1 * (1 + 2.5 * 10)) = 26
+      const costOfOne = hyperdrive.calculateCost(10);
+      const result = hyperdrive.calculateMaxUpgradeCount(10, (costOfOne - 1) as PositiveNumber);
+      expect(result).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1693

`calculateMaxUpgradeCount` returns 1 instead of 0 at extreme Bladeburner skill levels (e.g. 1e50) because floating-point precision loss makes `calculateCost` return 0, which always passes the `<= cost` check.

## Root Cause

`calculateCost` computes `actualCount = currentLevel + count - currentLevel`. At level 1e50, IEEE 754 float64 cannot represent `1e50 + 1` distinctly from `1e50`, so `actualCount` becomes 0 and the cost is 0. `calculateMaxUpgradeCount` then sees `0 <= availablePoints` → true → returns 1.

Note: `canUpgrade()` already has a correct guard for this (`actualCount === 0` check at line 141), but `calculateMaxUpgradeCount` (used by the formulas API) did not.

## Fix

Added an early guard in `calculateMaxUpgradeCount`: if `calculateCost(currentLevel, 1)` returns 0, no upgrade is possible at this precision — return 0 immediately.

3-line change in `src/Bladeburner/Skill.ts`.

## Test

New test file `test/jest/Bladeburner/Skill.test.ts` with 3 tests:
- Verifies `calculateMaxUpgradeCount` returns 0 at level 1e50 (the reported bug)
- Verifies normal-level behavior still works
- Verifies 0 is returned when cost is below the price of one level

## Note

PR #1724 addressed the same issue with test coverage but no implementation fix. That PR has been in draft since Nov 2024.

## Checklist

- [x] Branched from `dev`
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run test` passes (52 suites, 4394 tests)
- [x] No bundled files or index.html included
- [x] Test added that reproduces the bug