### PR TITLE
JEST: Update tests related to calculateExp and clampNumber

### DIFF
--- a/test/jest/formulas/Skill.test.ts
+++ b/test/jest/formulas/Skill.test.ts
@@ -1,3 +1,4 @@
+import { CONSTANTS } from "../../../src/Constants";
 import { calculateSkill, calculateExp } from "../../../src/PersonObjects/formulas/skill";
 
 describe("calculateSkill", () => {
@@ -18,7 +19,11 @@ describe("calculateSkill", () => {
     expect(calculateSkill(calculateExp(skill, 3.3), 3.3)).toBe(skill);
   });
   test("Special cases", () => {
-    expect(() => calculateExp(NaN)).toThrow();
+    if (CONSTANTS.isDevBranch) {
+      expect(() => calculateExp(NaN)).toThrow();
+    } else {
+      expect(calculateExp(NaN)).toBe(0);
+    }
     expect(calculateExp(Infinity)).toBe(Number.MAX_VALUE);
     expect(calculateExp(-Infinity)).toBe(0);
 


### PR DESCRIPTION
Context:
- #2711
- https://github.com/bitburner-official/bitburner-src/pull/1104#pullrequestreview-1903722595
- https://discord.com/channels/415207508303544321/459097632896188436/1499634842822770709

```
IIRC the justification for only throwing on Dev was so it would be extra annoying on dev and force us to fix whatever issue is allowing a NaN to slip in, without having the potential to break a player's savegame on the stable release. We can keep it that way or standardize it to work the same on both, but if we keep it how it is let's just update the test at some point so it accounts for the different behavior based on isDevBranch. Not a blocker for 3.0.0 release
```