### PR TITLE
DOCUMENTATION: Update RAM cost of hacknet APIs and remove unnecessary RAM cost docs

### DIFF
--- a/markdown/bitburner.hacknet.getcacheupgradecost.md
+++ b/markdown/bitburner.hacknet.getcacheupgradecost.md
@@ -72,7 +72,7 @@ Cost of upgrading the specified Hacknet Node's cache.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.getcoreupgradecost.md
+++ b/markdown/bitburner.hacknet.getcoreupgradecost.md
@@ -72,7 +72,7 @@ Cost of upgrading the specified Hacknet Node's number of cores.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Returns the cost of upgrading the number of cores of the specified Hacknet Node by n.
 

--- a/markdown/bitburner.hacknet.gethashupgradelevel.md
+++ b/markdown/bitburner.hacknet.gethashupgradelevel.md
@@ -54,7 +54,7 @@ Level of the upgrade.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.gethashupgrades.md
+++ b/markdown/bitburner.hacknet.gethashupgrades.md
@@ -19,7 +19,7 @@ An array containing the available upgrades
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.getlevelupgradecost.md
+++ b/markdown/bitburner.hacknet.getlevelupgradecost.md
@@ -72,7 +72,7 @@ Cost of upgrading the specified Hacknet Node.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Returns the cost of upgrading the specified Hacknet Node by n levels.
 

--- a/markdown/bitburner.hacknet.getnodestats.md
+++ b/markdown/bitburner.hacknet.getnodestats.md
@@ -56,7 +56,7 @@ Object containing a variety of stats about the specified Hacknet Node.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Returns an object containing a variety of stats about the specified Hacknet Node.
 

--- a/markdown/bitburner.hacknet.getpurchasenodecost.md
+++ b/markdown/bitburner.hacknet.getpurchasenodecost.md
@@ -19,7 +19,7 @@ Cost of purchasing a new Hacknet Node.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Returns the cost of purchasing a new Hacknet Node.
 

--- a/markdown/bitburner.hacknet.getramupgradecost.md
+++ b/markdown/bitburner.hacknet.getramupgradecost.md
@@ -72,7 +72,7 @@ Cost of upgrading the specified Hacknet Node's RAM.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Returns the cost of upgrading the RAM of the specified Hacknet Node n times.
 

--- a/markdown/bitburner.hacknet.getstudymult.md
+++ b/markdown/bitburner.hacknet.getstudymult.md
@@ -19,7 +19,7 @@ Multiplier.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.gettrainingmult.md
+++ b/markdown/bitburner.hacknet.gettrainingmult.md
@@ -19,7 +19,7 @@ Multiplier.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.hashcapacity.md
+++ b/markdown/bitburner.hacknet.hashcapacity.md
@@ -19,7 +19,7 @@ Number of hashes you can store.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.hashcost.md
+++ b/markdown/bitburner.hacknet.hashcost.md
@@ -72,7 +72,7 @@ Number of hashes required for the specified upgrade.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.maxnumnodes.md
+++ b/markdown/bitburner.hacknet.maxnumnodes.md
@@ -19,5 +19,5 @@ Maximum number of hacknet nodes.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 

--- a/markdown/bitburner.hacknet.numhashes.md
+++ b/markdown/bitburner.hacknet.numhashes.md
@@ -19,7 +19,7 @@ Number of hashes you have.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.numnodes.md
+++ b/markdown/bitburner.hacknet.numnodes.md
@@ -19,7 +19,7 @@ Number of hacknet nodes.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Returns the number of Hacknet Nodes you own.
 

--- a/markdown/bitburner.hacknet.purchasenode.md
+++ b/markdown/bitburner.hacknet.purchasenode.md
@@ -19,7 +19,7 @@ The index of the Hacknet Node or if the player cannot afford to purchase a new H
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Purchases a new Hacknet Node. Returns a number with the index of the Hacknet Node. This index is equivalent to the number at the end of the Hacknet Node’s name (e.g. The Hacknet Node named `hacknet-node-4` will have an index of 4).
 

--- a/markdown/bitburner.hacknet.spendhashes.md
+++ b/markdown/bitburner.hacknet.spendhashes.md
@@ -88,7 +88,7 @@ True if the upgrade is successfully purchased, and false otherwise.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.upgradecache.md
+++ b/markdown/bitburner.hacknet.upgradecache.md
@@ -72,7 +72,7 @@ True if the Hacknet Node’s cache level is successfully upgraded, false otherwi
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
 

--- a/markdown/bitburner.hacknet.upgradecore.md
+++ b/markdown/bitburner.hacknet.upgradecore.md
@@ -72,7 +72,7 @@ True if the Hacknet Node’s cores are successfully purchased, false otherwise.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Tries to purchase n cores for the specified Hacknet Node.
 

--- a/markdown/bitburner.hacknet.upgradelevel.md
+++ b/markdown/bitburner.hacknet.upgradelevel.md
@@ -72,7 +72,7 @@ True if the Hacknet Node’s level is successfully upgraded, false otherwise.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Tries to upgrade the level of the specified Hacknet Node by n.
 

--- a/markdown/bitburner.hacknet.upgraderam.md
+++ b/markdown/bitburner.hacknet.upgraderam.md
@@ -72,7 +72,7 @@ True if the Hacknet Node’s RAM is successfully upgraded, false otherwise.
 
 ## Remarks
 
-RAM cost: 0 GB
+RAM cost: 0.5 GB
 
 Tries to upgrade the specified Hacknet Node’s RAM n times. Note that each upgrade doubles the Node’s RAM. So this is equivalent to multiplying the Node’s RAM by 2 n.
 

--- a/markdown/bitburner.ns.args.md
+++ b/markdown/bitburner.ns.args.md
@@ -6,17 +6,13 @@
 
 Arguments passed into the script.
 
+These arguments can be accessed as a normal array by using the `[]` operator (`args[0]`<!-- -->, `args[1]`<!-- -->, etc...). Arguments can be string, number, or boolean. Use `args.length` to get the number of arguments that were passed into a script.
+
 **Signature:**
 
 ```typescript
 readonly args: ScriptArg[];
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-
-Arguments passed into a script can be accessed as a normal array by using the `[]` operator (`args[0]`<!-- -->, `args[1]`<!-- -->, etc...). Arguments can be string, number, or boolean. Use `args.length` to get the number of arguments that were passed into a script.
 
 ## Example
 

--- a/markdown/bitburner.ns.bladeburner.md
+++ b/markdown/bitburner.ns.bladeburner.md
@@ -11,8 +11,3 @@ Namespace for [Bladeburner](./bitburner.bladeburner.md) functions. Contains spoi
 ```typescript
 readonly bladeburner: Bladeburner;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.cloud.md
+++ b/markdown/bitburner.ns.cloud.md
@@ -11,8 +11,3 @@ Namespace for [cloud](./bitburner.cloud.md) functions.
 ```typescript
 readonly cloud: Cloud;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.codingcontract.md
+++ b/markdown/bitburner.ns.codingcontract.md
@@ -11,8 +11,3 @@ Namespace for [coding contract](./bitburner.codingcontract.md) functions.
 ```typescript
 readonly codingcontract: CodingContract;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.corporation.md
+++ b/markdown/bitburner.ns.corporation.md
@@ -11,8 +11,3 @@ Namespace for [corporation](./bitburner.corporation.md) functions. Contains spoi
 ```typescript
 readonly corporation: Corporation;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.dnet.md
+++ b/markdown/bitburner.ns.dnet.md
@@ -11,8 +11,3 @@ Namespace for darknet functions. Contains spoilers.
 ```typescript
 readonly dnet: Darknet;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.format.md
+++ b/markdown/bitburner.ns.format.md
@@ -11,8 +11,3 @@ Namespace for [formatting](./bitburner.format.md) functions.
 ```typescript
 readonly format: Format;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.formulas.md
+++ b/markdown/bitburner.ns.formulas.md
@@ -11,8 +11,3 @@ Namespace for [formulas](./bitburner.formulas.md) functions.
 ```typescript
 readonly formulas: Formulas;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.gang.md
+++ b/markdown/bitburner.ns.gang.md
@@ -11,8 +11,3 @@ Namespace for [gang](./bitburner.gang.md) functions. Contains spoilers.
 ```typescript
 readonly gang: Gang;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.go.md
+++ b/markdown/bitburner.ns.go.md
@@ -11,8 +11,3 @@ Namespace for [Go](./bitburner.go.md) functions.
 ```typescript
 readonly go: Go;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.grafting.md
+++ b/markdown/bitburner.ns.grafting.md
@@ -11,8 +11,3 @@ Namespace for [grafting](./bitburner.grafting.md) functions. Contains spoilers.
 ```typescript
 readonly grafting: Grafting;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.hacknet.md
+++ b/markdown/bitburner.ns.hacknet.md
@@ -11,8 +11,3 @@ Namespace for [hacknet](./bitburner.hacknet.md) functions. Some of this API cont
 ```typescript
 readonly hacknet: Hacknet;
 ```
-
-## Remarks
-
-RAM cost: 0GB.
-

--- a/markdown/bitburner.ns.hacknet.md
+++ b/markdown/bitburner.ns.hacknet.md
@@ -14,5 +14,5 @@ readonly hacknet: Hacknet;
 
 ## Remarks
 
-RAM cost: 4 GB.
+RAM cost: 0GB.
 

--- a/markdown/bitburner.ns.infiltration.md
+++ b/markdown/bitburner.ns.infiltration.md
@@ -11,8 +11,3 @@ Namespace for [infiltration](./bitburner.infiltration.md) functions.
 ```typescript
 readonly infiltration: Infiltration;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -69,6 +69,8 @@ Description
 
 Arguments passed into the script.
 
+These arguments can be accessed as a normal array by using the `[]` operator (`args[0]`<!-- -->, `args[1]`<!-- -->, etc...). Arguments can be string, number, or boolean. Use `args.length` to get the number of arguments that were passed into a script.
+
 
 </td></tr>
 <tr><td>

--- a/markdown/bitburner.ns.singularity.md
+++ b/markdown/bitburner.ns.singularity.md
@@ -11,8 +11,3 @@ Namespace for [singularity](./bitburner.singularity.md) functions. Contains spoi
 ```typescript
 readonly singularity: Singularity;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.sleeve.md
+++ b/markdown/bitburner.ns.sleeve.md
@@ -11,8 +11,3 @@ Namespace for [sleeve](./bitburner.sleeve.md) functions. Contains spoilers.
 ```typescript
 readonly sleeve: Sleeve;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.stanek.md
+++ b/markdown/bitburner.ns.stanek.md
@@ -11,8 +11,3 @@ Namespace for [Stanek](./bitburner.stanek.md) functions. Contains spoilers.
 ```typescript
 readonly stanek: Stanek;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.stock.md
+++ b/markdown/bitburner.ns.stock.md
@@ -11,8 +11,3 @@ Namespace for [stock](./bitburner.stock.md) functions.
 ```typescript
 readonly stock: Stock;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/markdown/bitburner.ns.ui.md
+++ b/markdown/bitburner.ns.ui.md
@@ -11,8 +11,3 @@ Namespace for [user interface](./bitburner.userinterface.md) functions.
 ```typescript
 readonly ui: UserInterface;
 ```
-
-## Remarks
-
-RAM cost: 0 GB
-

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6999,113 +6999,93 @@ interface UserInterface {
 export interface NS {
   /**
    * Namespace for {@link Hacknet | hacknet} functions. Some of this API contains spoilers.
-   * @remarks RAM cost: 0GB.
    */
   readonly hacknet: Hacknet;
 
   /**
    * Namespace for {@link Bladeburner | Bladeburner} functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly bladeburner: Bladeburner;
 
   /**
    * Namespace for {@link CodingContract | coding contract} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly codingcontract: CodingContract;
 
   /**
    * Namespace for {@link Cloud | cloud} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly cloud: Cloud;
 
   /**
    * Namespace for darknet functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly dnet: Darknet;
 
   /**
    * Namespace for {@link Format | formatting} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly format: Format;
 
   /**
    * Namespace for {@link Gang | gang} functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly gang: Gang;
 
   /**
    * Namespace for {@link Go | Go} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly go: Go;
 
   /**
    * Namespace for {@link Sleeve | sleeve} functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly sleeve: Sleeve;
 
   /**
    * Namespace for {@link Stock | stock} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly stock: Stock;
 
   /**
    * Namespace for {@link Formulas | formulas} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly formulas: Formulas;
 
   /**
    * Namespace for {@link Stanek | Stanek} functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly stanek: Stanek;
 
   /**
    * Namespace for {@link Infiltration | infiltration} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly infiltration: Infiltration;
 
   /**
    * Namespace for {@link Corporation | corporation} functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly corporation: Corporation;
 
   /**
    * Namespace for {@link UserInterface | user interface} functions.
-   * @remarks RAM cost: 0 GB
    */
   readonly ui: UserInterface;
 
   /**
    * Namespace for {@link Singularity | singularity} functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly singularity: Singularity;
 
   /**
    * Namespace for {@link Grafting | grafting} functions. Contains spoilers.
-   * @remarks RAM cost: 0 GB
    */
   readonly grafting: Grafting;
 
   /**
    * Arguments passed into the script.
    *
-   * @remarks
-   * RAM cost: 0 GB
-   *
-   * Arguments passed into a script can be accessed as a normal array by using the `[]` operator
+   * These arguments can be accessed as a normal array by using the `[]` operator
    * (`args[0]`, `args[1]`, etc...).
    * Arguments can be string, number, or boolean.
    * Use `args.length` to get the number of arguments that were passed into a script.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2925,7 +2925,7 @@ export interface Hacknet {
   /**
    * Get the number of hacknet nodes you own.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Returns the number of Hacknet Nodes you own.
    *
@@ -2936,7 +2936,7 @@ export interface Hacknet {
   /**
    * Get the maximum number of hacknet nodes.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * @returns Maximum number of hacknet nodes.
    */
@@ -2945,7 +2945,7 @@ export interface Hacknet {
   /**
    * Purchase a new hacknet node.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Purchases a new Hacknet Node. Returns a number with the index of the
    * Hacknet Node. This index is equivalent to the number at the end of
@@ -2961,7 +2961,7 @@ export interface Hacknet {
   /**
    * Get the price of the next hacknet node.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Returns the cost of purchasing a new Hacknet Node.
    *
@@ -2972,7 +2972,7 @@ export interface Hacknet {
   /**
    * Get the stats of a hacknet node.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Returns an object containing a variety of stats about the specified Hacknet Node.
    *
@@ -2988,7 +2988,7 @@ export interface Hacknet {
   /**
    * Upgrade the level of a hacknet node.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Tries to upgrade the level of the specified Hacknet Node by n.
    *
@@ -3006,7 +3006,7 @@ export interface Hacknet {
   /**
    * Upgrade the RAM of a hacknet node.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Tries to upgrade the specified Hacknet Node’s RAM n times.
    * Note that each upgrade doubles the Node’s RAM.
@@ -3026,7 +3026,7 @@ export interface Hacknet {
   /**
    * Upgrade the core of a hacknet node.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Tries to purchase n cores for the specified Hacknet Node.
    *
@@ -3044,7 +3044,7 @@ export interface Hacknet {
   /**
    * Upgrade the cache of a hacknet node.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3064,7 +3064,7 @@ export interface Hacknet {
   /**
    * Calculate the cost of upgrading hacknet node levels.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Returns the cost of upgrading the specified Hacknet Node by n levels.
    *
@@ -3080,7 +3080,7 @@ export interface Hacknet {
   /**
    * Calculate the cost of upgrading hacknet node RAM.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Returns the cost of upgrading the RAM of the specified Hacknet Node n times.
    *
@@ -3096,7 +3096,7 @@ export interface Hacknet {
   /**
    * Calculate the cost of upgrading hacknet node cores.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * Returns the cost of upgrading the number of cores of the specified Hacknet Node by n.
    *
@@ -3112,7 +3112,7 @@ export interface Hacknet {
   /**
    * Calculate the cost of upgrading hacknet node cache.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3130,7 +3130,7 @@ export interface Hacknet {
   /**
    * Get the total number of hashes stored.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3143,7 +3143,7 @@ export interface Hacknet {
   /**
    * Get the maximum number of hashes you can store.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3156,7 +3156,7 @@ export interface Hacknet {
   /**
    * Get the cost of a hash upgrade.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3178,7 +3178,7 @@ export interface Hacknet {
   /**
    * Purchase a hash upgrade.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3207,7 +3207,7 @@ export interface Hacknet {
   /**
    * Get the list of hash upgrades
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3223,7 +3223,7 @@ export interface Hacknet {
   /**
    * Get the level of a hash upgrade.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3234,7 +3234,7 @@ export interface Hacknet {
   /**
    * Get the multiplier to study.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -3245,7 +3245,7 @@ export interface Hacknet {
   /**
    * Get the multiplier to training.
    * @remarks
-   * RAM cost: 0 GB
+   * RAM cost: 0.5 GB
    *
    * This function is only applicable for Hacknet Servers (the upgraded version of a Hacknet Node).
    *
@@ -6999,7 +6999,7 @@ interface UserInterface {
 export interface NS {
   /**
    * Namespace for {@link Hacknet | hacknet} functions. Some of this API contains spoilers.
-   * @remarks RAM cost: 4 GB.
+   * @remarks RAM cost: 0GB.
    */
   readonly hacknet: Hacknet;
 


### PR DESCRIPTION
We recently changed the RAM cost of hacknet APIs in #2502.