### PR TITLE
UI: Reload immediately after importing, deleting save data or killing all scripts

### DIFF
--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -332,7 +332,7 @@ class BitburnerSaveObject implements BitburnerSaveObjectType {
       dialogBoxCreate(`Cannot import save data: ${error}`);
       return;
     }
-    setTimeout(() => location.reload(), 1000);
+    setTimeout(() => location.reload(), 0);
   }
 
   async getSaveDataFromFile(files: FileList | null): Promise<SaveData> {

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -224,7 +224,7 @@ export function GameRoot(): React.ReactElement {
     saveObject
       .saveGame()
       .then(() => {
-        setTimeout(() => htmlLocation.reload(), 2000);
+        setTimeout(() => htmlLocation.reload(), 0);
       })
       .catch((error) => {
         exceptionAlert(error);

--- a/src/ui/React/DeleteGameButton.tsx
+++ b/src/ui/React/DeleteGameButton.tsx
@@ -27,7 +27,7 @@ export function DeleteGameButton({ color = "primary" }: IProps): React.ReactElem
           deleteGame()
             .then(() => {
               pushDisableRestore();
-              setTimeout(() => location.reload(), 1000);
+              setTimeout(() => location.reload(), 0);
             })
             .catch((r) => console.error("Could not delete game: %o", r));
         }}


### PR DESCRIPTION
I notice that sometimes after importing a save file, the game reloads and restores the old data. When testing the autosave feature with a very high frequency (saving every second), I can reproduce this issue consistently. It happens when the game autosaves between the import and the reload.

Previously, I was hesitant to lower the delay because when saving to IndexedDB, `request.onsuccess` does not guarantee that the data is persisted to physical storage. With #2623, we no longer have to worry about this issue.

Edit: When the autosave frequency is high enough (`Engine.Counters.autoSaveCounter=1;Settings.AutosaveInterval=1;`), deleting with `window.indexedDB.deleteDatabase` behaves strangely (`onblocked` is called). This is unrelated to this PR. I'll investigate it later.