### PR TITLE
API: Update RAM cost of nextUpdate and similar APIs

### DIFF
--- a/markdown/bitburner.bladeburner.nextupdate.md
+++ b/markdown/bitburner.bladeburner.nextupdate.md
@@ -19,7 +19,7 @@ Promise that resolves to the number of milliseconds of Bladeburner time that wer
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 
 The amount of real time spent asleep between updates can vary due to "bonus time" (usually 1 second).
 

--- a/markdown/bitburner.corporation.nextupdate.md
+++ b/markdown/bitburner.corporation.nextupdate.md
@@ -19,7 +19,7 @@ Promise that resolves to the name of the state that was just processed.
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 
 The amount of real time spent asleep between updates can vary due to "bonus time" (usually 200 milliseconds - 2 seconds).
 

--- a/markdown/bitburner.darknet.nextmutation.md
+++ b/markdown/bitburner.darknet.nextmutation.md
@@ -29,5 +29,5 @@ Promise&lt;void&gt;
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 

--- a/markdown/bitburner.gang.nextupdate.md
+++ b/markdown/bitburner.gang.nextupdate.md
@@ -19,7 +19,7 @@ Promise that resolves to the number of milliseconds of Gang time that were proce
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 
 The amount of real time spent asleep between updates can vary due to "bonus time".
 

--- a/markdown/bitburner.grafting.waitforongoinggrafting.md
+++ b/markdown/bitburner.grafting.waitforongoinggrafting.md
@@ -19,5 +19,5 @@ A promise that resolves when the current grafting finishes or is canceled. If th
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 

--- a/markdown/bitburner.stock.nextupdate.md
+++ b/markdown/bitburner.stock.nextupdate.md
@@ -19,7 +19,7 @@ Promise that resolves to the number of milliseconds of Stock Market time that we
 
 ## Remarks
 
-RAM cost: 1 GB
+RAM cost: 0 GB
 
 The amount of real time spent asleep between updates can vary due to "bonus time" (usually 4 seconds - 6 seconds).
 

--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -77,7 +77,7 @@ export const RamCostConstants = {
   InfiltrationCalculateRewards: 2.5,
   InfiltrationGetInfiltrations: 15,
 
-  CycleTiming: 1,
+  CycleTiming: 0,
 } as const;
 
 function SF4Cost(cost: number): () => number {
@@ -461,7 +461,7 @@ const grafting = {
   getAugmentationGraftTime: 3.75,
   getGraftableAugmentations: 5,
   graftAugmentation: 7.5,
-  waitForOngoingGrafting: 1,
+  waitForOngoingGrafting: 0,
 } as const;
 
 const corporation = {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1725,7 +1725,7 @@ export interface Stock {
   /**
    * Sleep until the next Stock Market price update has happened.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * The amount of real time spent asleep between updates can vary due to "bonus time"
    * (usually 4 seconds - 6 seconds).
@@ -3986,7 +3986,7 @@ export interface Bladeburner {
   /**
    * Sleep until the next Bladeburner update has happened.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * The amount of real time spent asleep between updates can vary due to "bonus time"
    * (usually 1 second).
@@ -4788,7 +4788,7 @@ export interface Darknet {
    * - New servers appear on the net (which may be previously offline servers, but cleaned and with a new password).
    *
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    */
   nextMutation(): Promise<void>;
 
@@ -5143,7 +5143,7 @@ export interface Gang {
   /**
    * Sleeps until the next Gang update has happened.
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * The amount of real time spent asleep between updates can vary due to "bonus time".
    *
@@ -6108,7 +6108,7 @@ export interface Grafting {
    * Wait until the ongoing grafting finishes or is canceled.
    *
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * @returns A promise that resolves when the current grafting finishes or is canceled. If there is no current work,
    * the promise resolves immediately. If the current work is not a grafting work, the promise rejects immediately.
@@ -10458,7 +10458,7 @@ export interface Corporation extends WarehouseAPI, OfficeAPI {
    * Sleep until the next Corporation update happens.
    *
    * @remarks
-   * RAM cost: 1 GB
+   * RAM cost: 0 GB
    *
    * The amount of real time spent asleep between updates can vary due to "bonus time"
    * (usually 200 milliseconds - 2 seconds).


### PR DESCRIPTION
This is the optional suggestion mentioned in #2684.

Context: `Singularity.getCurrentWork` exposes the `nextCompletion` promise. This is the same promise returned by `waitForOngoingGrafting`, but `getCurrentWork` costs 0.5 GB, whereas `waitForOngoingGrafting` and similar APIs cost 1 GB.

The original suggestion is to reduce the cost to 0.5GB or another value. In addition to `waitForOngoingGrafting` and the `nextUpdate` APIs, there are other APIs used to wait until an event occurs, such as port `nextWrite`, Go `opponentNextTurn`. These APIs cost 0GB, so aligning all such APIs to 0 GB would be consistent.

If you think reducing the cost to 0GB is too much, I can set them to 0.5GB.