### PR TITLE
CODEBASE: Use type-only imports in ArrayHelpers.ts

### DIFF
--- a/src/utils/helpers/ArrayHelpers.ts
+++ b/src/utils/helpers/ArrayHelpers.ts
@@ -1,4 +1,4 @@
-import { Truthy } from "lodash";
+import type { Truthy } from "lodash";
 
 /**
  * Returns the input array as a comma separated string.


### PR DESCRIPTION
I forgot to commit this file in #2608.