### PR TITLE
TOOL: Remove redundant "$" from JS/TS regex in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -134,7 +134,7 @@ module.exports = (env, argv) => {
     module: {
       rules: [
         {
-          test: /\.(js$|jsx|ts|tsx)$/,
+          test: /\.(js|jsx|ts|tsx)$/,
           exclude: /node_modules/,
           resourceQuery: { not: /raw/ },
           use: {


### PR DESCRIPTION
I'm about to make some changes in `src/Achievements/AchievementsRoot.tsx`. While checking previous changes in that file, I found a weird regex change in https://github.com/danielyxie/bitburner/pull/2409.

I'm fairly sure the "$" usage is redundant.