### PR TITLE
API: Update error message of ns.singularity.joinFaction

### DIFF
--- a/markdown/bitburner.singularity.joinfaction.md
+++ b/markdown/bitburner.singularity.joinfaction.md
@@ -52,11 +52,13 @@ Name of faction to join.
 
 boolean
 
-True if player joined the faction, and false otherwise.
+True if the player successfully accepts an invitation, and false otherwise.
 
 ## Remarks
 
 RAM cost: 3 GB \* 16/4/1
 
 This function will automatically accept an invitation from a faction and join it.
+
+Note that this function returns false if you are already a member of the specified faction.
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -779,6 +779,11 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       helpers.checkSingularityAccess(ctx);
       const facName = getEnumHelper("FactionName").nsGetMember(ctx, _facName);
 
+      if (Player.factions.includes(facName)) {
+        helpers.log(ctx, () => `You are already a member of faction '${facName}'`);
+        return false;
+      }
+
       if (!Player.factionInvitations.includes(facName)) {
         helpers.log(ctx, () => `You have not been invited by faction '${facName}'`);
         return false;

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2362,8 +2362,10 @@ export interface Singularity {
    *
    * This function will automatically accept an invitation from a faction and join it.
    *
+   * Note that this function returns false if you are already a member of the specified faction.
+   *
    * @param faction - Name of faction to join.
-   * @returns True if player joined the faction, and false otherwise.
+   * @returns True if the player successfully accepts an invitation, and false otherwise.
    */
   joinFaction(faction: FactionName): boolean;
 


### PR DESCRIPTION
When joining a faction that you are already a member of, `ns.singularity.joinFaction` prints `You have not been invited by faction foo`. Technically, this is not wrong, but we should say the real reason.

Note that this does not change the behavior of this PR. However, when looking at other APIs, I found that we are not consistent in this kind of behavior. With Bladeburner and Stanek, `joinBladeburnerFaction`, `joinBladeburnerDivision`, and `acceptGift` return true if you are already a member. With gang and corp, `createGang` and `createCorporation` return false if the mechanic has already been activated.

This is too messy, so I did not change anything else.