### PR TITLE
CODEBASE: Add comments explaining redundant check in product calculation

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -873,6 +873,18 @@ export class Division {
           }
           prod *= corpConstants.secondsPerMarketCycle * marketCycles;
 
+          //Calculate net change in warehouse storage making the Products will cost
+          let netStorageSize = product.size;
+          for (const [reqMatName, reqQty] of getRecordEntries(product.requiredMaterials)) {
+            netStorageSize -= MaterialInfo[reqMatName].size * reqQty;
+          }
+
+          //If there's not enough space in warehouse, limit the amount of Product
+          if (netStorageSize > 0) {
+            const maxAmt = Math.floor((warehouse.size - warehouse.sizeUsed) / netStorageSize);
+            prod = Math.min(maxAmt, prod);
+          }
+
           warehouse.smartSupplyStore += prod / (corpConstants.secondsPerMarketCycle * marketCycles);
 
           //Make sure we have enough resources to make our Products

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -873,12 +873,12 @@ export class Division {
           }
           prod *= corpConstants.secondsPerMarketCycle * marketCycles;
 
+          // The "netStorageSize" check is redundant, but retained in case the product size calculation changes.
           //Calculate net change in warehouse storage making the Products will cost
           let netStorageSize = product.size;
           for (const [reqMatName, reqQty] of getRecordEntries(product.requiredMaterials)) {
             netStorageSize -= MaterialInfo[reqMatName].size * reqQty;
           }
-
           //If there's not enough space in warehouse, limit the amount of Product
           if (netStorageSize > 0) {
             const maxAmt = Math.floor((warehouse.size - warehouse.sizeUsed) / netStorageSize);

--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -873,18 +873,6 @@ export class Division {
           }
           prod *= corpConstants.secondsPerMarketCycle * marketCycles;
 
-          //Calculate net change in warehouse storage making the Products will cost
-          let netStorageSize = product.size;
-          for (const [reqMatName, reqQty] of getRecordEntries(product.requiredMaterials)) {
-            netStorageSize -= MaterialInfo[reqMatName].size * reqQty;
-          }
-
-          //If there's not enough space in warehouse, limit the amount of Product
-          if (netStorageSize > 0) {
-            const maxAmt = Math.floor((warehouse.size - warehouse.sizeUsed) / netStorageSize);
-            prod = Math.min(maxAmt, prod);
-          }
-
           warehouse.smartSupplyStore += prod / (corpConstants.secondsPerMarketCycle * marketCycles);
 
           //Make sure we have enough resources to make our Products


### PR DESCRIPTION
This check is only relevant when processing materials, where the total size of output materials may differ from the total size of input materials. For products, the output size always equals the total size of the input materials, so the check is unnecessary.

https://github.com/bitburner-official/bitburner-src/blob/c72a2928eb6fa50678fa4793ea8cef2cef1a2c5a/src/Corporation/Product.ts#L208-L212

https://github.com/bitburner-official/bitburner-src/blob/c72a2928eb6fa50678fa4793ea8cef2cef1a2c5a/src/Corporation/Division.ts#L876-L886

`netStorageSize` is always 0 or a very small value (due to floating-point imprecision).
- Pharmaceutical: -6.938893903907228e-18
- Robotics: 5.551115123125783e-17
- Real Estate: 2.7755575615628914e-17