### PR TITLE
INFILTRATION: Add HJKL key mappings for infiltration arrows

### DIFF
--- a/src/Infiltration/utils.ts
+++ b/src/Infiltration/utils.ts
@@ -14,15 +14,19 @@ export function getArrow(event: KeyboardLikeEvent): Arrow | undefined {
   switch (event.key) {
     case KEY.UP_ARROW:
     case KEY.W:
+    case KEY.K:
       return upArrowSymbol;
     case KEY.LEFT_ARROW:
     case KEY.A:
+    case KEY.H:
       return leftArrowSymbol;
     case KEY.DOWN_ARROW:
     case KEY.S:
+    case KEY.J:
       return downArrowSymbol;
     case KEY.RIGHT_ARROW:
     case KEY.D:
+    case KEY.L:
       return rightArrowSymbol;
   }
 }


### PR DESCRIPTION
Adds vim HJKL navigation to the infiltration minigames.

Since the game already supports editing in Vim-mode, i thought this was fitting. I definitely missed it when infiltrating.
