### PR TITLE
MISC: Apply SF override to charisma calculations

### DIFF
--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -602,6 +602,10 @@ export function canAccessCotMG(this: PlayerObject): boolean {
   return canAccessBitNodeFeature(13);
 }
 
+/**
+ * To ensure the "SF override" option work properly, this function should only be used in special cases. In most cases,
+ * activeSourceFileLvl should be used instead.
+ */
 export function sourceFileLvl(this: PlayerObject, n: number): number {
   return this.sourceFiles.get(n) ?? 0;
 }

--- a/src/PersonObjects/formulas/reputation.ts
+++ b/src/PersonObjects/formulas/reputation.ts
@@ -52,7 +52,7 @@ export function getFactionFieldWorkRepGain(p: IPerson, favor: number): number {
 }
 
 function getDarknetCharismaBonus(p: IPerson, scalar: number = 1): number {
-  if (Player.sourceFileLvl(15) >= 3) {
+  if (Player.activeSourceFileLvl(15) >= 3) {
     return p.skills.charisma * scalar;
   }
   return 0;

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -310,7 +310,7 @@ export function prestigeSourceFile(isFlume: boolean): void {
   }
 
   // BitNode 12: The Recursion
-  if (Player.bitNodeN === 12 && Player.activeSourceFileLvl(12) > 100) {
+  if (Player.bitNodeN === 12 && Player.sourceFileLvl(12) > 100) {
     delayedDialog("Saynt_Garmo is watching you");
   }
 

--- a/src/Work/Formulas.ts
+++ b/src/Work/Formulas.ts
@@ -130,7 +130,7 @@ export const calculateCompanyWorkStats = (
   // If player has SF-11, calculate salary multiplier from favor
   const favorMult = isNaN(favor) ? 1 : 1 + favor / 100;
   const bn11Mult = Player.activeSourceFileLvl(11) > 0 ? favorMult : 1;
-  const sf15Mult = Player.sourceFileLvl(15) > 1 ? getMultiplierFromCharisma(1.5) : 1;
+  const sf15Mult = Player.activeSourceFileLvl(15) > 1 ? getMultiplierFromCharisma(1.5) : 1;
 
   const gains = scaleWorkStats(
     multWorkStats(


### PR DESCRIPTION
While checking usages of `sourceFileLvl`, I found some places that should call `activeSourceFileLvl` instead of `sourceFileLvl`.

The change in `src\Prestige.ts` is optional. In that file, when showing dialogs after prestige, we use `sourceFileLvl` instead of `activeSourceFileLvl`.