### PR TITLE
MISC: Improve error messages for invalid module parsing

### DIFF
--- a/src/utils/ScriptTransformer.ts
+++ b/src/utils/ScriptTransformer.ts
@@ -141,7 +141,7 @@ export function getModuleScript(
   for (const extension of validScriptExtensions) {
     const filename = resolveScriptFilePath(moduleName, baseModule, extension);
     if (!filename) {
-      throw new ModuleResolutionError(`Invalid module: "${moduleName}". Base module: "${baseModule}".`);
+      throw new ModuleResolutionError(`Invalid module path: "${moduleName}". Base module: "${baseModule}".`);
     }
     script = scripts.get(filename);
     if (script) {
@@ -149,7 +149,7 @@ export function getModuleScript(
     }
   }
   if (!script) {
-    throw new ModuleResolutionError(`Invalid module: "${moduleName}". Base module: "${baseModule}".`);
+    throw new ModuleResolutionError(`Module not found: "${moduleName}". Base module: "${baseModule}".`);
   }
   return script;
 }


### PR DESCRIPTION
One of the most common newbie mistakes is to scp a script without its dependencies. For example, a player may scp `foo.js` which depends on `bar.js`, but they forget to scp `bar.js`. When running `foo.js`, the current error is:
```
Cannot calculate RAM usage of foo.js. Reason: Invalid module: "bar". Base module: "foo.js".
```
"Invalid module" message is too generic. A more precise message is:
```
Cannot calculate RAM usage of foo.js. Reason: Module not found: "bar". Base module: "foo.js".
```
