### PR TITLE
BUGFIX: Player can switch tabs without losing focus on current work

### DIFF
--- a/src/NetscriptFunctions/Grafting.ts
+++ b/src/NetscriptFunctions/Grafting.ts
@@ -89,7 +89,6 @@ export function NetscriptGrafting(): InternalAPI<IGrafting> {
           Player.startFocusing();
           Router.toPage(Page.Work);
         } else if (wasFocusing) {
-          Player.stopFocusing();
           Router.toPage(Page.Terminal);
         }
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -283,7 +283,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           Player.startFocusing();
           Router.toPage(Page.Work);
         } else if (wasFocusing) {
-          Player.stopFocusing();
           Router.toPage(Page.Terminal);
         }
         helpers.log(ctx, () => `Started ${classType} at ${universityName}`);
@@ -365,7 +364,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           Player.startFocusing();
           Router.toPage(Page.Work);
         } else if (wasFocusing) {
-          Player.stopFocusing();
           Router.toPage(Page.Terminal);
         }
         helpers.log(ctx, () => `Started training ${classType} at ${gymName}`);
@@ -570,7 +568,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         Router.toPage(Page.Work);
         return true;
       } else if (Player.focus && !focus) {
-        Player.stopFocusing();
         Router.toPage(Page.Terminal);
         return true;
       }
@@ -709,7 +706,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           Player.startFocusing();
           Router.toPage(Page.Work);
         } else if (wasFocused) {
-          Player.stopFocusing();
           Router.toPage(Page.Terminal);
         }
         helpers.log(ctx, () => `Began working at '${companyName}' with position '${jobName}'`);
@@ -834,7 +830,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
               Player.startFocusing();
               Router.toPage(Page.Work);
             } else if (wasFocusing) {
-              Player.stopFocusing();
               Router.toPage(Page.Terminal);
             }
             helpers.log(ctx, () => `Started carrying out hacking contracts for '${faction.name}'`);
@@ -855,7 +850,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
               Player.startFocusing();
               Router.toPage(Page.Work);
             } else if (wasFocusing) {
-              Player.stopFocusing();
               Router.toPage(Page.Terminal);
             }
             helpers.log(ctx, () => `Started carrying out field missions for '${faction.name}'`);
@@ -876,7 +870,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
               Player.startFocusing();
               Router.toPage(Page.Work);
             } else if (wasFocusing) {
-              Player.stopFocusing();
               Router.toPage(Page.Terminal);
             }
             helpers.log(ctx, () => `Started carrying out security work for '${faction.name}'`);
@@ -1009,7 +1002,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
           Player.startFocusing();
           Router.toPage(Page.Work);
         } else if (wasFocusing) {
-          Player.stopFocusing();
           Router.toPage(Page.Terminal);
         }
         helpers.log(ctx, () => `Began creating program: '${programName}'`);
@@ -1059,7 +1051,6 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         Player.startFocusing();
         Router.toPage(Page.Work);
       } else if (wasFocusing) {
-        Player.stopFocusing();
         Router.toPage(Page.Terminal);
       }
       return crimeTime;

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -266,6 +266,13 @@ export function GameRoot(): React.ReactElement {
           }
           break;
       }
+      // If the current page is Page.Work, the player is focusing on their current work. Switching to another page ends
+      // that focus, so we must call Player.stopFocusing() immediately after Router.toPage() to keep Player.focus in
+      // sync. Instead of repeating this logic wherever Router.toPage() is called, we should centralize the check and
+      // the Player.stopFocusing() call here.
+      if (pageWithContext.page === Page.Work && page !== Page.Work && Player.currentWork && Player.focus) {
+        Player.stopFocusing();
+      }
       setNextPage({ page, ...context } as PageWithContext);
     },
     back: () => {

--- a/src/ui/WorkInProgressRoot.tsx
+++ b/src/ui/WorkInProgressRoot.tsx
@@ -219,7 +219,6 @@ export function WorkInProgressRoot(): React.ReactElement {
         },
         unfocus: () => {
           Router.toPage(Page.City);
-          Player.stopFocusing();
         },
       },
       title: `You are attempting ${crime.workName}`,
@@ -266,7 +265,6 @@ export function WorkInProgressRoot(): React.ReactElement {
         },
         unfocus: () => {
           Router.toPage(Page.Location, { location: Locations[classWork.location] });
-          Player.stopFocusing();
         },
       },
       title: (
@@ -303,7 +301,6 @@ export function WorkInProgressRoot(): React.ReactElement {
         },
         unfocus: () => {
           Router.toPage(Page.Terminal);
-          Player.stopFocusing();
         },
       },
       title: (
@@ -334,7 +331,6 @@ export function WorkInProgressRoot(): React.ReactElement {
         },
         unfocus: () => {
           Router.toPage(Page.Terminal);
-          Player.stopFocusing();
         },
       },
       title: (
@@ -388,7 +384,6 @@ export function WorkInProgressRoot(): React.ReactElement {
         },
         unfocus: () => {
           Router.toPage(Page.Faction, { faction });
-          Player.stopFocusing();
         },
       },
       title: (
@@ -439,7 +434,6 @@ export function WorkInProgressRoot(): React.ReactElement {
           Router.toPage(Page.Job);
         },
         unfocus: () => {
-          Player.stopFocusing();
           Router.toPage(Page.Job);
         },
       },


### PR DESCRIPTION
MRE:
- Load a clean save file.
- Training at a gym.
- Press the RFA status icon in the overview window.
- The current tab switches to the setting page, but `Player.focus` is true.

I initially planned to fix the bug in `RemoteFileApiConnectionStatus.tsx`, but decided to centralize the check instead, as noted in the comments.