### PR TITLE
DEVMENU: Initialize dark net data when setting SF15 level

### DIFF
--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -14,6 +14,7 @@ import { validBitNodes } from "../../BitNode/Constants";
 import { DeleteServer, GetAllServers } from "../../Server/AllServers";
 import { HacknetServer } from "../../Hacknet/HacknetServer";
 import { AutoExpandAccordion } from "../../ui/AutoExpand/AutoExpandAccordion";
+import { getDarkscapeNavigator } from "../../DarkNet/effects/effects";
 
 const useStyles = makeStyles()({
   group: {
@@ -45,6 +46,9 @@ export function SourceFilesDev({ parentRerender }: { parentRerender: () => void 
           // Make sure that Player.hacknetNodes contains only the hostnames of hacknet servers.
           Player.hacknetNodes = Player.hacknetNodes.filter((node) => typeof node === "string");
         }
+      }
+      if (sfN === 15 && sfLvl !== 0) {
+        getDarkscapeNavigator();
       }
       if (sfLvl === 0) {
         Player.sourceFiles.delete(sfN);


### PR DESCRIPTION
This PR fixes a bug in the SF tool:
- Load a clean save file.
- Set SF15 to level 1 or higher.
- Check the DarkNet tab. There is no dnet server except darkweb.
- Save and reload.
- Wait a few seconds. There is an exception alert: `Caught an exception: Error: The connection between darkweb and home is unidirectional.`

The fix is trivial.