### PR TITLE
BLADEBURNER: Restore check against available team members

### DIFF
--- a/src/Bladeburner/Actions/Operation.ts
+++ b/src/Bladeburner/Actions/Operation.ts
@@ -93,6 +93,8 @@ export const operationSkillSuccessBonus = (inst: Bladeburner) => {
   return inst.getSkillMult(BladeburnerMultName.SuccessChanceOperation);
 };
 
-export function operationTeamSuccessBonus(this: Operation | BlackOperation) {
-  return Math.pow(this.teamCount + 1, 0.05);
+export function operationTeamSuccessBonus(this: Operation | BlackOperation, inst: Bladeburner) {
+  this.teamCount = Math.min(this.teamCount, inst.teamSize);
+  const teamMultiplier = Math.pow(this.teamCount + 1, 0.05);
+  return teamMultiplier;
 }


### PR DESCRIPTION
Context and steps to reproduce at [discord](https://discord.com/channels/415207508303544321/415213413745164318/1493469467559329843)
Partial revert of #2541

Post restoration of this `min`, the UI boxes correctly cap at however many teammates have survived/are assigned. From my experimentation, the >0 check is still not necessary - if I missed an edge case I'll restore it too.

`lint`,`format`,`test` and `doc` all completed