### PR TITLE
DOCUMENTATION: Clarify scp and exec darknet permissions in API docs

### DIFF
--- a/markdown/bitburner.ns.exec.md
+++ b/markdown/bitburner.ns.exec.md
@@ -132,4 +132,5 @@ ns.exec("generic-hack.js", "joesguns", {threads: 10});
 // arguments to the script.
 ns.exec("foo.js", "foodnstuff", 5, 1, "test");
 ```
+For darknet servers: A session must be established with the target server, and the script must be running on a server that is directly connected to the target, or the target must have a backdoor or stasis link installed.
 

--- a/markdown/bitburner.ns.scp.md
+++ b/markdown/bitburner.ns.scp.md
@@ -112,5 +112,5 @@ const server = ns.args[0];
 const files = ["hack.js", "weaken.js", "grow.js"];
 ns.scp(files, server, "home");
 ```
-For darknet servers: The destination requires a session, but unlike [exec](./bitburner.ns.exec.md)<!-- -->, does not require a direct connection — scp works at any distance. The source server has no darknet requirements (no session, no connection). Use [dnet.authenticate](./bitburner.darknet.authenticate.md) (requires direct connection) or [dnet.connectToSession](./bitburner.darknet.connecttosession.md) (works at any distance) to establish a session.
+For darknet servers: The destination requires a session, but unlike [exec](./bitburner.ns.exec.md)<!-- -->, does not require a direct connection — scp works at any distance. The source server has no darknet requirements (no session or connection needed). Use [dnet.authenticate](./bitburner.darknet.authenticate.md) (requires direct connection) or [dnet.connectToSession](./bitburner.darknet.connecttosession.md) (at any distance) to establish a session.
 

--- a/markdown/bitburner.ns.scp.md
+++ b/markdown/bitburner.ns.scp.md
@@ -112,5 +112,5 @@ const server = ns.args[0];
 const files = ["hack.js", "weaken.js", "grow.js"];
 ns.scp(files, server, "home");
 ```
-For password-protected servers (such as darknet servers), a session must be established with the destination server before using this function. (The source server does not require a session.)
+For darknet servers: The destination requires a session, but unlike [exec](./bitburner.ns.exec.md)<!-- -->, does not require a direct connection — scp works at any distance. The source server has no darknet requirements (no session, no connection). Use [dnet.authenticate](./bitburner.darknet.authenticate.md) (requires direct connection) or [dnet.connectToSession](./bitburner.darknet.connecttosession.md) (works at any distance) to establish a session.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7905,6 +7905,11 @@ export interface NS {
    * // arguments to the script.
    * ns.exec("foo.js", "foodnstuff", 5, 1, "test");
    * ```
+   *
+   * For darknet servers: A session must be established with the target server, and the script must be
+   * running on a server that is directly connected to the target, or the target must have a backdoor or
+   * stasis link installed.
+   *
    * @param script - Filename of script to execute. This file must already exist on the target server.
    * @param host - Hostname/IP of the target server on which to execute the script.
    * @param threadOrOptions - Either an integer number of threads for new script, or a {@link RunOptions} object. Threads defaults to 1.
@@ -8042,7 +8047,11 @@ export interface NS {
    * ns.scp(files, server, "home");
    * ```
    *
-   * For password-protected servers (such as darknet servers), a session must be established with the destination server before using this function. (The source server does not require a session.)
+   * For darknet servers: The destination requires a session, but unlike {@link NS.exec | exec}, does not
+   * require a direct connection — scp works at any distance. The source server has no darknet requirements
+   * (no session, no connection). Use {@link Darknet.authenticate | dnet.authenticate} (requires direct
+   * connection) or {@link Darknet.connectToSession | dnet.connectToSession} (works at any distance) to
+   * establish a session.
    *
    * @param files - Filename or an array of filenames of script/literature files to copy. Note that if a file is located in a subdirectory, the filename must include the leading `/`.
    * @param destination - Hostname/IP of the destination server, which is the server to which the file will be copied.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -8049,8 +8049,8 @@ export interface NS {
    *
    * For darknet servers: The destination requires a session, but unlike {@link NS.exec | exec}, does not
    * require a direct connection — scp works at any distance. The source server has no darknet requirements
-   * (no session, no connection). Use {@link Darknet.authenticate | dnet.authenticate} (requires direct
-   * connection) or {@link Darknet.connectToSession | dnet.connectToSession} (works at any distance) to
+   * (no session or connection needed). Use {@link Darknet.authenticate | dnet.authenticate} (requires direct
+   * connection) or {@link Darknet.connectToSession | dnet.connectToSession} (at any distance) to
    * establish a session.
    *
    * @param files - Filename or an array of filenames of script/literature files to copy. Note that if a file is located in a subdirectory, the filename must include the leading `/`.


### PR DESCRIPTION
The scp JSDoc mentions needing a session for darknet servers, but doesn't explain that unlike exec, scp doesn't need a direct connection — it works at any distance. This is the main thing that confused the reporter in #2530.

Updated the scp note to spell out the full picture: destination needs a session (but no connection), source needs nothing at all. Added cross-references to `dnet.authenticate` and `dnet.connectToSession` so players know how to actually get a session.

Also added a darknet note to exec, which had zero mention of darknet/session/connection requirements.

Fixes #2530