### PR TITLE
DEPS: Update Electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "babel-plugin-transform-barrels": "^1.0.17",
         "css-loader": "^7.1.2",
         "csstype": "3.1.3",
-        "electron": "^41.0.3",
+        "electron": "^41.4.0",
         "eslint": "^8.52.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -8304,9 +8304,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "41.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.0.3.tgz",
-      "integrity": "sha512-IDjx8liW1q+r7+MOip5W1Eo1eMwJzVObmYrd9yz2dPCkS7XlgLq3qPVMR80TpiROFp73iY30kTzMdpA6fEVs3A==",
+      "version": "41.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.4.0.tgz",
+      "integrity": "sha512-1afmxJGyrZ4bve+PDCs8YtNjjVu4cPwUtSjx36o6gyJWI0NvhebMKtIzzKNOScRyXntH2hX0i350Xgm3BKiEYQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "babel-plugin-transform-barrels": "^1.0.17",
     "css-loader": "^7.1.2",
     "csstype": "3.1.3",
-    "electron": "^41.0.3",
+    "electron": "^41.4.0",
     "eslint": "^8.52.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",


### PR DESCRIPTION
On Discord, we discussed updating dependencies to fix vulnerabilities. This is the current npm audit log:
```
# npm audit report

@tootallnate/once  <3.0.1
@tootallnate/once vulnerable to Incorrect Control Flow Scoping - https://github.com/advisories/GHSA-vpq2-c234-7xj6
fix available via `npm audit fix --force`
Will install jest-environment-jsdom@30.3.0, which is a breaking change
node_modules/@tootallnate/once
  http-proxy-agent  4.0.1 - 5.0.0
  Depends on vulnerable versions of @tootallnate/once
  node_modules/jest-environment-jsdom/node_modules/http-proxy-agent
    jsdom  16.6.0 - 22.1.0
    Depends on vulnerable versions of http-proxy-agent
    node_modules/jest-environment-jsdom/node_modules/jsdom
      jest-environment-jsdom  27.0.1 - 30.0.0-rc.1
      Depends on vulnerable versions of jsdom
      node_modules/jest-environment-jsdom

@xmldom/xmldom  <=0.8.12 || 0.9.0 - 0.9.9
Severity: high
xmldom: Uncontrolled recursion in XML serialization leads to DoS - https://github.com/advisories/GHSA-2v35-w6hq-6mfw
xmldom: Uncontrolled recursion in XML serialization leads to DoS - https://github.com/advisories/GHSA-2v35-w6hq-6mfw
xmldom has XML injection through unvalidated DocumentType serialization - https://github.com/advisories/GHSA-f6ww-3ggp-fr8h
xmldom has XML injection through unvalidated DocumentType serialization - https://github.com/advisories/GHSA-f6ww-3ggp-fr8h
xmldom has XML node injection through unvalidated processing instruction serialization - https://github.com/advisories/GHSA-x6wf-f3px-wcqx
xmldom has XML node injection through unvalidated processing instruction serialization - https://github.com/advisories/GHSA-x6wf-f3px-wcqx
xmldom has XML node injection through unvalidated comment serialization - https://github.com/advisories/GHSA-j759-j44w-7fr8
xmldom has XML node injection through unvalidated comment serialization - https://github.com/advisories/GHSA-j759-j44w-7fr8
xmldom: XML injection via unsafe CDATA serialization allows attacker-controlled markup insertion - https://github.com/advisories/GHSA-wh4c-j3r5-mjhp
xmldom: XML injection via unsafe CDATA serialization allows attacker-controlled markup insertion - https://github.com/advisories/GHSA-wh4c-j3r5-mjhp
No fix available
node_modules/@mathjax/src/node_modules/@xmldom/xmldom
node_modules/@xmldom/xmldom
  speech-rule-engine  4.1.0-beta.0 - 4.1.3 || 5.0.0-alpha.1 - 5.0.0-beta.7
  Depends on vulnerable versions of @xmldom/xmldom
  node_modules/@mathjax/src/node_modules/speech-rule-engine
    @mathjax/src  *
    Depends on vulnerable versions of speech-rule-engine
    node_modules/@mathjax/src

brace-expansion  <=1.1.12 || 2.0.0 - 2.0.2 || 4.0.0 - 5.0.4
Severity: moderate
brace-expansion: Zero-step sequence causes process hang and memory exhaustion - https://github.com/advisories/GHSA-f886-m6hf-6m8v
brace-expansion: Zero-step sequence causes process hang and memory exhaustion - https://github.com/advisories/GHSA-f886-m6hf-6m8v
brace-expansion: Zero-step sequence causes process hang and memory exhaustion - https://github.com/advisories/GHSA-f886-m6hf-6m8v
fix available via `npm audit fix`
node_modules/@electron/universal/node_modules/brace-expansion
node_modules/@mathjax/src/node_modules/brace-expansion
node_modules/@microsoft/api-extractor/node_modules/brace-expansion
node_modules/brace-expansion

dompurify  <=3.3.3
Severity: moderate
DOMPurify is vulnerable to mutation-XSS via Re-Contextualization  - https://github.com/advisories/GHSA-h8r8-wccr-v5f2
DOMPurify contains a Cross-site Scripting vulnerability - https://github.com/advisories/GHSA-v2wj-7wpq-c8vv
DOMPurify ADD_ATTR predicate skips URI validation - https://github.com/advisories/GHSA-cjmm-f4jc-qw8r
DOMPurify USE_PROFILES prototype pollution allows event handlers - https://github.com/advisories/GHSA-cj63-jhhr-wcxv
DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation - https://github.com/advisories/GHSA-39q2-94rc-95cp
DOMPurify: FORBID_TAGS bypassed by function-based ADD_TAGS predicate (asymmetry with FORBID_ATTR fix) - https://github.com/advisories/GHSA-h7mw-gpvr-xq4m
DOMPurify has a SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode - https://github.com/advisories/GHSA-crv5-9vww-q3g8
DOMPurify: Prototype Pollution to XSS Bypass via CUSTOM_ELEMENT_HANDLING Fallback - https://github.com/advisories/GHSA-v9jr-rg53-9pgp
fix available via `npm audit fix --force`
Will install monaco-editor@0.53.0, which is a breaking change
node_modules/dompurify
  monaco-editor  >=0.54.0-dev-20250909
  Depends on vulnerable versions of dompurify
  node_modules/monaco-editor

electron  41.0.0-alpha.1 - 41.0.4
Severity: moderate
Electron: Use-after-free in offscreen shared texture release() callback - https://github.com/advisories/GHSA-8x5q-pvf5-64mp
Electron: Crash in clipboard.readImage() on malformed clipboard image data - https://github.com/advisories/GHSA-f37v-82c4-4x64
Electron: Named window.open targets not scoped to the opener's browsing context - https://github.com/advisories/GHSA-f3pv-wv63-48x8
fix available via `npm audit fix`
node_modules/electron

flatted  <=3.4.1
Severity: high
Prototype Pollution via parse() in NodeJS flatted - https://github.com/advisories/GHSA-rf6f-7fwh-wjgh
fix available via `npm audit fix`
node_modules/flatted

follow-redirects  <=1.15.11
Severity: moderate
follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets - https://github.com/advisories/GHSA-r4q5-vmmm-2653
fix available via `npm audit fix`
node_modules/follow-redirects

lodash  <=4.17.23
Severity: high
lodash vulnerable to Code Injection via `_.template` imports key names - https://github.com/advisories/GHSA-r5fr-rjxr-66jc
lodash vulnerable to Prototype Pollution via array path bypass in `_.unset` and `_.omit` - https://github.com/advisories/GHSA-f23m-r3pf-42rh
fix available via `npm audit fix`
node_modules/lodash
  @microsoft/api-extractor  4.0.0 - 7.58.0 || >=8.0.0
  Depends on vulnerable versions of lodash
  node_modules/@microsoft/api-extractor

node-forge  <=1.3.3
Severity: high
Forge has a basicConstraints bypass in its certificate chain verification (RFC 5280 violation) - https://github.com/advisories/GHSA-2328-f5f3-gj25
Forge has signature forgery in Ed25519 due to missing S > L check - https://github.com/advisories/GHSA-q67f-28xg-22rw
Forge has Denial of Service via Infinite Loop in BigInteger.modInverse() with Zero Input - https://github.com/advisories/GHSA-5m6q-g25r-mvwx
Forge has signature forgery in RSA-PKCS due to ASN.1 extra field   - https://github.com/advisories/GHSA-ppp5-5v6c-4jwp
fix available via `npm audit fix`
node_modules/node-forge

path-to-regexp  <0.1.13
Severity: high
path-to-regexp vulnerable to Regular Expression Denial of Service via multiple route parameters - https://github.com/advisories/GHSA-37ch-88jc-xwx2
fix available via `npm audit fix`
node_modules/path-to-regexp

picomatch  <=2.3.1 || 4.0.0 - 4.0.3
Severity: high
Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching - https://github.com/advisories/GHSA-3v7f-55p6-f55p
Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching - https://github.com/advisories/GHSA-3v7f-55p6-f55p
Picomatch has a ReDoS vulnerability via extglob quantifiers - https://github.com/advisories/GHSA-c2c7-rcm5-vvqj
Picomatch has a ReDoS vulnerability via extglob quantifiers - https://github.com/advisories/GHSA-c2c7-rcm5-vvqj
fix available via `npm audit fix`
node_modules/@types/jest/node_modules/picomatch
node_modules/picomatch

postcss  <8.5.10
Severity: moderate
PostCSS has XSS via Unescaped </style> in its CSS Stringify Output - https://github.com/advisories/GHSA-qx2v-qp2m-jg93
fix available via `npm audit fix`
node_modules/postcss

uuid  <14.0.0
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
fix available via `npm audit fix --force`
Will install webpack-dev-server@1.16.5, which is a breaking change
node_modules/uuid
  sockjs  >=0.3.17
  Depends on vulnerable versions of uuid
  node_modules/sockjs
    webpack-dev-server  >=2.0.0-beta
    Depends on vulnerable versions of sockjs
    node_modules/webpack-dev-server
      @pmmmwh/react-refresh-webpack-plugin  >=0.6.0-beta.0
      Depends on vulnerable versions of webpack-dev-server
      node_modules/@pmmmwh/react-refresh-webpack-plugin

yaml  1.0.0 - 1.10.2
Severity: moderate
yaml is vulnerable to Stack Overflow via deeply nested YAML collections - https://github.com/advisories/GHSA-48c2-rrv3-qjmp
fix available via `npm audit fix`
node_modules/yaml

24 vulnerabilities (4 low, 11 moderate, 9 high)
```
Relevant package trees:
```
foo\Bitburner>npm ls @tootallnate/once
bitburner@3.0.0 foo\Bitburner
`-- jest-environment-jsdom@29.7.0
  `-- jsdom@20.0.3
    `-- http-proxy-agent@5.0.0
      `-- @tootallnate/once@2.0.0

foo\Bitburner>npm ls @xmldom/xmldom
bitburner@3.0.0 foo\Bitburner
+-- @electron/packager@18.4.4
| `-- plist@3.1.0
|   `-- @xmldom/xmldom@0.8.11
`-- @mathjax/src@4.1.0
  `-- speech-rule-engine@5.0.0-beta.3
    `-- @xmldom/xmldom@0.9.8

foo\Bitburner>npm ls brace-expansion
bitburner@3.0.0 foo\Bitburner
+-- @electron/packager@18.4.4
| `-- @electron/universal@2.0.3
|   `-- minimatch@9.0.9
|     `-- brace-expansion@2.0.2
+-- @mathjax/src@4.1.0
| `-- mj-context-menu@1.0.0
|   `-- rimraf@6.1.2
|     `-- glob@13.0.0
|       `-- minimatch@10.2.4
|         `-- brace-expansion@5.0.4
+-- @microsoft/api-extractor@7.57.7
| `-- minimatch@10.2.3
|   `-- brace-expansion@5.0.4
`-- eslint-plugin-react@7.37.5
  `-- minimatch@3.1.5
    `-- brace-expansion@1.1.12

foo\Bitburner>npm ls dompurify
bitburner@3.0.0 foo\Bitburner
`-- monaco-editor@0.55.1
  `-- dompurify@3.2.7

foo\Bitburner>npm ls electron
bitburner@3.0.0 foo\Bitburner
`-- electron@41.0.3

foo\Bitburner>npm ls flatted
bitburner@3.0.0 foo\Bitburner
`-- eslint@8.52.0
  `-- file-entry-cache@6.0.1
    `-- flat-cache@3.1.1
      `-- flatted@3.4.1

foo\Bitburner>npm ls follow-redirects
bitburner@3.0.0 foo\Bitburner
`-- webpack-dev-server@5.2.2
  `-- http-proxy-middleware@2.0.9
    `-- http-proxy@1.18.1
      `-- follow-redirects@1.15.9

foo\Bitburner>npm ls lodash
bitburner@3.0.0 foo\Bitburner
+-- @microsoft/api-extractor@7.57.7
| `-- lodash@4.17.23 deduped
+-- html-webpack-plugin@5.6.3
| +-- lodash@4.17.23 deduped
| `-- pretty-error@4.0.0
|   +-- lodash@4.17.23 deduped
|   `-- renderkid@3.0.0
|     `-- lodash@4.17.23 deduped
`-- lodash@4.17.23

foo\Bitburner>npm ls node-forge
bitburner@3.0.0 foo\Bitburner
`-- webpack-dev-server@5.2.2
  `-- selfsigned@2.4.1
    `-- node-forge@1.3.2

foo\Bitburner>npm ls path-to-regexp
bitburner@3.0.0 foo\Bitburner
`-- webpack-dev-server@5.2.2
  `-- express@4.22.1
    `-- path-to-regexp@0.1.12

foo\Bitburner>npm ls picomatch
bitburner@3.0.0 foo\Bitburner
+-- @types/jest@30.0.0
| `-- expect@30.0.4
|   `-- jest-util@30.0.2
|     `-- picomatch@4.0.3
+-- babel-jest@29.7.0
| `-- @jest/transform@29.7.0
|   `-- micromatch@4.0.8
|     `-- picomatch@2.3.1 deduped
+-- jest-environment-jsdom@29.7.0
| `-- jest-util@29.7.0
|   `-- picomatch@2.3.1
`-- webpack-dev-server@5.2.2
  `-- chokidar@3.6.0
    +-- anymatch@3.1.3
    | `-- picomatch@2.3.1 deduped
    `-- readdirp@3.6.0
      `-- picomatch@2.3.1 deduped

foo\Bitburner>npm ls postcss
bitburner@3.0.0 foo\Bitburner
`-- css-loader@7.1.2
  +-- icss-utils@5.1.0
  | `-- postcss@8.4.49 deduped
  +-- postcss-modules-extract-imports@3.1.0
  | `-- postcss@8.4.49 deduped
  +-- postcss-modules-local-by-default@4.1.0
  | `-- postcss@8.4.49 deduped
  +-- postcss-modules-scope@3.2.1
  | `-- postcss@8.4.49 deduped
  +-- postcss-modules-values@4.0.0
  | `-- postcss@8.4.49 deduped
  `-- postcss@8.4.49

foo\Bitburner>npm ls uuid
bitburner@3.0.0 foo\Bitburner
`-- webpack-dev-server@5.2.2
  `-- sockjs@0.3.24
    `-- uuid@8.3.2

foo\Bitburner>npm ls yaml
bitburner@3.0.0 foo\Bitburner
`-- @emotion/react@11.14.0
  `-- @emotion/babel-plugin@11.13.5
    `-- babel-plugin-macros@3.1.0
      `-- cosmiconfig@7.1.0
        `-- yaml@1.10.2
```
I decided to update only electron. The vulnerabilities are mostly in dev packages. Some, such as lodash, are present in the production build, but they are not meaningfully "exploitable", considering how Bitburner works (we allow running arbitrary js code in the sandboxed js vm, so those vulnerabilities are not useful for malicious code at all). With some vulnerabilities, we need to wait for upstream fixes, e.g., dompurify in monaco.

Fixing these vulnerabilities results in non-trivial updates to `package-lock.json`. I am fairly hesitant to do that right now, given the upcoming stable release. It is better to handle these updates in the next dev cycle.

Tested on Windows 10 and Debian 13.