### PR TITLE
UI: Remove unnecessary max-width of tab list in in-game editor

### DIFF
--- a/src/ScriptEditor/ui/Tabs.tsx
+++ b/src/ScriptEditor/ui/Tabs.tsx
@@ -18,7 +18,6 @@ import { OpenScript } from "./OpenScript";
 import { Tab } from "./Tab";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 
-const tabsMaxWidth = 1640;
 const searchWidth = 180;
 
 interface IProps {
@@ -101,7 +100,6 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
         <Droppable droppableId="tabs" direction="horizontal">
           {(provided, snapshot) => (
             <Box
-              maxWidth={`${tabsMaxWidth}px`}
               display="flex"
               flexGrow="1"
               flexDirection="row"


### PR DESCRIPTION
On high-resolution screens, the tab list gets cut off.

Before:

<img width="1663" height="95" alt="before" src="https://github.com/user-attachments/assets/4a6a7505-d2c6-47fb-95d9-0e1662a4db5b" />

After:

<img width="1669" height="97" alt="after" src="https://github.com/user-attachments/assets/4e444659-bf35-4b36-9fd2-dffbd31b22b0" />