### PR TITLE
NETSCRIPT: Better error message for port serialization failure

### DIFF
--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -32,7 +32,9 @@ export class Port {
       try {
         value = structuredClone(data);
       } catch (ex) {
-        throw new Error("You can't send Functions, Promises, NS, or other unserializable data through ports!", {cause: ex});
+        throw new Error("You can't send Functions, Promises, NS, or other unserializable data through ports!", {
+          cause: ex,
+        });
       }
     }
     this.data.push(value);

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -27,7 +27,15 @@ export class Port {
   resolver: Resolver | null = null;
   promise: Promise<void> | null = null;
   add(data: unknown) {
-    this.data.push(data);
+    let value = data;
+    if (isObjectLike(data)) {
+      try {
+        value = structuredClone(data);
+      } catch (ex) {
+        throw new Error("You can't send Functions, Promises, NS, or other unserializable data through ports!", {cause: ex});
+      }
+    }
+    this.data.push(value);
     if (!this.resolver) return;
     this.resolver();
     this.resolver = null;
@@ -45,7 +53,7 @@ export class PortHandle implements NetscriptPort {
   write(value: unknown): unknown {
     const port = getPort(this.n);
     // Primitives don't need to be cloned.
-    port.add(isObjectLike(value) ? structuredClone(value) : value);
+    port.add(value);
     if (port.data.length > Settings.MaxPortCapacity) return port.data.shift();
     return null;
   }
@@ -54,7 +62,7 @@ export class PortHandle implements NetscriptPort {
     const port = getPort(this.n);
     if (port.data.length >= Settings.MaxPortCapacity) return false;
     // Primitives don't need to be cloned.
-    port.add(isObjectLike(value) ? structuredClone(value) : value);
+    port.add(value);
     return true;
   }
 


### PR DESCRIPTION
This addresses one of the parts of #2684
<img width="1135" height="787" alt="image" src="https://github.com/user-attachments/assets/70c1dc52-4a80-45d0-b6d7-c54af5c00c9b" />

Regular data still works.