### PR TITLE
UI: Fix scrollTo firing on every render instead of page change

### DIFF
--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -285,7 +285,7 @@ export function GameRoot(): React.ReactElement {
 
   useEffect(() => {
     if (pageWithContext.page !== Page.Terminal) window.scrollTo(0, 0);
-  });
+  }, [pageWithContext.page]);
 
   function softReset(): void {
     dialogBoxCreate("Soft Reset!");


### PR DESCRIPTION
## Summary

Fixes #2616

The `useEffect` in `GameRoot.tsx` that scrolls to the top of the page had no dependency array, causing `window.scrollTo(0, 0)` to fire after every React render. On pages using `useCycleRerender()` (Corporation, Gang, Stock Market), this triggered ~5 unnecessary `scrollTo` calls per second and forced browser layout recalculations.

## Root Cause

```tsx
useEffect(() => {
  if (pageWithContext.page !== Page.Terminal) window.scrollTo(0, 0);
}); // ← no dependency array = runs every render
```

Without a dependency array, React runs the effect after every render. The intent is clearly to scroll on page change only.

## Fix

Added `[pageWithContext.page]` as the dependency array. The effect only depends on the current page, so it should only re-run when the page changes.

One-line change.

## Test

New test file `test/jest/ui/GameRootScrollTo.test.ts` with 3 tests:
- Demonstrates the bug: without deps, `scrollTo` fires on every render (5 calls for 5 renders)
- With the fix: `scrollTo` fires only on page change (2 calls for 5 renders across 2 pages)
- Terminal page is correctly excluded from scrolling

## Checklist

- [x] Branched from `dev`
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run test` passes (52 suites, 4394 tests)
- [x] No bundled files or index.html included
- [x] Test added