### PR TITLE
DARKNET: Fix typo in authentication response message

### DIFF
--- a/src/DarkNet/effects/labyrinth.ts
+++ b/src/DarkNet/effects/labyrinth.ts
@@ -270,7 +270,7 @@ export const handleLabyrinthPassword = (
     return {
       passwordAttempted: attemptedPassword,
       code: ResponseCodeEnum.Success,
-      message: "You have discovered the end the labyrinth.",
+      message: "You have discovered the end of the labyrinth.",
       data: labServer.password,
     };
   }


### PR DESCRIPTION
It's just as the title said.