### PR TITLE
HACKNET: fix application of limits in cost functions

### DIFF
--- a/src/Hacknet/formulas/HacknetNodes.ts
+++ b/src/Hacknet/formulas/HacknetNodes.ts
@@ -16,7 +16,7 @@ export function calculateLevelUpgradeCost(startingLevel: number, extraLevels = 1
     return 0;
   }
 
-  if (startingLevel >= HacknetNodeConstants.MaxLevel || startingLevel + extraLevels > HacknetNodeConstants.MaxLevel) {
+  if (startingLevel + sanitizedLevels > HacknetNodeConstants.MaxLevel) {
     return Infinity;
   }
 
@@ -39,7 +39,7 @@ export function calculateRamUpgradeCost(startingRam: number, extraLevels = 1, co
 
   if (
     startingRam >= HacknetNodeConstants.MaxRam ||
-    startingRam * Math.pow(2, extraLevels) > HacknetNodeConstants.MaxRam
+    startingRam * Math.pow(2, sanitizedLevels) > HacknetNodeConstants.MaxRam
   ) {
     return Infinity;
   }
@@ -69,7 +69,7 @@ export function calculateCoreUpgradeCost(startingCores: number, extraLevels = 1,
     return 0;
   }
 
-  if (startingCores >= HacknetNodeConstants.MaxCores || startingCores + extraLevels > HacknetNodeConstants.MaxCores) {
+  if (startingCores >= HacknetNodeConstants.MaxCores || startingCores + sanitizedCores > HacknetNodeConstants.MaxCores) {
     return Infinity;
   }
 

--- a/src/Hacknet/formulas/HacknetNodes.ts
+++ b/src/Hacknet/formulas/HacknetNodes.ts
@@ -16,7 +16,7 @@ export function calculateLevelUpgradeCost(startingLevel: number, extraLevels = 1
     return 0;
   }
 
-  if (startingLevel >= HacknetNodeConstants.MaxLevel) {
+  if (startingLevel >= HacknetNodeConstants.MaxLevel || startingLevel + extraLevels > HacknetNodeConstants.MaxLevel) {
     return Infinity;
   }
 
@@ -37,7 +37,10 @@ export function calculateRamUpgradeCost(startingRam: number, extraLevels = 1, co
     return 0;
   }
 
-  if (startingRam >= HacknetNodeConstants.MaxRam) {
+  if (
+    startingRam >= HacknetNodeConstants.MaxRam ||
+    startingRam * Math.pow(2, extraLevels) > HacknetNodeConstants.MaxRam
+  ) {
     return Infinity;
   }
 
@@ -60,20 +63,20 @@ export function calculateRamUpgradeCost(startingRam: number, extraLevels = 1, co
   return totalCost;
 }
 
-export function calculateCoreUpgradeCost(startingCore: number, extraLevels = 1, costMult = 1): number {
+export function calculateCoreUpgradeCost(startingCores: number, extraLevels = 1, costMult = 1): number {
   const sanitizedCores = Math.round(extraLevels);
   if (isNaN(sanitizedCores) || sanitizedCores < 1) {
     return 0;
   }
 
-  if (startingCore >= HacknetNodeConstants.MaxCores) {
+  if (startingCores >= HacknetNodeConstants.MaxCores || startingCores + extraLevels > HacknetNodeConstants.MaxCores) {
     return Infinity;
   }
 
   const coreBaseCost = HacknetNodeConstants.CoreBaseCost;
   const mult = HacknetNodeConstants.UpgradeCoreMult;
   let totalCost = 0;
-  let currentCores = startingCore;
+  let currentCores = startingCores;
   for (let i = 0; i < sanitizedCores; ++i) {
     totalCost += coreBaseCost * Math.pow(mult, currentCores - 1);
     ++currentCores;

--- a/src/Hacknet/formulas/HacknetNodes.ts
+++ b/src/Hacknet/formulas/HacknetNodes.ts
@@ -37,10 +37,7 @@ export function calculateRamUpgradeCost(startingRam: number, extraLevels = 1, co
     return 0;
   }
 
-  if (
-    startingRam >= HacknetNodeConstants.MaxRam ||
-    startingRam * Math.pow(2, sanitizedLevels) > HacknetNodeConstants.MaxRam
-  ) {
+  if (startingRam * Math.pow(2, sanitizedLevels) > HacknetNodeConstants.MaxRam) {
     return Infinity;
   }
 
@@ -69,7 +66,7 @@ export function calculateCoreUpgradeCost(startingCores: number, extraLevels = 1,
     return 0;
   }
 
-  if (startingCores >= HacknetNodeConstants.MaxCores || startingCores + sanitizedCores > HacknetNodeConstants.MaxCores) {
+  if (startingCores + sanitizedCores > HacknetNodeConstants.MaxCores) {
     return Infinity;
   }
 

--- a/src/Hacknet/formulas/HacknetServers.ts
+++ b/src/Hacknet/formulas/HacknetServers.ts
@@ -22,7 +22,10 @@ export function calculateLevelUpgradeCost(startingLevel: number, extraLevels = 1
     return 0;
   }
 
-  if (startingLevel >= HacknetServerConstants.MaxLevel) {
+  if (
+    startingLevel >= HacknetServerConstants.MaxLevel ||
+    startingLevel + extraLevels > HacknetServerConstants.MaxLevel
+  ) {
     return Infinity;
   }
 
@@ -43,7 +46,10 @@ export function calculateRamUpgradeCost(startingRam: number, extraLevels = 1, co
     return 0;
   }
 
-  if (startingRam >= HacknetServerConstants.MaxRam) {
+  if (
+    startingRam >= HacknetServerConstants.MaxRam ||
+    startingRam * Math.pow(2, extraLevels) > HacknetServerConstants.MaxRam
+  ) {
     return Infinity;
   }
 
@@ -70,7 +76,10 @@ export function calculateCoreUpgradeCost(startingCores: number, extraLevels = 1,
     return 0;
   }
 
-  if (startingCores >= HacknetServerConstants.MaxCores) {
+  if (
+    startingCores >= HacknetServerConstants.MaxCores ||
+    startingCores + extraLevels > HacknetServerConstants.MaxCores
+  ) {
     return Infinity;
   }
 
@@ -93,7 +102,10 @@ export function calculateCacheUpgradeCost(startingCache: number, extraLevels = 1
     return 0;
   }
 
-  if (startingCache >= HacknetServerConstants.MaxCache) {
+  if (
+    startingCache >= HacknetServerConstants.MaxCache ||
+    startingCache + extraLevels > HacknetServerConstants.MaxCache
+  ) {
     return Infinity;
   }
 

--- a/src/Hacknet/formulas/HacknetServers.ts
+++ b/src/Hacknet/formulas/HacknetServers.ts
@@ -22,10 +22,7 @@ export function calculateLevelUpgradeCost(startingLevel: number, extraLevels = 1
     return 0;
   }
 
-  if (
-    startingLevel >= HacknetServerConstants.MaxLevel ||
-    startingLevel + extraLevels > HacknetServerConstants.MaxLevel
-  ) {
+  if (startingLevel + sanitizedLevels > HacknetServerConstants.MaxLevel) {
     return Infinity;
   }
 
@@ -46,10 +43,7 @@ export function calculateRamUpgradeCost(startingRam: number, extraLevels = 1, co
     return 0;
   }
 
-  if (
-    startingRam >= HacknetServerConstants.MaxRam ||
-    startingRam * Math.pow(2, extraLevels) > HacknetServerConstants.MaxRam
-  ) {
+  if (startingRam * Math.pow(2, sanitizedLevels) > HacknetServerConstants.MaxRam) {
     return Infinity;
   }
 
@@ -76,10 +70,7 @@ export function calculateCoreUpgradeCost(startingCores: number, extraLevels = 1,
     return 0;
   }
 
-  if (
-    startingCores >= HacknetServerConstants.MaxCores ||
-    startingCores + extraLevels > HacknetServerConstants.MaxCores
-  ) {
+  if (startingCores + sanitizedLevels > HacknetServerConstants.MaxCores) {
     return Infinity;
   }
 
@@ -102,10 +93,7 @@ export function calculateCacheUpgradeCost(startingCache: number, extraLevels = 1
     return 0;
   }
 
-  if (
-    startingCache >= HacknetServerConstants.MaxCache ||
-    startingCache + extraLevels > HacknetServerConstants.MaxCache
-  ) {
+  if (startingCache + sanitizedLevels > HacknetServerConstants.MaxCache) {
     return Infinity;
   }
 

--- a/test/jest/Hacknet.test.ts
+++ b/test/jest/Hacknet.test.ts
@@ -1,0 +1,135 @@
+import { HacknetNodeConstants, HacknetServerConstants } from "../../src/Hacknet/data/Constants";
+import {
+  calculateCoreUpgradeCost as calculateCoreUpgradeCostNode,
+  calculateLevelUpgradeCost as calculateLevelUpgradeCostNode,
+  calculateRamUpgradeCost as calculateRamUpgradeCostNode,
+} from "../../src/Hacknet/formulas/HacknetNodes";
+import {
+  calculateCoreUpgradeCost as calculateCoreUpgradeCostServer,
+  calculateLevelUpgradeCost as calculateLevelUpgradeCostServer,
+  calculateRamUpgradeCost as calculateRamUpgradeCostServer,
+} from "../../src/Hacknet/formulas/HacknetServers";
+
+describe("HacknetNode calculations", () => {
+  describe("calculateLevelUpgradeCost applies limits", () => {
+    it("bails out for NaN", () => {
+      expect(calculateLevelUpgradeCostNode(1, NaN, 1)).toBe(0);
+    });
+    it("fails for extraLevels < 1", () => {
+      expect(calculateLevelUpgradeCostNode(1, -1, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostNode(1, 0, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostNode(1, 0.4, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostNode(1, 0.5, 1)).toBeGreaterThan(0);
+      expect(calculateLevelUpgradeCostNode(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
+      expect(calculateLevelUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("limits maximum level correctly", () => {
+      expect(calculateLevelUpgradeCostNode(HacknetNodeConstants.MaxLevel, 1, 1)).toBe(Infinity);
+      expect(calculateLevelUpgradeCostNode(HacknetNodeConstants.MaxLevel + 1, 1, 1)).toBe(Infinity);
+      expect(calculateLevelUpgradeCostNode(HacknetNodeConstants.MaxLevel - 1, 1, 1)).toBeGreaterThan(0);
+      expect(calculateLevelUpgradeCostNode(HacknetNodeConstants.MaxLevel - 2, 5, 1)).toBe(Infinity);
+    });
+  });
+
+  describe("calculateRamUpgradeCost applies limits", () => {
+    it("bails out for NaN", () => {
+      expect(calculateRamUpgradeCostNode(1, NaN, 1)).toBe(0);
+    });
+    it("fails for extraLevels < 1", () => {
+      expect(calculateRamUpgradeCostNode(1, -1, 1)).toBe(0);
+      expect(calculateRamUpgradeCostNode(1, 0, 1)).toBe(0);
+      expect(calculateRamUpgradeCostNode(1, 0.4, 1)).toBe(0);
+      expect(calculateRamUpgradeCostNode(1, 0.5, 1)).toBeGreaterThan(0);
+      expect(calculateRamUpgradeCostNode(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
+      expect(calculateRamUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("limits maximum level correctly", () => {
+      expect(calculateRamUpgradeCostNode(HacknetNodeConstants.MaxRam, 1, 1)).toBe(Infinity);
+      expect(calculateRamUpgradeCostNode(HacknetNodeConstants.MaxRam + 1, 1, 1)).toBe(Infinity);
+      expect(calculateRamUpgradeCostNode(HacknetNodeConstants.MaxRam - 1, 1, 1)).toBeGreaterThan(0);
+      expect(calculateRamUpgradeCostNode(HacknetNodeConstants.MaxRam - 2, 5, 1)).toBe(Infinity);
+    });
+  });
+
+  describe("calculateCoreUpgradeCost applies limits", () => {
+    it("bails out for NaN", () => {
+      expect(calculateCoreUpgradeCostNode(1, NaN, 1)).toBe(0);
+    });
+    it("fails for extraLevels < 1", () => {
+      expect(calculateCoreUpgradeCostNode(1, -1, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostNode(1, 0, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostNode(1, 0.4, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostNode(1, 0.5, 1)).toBeGreaterThan(0);
+      expect(calculateCoreUpgradeCostNode(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
+      expect(calculateCoreUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("limits maximum level correctly", () => {
+      expect(calculateCoreUpgradeCostNode(HacknetNodeConstants.MaxCores, 1, 1)).toBe(Infinity);
+      expect(calculateCoreUpgradeCostNode(HacknetNodeConstants.MaxCores + 1, 1, 1)).toBe(Infinity);
+      expect(calculateCoreUpgradeCostNode(HacknetNodeConstants.MaxCores - 1, 1, 1)).toBeGreaterThan(0);
+      expect(calculateCoreUpgradeCostNode(HacknetNodeConstants.MaxCores - 2, 5, 1)).toBe(Infinity);
+    });
+  });
+});
+
+describe("HacknetServer calculations", () => {
+  describe("calculateLevelUpgradeCost applies limits", () => {
+    it("bails out for NaN", () => {
+      expect(calculateLevelUpgradeCostServer(1, NaN, 1)).toBe(0);
+    });
+    it("fails for extraLevels < 1", () => {
+      expect(calculateLevelUpgradeCostServer(1, -1, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostServer(1, 0, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostServer(1, 0.4, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostServer(1, 0.5, 1)).toBeGreaterThan(0);
+      expect(calculateLevelUpgradeCostServer(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
+      expect(calculateLevelUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("limits maximum level correctly", () => {
+      expect(calculateLevelUpgradeCostServer(HacknetServerConstants.MaxLevel, 1, 1)).toBe(Infinity);
+      expect(calculateLevelUpgradeCostServer(HacknetServerConstants.MaxLevel + 1, 1, 1)).toBe(Infinity);
+      expect(calculateLevelUpgradeCostServer(HacknetServerConstants.MaxLevel - 1, 1, 1)).toBeGreaterThan(0);
+      expect(calculateLevelUpgradeCostServer(HacknetServerConstants.MaxLevel - 2, 5, 1)).toBe(Infinity);
+    });
+  });
+
+  describe("calculateRamUpgradeCost applies limits", () => {
+    it("bails out for NaN", () => {
+      expect(calculateRamUpgradeCostServer(1, NaN, 1)).toBe(0);
+    });
+    it("fails for extraLevels < 1", () => {
+      expect(calculateRamUpgradeCostServer(1, -1, 1)).toBe(0);
+      expect(calculateRamUpgradeCostServer(1, 0, 1)).toBe(0);
+      expect(calculateRamUpgradeCostServer(1, 0.4, 1)).toBe(0);
+      expect(calculateRamUpgradeCostServer(1, 0.5, 1)).toBeGreaterThan(0);
+      expect(calculateRamUpgradeCostServer(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
+      expect(calculateRamUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("limits maximum level correctly", () => {
+      expect(calculateRamUpgradeCostServer(HacknetServerConstants.MaxRam, 1, 1)).toBe(Infinity);
+      expect(calculateRamUpgradeCostServer(HacknetServerConstants.MaxRam + 1, 1, 1)).toBe(Infinity);
+      expect(calculateRamUpgradeCostServer(HacknetServerConstants.MaxRam - 1, 1, 1)).toBeGreaterThan(0);
+      expect(calculateRamUpgradeCostServer(HacknetServerConstants.MaxRam - 2, 5, 1)).toBe(Infinity);
+    });
+  });
+
+  describe("calculateCoreUpgradeCost applies limits", () => {
+    it("bails out for NaN", () => {
+      expect(calculateCoreUpgradeCostServer(1, NaN, 1)).toBe(0);
+    });
+    it("fails for extraLevels < 1", () => {
+      expect(calculateCoreUpgradeCostServer(1, -1, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostServer(1, 0, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostServer(1, 0.4, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostServer(1, 0.5, 1)).toBeGreaterThan(0);
+      expect(calculateCoreUpgradeCostServer(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
+      expect(calculateCoreUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("limits maximum level correctly", () => {
+      expect(calculateCoreUpgradeCostServer(HacknetServerConstants.MaxCores, 1, 1)).toBe(Infinity);
+      expect(calculateCoreUpgradeCostServer(HacknetServerConstants.MaxCores + 1, 1, 1)).toBe(Infinity);
+      expect(calculateCoreUpgradeCostServer(HacknetServerConstants.MaxCores - 1, 1, 1)).toBeGreaterThan(0);
+      expect(calculateCoreUpgradeCostServer(HacknetServerConstants.MaxCores - 2, 5, 1)).toBe(Infinity);
+    });
+  });
+});

--- a/test/jest/Hacknet.test.ts
+++ b/test/jest/Hacknet.test.ts
@@ -15,13 +15,15 @@ describe("HacknetNode calculations", () => {
     it("bails out for NaN", () => {
       expect(calculateLevelUpgradeCostNode(1, NaN, 1)).toBe(0);
     });
-    it("fails for extraLevels < 1", () => {
+    it("fails for invalid extraLevels", () => {
       expect(calculateLevelUpgradeCostNode(1, -1, 1)).toBe(0);
       expect(calculateLevelUpgradeCostNode(1, 0, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("correctly rounds values between 0.5 and 1", () => {
       expect(calculateLevelUpgradeCostNode(1, 0.4, 1)).toBe(0);
       expect(calculateLevelUpgradeCostNode(1, 0.5, 1)).toBeGreaterThan(0);
       expect(calculateLevelUpgradeCostNode(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
-      expect(calculateLevelUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
     });
     it("limits maximum level correctly", () => {
       expect(calculateLevelUpgradeCostNode(HacknetNodeConstants.MaxLevel, 1, 1)).toBe(Infinity);
@@ -35,13 +37,15 @@ describe("HacknetNode calculations", () => {
     it("bails out for NaN", () => {
       expect(calculateRamUpgradeCostNode(1, NaN, 1)).toBe(0);
     });
-    it("fails for extraLevels < 1", () => {
+    it("fails for invalid extraLevels", () => {
       expect(calculateRamUpgradeCostNode(1, -1, 1)).toBe(0);
       expect(calculateRamUpgradeCostNode(1, 0, 1)).toBe(0);
+      expect(calculateRamUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("correctly rounds values between 0.5 and 1", () => {
       expect(calculateRamUpgradeCostNode(1, 0.4, 1)).toBe(0);
       expect(calculateRamUpgradeCostNode(1, 0.5, 1)).toBeGreaterThan(0);
       expect(calculateRamUpgradeCostNode(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
-      expect(calculateRamUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
     });
     it("limits maximum level correctly", () => {
       expect(calculateRamUpgradeCostNode(HacknetNodeConstants.MaxRam, 1, 1)).toBe(Infinity);
@@ -55,13 +59,15 @@ describe("HacknetNode calculations", () => {
     it("bails out for NaN", () => {
       expect(calculateCoreUpgradeCostNode(1, NaN, 1)).toBe(0);
     });
-    it("fails for extraLevels < 1", () => {
+    it("fails for invalid extraLevels", () => {
       expect(calculateCoreUpgradeCostNode(1, -1, 1)).toBe(0);
       expect(calculateCoreUpgradeCostNode(1, 0, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("correctly rounds values between 0.5 and 1", () => {
       expect(calculateCoreUpgradeCostNode(1, 0.4, 1)).toBe(0);
       expect(calculateCoreUpgradeCostNode(1, 0.5, 1)).toBeGreaterThan(0);
       expect(calculateCoreUpgradeCostNode(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
-      expect(calculateCoreUpgradeCostNode(1, 1, 1)).toBeGreaterThan(0);
     });
     it("limits maximum level correctly", () => {
       expect(calculateCoreUpgradeCostNode(HacknetNodeConstants.MaxCores, 1, 1)).toBe(Infinity);
@@ -77,13 +83,15 @@ describe("HacknetServer calculations", () => {
     it("bails out for NaN", () => {
       expect(calculateLevelUpgradeCostServer(1, NaN, 1)).toBe(0);
     });
-    it("fails for extraLevels < 1", () => {
+    it("fails for invalid extraLevels", () => {
       expect(calculateLevelUpgradeCostServer(1, -1, 1)).toBe(0);
       expect(calculateLevelUpgradeCostServer(1, 0, 1)).toBe(0);
+      expect(calculateLevelUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("correctly rounds values between 0.5 and 1", () => {
       expect(calculateLevelUpgradeCostServer(1, 0.4, 1)).toBe(0);
       expect(calculateLevelUpgradeCostServer(1, 0.5, 1)).toBeGreaterThan(0);
       expect(calculateLevelUpgradeCostServer(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
-      expect(calculateLevelUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
     });
     it("limits maximum level correctly", () => {
       expect(calculateLevelUpgradeCostServer(HacknetServerConstants.MaxLevel, 1, 1)).toBe(Infinity);
@@ -97,13 +105,15 @@ describe("HacknetServer calculations", () => {
     it("bails out for NaN", () => {
       expect(calculateRamUpgradeCostServer(1, NaN, 1)).toBe(0);
     });
-    it("fails for extraLevels < 1", () => {
+    it("fails for invalid extraLevels", () => {
       expect(calculateRamUpgradeCostServer(1, -1, 1)).toBe(0);
       expect(calculateRamUpgradeCostServer(1, 0, 1)).toBe(0);
+      expect(calculateRamUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("correctly rounds values between 0.5 and 1", () => {
       expect(calculateRamUpgradeCostServer(1, 0.4, 1)).toBe(0);
       expect(calculateRamUpgradeCostServer(1, 0.5, 1)).toBeGreaterThan(0);
       expect(calculateRamUpgradeCostServer(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
-      expect(calculateRamUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
     });
     it("limits maximum level correctly", () => {
       expect(calculateRamUpgradeCostServer(HacknetServerConstants.MaxRam, 1, 1)).toBe(Infinity);
@@ -117,13 +127,15 @@ describe("HacknetServer calculations", () => {
     it("bails out for NaN", () => {
       expect(calculateCoreUpgradeCostServer(1, NaN, 1)).toBe(0);
     });
-    it("fails for extraLevels < 1", () => {
+    it("fails for invalid extraLevels", () => {
       expect(calculateCoreUpgradeCostServer(1, -1, 1)).toBe(0);
       expect(calculateCoreUpgradeCostServer(1, 0, 1)).toBe(0);
+      expect(calculateCoreUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
+    });
+    it("correctly rounds values between 0.5 and 1", () => {
       expect(calculateCoreUpgradeCostServer(1, 0.4, 1)).toBe(0);
       expect(calculateCoreUpgradeCostServer(1, 0.5, 1)).toBeGreaterThan(0);
       expect(calculateCoreUpgradeCostServer(1, 0.9999999999999999, 1)).toBeGreaterThan(0);
-      expect(calculateCoreUpgradeCostServer(1, 1, 1)).toBeGreaterThan(0);
     });
     it("limits maximum level correctly", () => {
       expect(calculateCoreUpgradeCostServer(HacknetServerConstants.MaxCores, 1, 1)).toBe(Infinity);


### PR DESCRIPTION
Hacknet Node/Server cost calculation function fail to correctly calculate the upgrade cost under certain conditions: if the node/server is not at max level/ram/core/cache and the amount of upgrades surpasses the maximum (i.e. current cores + new cores > max_cores), the cost will incorrectly be calculated event for stats which are not allowed. See the following example:
```js
export async function main(ns: NS) {
  ns.print(`node id: 0, node level: ${ns.hacknet.getNodeStats(0).level}, cost for 5_000 levels: ${ns.hacknet.getLevelUpgradeCost(0, 5_000)}`);
  ns.print(`node id: 1, node level: ${ns.hacknet.getNodeStats(1).level}, cost for 5_000 levels: ${ns.hacknet.getLevelUpgradeCost(1, 5_000)}`);
}
```
Which will output this:
```
node id: 0, node level: 200, cost for 5_000 levels: Infinity
node id: 1, node level: 1, cost for 5_000 levels: 1.5738957360987797e+89
```

I've fixed this edge case for all hacknet cost calculation functions and also added a few tests which should hopefully catch the edge cases in the future.