### PR TITLE
UI: Ensure intelligence override is a positive integer

### DIFF
--- a/markdown/bitburner.bitnodeoptions.md
+++ b/markdown/bitburner.bitnodeoptions.md
@@ -12,7 +12,7 @@ Default value:
 
 - All boolean options: false
 
-If you specify intelligenceOverride, it must be a non-negative integer.
+If you specify intelligenceOverride, it must be a positive integer.
 
 **Signature:**
 

--- a/markdown/bitburner.md
+++ b/markdown/bitburner.md
@@ -123,7 +123,7 @@ Default value:
 
 - All boolean options: false
 
-If you specify intelligenceOverride, it must be a non-negative integer.
+If you specify intelligenceOverride, it must be a positive integer.
 
 
 </td></tr>

--- a/src/BitNode/ui/BitNodeAdvancedOptions.tsx
+++ b/src/BitNode/ui/BitNodeAdvancedOptions.tsx
@@ -271,13 +271,13 @@ function IntelligenceOverride({
               disabled={!enabled}
               value={intelligenceOverride !== undefined ? intelligenceOverride : ""}
               onChange={(event) => {
-                // Empty string will be automatically changed to "0".
+                // Empty string will be automatically changed to "1".
                 if (event.target.value === "") {
-                  callbacks.setIntelligenceOverride(0);
+                  callbacks.setIntelligenceOverride(1);
                   return;
                 }
                 const value = Number.parseInt(event.target.value);
-                if (!Number.isInteger(value) || value < 0) {
+                if (!Number.isInteger(value) || value < 1) {
                   return;
                 }
                 callbacks.setIntelligenceOverride(value);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1852,7 +1852,7 @@ export type Task = StudyTask | CompanyWorkTask | CreateProgramWorkTask | CrimeTa
  *
  * - All boolean options: false
  *
- * If you specify intelligenceOverride, it must be a non-negative integer.
+ * If you specify intelligenceOverride, it must be a positive integer.
  *
  * @public
  */


### PR DESCRIPTION
This constraint is enforced by `validateBitNodeOptions` when using NS APIs, but the documentation incorrectly states that it must be a non-negative integer. The UI also does not enforce this rule.

<img width="407" height="315" alt="Capture" src="https://github.com/user-attachments/assets/9cc4135c-1e55-41a9-b2c2-09859d253948" />

Allowing a value of 0 is useful if the player wants to "pretend" that they have not unlocked Intelligence, but this use case is too niche to support.
