### PR TITLE
API: Change getDarkwebPrograms return type to ProgramName[]

### DIFF
--- a/markdown/bitburner.singularity.getdarkwebprograms.md
+++ b/markdown/bitburner.singularity.getdarkwebprograms.md
@@ -9,11 +9,11 @@ Get a list of programs offered on the dark web.
 **Signature:**
 
 ```typescript
-getDarkwebPrograms(): string[];
+getDarkwebPrograms(): ProgramName[];
 ```
 **Returns:**
 
-string\[\]
+[ProgramName](./bitburner.programname.md)<!-- -->\[\]
 
 - a list of programs available for purchase on the dark web, or \[\] if Tor has not been purchased
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2835,7 +2835,7 @@ export interface Singularity {
    * @returns - a list of programs available for purchase on the dark web, or [] if Tor has not
    * been purchased
    */
-  getDarkwebPrograms(): string[];
+  getDarkwebPrograms(): ProgramName[];
 
   /**
    * Check the price of an exploit on the dark web


### PR DESCRIPTION
This is useful when passing the return values of `getDarkwebPrograms` to other APIs, such as `getDarkwebProgramCost` and `purchaseProgram`.