### PR TITLE
CODEBASE: Fix passive event listener warning

### DIFF
--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -77,7 +77,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
 
   useEffect(() => {
     const clearSubscription = DarknetEvents.subscribe(() => updateDisplay());
-    draggableBackground.current?.addEventListener("wheel", (e) => e.preventDefault());
+    draggableBackground.current?.addEventListener("wheel", (e) => e.preventDefault(), { passive: false });
     scrollTo(DarknetState.netViewTopScroll, DarknetState.netViewLeftScroll);
     updateDisplay();
 


### PR DESCRIPTION
When opening the Dark Net tab, the console shows this warning (verbose log level):
```
[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
```

Quotes from MDN (https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive):
```
[passive Optional](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive)
A boolean value that, if true, indicates that the function specified by listener will never call [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). If a passive listener calls preventDefault(), nothing will happen and a console warning may be generated.

If this option is not specified it defaults to false – except that in browsers other than Safari, it defaults to true for [wheel](https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event), [mousewheel](https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event), [touchstart](https://developer.mozilla.org/en-US/docs/Web/API/Element/touchstart_event) and [touchmove](https://developer.mozilla.org/en-US/docs/Web/API/Element/touchmove_event) events. See [Using passive listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners) to learn more.
```
We need to explicitly set `passive` to false for the `wheel` event.

@ficocelliguy It is unclear why `e.preventDefault()` is required here. Removing this listener appears to improve scroll smoothness, although this may be a placebo. Could you test it again to see whether we need this event listener?