### PR TITLE
DOCUMENTATION: Fix api-extractor warnings

### DIFF
--- a/markdown/bitburner.basetask.md
+++ b/markdown/bitburner.basetask.md
@@ -4,6 +4,8 @@
 
 ## BaseTask interface
 
+Base interface of all tasks.
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.hackingformulas.md
+++ b/markdown/bitburner.hackingformulas.md
@@ -134,7 +134,7 @@ Calculate hack time.
 
 </td><td>
 
-Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is .
+Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is `1 + (cores - 1) / 16}`<!-- -->.
 
 
 </td></tr>

--- a/markdown/bitburner.hackingformulas.weakeneffect.md
+++ b/markdown/bitburner.hackingformulas.weakeneffect.md
@@ -4,7 +4,7 @@
 
 ## HackingFormulas.weakenEffect() method
 
-Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is .
+Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is `1 + (cores - 1) / 16}`<!-- -->.
 
 **Signature:**
 

--- a/markdown/bitburner.md
+++ b/markdown/bitburner.md
@@ -67,6 +67,8 @@ Player must have installed a backdoor on this server.
 
 </td><td>
 
+Base interface of all tasks.
+
 
 </td></tr>
 <tr><td>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1744,6 +1744,11 @@ export interface Stock {
   nextUpdate(): Promise<number>;
 }
 
+/**
+ * Base interface of all tasks.
+ *
+ * @public
+ */
 interface BaseTask {
   /**
    * This promise resolves when the task completes or is canceled.
@@ -6320,7 +6325,7 @@ interface HackingFormulas {
    * Calculate the security decrease from a weaken operation.
    * Unlike other hacking formulas, weaken effect depends only on thread count and
    * core count, not on server or player properties. The core bonus formula is
-   * {@code 1 + (cores - 1) / 16}.
+   * `1 + (cores - 1) / 16}`.
    * @param threads - Number of threads running weaken.
    * @param cores - Number of cores on the host server. Default 1.
    * @returns The security decrease amount.


### PR DESCRIPTION
Warnings:
```
Warning: src/ScriptEditor/NetscriptDefinitions.d.ts:1747:1 - (ae-missing-release-tag) "BaseTask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal) 
Warning: src/ScriptEditor/NetscriptDefinitions.d.ts:6325:7 - (tsdoc-undefined-tag) The TSDoc tag "@code" is not defined in this configuration
```