### PR TITLE
BUGFIX: calculateExp throws errors in edge cases

### DIFF
--- a/src/PersonObjects/formulas/skill.ts
+++ b/src/PersonObjects/formulas/skill.ts
@@ -5,6 +5,11 @@ import { clampNumber } from "../../utils/helpers/clampNumber";
  * stat level. Stat-agnostic (same formula for every stat)
  */
 export function calculateSkill(exp: number, mult = 1): number {
+  // Mult can be 0 in BN12 when the player has a very high SF12 level. In this case, the skill level will never change
+  // from its initial value (1 for most stats, except intelligence).
+  if (mult === 0) {
+    return 1;
+  }
   const value = Math.floor(mult * (32 * Math.log(exp + 534.6) - 200));
   return clampNumber(value, 1);
 }

--- a/src/PersonObjects/formulas/skill.ts
+++ b/src/PersonObjects/formulas/skill.ts
@@ -12,7 +12,7 @@ export function calculateSkill(exp: number, mult = 1): number {
 export function calculateExp(skill: number, mult = 1): number {
   const floorSkill = Math.floor(skill);
   let value = Math.exp((skill / mult + 200) / 32) - 534.6;
-  if (skill === floorSkill && Number.isFinite(skill)) {
+  if (skill === floorSkill && Number.isFinite(skill) && Number.isFinite(value)) {
     // Check for floating point rounding issues that would cause the inverse
     // operation to return the wrong result.
     let calcSkill = calculateSkill(value, mult);


### PR DESCRIPTION
MRE: Load a clean new save file, set SF12 to 35842 or higher (`Player.sourceFiles.set(12, 35842)`), then bitflume to BN12.

```
clampNumber.ts:16 Uncaught Error: NaN passed into clampNumber()
    at clampNumber (clampNumber.ts:16:78)
    at calculateSkill (skill.ts:16:81)
    at calculateExp (skill.ts:24:21)
    at setInitialExpForPlayer (Prestige.ts:78:137)
    at prestigeSourceFile (Prestige.ts:370:3)
    at enterBitNode (RedPill.tsx:75:64)
    at onClick (PortalModal.tsx:120:61)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:16)
    at invokeGuardedCallback (react-dom.development.js:4056:31)
```

In BN12, with a high SF12 level, the `mult` passed to `calculateExp` can be 0, so `value` can be Infinity. Before #2274, `value` would be clamped to `Number.MAX_VALUE` in that case. However, after the change in #2274, `calculateSkill` will be called in the new if block. With exp = Infinity and mult = 0, `Math.floor(mult * (32 * Math.log(exp + 534.6) - 200))` evaluates to NaN.