### PR TITLE
BUGFIX: Fix tab completion for multi-word quoted autocomplete options

### DIFF
--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -17,14 +17,21 @@ import { parseUnknownError } from "../utils/ErrorHelper";
 import { DarknetServer } from "../Server/DarknetServer";
 import { CompletedProgramName } from "@enums";
 
+/** Extract the text being autocompleted, handling unclosed double quotes as a single token */
+export function extractCurrentText(terminalText: string): string {
+  const quoteCount = (terminalText.match(/"/g) || []).length;
+  if (quoteCount % 2 === 1) return terminalText.substring(terminalText.lastIndexOf('"'));
+  return /[^ ]*$/.exec(terminalText)?.[0] ?? "";
+}
+
 /** Suggest all completion possibilities for the last argument in the last command being typed
  * @param terminalText The current full text entered in the terminal
  * @param baseDir The current working directory.
  * @returns Array of possible string replacements for the current text being autocompleted.
  */
 export async function getTabCompletionPossibilities(terminalText: string, baseDir = root): Promise<string[]> {
-  // Get the current command text
-  const currentText = /[^ ]*$/.exec(terminalText)?.[0] ?? "";
+  // Get the current command text, treating unclosed quotes as a single token
+  const currentText = extractCurrentText(terminalText);
   // Remove the current text from the commands string
   const valueWithoutCurrent = terminalText.substring(0, terminalText.length - currentText.length);
   // Parse the commands string, this handles alias replacement as well.

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -6,7 +6,7 @@ import { Paper, Popper, TextField, Typography } from "@mui/material";
 import { KEY } from "../../utils/KeyboardEventKey";
 import { Terminal } from "../../Terminal";
 import { Player } from "@player";
-import { getTabCompletionPossibilities } from "../getTabCompletionPossibilities";
+import { extractCurrentText, getTabCompletionPossibilities } from "../getTabCompletionPossibilities";
 import { Settings } from "../../Settings/Settings";
 import { longestCommonStart } from "../../utils/StringHelperFunctions";
 import { exceptionAlert } from "../../utils/helpers/exceptionAlert";
@@ -264,13 +264,16 @@ export function TerminalInput(): React.ReactElement {
       if (possibilities.length === 0) return;
 
       setSearchResults([]);
+      // Use quote-aware replacement: if mid-quote, replace from the opening quote
+      const currentText = extractCurrentText(value);
+      const replacePattern = currentText.startsWith('"') ? /"[^"]*$/ : /[^ ]*$/;
       if (possibilities.length === 1) {
-        saveValue(value.replace(/[^ ]*$/, possibilities[0]) + " ");
+        saveValue(value.replace(replacePattern, possibilities[0]) + " ");
         return;
       }
       // More than one possibility, check to see if there is a longer common string than currentText.
       const longestMatch = longestCommonStart(possibilities);
-      saveValue(value.replace(/[^ ]*$/, longestMatch));
+      saveValue(value.replace(replacePattern, longestMatch));
       setPossibilities(possibilities);
     }
 

--- a/test/jest/Terminal/tabCompletion.test.ts
+++ b/test/jest/Terminal/tabCompletion.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 
 import { Player } from "../../../src/Player";
-import { getTabCompletionPossibilities } from "../../../src/Terminal/getTabCompletionPossibilities";
+import { getTabCompletionPossibilities, extractCurrentText } from "../../../src/Terminal/getTabCompletionPossibilities";
 import { Server } from "../../../src/Server/Server";
 import { AddToAllServers, prestigeAllServers } from "../../../src/Server/AllServers";
 import { LocationName } from "../../../src/Enums";
@@ -184,6 +184,27 @@ describe("getTabCompletionPossibilities", function () {
       const options = await getTabCompletionPossibilities(`${command} `, root);
       expect(options.sort()).toEqual(["folder1/", "anotherFolder/"].sort());
     }
+  });
+});
+
+describe("extractCurrentText", () => {
+  it("returns last word for unquoted input", () => {
+    expect(extractCurrentText("run myscript.js foo")).toBe("foo");
+  });
+  it("returns empty string for input ending with space", () => {
+    expect(extractCurrentText("run myscript.js ")).toBe("");
+  });
+  it("returns text from opening quote for unclosed double quote", () => {
+    expect(extractCurrentText('run myscript.js "nonunique se')).toBe('"nonunique se');
+  });
+  it("returns last word when all quotes are closed", () => {
+    expect(extractCurrentText('run myscript.js "arg1" foo')).toBe("foo");
+  });
+  it("handles empty input", () => {
+    expect(extractCurrentText("")).toBe("");
+  });
+  it("returns text from opening quote with one word inside", () => {
+    expect(extractCurrentText('run "partial')).toBe('"partial');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1014

Tab completion breaks when a script's `autocomplete()` returns multi-word quoted options (e.g., `"nonunique second word"`). Typing `"nonunique se` + Tab produces no completions because the system only matches the last space-separated word (`se`) against the full quoted options.

## Root Cause

Two places use the regex `/[^ ]*$/` to extract the "current text" being completed:

1. `getTabCompletionPossibilities.ts:27` — extracts `currentText` for matching against options
2. `TerminalInput.tsx:259,264` — replaces the matched portion with the selected completion

This regex splits on spaces blindly and doesn't understand quotes. When mid-quote (e.g., `"nonunique se`), it extracts only `se` instead of the full quoted fragment `"nonunique se`, so the `startsWith` match against `"nonunique second word"` fails.

## Fix

- Added `extractCurrentText()` helper that detects unclosed double quotes (odd quote count) and extracts everything from the opening `"` as a single token. Falls back to the original space-split behavior when all quotes are balanced.
- Updated `TerminalInput.tsx` to use the same quote-aware logic for the replacement regex — when mid-quote, replaces from the opening `"` instead of just the last word.

## Test script

```js
// Save as autocomplete-test.js and run: run autocomplete-test.js
export function autocomplete() {
  return ['"unique first"', '"nonunique second word"', '"nonunique sea word"'];
}
export async function main(ns) {
  ns.tprint(ns.args);
}
```

Type `run autocomplete-test.js "nonunique se` + Tab → should show both matching options.

## Test

6 new unit tests for `extractCurrentText` covering: unquoted input, trailing space, unclosed quote, closed quotes, empty input, and single-word quote.

## Checklist

- [x] Branched from `dev`
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run test` passes (51 suites, 4397 tests)
- [x] No bundled files or index.html included
- [x] Test added that reproduces the bug