### PR TITLE
BUGFIX: Follow-up to #2660

### DIFF
--- a/src/PersonObjects/Person.ts
+++ b/src/PersonObjects/Person.ts
@@ -149,6 +149,14 @@ export abstract class Person implements IPerson {
   overrideIntelligence(): void {
     // Do not set anything if the player has not unlocked Intelligence.
     if (Player.sourceFileLvl(5) === 0 && Player.bitNodeN !== 5) {
+      // WIP: This is not enough. Try disabling the code in RedPill.tsx, enabling this code, then running tests.
+      // At this point, "bitNodeN" is "newBitNode", but we need both "newBitNode" and "destroyedBitNode".
+      // this.skills.intelligence = 0;
+      // this.exp.intelligence = 0;
+      // this.persistentIntelligenceData.exp = 0;
+      // if (Player.bitNodeN === 5 && Player.skills.intelligence === 0) {
+      //   Player.skills.intelligence = 1;
+      // }
       return;
     }
     const persistentIntelligenceSkill = this.calculateSkill(this.persistentIntelligenceData.exp, 1);

--- a/src/PersonObjects/Person.ts
+++ b/src/PersonObjects/Person.ts
@@ -147,16 +147,14 @@ export abstract class Person implements IPerson {
   }
 
   overrideIntelligence(): void {
-    // Do not set anything if the player has not unlocked Intelligence.
+    // Reset intelligence data if the player has not unlocked Intelligence.
+    // Note that this check cannot reset intelligence data in some edge cases (e.g., bitflume from non-BN5 to BN5). This
+    // is an accepted limitation.
+    // For more information, please check https://github.com/bitburner-official/bitburner-src/pull/2666
     if (Player.sourceFileLvl(5) === 0 && Player.bitNodeN !== 5) {
-      // WIP: This is not enough. Try disabling the code in RedPill.tsx, enabling this code, then running tests.
-      // At this point, "bitNodeN" is "newBitNode", but we need both "newBitNode" and "destroyedBitNode".
-      // this.skills.intelligence = 0;
-      // this.exp.intelligence = 0;
-      // this.persistentIntelligenceData.exp = 0;
-      // if (Player.bitNodeN === 5 && Player.skills.intelligence === 0) {
-      //   Player.skills.intelligence = 1;
-      // }
+      this.skills.intelligence = 0;
+      this.exp.intelligence = 0;
+      this.persistentIntelligenceData.exp = 0;
       return;
     }
     const persistentIntelligenceSkill = this.calculateSkill(this.persistentIntelligenceData.exp, 1);

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -135,12 +135,14 @@ export function prestigeAugmentation(this: PlayerObject): void {
   this.hp.current = this.hp.max;
 
   this.finishWork(true, true);
+  // We need to call overrideIntelligence here instead of prestigeSourceFile to reset intelligence data when installing
+  // augmentations.
+  this.overrideIntelligence();
 }
 
 export function prestigeSourceFile(this: PlayerObject): void {
   this.entropy = 0;
   this.prestigeAugmentation();
-  this.overrideIntelligence();
   this.karma = 0;
   // Duplicate sleeves are reset to level 1 every Bit Node (but the number of sleeves you have persists)
   this.sleeves.forEach((sleeve) => sleeve.prestige());

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -63,7 +63,10 @@ export function enterBitNode(
 
   if (!isFlume) {
     giveSourceFile(destroyedBitNode);
-  } else if (Player.sourceFileLvl(5) === 0 && newBitNode !== 5) {
+  }
+  // WIP
+  if (Player.sourceFileLvl(5) === 0 && destroyedBitNode !== 5) {
+    // if (Player.sourceFileLvl(5) === 0 && newBitNode !== 5) {
     Player.skills.intelligence = 0;
     Player.exp.intelligence = 0;
     Player.persistentIntelligenceData.exp = 0;

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -35,9 +35,6 @@ function giveSourceFile(bitNodeNumber: number): void {
     }
   } else {
     Player.sourceFiles.set(bitNodeNumber, 1);
-    if (bitNodeNumber === 5 && Player.skills.intelligence === 0) {
-      Player.skills.intelligence = 1;
-    }
     dialogBoxCreate(
       <>
         You received a Source-File for destroying a BitNode!
@@ -63,14 +60,6 @@ export function enterBitNode(
 
   if (!isFlume) {
     giveSourceFile(destroyedBitNode);
-  }
-  if (Player.sourceFileLvl(5) === 0 && (destroyedBitNode !== 5 || newBitNode !== 5)) {
-    Player.skills.intelligence = 0;
-    Player.exp.intelligence = 0;
-    Player.persistentIntelligenceData.exp = 0;
-  }
-  if (newBitNode === 5 && Player.skills.intelligence === 0) {
-    Player.skills.intelligence = 1;
   }
   // Set new Bit Node
   Player.bitNodeN = newBitNode;

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -64,9 +64,7 @@ export function enterBitNode(
   if (!isFlume) {
     giveSourceFile(destroyedBitNode);
   }
-  // WIP
-  if (Player.sourceFileLvl(5) === 0 && destroyedBitNode !== 5) {
-    // if (Player.sourceFileLvl(5) === 0 && newBitNode !== 5) {
+  if (Player.sourceFileLvl(5) === 0 && (destroyedBitNode !== 5 || newBitNode !== 5)) {
     Player.skills.intelligence = 0;
     Player.exp.intelligence = 0;
     Player.persistentIntelligenceData.exp = 0;

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -727,6 +727,13 @@ describe("Intelligence", () => {
     expectIntelligenceExp(1000);
   });
   describe("Reset intelligence data", () => {
+    test("Install augmentations", () => {
+      manuallySetIntelligenceExp(50);
+      expectIntelligenceExp(50);
+      Player.queueAugmentation(AugmentationName.Targeting1);
+      expect(installAugmentations()).toStrictEqual(true);
+      expectInitialIntelligenceData();
+    });
     test("Bitflume", () => {
       const ns = getNS();
 
@@ -738,12 +745,19 @@ describe("Intelligence", () => {
       // Reset intelligence data
       expectInitialIntelligenceData();
 
+      // We intentionally skip this scenario.
+      // For more information, please check https://github.com/bitburner-official/bitburner-src/pull/2666
+      // // Bitflume from non-BN5 to BN5.
+      // expect(Player.bitNodeN).toStrictEqual(1);
+      // manuallySetIntelligenceExp(50);
+      // expectIntelligenceExp(50);
+      // ns.singularity.b1tflum3(5);
+      // // Reset intelligence data and skill = 1
+      // expectIntelligenceExp(0);
+
       // Bitflume from non-BN5 to BN5.
-      expect(Player.bitNodeN).toStrictEqual(1);
-      manuallySetIntelligenceExp(50);
-      expectIntelligenceExp(50);
       ns.singularity.b1tflum3(5);
-      // Reset intelligence data and skill = 1
+      // Check if skill is set to 1.
       expectIntelligenceExp(0);
 
       // Bitflume from BN5 to BN5.
@@ -776,19 +790,24 @@ describe("Intelligence", () => {
       // Reset intelligence data
       expectInitialIntelligenceData();
 
-      // Destroy WD of non-BN5 and jump to BN5.
-      expect(Player.bitNodeN).toStrictEqual(1);
-      manuallySetIntelligenceExp(50);
-      expectIntelligenceExp(50);
-      setUpBeforeDestroyingWD();
-      ns.singularity.destroyW0r1dD43m0n(5);
-      // Reset intelligence data and skill = 1
-      expectIntelligenceExp(0);
+      // We intentionally skip this scenario.
+      // For more information, please check https://github.com/bitburner-official/bitburner-src/pull/2666
+      // // Destroy WD of non-BN5 and jump to BN5.
+      // expect(Player.bitNodeN).toStrictEqual(1);
+      // manuallySetIntelligenceExp(50);
+      // expectIntelligenceExp(50);
+      // setUpBeforeDestroyingWD();
+      // ns.singularity.destroyW0r1dD43m0n(5);
+      // // Reset intelligence data and skill = 1
+      // expectIntelligenceExp(0);
 
       // Destroy WD of BN5 and jump to BN5.
+      ns.singularity.b1tflum3(5);
       // Check the initial state that we want to test: in BN5 and do not have SF5.
       expect(Player.bitNodeN).toStrictEqual(5);
       expect(Player.sourceFileLvl(5)).toStrictEqual(0);
+      // Check if skill is set to 1.
+      expectIntelligenceExp(0);
       Player.gainIntelligenceExp(50);
       expectIntelligenceExp(50);
       setUpBeforeDestroyingWD();

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -725,48 +725,84 @@ describe("Intelligence", () => {
 
     Player.gainIntelligenceExp(1000);
     expectIntelligenceExp(1000);
-
-    // WIP: Not lose exp when bitfluming from BN5 to BN5 again.
-    expect(Player.bitNodeN).toStrictEqual(5);
-    ns.singularity.b1tflum3(5);
-    expectIntelligenceExp(1000);
   });
   describe("Reset intelligence data", () => {
     test("Bitflume", () => {
       const ns = getNS();
 
-      // Bitflume to non-BN5.
+      // Bitflume from non-BN5 to non-BN5.
+      expect(Player.bitNodeN).toStrictEqual(1);
       manuallySetIntelligenceExp(50);
       expectIntelligenceExp(50);
       ns.singularity.b1tflum3(1);
+      // Reset intelligence data
       expectInitialIntelligenceData();
 
-      // Bitflume to BN5.
+      // Bitflume from non-BN5 to BN5.
+      expect(Player.bitNodeN).toStrictEqual(1);
       manuallySetIntelligenceExp(50);
       expectIntelligenceExp(50);
       ns.singularity.b1tflum3(5);
-      // WIP
+      // Reset intelligence data and skill = 1
       expectIntelligenceExp(0);
-      // expectIntelligenceExp(50);
+
+      // Bitflume from BN5 to BN5.
+      expect(Player.bitNodeN).toStrictEqual(5);
+      Player.gainIntelligenceExp(50);
+      expectIntelligenceExp(50);
+      // Bitflume to BN5 again.
+      ns.singularity.b1tflum3(5);
+      // Not lose exp when bitfluming from BN5 to BN5.
+      expectIntelligenceExp(50);
+
+      // Bitflume from BN5 to non-BN5.
+      expect(Player.bitNodeN).toStrictEqual(5);
+      Player.gainIntelligenceExp(50);
+      // 50 exp from the previous scenario + 50 exp from this scenario.
+      expectIntelligenceExp(100);
+      ns.singularity.b1tflum3(1);
+      // Reset intelligence data
+      expectInitialIntelligenceData();
     });
     test("Destroy WD", () => {
       const ns = getNS();
 
-      // Destroy WD and jump to non-BN5.
+      // Destroy WD of non-BN5 and jump to non-BN5.
+      expect(Player.bitNodeN).toStrictEqual(1);
       manuallySetIntelligenceExp(50);
       expectIntelligenceExp(50);
       setUpBeforeDestroyingWD();
       ns.singularity.destroyW0r1dD43m0n(1);
+      // Reset intelligence data
       expectInitialIntelligenceData();
 
-      // Destroy WD and jump to BN5.
+      // Destroy WD of non-BN5 and jump to BN5.
+      expect(Player.bitNodeN).toStrictEqual(1);
       manuallySetIntelligenceExp(50);
       expectIntelligenceExp(50);
       setUpBeforeDestroyingWD();
       ns.singularity.destroyW0r1dD43m0n(5);
-      // WIP
+      // Reset intelligence data and skill = 1
       expectIntelligenceExp(0);
-      // expectIntelligenceExp(50);
+
+      // Destroy WD of BN5 and jump to BN5.
+      // Check the initial state that we want to test: in BN5 and do not have SF5.
+      expect(Player.bitNodeN).toStrictEqual(5);
+      expect(Player.sourceFileLvl(5)).toStrictEqual(0);
+      Player.gainIntelligenceExp(50);
+      expectIntelligenceExp(50);
+      setUpBeforeDestroyingWD();
+      ns.singularity.destroyW0r1dD43m0n(5);
+      // 50 exp from Player.gainIntelligenceExp() + 300 exp reward of destroying WD.
+      expectIntelligenceExp(350);
+
+      // Destroy WD of BN5 and jump to non-BN5.
+      Player.gainIntelligenceExp(50);
+      // 350 exp from the previous scenario + 50 exp from Player.gainIntelligenceExp().
+      expectIntelligenceExp(400);
+      setUpBeforeDestroyingWD();
+      ns.singularity.destroyW0r1dD43m0n(1);
+      expectIntelligenceExp(700);
     });
   });
   test("Cannot gain intelligence exp without SF5 or being in BN5", () => {

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -163,6 +163,30 @@ function testIntelligenceOverride(
   expect(Player.persistentIntelligenceData.exp).toStrictEqual(1e6 + intelligenceExpGainOnPrestige * 2);
 }
 
+/** Sets intelligence exp while bypassing the requirements (SF5 or being in BN5). */
+function manuallySetIntelligenceExp(exp: number): void {
+  Player.exp.intelligence = exp;
+  Player.skills.intelligence = Math.floor(Player.calculateSkill(Player.exp.intelligence, 1));
+  Player.persistentIntelligenceData.exp = exp;
+}
+
+function expectIntelligenceExp(exp: number): void {
+  expect(Player.exp.intelligence).toStrictEqual(exp);
+  expect(Player.skills.intelligence).toStrictEqual(Math.floor(Player.calculateSkill(exp, 1)));
+  expect(Player.persistentIntelligenceData.exp).toStrictEqual(exp);
+}
+
+/**
+ * This function is not equivalent to expectIntelligenceExp(0). The intelligence skill level starts at 0, not 1 like
+ * other stats. This function specifically verifies the initial state of intelligence data (before entering BN5).
+ */
+function expectInitialIntelligenceData(): void {
+  expect(Player.exp.intelligence).toStrictEqual(0);
+  // The intelligence skill level starts at 0.
+  expect(Player.skills.intelligence).toStrictEqual(0);
+  expect(Player.persistentIntelligenceData.exp).toStrictEqual(0);
+}
+
 function setUpBeforeDestroyingWD(): void {
   Player.queueAugmentation(AugmentationName.TheRedPill);
   installAugmentations();
@@ -644,5 +668,124 @@ describe("purchaseProgram", () => {
       expect(ns.singularity.purchaseProgram(CompletedProgramName.bruteSsh)).toStrictEqual(false);
       expect(Player.hasProgram(CompletedProgramName.bruteSsh)).toStrictEqual(false);
     });
+  });
+});
+
+describe("Intelligence", () => {
+  beforeEach(() => {
+    setupBasicTestingEnvironment();
+    expect(Player.bitNodeN).toStrictEqual(1);
+    expect(Player.sourceFileLvl(5)).toStrictEqual(0);
+    expectInitialIntelligenceData();
+  });
+  test("Get SF5", () => {
+    // This is the most common scenario. Some checks in this test will be repeated in other tests.
+    const ns = getNS();
+    ns.singularity.b1tflum3(5);
+    expectIntelligenceExp(0);
+
+    Player.gainIntelligenceExp(1000);
+    expectIntelligenceExp(1000);
+
+    setUpBeforeDestroyingWD();
+    ns.singularity.destroyW0r1dD43m0n(5);
+    expectIntelligenceExp(1300);
+    expect(Player.sourceFileLvl(5)).toStrictEqual(1);
+
+    setUpBeforeDestroyingWD();
+    ns.singularity.destroyW0r1dD43m0n(5);
+    expectIntelligenceExp(1600);
+    expect(Player.sourceFileLvl(5)).toStrictEqual(2);
+
+    setUpBeforeDestroyingWD();
+    ns.singularity.destroyW0r1dD43m0n(1);
+    expectIntelligenceExp(1900);
+    expect(Player.sourceFileLvl(5)).toStrictEqual(3);
+  });
+  test("Can gain intelligence exp with SF5", () => {
+    Player.sourceFiles.set(5, 1);
+    const ns = getNS();
+    ns.singularity.b1tflum3(1);
+    expectIntelligenceExp(0);
+
+    Player.gainIntelligenceExp(1000);
+    expectIntelligenceExp(1000);
+
+    ns.singularity.b1tflum3(1);
+    expectIntelligenceExp(1000);
+
+    setUpBeforeDestroyingWD();
+    ns.singularity.destroyW0r1dD43m0n(1);
+    expectIntelligenceExp(1300);
+  });
+  test("Can gain intelligence exp in BN5", () => {
+    const ns = getNS();
+    ns.singularity.b1tflum3(5);
+    expectIntelligenceExp(0);
+
+    Player.gainIntelligenceExp(1000);
+    expectIntelligenceExp(1000);
+
+    // WIP: Not lose exp when bitfluming from BN5 to BN5 again.
+    expect(Player.bitNodeN).toStrictEqual(5);
+    ns.singularity.b1tflum3(5);
+    expectIntelligenceExp(1000);
+  });
+  describe("Reset intelligence data", () => {
+    test("Bitflume", () => {
+      const ns = getNS();
+
+      // Bitflume to non-BN5.
+      manuallySetIntelligenceExp(50);
+      expectIntelligenceExp(50);
+      ns.singularity.b1tflum3(1);
+      expectInitialIntelligenceData();
+
+      // Bitflume to BN5.
+      manuallySetIntelligenceExp(50);
+      expectIntelligenceExp(50);
+      ns.singularity.b1tflum3(5);
+      // WIP
+      expectIntelligenceExp(0);
+      // expectIntelligenceExp(50);
+    });
+    test("Destroy WD", () => {
+      const ns = getNS();
+
+      // Destroy WD and jump to non-BN5.
+      manuallySetIntelligenceExp(50);
+      expectIntelligenceExp(50);
+      setUpBeforeDestroyingWD();
+      ns.singularity.destroyW0r1dD43m0n(1);
+      expectInitialIntelligenceData();
+
+      // Destroy WD and jump to BN5.
+      manuallySetIntelligenceExp(50);
+      expectIntelligenceExp(50);
+      setUpBeforeDestroyingWD();
+      ns.singularity.destroyW0r1dD43m0n(5);
+      // WIP
+      expectIntelligenceExp(0);
+      // expectIntelligenceExp(50);
+    });
+  });
+  test("Cannot gain intelligence exp without SF5 or being in BN5", () => {
+    const ns = getNS();
+    Player.gainIntelligenceExp(1000);
+    expectInitialIntelligenceData();
+
+    ns.singularity.b1tflum3(1);
+    expectInitialIntelligenceData();
+
+    setUpBeforeDestroyingWD();
+    ns.singularity.destroyW0r1dD43m0n(1);
+    expectInitialIntelligenceData();
+  });
+  test("Cannot gain intelligence exp even with intelligence skill > 0", () => {
+    manuallySetIntelligenceExp(50);
+    expectIntelligenceExp(50);
+
+    Player.gainIntelligenceExp(1000);
+    expectIntelligenceExp(50);
   });
 });


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/pull/2660#discussion_r3082824399

https://github.com/bitburner-official/bitburner-src/blob/45bce6e45e0fd618194cd535559e774a5ae69f08/src/RedPill.tsx#L64-L70

This else-if has some problems:
- It does not reset (incorrect) int data when destroying WD (it should be an if instead of an if-else).
- It checks `newBitNode` instead of `destroyedBitNode`, which appears to be a bug. Even if the first issue is fixed, this still fails in cases like: starting in BN1 with incorrect int data, then destroying WD and entering BN5 (`newBitNode = 5`). In this case, the check does not reset the data.

Another questionable behavior: exp is not reset when bitfluming from BN5 to BN5 again (without SF5). I'm not sure if we should "fix" this.

I added some Jest tests and highlighted these issues with `// WIP` comments. There is also some commented-out code. I'll remove them after we agree on the expected behavior.