### PR TITLE
BLADEBURNER: Add tooltips explaining why skill upgrades are disabled

### DIFF
--- a/src/Bladeburner/ui/SkillElem.tsx
+++ b/src/Bladeburner/ui/SkillElem.tsx
@@ -3,7 +3,7 @@ import type { Bladeburner } from "../Bladeburner";
 import React, { useMemo } from "react";
 import { CopyableText } from "../../ui/React/CopyableText";
 import { formatBigNumber } from "../../ui/formatNumber";
-import { Box, IconButton, Paper, Typography } from "@mui/material";
+import { Box, IconButton, Paper, Tooltip, Typography } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 import { Skill } from "../Skill";
@@ -18,10 +18,8 @@ export function SkillElem({ skill, bladeburner, onUpgrade }: SkillElemProps): Re
   const skillName = skill.name;
   const skillLevel = bladeburner.getSkillLevel(skillName);
   const pointCost = useMemo(() => skill.calculateCost(skillLevel), [skill, skillLevel]);
-  // No need to support "+1" button when the skill level reaches Number.MAX_SAFE_INTEGER.
-  const isSupported = skillLevel < Number.MAX_SAFE_INTEGER;
   // Use skill.canUpgrade() instead of reimplementing all conditional checks.
-  const canLevel = isSupported && skill.canUpgrade(bladeburner, 1).available;
+  const check = skill.canUpgrade(bladeburner, 1);
   /**
    * maxLvl is only useful when we check if we should show "MAX LEVEL". For the check of the icon button, we don't need
    * it. This condition is checked in skill.canUpgrade().
@@ -37,10 +35,14 @@ export function SkillElem({ skill, bladeburner, onUpgrade }: SkillElemProps): Re
     <Paper sx={{ my: 1, p: 1 }}>
       <Box display="flex" flexDirection="row" alignItems="center">
         <CopyableText variant="h6" color="primary" value={skillName} />
-        {!canLevel ? (
-          <IconButton disabled>
-            <CloseIcon />
-          </IconButton>
+        {!check.available ? (
+          <Tooltip title={check.error}>
+            <span>
+              <IconButton disabled>
+                <CloseIcon />
+              </IconButton>
+            </span>
+          </Tooltip>
         ) : (
           <IconButton onClick={onClick}>
             <AddIcon />
@@ -51,7 +53,7 @@ export function SkillElem({ skill, bladeburner, onUpgrade }: SkillElemProps): Re
       {maxLvl ? (
         <Typography>MAX LEVEL</Typography>
       ) : (
-        <Typography>Skill Points required: {isSupported ? formatBigNumber(pointCost) : "N/A"}</Typography>
+        <Typography>Skill Points required: {formatBigNumber(pointCost)}</Typography>
       )}
       <Typography>{skill.desc}</Typography>
     </Paper>


### PR DESCRIPTION
When skill upgrades are disabled, we currently don't explain why. Furthermore, if a skill level is too high, the cost displays as "N/A", leading some players to mistakenly think the button is disabled because the game cannot calculate the cost.

This PR adds tooltips explaining why upgrades are disabled and replaces the "N/A" display with the actual calculated cost (showing "0" if the cost is zero).

Before:

<img width="830" height="120" alt="before" src="https://github.com/user-attachments/assets/973d18c7-c089-49fd-adc7-54c9b21b1255" />

After:

<img width="839" height="116" alt="after-1" src="https://github.com/user-attachments/assets/15c2bb71-4487-46c9-97ca-deaf5f330dc5" />

<img width="865" height="115" alt="after-2" src="https://github.com/user-attachments/assets/892cb87f-217f-4eb4-8730-4c525562a658" />

<img width="829" height="118" alt="after-3" src="https://github.com/user-attachments/assets/95d5e730-d82c-4606-a135-ba1fc1cbc37b" />

<img width="1034" height="108" alt="after-4" src="https://github.com/user-attachments/assets/74000380-1b60-44f3-9fa9-6707f9965ebf" />
