### PR TITLE
MISC: Support angle bracket type assertions in RAM calculation

### DIFF
--- a/src/ThirdParty/acorn-typescript-walk/index.ts
+++ b/src/ThirdParty/acorn-typescript-walk/index.ts
@@ -81,7 +81,7 @@ export function extendAcornWalkForTypeScriptNodes(base: any) {
   }
   // Only walk relevant TypeScript nodes.
   base.TSModuleBlock = base.BlockStatement;
-  base.TSAsExpression = base.TSNonNullExpression = base.ExpressionStatement;
+  base.TSTypeAssertion = base.TSAsExpression = base.TSNonNullExpression = base.ExpressionStatement;
   base.TSModuleDeclaration = (node: any, state: any, callback: any) => {
     callback(node.body, state);
   };


### PR DESCRIPTION
We currently support `TSAsExpression` (`foo as bar`) but not `TSTypeAssertion` (`<bar>foo`).

Test code:
```ts
export async function main(ns: NS) {
  <Server>ns.getServer();
}
```

Before:

<img width="864" height="427" alt="before" src="https://github.com/user-attachments/assets/a89eca1d-39c1-42cd-b84a-4c1d2543e400" />

After:

<img width="865" height="423" alt="after" src="https://github.com/user-attachments/assets/572c7944-6116-4645-b9d2-90b82ee986f4" />

Closes #2750.