### PR TITLE
BUGFIX: DarkscapeNavigator program is not granted on BN prestige when having SF15

### DIFF
--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -239,6 +239,10 @@ export function prestigeSourceFile(isFlume: boolean): void {
   // Re-create foreign servers
   initForeignServers(Player.getHomeComputer());
 
+  if (canAccessBitNodeFeature(15)) {
+    getDarkscapeNavigator();
+  }
+
   if (Player.activeSourceFileLvl(9) >= 2) {
     homeComp.setMaxRam(128);
   } else if (Player.activeSourceFileLvl(1) > 0) {


### PR DESCRIPTION
MRE:
- Load a clean save file.
- Set SF15.1
- Bitflume and check the home server.

We do this in `prestigeAugmentation`, but not in `prestigeSourceFile`.