### PR TITLE
MISC: Update description of "BN9: Challenge" achievement

### DIFF
--- a/src/Achievements/AchievementData.json
+++ b/src/Achievements/AchievementData.json
@@ -454,7 +454,7 @@
     "CHALLENGE_BN9": {
       "ID": "CHALLENGE_BN9",
       "Name": "BN9: Challenge",
-      "Description": "Destroy BN9 without using hacknet servers."
+      "Description": "Destroy BN9 without using hacknet servers or hacknet nodes."
     },
     "CHALLENGE_BN10": {
       "ID": "CHALLENGE_BN10",


### PR DESCRIPTION
A player uses the "Disable Hacknet Server" option, then buy hacknet nodes without knowing that this achievement checks money source properties that are shared by hacknet nodes and hacknet servers.

The alternate fix is to split `hacknet` and `hacknet_expenses`. I'll do that instead if requested.

I'll ask Snarling or hydroflame to update the description on Steam once the stable version is released.