### PR TITLE
MISC: Clarify what "backdoor" does in "help" command

### DIFF
--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -121,7 +121,8 @@ export const HelpTexts: Record<string, string[]> = {
   backdoor: [
     "Usage: backdoor",
     " ",
-    "Install a backdoor on the current machine, grants a secret bonus depending on the machine.",
+    "Installs a backdoor on the current machine, which allows the player to connect from any machine and grants a secret ",
+    "bonus, such as store discounts, depending on the machine.",
     " ",
     "Requires root access to run.",
     " ",

--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -121,8 +121,8 @@ export const HelpTexts: Record<string, string[]> = {
   backdoor: [
     "Usage: backdoor",
     " ",
-    "Installs a backdoor on the current machine, which allows the player to connect to it from any machine and grants a secret bonus, ",
-    "such as store discounts, depending on the machine.",
+    "Installs a backdoor on the current server, which allows the player to connect to it from any ",
+    "server. It may also grant a secret bonus, such as store discounts, depending on the server.",
     " ",
     "Requires root access to run.",
     " ",

--- a/src/Terminal/HelpText.ts
+++ b/src/Terminal/HelpText.ts
@@ -121,8 +121,8 @@ export const HelpTexts: Record<string, string[]> = {
   backdoor: [
     "Usage: backdoor",
     " ",
-    "Installs a backdoor on the current machine, which allows the player to connect from any machine and grants a secret ",
-    "bonus, such as store discounts, depending on the machine.",
+    "Installs a backdoor on the current machine, which allows the player to connect to it from any machine and grants a secret bonus, ",
+    "such as store discounts, depending on the machine.",
     " ",
     "Requires root access to run.",
     " ",


### PR DESCRIPTION
I found the help text for backdoor unhelpful, this is how i wouldve explained it to myself while trying to replicate the format of other entries in the help command