### PR TITLE
UI: Show Darknet BitNode mutlipliers and separate Darknet from crime in player multipliers

### DIFF
--- a/src/BitNode/ui/BitnodeMultipliersDescription.tsx
+++ b/src/BitNode/ui/BitnodeMultipliersDescription.tsx
@@ -68,6 +68,7 @@ export const BitNodeMultipliersDisplay = ({ n, level, hideMultsIfCannotAccessFea
       <CloudServersMults n={n} mults={mults} />
       <StockMults n={n} mults={mults} />
       <CrimeMults n={n} mults={mults} />
+      <DarknetMults n={n} mults={mults} />
       <InfiltrationMults n={n} mults={mults} />
       <CompanyMults n={n} mults={mults} />
       <GangMults n={n} mults={mults} hideMultsIfCannotAccessFeature={hideMultsIfCannotAccessFeature} />
@@ -224,6 +225,17 @@ function CrimeMults({ mults }: IMultsProps): React.ReactElement {
   };
 
   return <BNMultTable sectionName="Crime" rowData={rows} mults={mults} />;
+}
+
+function DarknetMults({ mults }: IMultsProps): React.ReactElement {
+  const rows: IBNMultRows = {
+    DarknetMoneyMultiplier: {
+      name: "Darknet Money",
+      color: Settings.theme.money,
+    },
+  };
+
+  return <BNMultTable sectionName="Darknet" rowData={rows} mults={mults} />;
 }
 
 function SkillMults({ mults }: IMultsProps): React.ReactElement {

--- a/src/ui/CharacterStats.tsx
+++ b/src/ui/CharacterStats.tsx
@@ -533,14 +533,18 @@ export function CharacterStats(): React.ReactElement {
                   effValue: Player.mults.crime_money * currentNodeMults.CrimeMoney,
                   color: Settings.theme.money,
                 },
+              ]}
+              color={Settings.theme.combat}
+            />
+            <MultiplierTable
+              rows={[
                 {
                   mult: "Darknet Money",
                   value: Player.mults.dnet_money,
                   effValue: Player.mults.dnet_money * currentNodeMults.DarknetMoneyMultiplier,
-                  color: Settings.theme.money,
                 },
               ]}
-              color={Settings.theme.combat}
+              color={Settings.theme.money}
             />
             {Player.canAccessBladeburner() && currentNodeMults.BladeburnerRank > 0 && (
               <MultiplierTable


### PR DESCRIPTION
On the stats page, this change separates Darknet mults from crime in player mults, and additionally includes the BN mults for Darknet. I've only included `darknet money` as I think that's the only property we ever really impact in BN mults, but I'll add the TRP in labyrinth one if that's useful.

Additionally, if we'd prefer `Dark Net` over `Darknet` I'll tweak it - it's not hugely consistent.

Before:
<img width="1822" height="765" alt="image" src="https://github.com/user-attachments/assets/dbf3d4cd-e5c8-4d5f-b5a8-87be0fa1bf19" />
<img width="1799" height="676" alt="image" src="https://github.com/user-attachments/assets/4b3a3403-2c8a-47f2-bbe2-08be2e438cff" />

After:
<img width="908" height="497" alt="darknetUI2" src="https://github.com/user-attachments/assets/528e5eaf-157e-437c-8a01-ee38a67a3ecc" />
<img width="904" height="410" alt="darknetUI1" src="https://github.com/user-attachments/assets/bb65de75-c578-4911-a79e-6779a1965230" />