### PR TITLE
UI: Add backdoor status to "scan-analyze"

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -649,7 +649,12 @@ export class Terminal {
       } else {
         this.print(`${infoPrefix}Root Access: ${hasRoot}` + "\n");
       }
-      this.print(`${infoPrefix}RAM: ${formatRam(server.maxRam)}` + "\n");
+      this.print(
+        `${infoPrefix}RAM: ${formatRam(server.maxRam)}` +
+          ", Backdoor: " +
+          (server.backdoorInstalled ? "YES" : "NO") +
+          "\n",
+      );
       node.children.forEach((n, i) =>
         printOutput(n, [...prefix, i === node.children.length - 1 ? "  " : "┃ "], i === node.children.length - 1),
       );


### PR DESCRIPTION
In my opinion, backdoor status should appear on `scan-analyze`. I copied the code that displayed backdoor status on `analyze` into the code for `scan-analyze` to achieve this goal.

As instructed by CONTRIBUTING.md, I ran `npm run format` and it made some changes that didn't seem to affect the functionality in testing.