### PR TITLE
WORKFLOWS: Update action versions

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,11 +22,11 @@ jobs:
     name: Build Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git-sha || inputs.git-sha || github.sha }}
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "npm"
@@ -39,14 +39,14 @@ jobs:
         shell: bash
         run: npm run electron-win
       - name: Upload x64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitburner-win32-x64
           include-hidden-files: true
           path: .build/bitburner-win32-x64/*
           if-no-files-found: error
       - name: Upload arm64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitburner-win32-arm64
           include-hidden-files: true
@@ -57,11 +57,11 @@ jobs:
     name: Build Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git-sha || inputs.git-sha || github.sha }}
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "npm"
@@ -72,14 +72,14 @@ jobs:
       - name: Build the Electron app
         run: npm run electron-linux
       - name: Upload x64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitburner-linux-x64
           include-hidden-files: true
           path: .build/bitburner-linux-x64/*
           if-no-files-found: error
       - name: Upload arm64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitburner-linux-arm64
           include-hidden-files: true
@@ -90,11 +90,11 @@ jobs:
     name: Build macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git-sha || inputs.git-sha || github.sha }}
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "npm"
@@ -105,7 +105,7 @@ jobs:
       - name: Build the Electron app
         run: npm run electron-mac
       - name: Upload darwin-universal artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bitburner-darwin-universal
           include-hidden-files: true

--- a/.github/workflows/build-upload-artifacts.yml
+++ b/.github/workflows/build-upload-artifacts.yml
@@ -19,9 +19,9 @@ jobs:
       contents: write
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: .build
           pattern: bitburner-*

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,8 +25,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: npm ci
@@ -38,7 +38,7 @@ jobs:
           else
             npm run build
           fi
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ".app"
       - name: Deploy to gh pages


### PR DESCRIPTION
Fixes #2717 

When running some Github actions, received some warnings about certain actions being deprecated due to upcoming node version requirements. See action run https://github.com/bitburner-official/bitburner-src/actions/runs/25240336774 as an example. It looks like without update these workflows may have run into some issues within the next couple months.

This PR just updates some of the commonly used workflows to use the latest version of the github actions, which has gotten rid of this warning. See workflow run https://github.com/bitburner-official/bitburner-src/actions/runs/25245022244 which had no warnings.