### PR TITLE
MISC: Clear recent scripts when installing augmentations

### DIFF
--- a/src/Netscript/Pid.ts
+++ b/src/Netscript/Pid.ts
@@ -9,29 +9,28 @@ export function generateNextPid(): number {
 
   // Cap the number of search iterations at some arbitrary value to avoid
   // infinite loops. We'll assume that players won't have a million running scripts.
-  for (let attemptCounter = 0; attemptCounter < 1e6; ++attemptCounter) {
+  for (let attemptCounter = 0; attemptCounter < 1e6; ++attemptCounter, ++pidCandidate) {
+    // ensure the candidate PID is a safe integer
+    if (pidCandidate >= Number.MAX_SAFE_INTEGER) {
+      pidCandidate = 1;
+    }
+    // ensure the PID is not in use
+    if (workerScripts.has(pidCandidate)) {
+      continue;
+    }
     /* Also check the recentScripts: The function `AddRecentScript` de-duplicates scripts by PID.
        * Therefore scripts which re-use a PID from that list do not show up the list of recent scripts
        * upon termination (if the previous script with that PID is still in the list at that point).
        * Such a PID re-use could happen after installing augmentations, which resets the PID counter
        * but does not clear the list recent scripts. */
-    if (!workerScripts.has(pidCandidate)
-         && recentScripts.some((r) => (r.runningScript.pid === pidCandidate))) {
-      // found a PID that's not in use
-      // set the counter to the successor of the found PID, wrapping back to 1 when it gets too high
-      pidCounter = pidCandidate + 1;
-      if (pidCounter >= Number.MAX_SAFE_INTEGER) {
-        pidCounter = 1;
-      }
-      return pidCandidate;
+    if(recentScripts.some((r) => (r.runningScript.pid === pidCandidate))) {
+      continue;
     }
-
-    ++pidCandidate;
-    if (pidCandidate >= Number.MAX_SAFE_INTEGER) {
-      pidCandidate = 1;
-    }
+    // found a PID that's not in use
+    pidCounter = pidCandidate + 1;
+    return pidCandidate;
   }
-  // ran out of attempts without finding a valid unused pid :-(
+  // ran out of attempts without finding an unused PID :-(
   return -1;
 }
 

--- a/src/Netscript/Pid.ts
+++ b/src/Netscript/Pid.ts
@@ -4,35 +4,28 @@ let pidCounter = 1;
 
 /** Find and return the next available PID for a script */
 export function generateNextPid(): number {
-  let tempCounter = pidCounter;
+  let pidCandidate = pidCounter;
 
   // Cap the number of search iterations at some arbitrary value to avoid
-  // infinite loops. We'll assume that players wont have 1mil+ running scripts
-  let found = false;
-  for (let i = 0; i < 1e6; ) {
-    if (!workerScripts.has(tempCounter + i)) {
-      found = true;
-      tempCounter = tempCounter + i;
-      break;
+  // infinite loops. We'll assume that players won't have a million running scripts.
+  for (let attemptCounter = 0; attemptCounter < 1e6; ++attemptCounter) {
+    if (!workerScripts.has(pidCandidate)) {
+      // found a PID that's not in use
+      // set the counter to the successor of the found PID, wrapping back to 1 when it gets too high
+      pidCounter = pidCandidate + 1;
+      if (pidCounter >= Number.MAX_SAFE_INTEGER) {
+        pidCounter = 1;
+      }
+      return pidCandidate;
     }
 
-    if (i === Number.MAX_SAFE_INTEGER - 1) {
-      i = 1;
-    } else {
-      ++i;
+    ++pidCandidate;
+    if (pidCandidate >= Number.MAX_SAFE_INTEGER) {
+      pidCandidate = 1;
     }
   }
-
-  if (found) {
-    pidCounter = tempCounter + 1;
-    if (pidCounter >= Number.MAX_SAFE_INTEGER) {
-      pidCounter = 1;
-    }
-
-    return tempCounter;
-  } else {
-    return -1;
-  }
+  // ran out of attempts without finding a valid unused pid :-(
+  return -1;
 }
 
 export function resetPidCounter(): void {

--- a/src/Netscript/Pid.ts
+++ b/src/Netscript/Pid.ts
@@ -1,5 +1,4 @@
 import { workerScripts } from "./WorkerScripts";
-import { recentScripts } from "../Netscript/RecentScripts";
 
 let pidCounter = 1;
 
@@ -26,12 +25,16 @@ export function generateNextPid(): number {
   return -1;
 }
 
+/**
+ * Reset the PID counter to 1.
+ *
+ * Note that the list of recently finished scripts has to be
+ * cleared (`recentScripts.splice(0)`) when resetting the PID counter.
+ * Otherwise scripts which re-use a PID that is still in the
+ * list of recent scripts do not show up there when they finish
+ * (if the previous script with that PID is still in the list at that point),
+ * because the function `AddRecentScript` de-duplicates scripts by PID.
+ */
 export function resetPidCounter(): void {
-  /* The function `AddRecentScript` de-duplicates scripts by PID.
-   * Therefore the list has to be cleared when resetting the PID counter.
-   * Otherwise scripts which re-use a PID from the list of recent scripts
-   * do not show up there when they finish (if the previous script with
-   * that PID is still in the list at that point). */
-  recentScripts.splice(0);
   pidCounter = 1;
 }

--- a/src/Netscript/Pid.ts
+++ b/src/Netscript/Pid.ts
@@ -1,4 +1,5 @@
 import { workerScripts } from "./WorkerScripts";
+import { recentScripts } from "./Netscript/RecentScripts";
 
 let pidCounter = 1;
 
@@ -9,7 +10,13 @@ export function generateNextPid(): number {
   // Cap the number of search iterations at some arbitrary value to avoid
   // infinite loops. We'll assume that players won't have a million running scripts.
   for (let attemptCounter = 0; attemptCounter < 1e6; ++attemptCounter) {
-    if (!workerScripts.has(pidCandidate)) {
+    /* Also check the recentScripts: The function `AddRecentScript` de-duplicates scripts by PID.
+       * Therefore scripts which re-use a PID from that list do not show up the list of recent scripts
+       * upon termination (if the previous script with that PID is still in the list at that point).
+       * Such a PID re-use could happen after installing augmentations, which resets the PID counter
+       * but does not clear the list recent scripts. */
+    if (!workerScripts.has(pidCandidate)
+         && recentScripts.some((r) => (r.runningScript.pid === pidCandidate))) {
       // found a PID that's not in use
       // set the counter to the successor of the found PID, wrapping back to 1 when it gets too high
       pidCounter = pidCandidate + 1;

--- a/src/Netscript/Pid.ts
+++ b/src/Netscript/Pid.ts
@@ -1,5 +1,5 @@
 import { workerScripts } from "./WorkerScripts";
-import { recentScripts } from "./Netscript/RecentScripts";
+import { recentScripts } from "../Netscript/RecentScripts";
 
 let pidCounter = 1;
 
@@ -19,11 +19,11 @@ export function generateNextPid(): number {
       continue;
     }
     /* Also check the recentScripts: The function `AddRecentScript` de-duplicates scripts by PID.
-       * Therefore scripts which re-use a PID from that list do not show up the list of recent scripts
-       * upon termination (if the previous script with that PID is still in the list at that point).
-       * Such a PID re-use could happen after installing augmentations, which resets the PID counter
-       * but does not clear the list recent scripts. */
-    if(recentScripts.some((r) => (r.runningScript.pid === pidCandidate))) {
+     * Therefore scripts which re-use a PID from that list do not show up the list of recent scripts
+     * upon termination (if the previous script with that PID is still in the list at that point).
+     * Such a PID re-use could happen after installing augmentations, which resets the PID counter
+     * but does not clear the list recent scripts. */
+    if (recentScripts.some((r) => r.runningScript.pid === pidCandidate)) {
       continue;
     }
     // found a PID that's not in use

--- a/src/Netscript/Pid.ts
+++ b/src/Netscript/Pid.ts
@@ -18,14 +18,6 @@ export function generateNextPid(): number {
     if (workerScripts.has(pidCandidate)) {
       continue;
     }
-    /* Also check the recentScripts: The function `AddRecentScript` de-duplicates scripts by PID.
-     * Therefore scripts which re-use a PID from that list do not show up the list of recent scripts
-     * upon termination (if the previous script with that PID is still in the list at that point).
-     * Such a PID re-use could happen after installing augmentations, which resets the PID counter
-     * but does not clear the list recent scripts. */
-    if (recentScripts.some((r) => r.runningScript.pid === pidCandidate)) {
-      continue;
-    }
     // found a PID that's not in use
     pidCounter = pidCandidate + 1;
     return pidCandidate;
@@ -35,5 +27,11 @@ export function generateNextPid(): number {
 }
 
 export function resetPidCounter(): void {
+  /* The function `AddRecentScript` de-duplicates scripts by PID.
+   * Therefore the list has to be cleared when resetting the PID counter.
+   * Otherwise scripts which re-use a PID from the list of recent scripts
+   * do not show up there when they finish (if the previous script with
+   * that PID is still in the list at that point). */
+  recentScripts.splice(0);
   pidCounter = 1;
 }

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -190,6 +190,8 @@ export function prestigeAugmentation(): void {
     }
   }
 
+  // clear recent scripts
+  recentScripts.splice(0);
   resetPidCounter();
   ProgramsSeen.clear();
   InvitationsSeen.clear();


### PR DESCRIPTION
# MISC: clear recent scripts when installing augmentations

Also refactors the PID generation code.

fixes #2669 

# bug fix

## before fix
<img width="492" height="206" alt="before_pre_reset" src="https://github.com/user-attachments/assets/cb6ea756-1f00-4c5c-b1f2-680a6967a639" />

soft reset
<img width="926" height="353" alt="before_post_reset" src="https://github.com/user-attachments/assets/4f79e0e3-5d8c-4b49-9509-e1d0938acaa5" />
The list of recently finished scripts only shows the two instances from before the soft reset and the last one that was ran:
<img width="521" height="175" alt="before_list" src="https://github.com/user-attachments/assets/adeba322-23d7-42c8-bb31-d6ece5a211c1" />

## after fix
<img width="506" height="213" alt="after_pre_reset" src="https://github.com/user-attachments/assets/80e41c6b-08ee-4e05-b176-05c73f40fee0" />

soft reset
<img width="494" height="282" alt="after_post_reset" src="https://github.com/user-attachments/assets/749c26e5-0c26-49da-bb58-63f399e71b62" />
Now all script instances have different PIDs and the list of recently finished scripts shows all five of them:
<img width="534" height="292" alt="after_list" src="https://github.com/user-attachments/assets/35196e48-b6b5-48e5-baa4-02bab11591d5" />


## test script
```javascript
/** @param {NS} Bitburner */
export async function main(Bitburner) {
  const rggrHistory = Bitburner.getRecentScripts();
  const rghPIDs = rggrHistory.map(grInstance => grInstance.pid);
  const hMinPID = Math.min(...rghPIDs);
  const hMaxPID = Math.max(...rghPIDs);
  const hOwnPID = Bitburner.pid;
  if(hMaxPID >= hOwnPID) {
    Bitburner.tprint(`WARNING: The PIDs have been reset!`);
    const nMargin = hMinPID - hOwnPID - 1;
    if(nMargin > 0) {
      Bitburner.tprint(`INFO: You should be able to run at least ${nMargin} scripts without PID collisions.`);
    } else {
      Bitburner.tprintf(`WARNING: There might be some PID collisions!`);
    }
  } else {
    Bitburner.tprint(`INFO: The PIDs seem to be fine.`);
  }
  if(hOwnPID in rghPIDs) {
    Bitburner.tprint(`SUCCESS: PID collision: There already is a script with PID ${hOwnPID} in the history!`);
    Bitburner.print(`WARNING: The log containing this message may get lost.`);
  }
}
```

