### PR TITLE
TOOL: Add Nix for reproducible local dev environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Dev shell for local Bitburner source builds";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            bash
+            git
+            nodejs_24
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- add a `flake.nix` dev shell for local Bitburner source builds
- pin dependencies in `flake.lock` so contributors get a reproducible environment
- provide the core tools needed to work on the repo: `bash`, `git`, and `nodejs_24`

## Why
Setting up a local environment can drift across machines depending on the host package manager, shell setup, and installed Node version. This adds a Nix-based entrypoint that makes the baseline development toolchain reproducible and easier to bootstrap for contributors who already use Nix or Mac, even WSL.

The shell intentionally stays small and focuses on the essentials needed to enter the repo and run the existing project workflows, while keeping the Node version aligned with the repo's current expectations.

## Testing
- ran `nix develop --command bash -lc 'node --version && git --version && bash --version | head -n 1'`
- verified the shell provides `node v24.14.0`, `git 2.53.0`, and `bash`

## Notes
- no runtime game code was changed
- this PR only adds Nix development environment files
