### PR TITLE
BUGFIX: Tutorial links to outdated FAQ url

### DIFF
--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -563,8 +563,8 @@ export async function main(ns) {
               materials for all NS APIs.
             </li>
             <li>
-              The <DocumentationLink page="help/beginner_faq.md">FAQ</DocumentationLink> contains questions often asked
-              by beginners of the game.
+              The <DocumentationLink page="help/faq.md">FAQ</DocumentationLink> contains questions often asked by
+              beginners of the game.
             </li>
           </ul>
           <Typography fontWeight="fontWeightBold">


### PR DESCRIPTION
`help/beginner_faq.md` was merged with `doc/FAQ.md` in #2427. The merged file is `help/faq.md`.