### PR TITLE
UI: Activate recovery mode on critical BN prestige bugs

### DIFF
--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -11,6 +11,7 @@ import { prestigeSourceFile } from "./Prestige";
 import { getDefaultBitNodeOptions, setBitNodeOptions } from "./BitNode/BitNodeUtils";
 import { prestigeWorkerScripts } from "./NetscriptWorker";
 import { exceptionAlert } from "./utils/helpers/exceptionAlert";
+import { ActivateRecoveryMode } from "./ui/React/RecoveryRoot";
 
 function giveSourceFile(bitNodeNumber: number): void {
   const sourceFileKey = "SourceFile" + bitNodeNumber.toString();
@@ -73,7 +74,16 @@ export function enterBitNode(
     setBitNodeOptions(getDefaultBitNodeOptions());
   }
 
-  prestigeSourceFile(isFlume);
+  try {
+    prestigeSourceFile(isFlume);
+  } catch (error) {
+    // prestigeSourceFile only throws on critical bugs. In these cases, we must activate recovery mode to ensure the
+    // player knows something went wrong and can notify us. Recovery mode also disables autosave, which may prevent the
+    // error from corrupting the save data.
+    ActivateRecoveryMode(error);
+    Router.toPage(Page.Recovery);
+    return;
+  }
 
   if (newBitNode === 6) {
     Router.toPage(Page.BladeburnerCinematic);


### PR DESCRIPTION
I just remember that gmacwen told us that the bug in #2667 can be used to farm SF12. MRE:
- Revert #2667
- Load a clean save file
- Bitflume to BN12
- Set SF12.35842 or higher
- Backdoor WD. You can also use the "Quick WD" dev tool.
- In the BitVerse UI, choose BN12. Keep clicking on it many times.
- Wait a few seconds/minutes for autosaving.
- Reload the game. Check SF12. It will be higher than 35842.

Bugs similar to #2667 are rare, but we can wrap `prestigeSourceFile` in a try-catch block to prevent exploits based on this kind of bug.