### PR TITLE
DOCUMENTATION: Update tutorial script for buying cloud servers

### DIFF
--- a/src/Documentation/doc/en/help/getting_started.md
+++ b/src/Documentation/doc/en/help/getting_started.md
@@ -367,12 +367,11 @@ Paste the following code into the [Script](../basic/scripts.md) editor:
 
     /** @param {NS} ns */
     export async function main(ns) {
-        // How much RAM each cloud server will have. In this case, it'll
-        // be 8GB.
+        // How much RAM each cloud server will have. In this case, it'll be 8GB.
         const ram = 8;
 
         // Iterator we'll use for our loop
-        let i = 0;
+        let i = ns.cloud.getServerNames().length;
 
         // Continuously try to purchase cloud servers until we've reached the maximum
         // amount of servers
@@ -381,16 +380,16 @@ Paste the following code into the [Script](../basic/scripts.md) editor:
             if (ns.getServerMoneyAvailable("home") > ns.cloud.getRamLimit(ram)) {
                 // If we have enough money, then:
                 //  1. Purchase the server
-                //  2. Copy our hacking script onto the newly-purchased cloud server
-                //  3. Run our hacking script on the newly-purchased cloud server with 3 threads
+                //  2. Copy our hacking script onto the newly purchased cloud server
+                //  3. Run our hacking script on the newly purchased cloud server with 3 threads
                 //  4. Increment our iterator to indicate that we've bought a new server
-                let hostname = ns.cloud.purchaseServer("cloud-server-" + i, ram);
+                const hostname = ns.cloud.purchaseServer("cloud-server-" + i, ram);
                 ns.scp("early-hack-template.js", hostname);
                 ns.exec("early-hack-template.js", hostname, 3);
                 ++i;
             }
-            //Make the script wait for a second before looping again.
-            //Removing this line will cause an infinite loop and crash the game.
+            // Make the script wait for a second before looping again.
+            // Removing this line will cause an infinite loop and crash the game.
             await ns.sleep(1000);
         }
     }

--- a/src/Documentation/doc/en/programming/game_frozen.md
+++ b/src/Documentation/doc/en/programming/game_frozen.md
@@ -33,12 +33,12 @@ Adding a sleep like in the first example, or changing the code so that the `awai
 
 Common infinite loop when translating the server purchasing script in starting guide to scripts is to have a while loop, where the condition's change is conditional:
 
-    var ram = 8;
-    var i = 0;
+    const ram = 8;
+    let i = ns.cloud.getServerNames().length;
 
     while (i < ns.cloud.getServerLimit()) {
         if (ns.getServerMoneyAvailable("home") > ns.cloud.getRamLimit(ram)) {
-            var hostname = ns.cloud.purchaseServer("cloud-server-" + i, ram);
+            const hostname = ns.cloud.purchaseServer("cloud-server-" + i, ram);
             ns.scp("early-hack-template.js", hostname);
             ns.exec("early-hack-template.js", hostname, 3);
             ++i;


### PR DESCRIPTION
We intentionally keep tutorial scripts non-optimal for learning purposes, but they should at least be bug-free. Currently, the script for buying cloud servers is somewhat buggy; while it works fine on the first run, it crashes with `scp: Invalid host: '' (empty string)` if the player already owns servers.

While experienced players can easily fix this, it can be a major roadblock for new players with limited programming experience. This PR updates the script to work properly even when the player reruns it.

The updated script still fits within the basic 8GB home RAM limit, so RAM usage is not a problem.