### PR TITLE
CODEBASE: Replace ipExists() linear scan with O(1) Map.has()

### DIFF
--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -89,12 +89,7 @@ export const disconnectServers = (server1: BaseServer, server2: BaseServer) => {
 };
 
 export function ipExists(ip: string): boolean {
-  for (const server of AllServers.values()) {
-    if (server.ip === ip) {
-      return true;
-    }
-  }
-  return false;
+  return AllServers.has(ip);
 }
 
 export function createUniqueRandomIp(): IPAddress {

--- a/test/jest/Server/AllServers.test.ts
+++ b/test/jest/Server/AllServers.test.ts
@@ -6,6 +6,7 @@ import {
   saveAllServers,
   renameServer,
   GetServer,
+  ipExists,
 } from "../../../src/Server/AllServers";
 import { Server } from "../../../src/Server/Server";
 import { IPAddress } from "../../../src/Types/strings";
@@ -35,6 +36,40 @@ describe("AllServers can be saved and loaded", () => {
     expect(loadedServer.hostname).toEqual(server1.hostname);
     expect(loadedServer.ip).toEqual(server1.ip);
     expect(loadedServer.numOpenPortsRequired).toEqual(server1.numOpenPortsRequired);
+  });
+});
+
+describe("ipExists", () => {
+  beforeEach(() => {
+    prestigeAllServers();
+  });
+
+  it("returns true for an IP that exists in AllServers", () => {
+    const server = new Server({ hostname: "test-server", ip: "10.20.30.40" as IPAddress });
+    AddToAllServers(server);
+    expect(ipExists("10.20.30.40")).toBe(true);
+  });
+
+  it("returns false for an IP that does not exist", () => {
+    expect(ipExists("99.99.99.99")).toBe(false);
+  });
+
+  it("does not use linear scan (performance: uses Map.has, not iteration)", () => {
+    // Add a server so the map is non-empty
+    const server = new Server({ hostname: "perf-test", ip: "1.1.1.1" as IPAddress });
+    AddToAllServers(server);
+
+    // Spy on Map.prototype.values to detect if ipExists iterates
+    const valuesSpy = jest.spyOn(Map.prototype, "values");
+
+    ipExists("1.1.1.1");
+    ipExists("2.2.2.2");
+
+    // With the fix (Map.has), values() should NOT be called by ipExists
+    // With the bug (for...of iteration), values() WOULD be called
+    expect(valuesSpy).not.toHaveBeenCalled();
+
+    valuesSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #2619

`ipExists()` iterated all server values with a `for...of` loop to check if an IP exists, even though `AllServers` already stores entries keyed by both hostname and IP address (set in `AddToAllServers`). Replaced with `AllServers.has(ip)` for O(1) lookup.

## Root Cause

```ts
// Before: O(n) linear scan
export function ipExists(ip: string): boolean {
  for (const server of AllServers.values()) {
    if (server.ip === ip) return true;
  }
  return false;
}
```

`AllServers.set(server.ip, server)` is called in `AddToAllServers` (line 128), so IP addresses are already keys in the Map. The linear scan was redundant.

`ipExists` is called by `createUniqueRandomIp()` in a retry loop, making server initialization O(n²) instead of O(n).

## Fix

```ts
// After: O(1) Map lookup
export function ipExists(ip: string): boolean {
  return AllServers.has(ip);
}
```

## Test

3 new tests added to `test/jest/Server/AllServers.test.ts`:
- Returns true for existing IP
- Returns false for non-existing IP
- **Performance test**: spies on `Map.prototype.values` to verify ipExists does NOT iterate the map (fails before fix, passes after)

## Checklist

- [x] Branched from `dev`
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run test` passes (51 suites, 4394 tests)
- [x] No bundled files or index.html included
- [x] Test added that reproduces the bug