### PR TITLE
DNET: Fix money mults on hard nodes

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -836,7 +836,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): BitNodeMultiplier
         StaneksGiftPowerMultiplier: 0.5,
         StaneksGiftExtraSize: 2,
 
-        DarknetMoneyMultiplier: 0.5,
+        DarknetMoneyMultiplier: 0.05,
 
         WorldDaemonDifficulty: 2,
       });
@@ -1036,7 +1036,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): BitNodeMultiplier
 
         StaneksGiftPowerMultiplier: 2,
         StaneksGiftExtraSize: 1,
-        DarknetMoneyMultiplier: 0.5,
+        DarknetMoneyMultiplier: 0.1,
 
         WorldDaemonDifficulty: 3,
       });


### PR DESCRIPTION
- Reduced dnet money scaling on BN 9 and 13

This is a quick fix for the current state; I will be adding other non-monetary cache rewards later