### PR TITLE
BLADEBURNER: Restrict team count of Ops/BlackOps to total team size

### DIFF
--- a/src/Bladeburner/Actions/TeamCasualties.ts
+++ b/src/Bladeburner/Actions/TeamCasualties.ts
@@ -51,7 +51,7 @@ export function resolveTeamCasualties(action: TeamActionWithCasualties, team: Op
   // (team.teamSize - losses) will set teamCount of ops/blackOps to 0 while it should be 8.
   let newTeamSize = team.teamSize - losses;
   if (newTeamSize < team.sleeveSize) {
-    team.killRandomSupportingSleeves(team.sleeveSize - team.teamSize);
+    team.killRandomSupportingSleeves(team.sleeveSize - newTeamSize);
     // If this happens, all team members died and some sleeves took damage. In this case, teamSize = sleeveSize.
     newTeamSize = team.sleeveSize;
   }

--- a/src/Bladeburner/Actions/TeamCasualties.ts
+++ b/src/Bladeburner/Actions/TeamCasualties.ts
@@ -44,12 +44,18 @@ export function resolveTeamCasualties(action: TeamActionWithCasualties, team: Op
    */
   const losses =
     minCasualties <= maxCasualties ? team.getTeamCasualtiesRoll(minCasualties, maxCasualties) : minCasualties;
-  team.teamSize -= losses;
-  if (team.teamSize < team.sleeveSize) {
+  // Calculate the new teamSize in a temporary variable and call the setter team.teamSize ONCE.
+  // Note that it's important to call the setter only once; otherwise, the team count of each operation won't be reset
+  // correctly.
+  // For example, if _teamSize is 9 (1 team member + 8 support sleeves) and "losses" is 9, calling the setter with
+  // (team.teamSize - losses) will set teamCount of ops/blackOps to 0 while it should be 8.
+  let newTeamSize = team.teamSize - losses;
+  if (newTeamSize < team.sleeveSize) {
     team.killRandomSupportingSleeves(team.sleeveSize - team.teamSize);
     // If this happens, all team members died and some sleeves took damage. In this case, teamSize = sleeveSize.
-    team.teamSize = team.sleeveSize;
+    newTeamSize = team.sleeveSize;
   }
+  team.teamSize = newTeamSize;
   team.teamLost += losses;
 
   return losses;

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -72,7 +72,31 @@ export class Bladeburner implements OperationTeam {
   skillPoints = 0;
   totalSkillPoints = 0;
 
-  teamSize = 0;
+  /**
+   * Do NOT directly read and write this field. You must use the getter/setter.
+   * We use _teamSize instead of a private field #teamSize to reduce the complexity of saving/loading code.
+   */
+  _teamSize = 0;
+  get teamSize() {
+    return this._teamSize;
+  }
+  set teamSize(value: number) {
+    // Ensure teamSize is a non-negative integer.
+    let newSize = value;
+    if (!Number.isInteger(newSize) || newSize < 0) {
+      newSize = 0;
+    }
+    // Early return if there is no change.
+    if (this._teamSize === newSize) {
+      return;
+    }
+    this._teamSize = newSize;
+    // Reduce teamCount of actions if it's greater than the team size.
+    for (const action of [...Object.values(this.operations), ...Object.values(BlackOperations)]) {
+      action.teamCount = Math.min(action.teamCount, this._teamSize);
+    }
+  }
+
   get sleeveSize() {
     return Player.sleevesSupportingBladeburner().length;
   }
@@ -1487,6 +1511,10 @@ export class Bladeburner implements OperationTeam {
       bladeburner.stamina = 1;
       bladeburner.maxStamina = 1;
       bladeburner.calculateMaxStamina();
+    }
+    // "_teamSize" was "teamSize" in pre-v3 versions.
+    if ("teamSize" in value.data && Number.isFinite(value.data.teamSize)) {
+      bladeburner.teamSize = value.data.teamSize as number;
     }
     return bladeburner;
   }

--- a/src/Bladeburner/ui/TeamSizeModal.tsx
+++ b/src/Bladeburner/ui/TeamSizeModal.tsx
@@ -15,25 +15,26 @@ interface TeamSizeModalProps {
 }
 
 export function TeamSizeModal({ bladeburner, action, open, onClose }: TeamSizeModalProps): React.ReactElement {
-  const [teamSize, setTeamSize] = useState<number | undefined>();
+  const [teamSize, setTeamSize] = useState(0);
 
   function confirmTeamSize(event: React.FormEvent): void {
     // Prevent reloading page when submitting form
     event.preventDefault();
-    if (teamSize === undefined) return;
-    const num = Math.round(teamSize);
-    if (isNaN(num) || num < 0) {
-      dialogBoxCreate("Invalid value entered for number of Team Members (must be numeric and non-negative)");
-    } else {
-      action.teamCount = num;
+    if (!Number.isInteger(teamSize) || teamSize < 0) {
+      dialogBoxCreate("Invalid value entered for number of Team Members (must be a non-negative integer)");
+      return;
     }
+    action.teamCount = teamSize;
     onClose();
   }
 
   function onTeamSize(event: React.ChangeEvent<HTMLInputElement>): void {
-    const x = parseFloat(event.target.value);
-    if (x > bladeburner.teamSize) setTeamSize(bladeburner.teamSize);
-    else setTeamSize(x);
+    const newTeamSize = Number(event.target.value);
+    if (newTeamSize > bladeburner.teamSize) {
+      setTeamSize(bladeburner.teamSize);
+    } else {
+      setTeamSize(newTeamSize);
+    }
   }
 
   return (

--- a/test/jest/Bladeburner/TeamCasualties.test.ts
+++ b/test/jest/Bladeburner/TeamCasualties.test.ts
@@ -1,5 +1,4 @@
 import { Player, setPlayer } from "@player";
-import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
 import type { ActionIdFor } from "../../../src/Bladeburner/Types";
 import type { Bladeburner } from "../../../src/Bladeburner/Bladeburner";
 import { BlackOperation } from "../../../src/Bladeburner/Actions/BlackOperation";
@@ -9,6 +8,10 @@ import { SleeveSupportWork } from "../../../src/PersonObjects/Sleeve/Work/Sleeve
 import { BladeburnerBlackOpName, BladeburnerContractName, BladeburnerOperationName } from "@enums";
 import { PlayerObject } from "../../../src/PersonObjects/Player/PlayerObject";
 import { recalculateNumberOfOwnedSleeves } from "../../../src/PersonObjects/Sleeve/SleeveCovenantPurchases";
+import { initGameEnvironment } from "../Utilities";
+import { BlackOperations } from "../../../src/Bladeburner/data/BlackOperations";
+
+initGameEnvironment();
 
 /**
  * You may want to use hook to help with debugging
@@ -26,11 +29,6 @@ describe("Bladeburner Team", () => {
 
   let inst: Bladeburner;
   let action: BlackOperation | Operation;
-
-  beforeAll(() => {
-    /* Initialise Formatters. Dependency of Bladeburner */
-    FormatsNeedToChange.emit();
-  });
 
   beforeEach(() => {
     setPlayer(new PlayerObject());
@@ -130,6 +128,51 @@ describe("Bladeburner Team", () => {
     it("at worst half the team when succeeding (rounding up)", () => {
       teamSize(5), startAction(OP), forceMaxCasualties(), teamUsed(5), actionSucceeds();
       expect(inst).toMatchObject({ teamSize: 2, teamLost: 3 });
+    });
+  });
+
+  describe("Check teamSize and teamCount", () => {
+    test("Failing actions", () => {
+      teamSize(10);
+      startAction(OP);
+      forceMaxCasualties();
+      for (const action of [...Object.values(inst.operations), ...Object.values(BlackOperations)]) {
+        action.teamCount = 10;
+        expect(action.teamCount).toStrictEqual(10);
+      }
+      actionFails();
+      expect(inst.teamSize).toStrictEqual(0);
+      for (const action of [...Object.values(inst.operations), ...Object.values(BlackOperations)]) {
+        expect(action.teamCount).toStrictEqual(0);
+      }
+    });
+    test("Sleeves", () => {
+      teamSize(1);
+      supportingSleeves(8);
+      expect(inst.teamSize).toStrictEqual(9);
+      startAction(OP);
+      forceMaxCasualties();
+      for (const action of [...Object.values(inst.operations), ...Object.values(BlackOperations)]) {
+        action.teamCount = 9;
+        expect(action.teamCount).toStrictEqual(9);
+      }
+      actionFails();
+      // The teamCount of all operations/black operations should be 8, not 0.
+      assertSleevesHaveBeenShocked();
+      expect(inst.teamSize).toStrictEqual(8);
+      for (const action of [...Object.values(inst.operations), ...Object.values(BlackOperations)]) {
+        expect(action.teamCount).toStrictEqual(8);
+      }
+      Player.sleeves[0].stopWork();
+      expect(inst.teamSize).toStrictEqual(7);
+      for (const action of [...Object.values(inst.operations), ...Object.values(BlackOperations)]) {
+        expect(action.teamCount).toStrictEqual(7);
+      }
+      Player.sleeves[0].startWork(new SleeveSupportWork());
+      expect(inst.teamSize).toStrictEqual(8);
+      for (const action of [...Object.values(inst.operations), ...Object.values(BlackOperations)]) {
+        expect(action.teamCount).toStrictEqual(7);
+      }
     });
   });
 

--- a/test/jest/__snapshots__/FullSave.test.ts.snap
+++ b/test/jest/__snapshots__/FullSave.test.ts.snap
@@ -75,6 +75,7 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
     "bladeburner": {
       "ctor": "Bladeburner",
       "data": {
+        "_teamSize": 0,
         "action": null,
         "actionTimeCurrent": 0,
         "actionTimeOverflow": 0,
@@ -281,7 +282,6 @@ exports[`Check Save File Continuity PlayerSave continuity 1`] = `
         "staminaBonus": 0,
         "storedCycles": 0,
         "teamLost": 0,
-        "teamSize": 0,
         "totalSkillPoints": 666,
       },
     },


### PR DESCRIPTION
Context: https://github.com/bitburner-official/bitburner-src/pull/2662#issuecomment-4246019502

MRE: Run test code on v2.8.1 and the current latest commit, then check console.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  ns.ui.openTail();
  console.clear();
  ns.atExit(() => {
    ns.bladeburner.stopBladeburnerAction();
  })
  Player.bladeburner.teamSize = 100;
  Player.bladeburner.operations.Investigation.count = 1000;
  ns.bladeburner.setTeamSize("Operations", "Investigation", 100);
  ns.bladeburner.startAction("Operations", "Investigation");
  while (true) {
    console.log("teamSize before", Player.bladeburner.teamSize);
    console.log("teamCount before", ns.bladeburner.getTeamSize("Operations", "Investigation"));
    ns.bladeburner.getActionEstimatedSuccessChance("Operations", "Investigation");
    console.log("teamSize after", Player.bladeburner.teamSize);
    console.log("teamCount after", ns.bladeburner.getTeamSize("Operations", "Investigation"));
    await ns.bladeburner.nextUpdate();
  }
}
```
Before #2541, `teamCount` was capped in `operationTeamSuccessBonus`, but this function is not the proper place to do that. As you can see in the test code (running on v2.8.1), `teamCount` is only capped when success chance is calculated, typically via the UI. This means if the player does not open the Bladeburner UI or call `getActionEstimatedSuccessChance`, `teamCount` is never updated.

This PR creates a new setter to centralize the check of `teamCount`.

It also fixed some issues in the team size modal. For example, if you type in that modal, you will see this warning:
```
Warning: A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components
```

There are still some issues with BlackOps, but I'll fix them later.