### PR TITLE
UI: Use "success" theme color for low infiltration difficulty instead of "primary"

### DIFF
--- a/src/Infiltration/ui/Intro.tsx
+++ b/src/Infiltration/ui/Intro.tsx
@@ -48,7 +48,7 @@ function coloredArrow(difficulty: number): JSX.Element {
   } else {
     return (
       <>
-        {arrowPart(Settings.theme.primary, cappedDifficulty * 13)}
+        {arrowPart(Settings.theme.success, cappedDifficulty * 13)}
         {arrowPart(Settings.theme.warning, (cappedDifficulty - 1) * 13)}
         {arrowPart(Settings.theme.warning, (cappedDifficulty - 2) * 13)}
         {arrowPart(Settings.theme.error, (cappedDifficulty - 3) * 26)}


### PR DESCRIPTION
This is a suggestion on Discord.

> by default, it would've been green, and in most cases the primary is changed to some other color in most themes, but success is usually left green, so it would be more logical to have it use success instead of primary

I'm a bit doubtful about the claim of "success is usually left green, so it would be more logical to have it use success instead of primary", so I'm neutral on this.

Before:

<img width="879" height="326" alt="before" src="https://github.com/user-attachments/assets/3bebf85e-0c37-49e8-8a57-0a22f4e8c148" />

After:

<img width="874" height="327" alt="after" src="https://github.com/user-attachments/assets/b1513f74-33af-4235-a898-61d92320fd36" />
