### PR TITLE
CORPORATION: Remove max width of division list

### DIFF
--- a/src/Corporation/ui/CorporationRoot.tsx
+++ b/src/Corporation/ui/CorporationRoot.tsx
@@ -27,7 +27,7 @@ export function CorporationRoot(): React.ReactElement {
 
   return (
     <Context.Corporation.Provider value={corporation}>
-      <Tabs variant="scrollable" value={divisionName} onChange={handleChange} sx={{ maxWidth: "65vw" }} scrollButtons>
+      <Tabs variant="scrollable" value={divisionName} onChange={handleChange} scrollButtons>
         <Tab label={corporation.name} value={"Overview"} />
         {[...corporation.divisions.values()].map((div) => (
           <Tab key={div.name} label={div.name} value={div.name} />


### PR DESCRIPTION
This limit looks strange to me, especially on high resolution screens.

Before:

<img width="1418" height="82" alt="before" src="https://github.com/user-attachments/assets/b9554c94-5368-4dd0-b919-e3d1e8639a6e" />

After:

<img width="1416" height="89" alt="after" src="https://github.com/user-attachments/assets/c2706d28-1c9c-4678-bd35-b88f8d27e494" />