### PR TITLE
UI: Use exponential notation when formatting very small HP or thread values

### DIFF
--- a/src/ui/formatNumber.ts
+++ b/src/ui/formatNumber.ts
@@ -193,8 +193,18 @@ export const formatInt = (n: number) => formatNumber(n, 3, 1000, true);
 export const formatSleeveMemory = formatInt;
 export const formatShares = formatInt;
 
-/** Display an integer up to 999,999 before collapsing to suffixed form with 3 fractional digits */
-export const formatHp = (n: number) => formatNumber(n, 3, 1e6, true);
+/**
+ * Format a number using basicFormatter for values below 1e6, and a suffixed form with up to 3 fractional digits for
+ * values at or above 1e6. This uses formatNumber, so check that function for nuanced details.
+ *
+ * Values in the range (0, 0.001) are displayed in exponential notation.
+ */
+export const formatHp = (n: number) => {
+  if (n > 0 && n < 0.001) {
+    return formatExponential(n);
+  }
+  return formatNumber(n, 3, 1e6, true);
+};
 export const formatThreads = formatHp;
 
 /** Display an integer up to 999,999,999 before collapsing to suffixed form with 3 fractional digits */


### PR DESCRIPTION
A player reported that HP can display as 0. This occurs because `formatHp` does not handle very small values well, causing nonzero values to be rounded and displayed as "0".

The same issue affects thread values. While threads are conceptually positive integers, the `threads` option in `BasicHGWOptions` can produce fractional effective values that may be displayed as "0" even when nonzero.

Before:

<img width="520" height="293" alt="before" src="https://github.com/user-attachments/assets/ed33c927-8f0e-4ef0-8463-5262aa981811" />

After:

<img width="580" height="283" alt="after" src="https://github.com/user-attachments/assets/0239b3e6-bc2d-4d4e-b059-53e9ba7c5ca1" />
