### PR TITLE
DEVMENU: Add tool to expose internal objects

### DIFF
--- a/src/DevMenu/Tools.ts
+++ b/src/DevMenu/Tools.ts
@@ -1,0 +1,40 @@
+import { Companies } from "../Company/Companies";
+import { DarknetState } from "../DarkNet/models/DarknetState";
+import { Factions } from "../Faction/Factions";
+import { Go } from "../Go/Go";
+import { Player } from "../Player";
+import { saveObject } from "../SaveObject";
+import { GetAllServers } from "../Server/AllServers";
+
+declare global {
+  // This property is available in the dev build and can be exposed via the dev menu
+  // eslint-disable-next-line no-var
+  var Bitburner: {
+    Player: typeof Player;
+    GetAllServers: typeof GetAllServers;
+    Factions: typeof Factions;
+    Companies: typeof Companies;
+    saveObject: typeof saveObject;
+    Go: typeof Go;
+    DarknetState: typeof DarknetState;
+  };
+  // eslint-disable-next-line no-var
+  var openDevMenu: () => void;
+}
+
+export function exposeInternalObjects(): void {
+  globalThis.Bitburner = {
+    // Most data is in this object
+    Player: Player,
+    // Manipulate data of servers
+    GetAllServers: GetAllServers,
+    // Manipulate data of Factions and Companies
+    Factions: Factions,
+    Companies: Companies,
+    // saveObject and loadGame can be used to create a custom save/load tool
+    saveObject: saveObject,
+    // These are global states that are not in the Player object
+    Go: Go,
+    DarknetState: DarknetState,
+  };
+}

--- a/src/DevMenu/ui/GeneralDev.tsx
+++ b/src/DevMenu/ui/GeneralDev.tsx
@@ -26,6 +26,7 @@ import { formatRam } from "../../ui/formatNumber";
 import { resetGangs } from "../../Gang/AllGangs";
 import { finishBitNode } from "../../BitNode/BitNodeUtils";
 import { AutoExpandAccordion } from "../../ui/AutoExpand/AutoExpandAccordion";
+import { exposeInternalObjects } from "../Tools";
 
 export function GeneralDev({ parentRerender }: { parentRerender: () => void }): React.ReactElement {
   const rerender = useRerender(400);
@@ -209,6 +210,7 @@ export function GeneralDev({ parentRerender }: { parentRerender: () => void }): 
         <br />
         <Button onClick={() => setError(true)}>Throw Error</Button>
         <Button onClick={checkMessages}>Check Messages</Button>
+        <Button onClick={exposeInternalObjects}>Expose internal objects</Button>
       </AccordionDetails>
     </AutoExpandAccordion>
   );

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -22,7 +22,6 @@ import { checkForMessagesToSend } from "./Message/MessageHelpers";
 import { loadAllRunningScripts, updateOnlineScriptTimes } from "./NetscriptWorker";
 import { Player } from "@player";
 import { saveObject, loadGame } from "./SaveObject";
-import { GetAllServers } from "./Server/AllServers";
 import { Settings } from "./Settings/Settings";
 import { FormatsNeedToChange } from "./ui/formatNumber";
 import { canAccessStockMarket, initSymbolToStockMap, processStockPrices } from "./StockMarket/StockMarket";
@@ -46,7 +45,6 @@ import { SnackbarEvents } from "./ui/React/Snackbar";
 import { SaveData } from "./types";
 import { Go } from "./Go/Go";
 import { EventEmitter } from "./utils/EventEmitter";
-import { Companies } from "./Company/Companies";
 import { resetGoPromises } from "./Go/boardAnalysis/goAI";
 import { getRecordEntries } from "./Types/Record";
 import { storeDarknetCycles } from "./DarkNet/models/DarknetState";
@@ -54,23 +52,7 @@ import { processDarknet } from "./DarkNet/controllers/NetworkMovement";
 import { hasDarknetAccess } from "./DarkNet/utils/darknetAuthUtils";
 import { initForeignServers } from "./Server/ServerHelpers";
 import { apr1 } from "./Terminal/commands/apr1";
-
-declare global {
-  // This property is only available in the dev build
-  // eslint-disable-next-line no-var
-  var Bitburner: {
-    Player: typeof Player;
-    GetAllServers: typeof GetAllServers;
-    Factions: typeof Factions;
-    Companies: typeof Companies;
-    SaveObject: {
-      saveObject: typeof saveObject;
-      loadGame: typeof loadGame;
-    };
-  };
-  // eslint-disable-next-line no-var
-  var openDevMenu: () => void;
-}
+import { exposeInternalObjects } from "./DevMenu/Tools";
 
 export const GameCycleEvents = new EventEmitter<[]>();
 
@@ -395,20 +377,7 @@ const Engine = {
 
     // Expose internal objects/functions in the dev build
     if (process.env.NODE_ENV === "development") {
-      globalThis.Bitburner = {
-        // Most data is in this object
-        Player: Player,
-        // Manipulate data of servers
-        GetAllServers: GetAllServers,
-        // Manipulate data of Factions and Companies
-        Factions: Factions,
-        Companies: Companies,
-        // saveObject and loadGame can be used to create a custom save/load tool
-        SaveObject: {
-          saveObject: saveObject,
-          loadGame: loadGame,
-        },
-      };
+      exposeInternalObjects();
     }
     globalThis.openDevMenu = () => apr1();
   },


### PR DESCRIPTION
To access internal objects, we usually use the "module raid" trick. However, with the current version of Monaco, using this trick in combination with the in-game editor floods the console with errors. Because of this, when testing the latest production builds, I sometimes use the React exploit to access the dev menu instead of module raid. I'm not sure whether that exploit can expose internal objects, and I haven't tested it.

This PR allows access to commonly used internal objects via the dev menu without relying on module raid. It also exposes `Go` and `DarknetState`.

This is a niche use case, and I may be the only one using it. If you prefer not to merge this, I can remove the dev menu changes and only expose those two objects.