### PR TITLE
UI: Ensure prompts shown by ns.prompt do not lose focus in the terminal tab

### DIFF
--- a/src/Documentation/doc/en/basic/terminal.md
+++ b/src/Documentation/doc/en/basic/terminal.md
@@ -100,3 +100,9 @@ with a semicolon (;). For example:
     $ run foo.js; tail foo.js
 
 Chained commands do **not** wait for functions like `hack` or `wget` to finish executing, and so may not always work as expected.
+
+## Quirks
+
+When your scripts render a text box (e.g., `<input>`, `<textarea>`) with the `autoFocus` attribute in the terminal or
+the tail log window, it may not focus automatically as expected. To be precise, the text box receives focus, but the
+terminal may immediately reclaim it. This depends on the specific timing of the render.

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -149,6 +149,8 @@ export class Terminal {
 
   // True if a Coding Contract prompt is opened
   contractOpen = false;
+  // True if a prompt is opened via the ns.prompt() API
+  nsPromptApiOpen = false;
 
   // Path of current directory
   currDir = "" as Directory;

--- a/src/Terminal/ui/TerminalInput.tsx
+++ b/src/Terminal/ui/TerminalInput.tsx
@@ -209,7 +209,9 @@ export function TerminalInput(): React.ReactElement {
   // Catch all key inputs and redirect them to the terminal.
   useEffect(() => {
     function keyDown(this: Document, event: KeyboardEvent): void {
-      if (Terminal.contractOpen) return;
+      if (Terminal.contractOpen || Terminal.nsPromptApiOpen) {
+        return;
+      }
       if (Terminal.action !== null && event.key === KEY.C && event.ctrlKey) {
         Terminal.finishAction(true);
         return;

--- a/src/ui/React/PromptManager.tsx
+++ b/src/ui/React/PromptManager.tsx
@@ -7,6 +7,7 @@ import Select, { SelectChangeEvent } from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
 import MenuItem from "@mui/material/MenuItem";
 import { KEY } from "../../utils/KeyboardEventKey";
+import { Terminal } from "../../Terminal";
 
 export const PromptEvent = new EventEmitter<[Prompt]>();
 
@@ -59,6 +60,8 @@ export function PromptManager({ hidden }: { hidden: boolean }): React.ReactEleme
     prompt?.resolve(value);
     setPrompt(null);
   };
+
+  Terminal.nsPromptApiOpen = !hidden && prompt !== null;
 
   return (
     <Modal open={!hidden && prompt !== null} onClose={close}>


### PR DESCRIPTION
Let's reproduce the issue in #924:
- Run `b.js` to compile `a.js`.
- Run `a.js`.

The prompt's text box loses focus immediately.

Now, in `a.js`, add `await ns.sleep(1000);` before `await ns.prompt`, then run `b.js` and `a.js` again. The prompt's text box no longer loses focus.

```js
// a.js
/** @param {NS} ns */
export async function main(ns) {
  await ns.prompt("Some dummy text", { type: "text" });
}
```
```js
// b.js
import { main as mainFoo } from "a";

/** @param {NS} ns */
export async function main(ns) {
  mainFoo;
}
```

When players type `run a.js` and press Enter, the `keyDown` handler for the Enter key may execute after the prompt's text box has rendered, depending on the render timing.

The fix here follows the same logic used to prevent this from happening with the coding contract modal.

Fixes #924.