### PR TITLE
DNET: Reset IP when servers restart

### DIFF
--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -1,10 +1,4 @@
-import {
-  changeIp,
-  connectServers,
-  DeleteServer,
-  disconnectServers,
-  GetServer,
-} from "../../Server/AllServers";
+import { changeIp, connectServers, DeleteServer, disconnectServers, GetServer } from "../../Server/AllServers";
 import {
   DarknetEvents,
   DarknetState,
@@ -66,7 +60,6 @@ export const mutateDarknet = (): void => {
   if (Math.random() > depthSpeedFactor) {
     return;
   }
-
 
   restartRandomServer();
   restartRandomServer();

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -61,10 +61,6 @@ export const mutateDarknet = (): void => {
     return;
   }
 
-  restartRandomServer();
-  restartRandomServer();
-  restartRandomServer();
-
   if (Math.random() < 0.3) {
     const islands = getIslands();
     const island = islands[Math.floor(Math.random() * islands.length)];

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -1,4 +1,10 @@
-import { connectServers, DeleteServer, disconnectServers, GetServer } from "../../Server/AllServers";
+import {
+  changeIp,
+  connectServers,
+  DeleteServer,
+  disconnectServers,
+  GetServer,
+} from "../../Server/AllServers";
 import {
   DarknetEvents,
   DarknetState,
@@ -60,6 +66,11 @@ export const mutateDarknet = (): void => {
   if (Math.random() > depthSpeedFactor) {
     return;
   }
+
+
+  restartRandomServer();
+  restartRandomServer();
+  restartRandomServer();
 
   if (Math.random() < 0.3) {
     const islands = getIslands();
@@ -307,6 +318,7 @@ export const restartServer = (server: DarknetServer): void => {
   serverState.authenticatedPIDs = [];
   serverState.serverLogs = [{ pid: -1, message: "Server restarting, terminating scripts..." }];
   server.backdoorInstalled = false;
+  changeIp(server);
   disconnectServer(server);
   addGuaranteedConnection(server);
 };

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -133,6 +133,13 @@ export const renameServer = (hostname: string, newName: string): void => {
   // No need to touch the entry keyed by IP
 };
 
+// Set a server's IP to a new, random, value
+export const changeIp = (server: BaseServer): void => {
+  AllServers.delete(server.ip);
+  server.ip = createUniqueRandomIp();
+  AllServers.set(server.ip, server);
+};
+
 export function prestigeAllServers(): void {
   AllServers.clear();
 }


### PR DESCRIPTION
At player's request, this PR assigns a new, random, IP to a darknet server when it is restarted, as if it was re-connected to the web and assigned a new IP. 

Context:
https://discord.com/channels/415207508303544321/1469814021883560046/1501258707827167242
https://discord.com/channels/415207508303544321/1469814021883560046/1501266896551543025
