### PR TITLE
DNET: Remove bonus time effect on authentication and heartbleed speed; fix ram rounding

### DIFF
--- a/src/DarkNet/controllers/ServerGenerator.ts
+++ b/src/DarkNet/controllers/ServerGenerator.ts
@@ -210,7 +210,7 @@ export const getTimingAttackConfig = (difficulty: number): ServerConfig => {
     "I spent some time on it, but that's not the password",
   ];
   const alphanumeric = difficulty > 16 && Math.random() < 0.3;
-  const length = (alphanumeric ? 0 : 3) + difficulty / 4;
+  const length = Math.min((alphanumeric ? 0 : 3) + difficulty / 4, 8);
   return {
     modelId: ModelIds.TimingAttack,
     password: getPassword(length, alphanumeric),

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -81,13 +81,7 @@ export const calculateAuthenticationTime = (
   const hasSf15_2Factor = Player.activeSourceFileLvl(15) > 2 ? 0.8 : 1;
 
   const time =
-    baseTime *
-    skillFactor *
-    backdoorFactor *
-    underleveledFactor *
-    hasBootsFactor *
-    hasSf15_2Factor *
-    threadsFactor;
+    baseTime * skillFactor * backdoorFactor * underleveledFactor * hasBootsFactor * hasSf15_2Factor * threadsFactor;
 
   // We need to call GetServer and check if it's a dnet server later because this function can be called by formulas
   // APIs (darknetServerData.hostname may be an invalid hostname).

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -79,7 +79,6 @@ export const calculateAuthenticationTime = (
   const underleveledFactor = applyUnderleveledFactor ? 1.5 + (chaRequired + 50) / (person.skills.charisma + 50) : 1;
   const hasBootsFactor = Player.hasAugmentation(AugmentationName.TheBoots) ? 0.8 : 1;
   const hasSf15_2Factor = Player.activeSourceFileLvl(15) > 2 ? 0.8 : 1;
-  const bonusTimeFactor = hasDarknetBonusTime() ? 0.75 : 1;
 
   const time =
     baseTime *
@@ -88,7 +87,6 @@ export const calculateAuthenticationTime = (
     underleveledFactor *
     hasBootsFactor *
     hasSf15_2Factor *
-    bonusTimeFactor *
     threadsFactor;
 
   // We need to call GetServer and check if it's a dnet server later because this function can be called by formulas

--- a/src/DarkNet/effects/ramblock.ts
+++ b/src/DarkNet/effects/ramblock.ts
@@ -12,6 +12,7 @@ import type { DarknetServerData, Person as IPerson } from "@nsdefs";
 import { clampNumber } from "../../utils/helpers/clampNumber";
 import { ResponseCodeEnum } from "../Enums";
 import { isLabyrinthServer } from "./labyrinth";
+import { roundToN } from "../../utils/helpers/roundToTwo";
 
 /*
  * Handles the effects of removing some blocked RAM from a Darknet server.
@@ -21,7 +22,7 @@ export const handleRamBlockRemoved = (ctx: NetscriptContext, server: DarknetServ
   const difficulty = server.difficulty + 1;
 
   const ramBlockRemoved = getRamBlockRemoved(server, threads);
-  server.blockedRam -= ramBlockRemoved;
+  server.blockedRam = roundToN(server.blockedRam - ramBlockRemoved, 4);
   server.updateRamUsed(server.ramUsed - ramBlockRemoved);
 
   if (server.blockedRam <= 0) {

--- a/src/DarkNet/effects/ramblock.ts
+++ b/src/DarkNet/effects/ramblock.ts
@@ -101,5 +101,5 @@ export const getRamBlock = (maxRam: number): number => {
     return [16, 32, maxRam - 8][Math.floor(Math.random() * 3)];
   }
 
-  return [maxRam, maxRam - 8, maxRam - 64, maxRam / 2][Math.floor(Math.random() * 4)];
+  return roundToTwo([maxRam, maxRam - 8, maxRam - 64, maxRam / 2][Math.floor(Math.random() * 4)]);
 };

--- a/src/DarkNet/effects/ramblock.ts
+++ b/src/DarkNet/effects/ramblock.ts
@@ -73,7 +73,7 @@ export const getRamBlockRemoved = (darknetServerData: DarknetServerData, threads
   const charismaFactor = 1 + player.skills.charisma / 100;
   const difficultyFactor = 2 * 0.92 ** (difficulty + 1);
   const baseAmount = 0.02;
-  return clampNumber(baseAmount * difficultyFactor * threads * charismaFactor, 0, remainingRamBlock);
+  return roundToTwo(clampNumber(baseAmount * difficultyFactor * threads * charismaFactor, 0, remainingRamBlock));
 };
 
 /*

--- a/src/DarkNet/effects/ramblock.ts
+++ b/src/DarkNet/effects/ramblock.ts
@@ -1,6 +1,6 @@
 import { Player } from "@player";
 import { addClue } from "./effects";
-import { formatNumber } from "../../ui/formatNumber";
+import { formatNumber, formatRam } from "../../ui/formatNumber";
 import { logger } from "./offlineServerHandling";
 import type { NetscriptContext } from "../../Netscript/APIWrapper";
 import type { DarknetServer } from "../../Server/DarknetServer";
@@ -31,10 +31,10 @@ export const handleRamBlockRemoved = (ctx: NetscriptContext, server: DarknetServ
   const xpGained = Player.mults.charisma_exp * threads * 10 * 1.1 ** difficulty;
   Player.gainCharismaExp(xpGained);
 
-  const result = `Liberated ${formatNumber(
+  const result = `Liberated ${formatRam(
     ramBlockRemoved,
     4,
-  )}gb of RAM from the server owner's processes. (Gained ${formatNumber(xpGained, 1)} cha xp.)`;
+  )} of RAM from the server owner's processes. (Gained ${formatNumber(xpGained, 1)} cha xp.)`;
   logger(ctx)(result);
   return {
     success: true,

--- a/src/DarkNet/effects/ramblock.ts
+++ b/src/DarkNet/effects/ramblock.ts
@@ -12,7 +12,7 @@ import type { DarknetServerData, Person as IPerson } from "@nsdefs";
 import { clampNumber } from "../../utils/helpers/clampNumber";
 import { ResponseCodeEnum } from "../Enums";
 import { isLabyrinthServer } from "./labyrinth";
-import { roundToN } from "../../utils/helpers/roundToTwo";
+import { roundToTwo } from "../../utils/helpers/roundToTwo";
 
 /*
  * Handles the effects of removing some blocked RAM from a Darknet server.
@@ -22,7 +22,7 @@ export const handleRamBlockRemoved = (ctx: NetscriptContext, server: DarknetServ
   const difficulty = server.difficulty + 1;
 
   const ramBlockRemoved = getRamBlockRemoved(server, threads);
-  server.blockedRam = roundToN(server.blockedRam - ramBlockRemoved, 4);
+  server.blockedRam = roundToTwo(server.blockedRam - ramBlockRemoved);
   server.updateRamUsed(server.ramUsed - ramBlockRemoved);
 
   if (server.blockedRam <= 0) {

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -26,7 +26,7 @@ import { Settings } from "../Settings/Settings";
 import type { ScriptKey } from "../utils/helpers/scriptKey";
 import { assertObject } from "../utils/TypeAssertion";
 import { clampNumber } from "../utils/helpers/clampNumber";
-import { roundToN } from "../utils/helpers/roundToTwo";
+import { roundToTwo } from "../utils/helpers/roundToTwo";
 
 export interface BaseServerConstructorParams {
   adminRights?: boolean;
@@ -234,7 +234,7 @@ export abstract class BaseServer implements IServer {
   }
 
   updateRamUsed(ram: number): void {
-    this.ramUsed = clampNumber(roundToN(ram, 4), 0, this.maxRam);
+    this.ramUsed = roundToTwo(clampNumber(ram, 0, this.maxRam));
   }
 
   pushProgram(program: ProgramFilePath | CompletedProgramName): void {

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -26,6 +26,7 @@ import { Settings } from "../Settings/Settings";
 import type { ScriptKey } from "../utils/helpers/scriptKey";
 import { assertObject } from "../utils/TypeAssertion";
 import { clampNumber } from "../utils/helpers/clampNumber";
+import { roundToN } from "../utils/helpers/roundToTwo";
 
 export interface BaseServerConstructorParams {
   adminRights?: boolean;
@@ -233,7 +234,7 @@ export abstract class BaseServer implements IServer {
   }
 
   updateRamUsed(ram: number): void {
-    this.ramUsed = clampNumber(ram, 0, this.maxRam);
+    this.ramUsed = clampNumber(roundToN(ram, 4), 0, this.maxRam);
   }
 
   pushProgram(program: ProgramFilePath | CompletedProgramName): void {

--- a/src/utils/helpers/roundToTwo.ts
+++ b/src/utils/helpers/roundToTwo.ts
@@ -3,15 +3,5 @@
  * @param decimal A decimal value to trim to two places.
  */
 export function roundToTwo(decimal: number): number {
-  return roundToN(decimal, 2);
-}
-
-/**
- * Rounds a number to n decimal places.
- * @param decimal A decimal value to trim to n places.
- * @param digits the number of digits to trim to.
- */
-export function roundToN(decimal: number, digits: number): number {
-  const roundingFactor = 10 ** digits;
-  return Math.round(decimal * roundingFactor) / roundingFactor;
+  return Math.round(decimal * 100) / 100;
 }

--- a/src/utils/helpers/roundToTwo.ts
+++ b/src/utils/helpers/roundToTwo.ts
@@ -3,5 +3,15 @@
  * @param decimal A decimal value to trim to two places.
  */
 export function roundToTwo(decimal: number): number {
-  return Math.round(decimal * 100) / 100;
+  return roundToN(decimal, 2);
+}
+
+/**
+ * Rounds a number to n decimal places.
+ * @param decimal A decimal value to trim to n places.
+ * @param digits the number of digits to trim to.
+ */
+export function roundToN(decimal: number, digits: number): number {
+  const roundingFactor = 10 ** digits;
+  return Math.round(decimal * roundingFactor) / roundingFactor;
 }

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -34,7 +34,7 @@ import {
 import { getMostRecentAuthLog } from "../../../src/DarkNet/models/packetSniffing";
 import type { Result } from "@nsdefs";
 import { assertNonNullish } from "../../../src/utils/TypeAssertion";
-import { roundToN } from "../../../src/utils/helpers/roundToTwo";
+import { roundToTwo } from "../../../src/utils/helpers/roundToTwo";
 
 const hostnameOfNonExistentServer = "fake-server";
 const errorMessageForNonExistentServer = `Invalid host: '${hostnameOfNonExistentServer}'`;
@@ -1232,7 +1232,7 @@ describe("Use IP instead of hostname", () => {
     expect(result3.success).toStrictEqual(true);
     expect(result3.code).toStrictEqual(ResponseCodeEnum.Success);
     expect(updatedBlockedRam).toBeLessThan(initialBlockedRam);
-    expect(updatedBlockedRam).toEqual(roundToN(updatedBlockedRam, 4));
+    expect(updatedBlockedRam).toEqual(roundToTwo(updatedBlockedRam));
   });
   test("getBlockedRam", () => {
     const ns = getNsOnNonDarkwebDarknetServer();

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -34,6 +34,7 @@ import {
 import { getMostRecentAuthLog } from "../../../src/DarkNet/models/packetSniffing";
 import type { Result } from "@nsdefs";
 import { assertNonNullish } from "../../../src/utils/TypeAssertion";
+import { roundToN } from "../../../src/utils/helpers/roundToTwo";
 
 const hostnameOfNonExistentServer = "fake-server";
 const errorMessageForNonExistentServer = `Invalid host: '${hostnameOfNonExistentServer}'`;
@@ -1223,9 +1224,13 @@ describe("Use IP instead of hostname", () => {
     server.ramUsed = server.blockedRam = 1;
 
     const ns = getNS(server.hostname);
+    const initialBlockedRam = server.blockedRam;
     const result3 = await ns.dnet.memoryReallocation(ns.getIP());
+    const updatedBlockedRam = getDarknetServerOrThrow(server.hostname).blockedRam;
     expect(result3.success).toStrictEqual(true);
     expect(result3.code).toStrictEqual(ResponseCodeEnum.Success);
+    expect(updatedBlockedRam).toBeLessThan(initialBlockedRam);
+    expect(updatedBlockedRam).toEqual(roundToN(updatedBlockedRam, 4));
   });
   test("getBlockedRam", () => {
     const ns = getNsOnNonDarkwebDarknetServer();

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -54,7 +54,9 @@ beforeEach(() => {
   getDarkscapeNavigator();
   Player.getHomeComputer().programs.push(CompletedProgramName.formulas);
   Player.mults.charisma = 1e10;
+  Player.mults.hacking = 1e10;
   Player.gainCharismaExp(1e100);
+  Player.gainHackingExp(1e100);
   getNsOnServerNearLabyrinth();
 });
 


### PR DESCRIPTION
To prevent bonus time from messing with the timing of authentication, this PR removes bonus time as a factor from calculateAuthenticationTime. It remains only as a factor for xp gained from auth and money gained from phishing.

In addition, this PR ensures that the ram used on a server is always rounded to four digits, to prevent tiny floating point imprecisions from messing with available ram.