### PR TITLE
UI: Navigate to gym/university instead of city when stopping focusing on gym/class work

### DIFF
--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -262,10 +262,10 @@ export function WorkInProgressRoot(): React.ReactElement {
       buttons: {
         cancel: () => {
           Player.finishWork(true);
-          Router.toPage(Page.City);
+          Router.toPage(Page.Location, { location: Locations[classWork.location] });
         },
         unfocus: () => {
-          Router.toPage(Page.City);
+          Router.toPage(Page.Location, { location: Locations[classWork.location] });
           Player.stopFocusing();
         },
       },


### PR DESCRIPTION
## Summary

Fixes #710

"Do something else simultaneously" during gym/university work navigated to the City page, while the same button during faction/company work correctly returned to the originating page. Fixed to navigate to the specific gym or university location.

## Root Cause

In `WorkInProgressRoot.tsx`, the `isClassWork` handler for both `cancel` and `unfocus` used `Router.toPage(Page.City)`, while faction work used `Router.toPage(Page.Faction, { faction })` and company work used `Router.toPage(Page.Job)`. The ClassWork object already has a `.location` property — it just wasn't being used.

## Fix

Changed both `Router.toPage(Page.City)` calls in the `isClassWork` block to `Router.toPage(Page.Location, { location: Locations[classWork.location] })`.

2-line change.

## Demo

After the fix, clicking "Do something else simultaneously" while training at Crush Fitness Gym navigates to the Crush Fitness Gym page (showing Train Strength/Defense/Dexterity/Agility options), not the City map.


![gym-fix-demo](https://github.com/user-attachments/assets/f35b503f-63d1-49b8-a1fb-f8ba2f2a3a0c)



## Checklist

- [x] Branched from `dev`
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run test` passes (52 suites, 4395 tests)
- [x] No bundled files or index.html included
- [x] UI change includes GIF