### PR TITLE
MISC: Update description of "You and what army?" achievement

### DIFF
--- a/src/Achievements/AchievementData.json
+++ b/src/Achievements/AchievementData.json
@@ -384,7 +384,7 @@
     "SLEEVE_8": {
       "ID": "SLEEVE_8",
       "Name": "You and what army?",
-      "Description": "Purchase all duplicate sleeves from The Covenant."
+      "Description": "Acquire all 8 sleeves."
     },
     "INDECISIVE": {
       "ID": "INDECISIVE",


### PR DESCRIPTION
The current description is misleading. You must have 8 sleeves: 5 are purchased from The Covenant, and the remaining 3 are obtained from SF10.