### PR TITLE
BUGFIX: getAugmentationBasePrice ignores bitnode mult for SoA augs

### DIFF
--- a/markdown/bitburner.singularity.getaugmentationbaseprice.md
+++ b/markdown/bitburner.singularity.getaugmentationbaseprice.md
@@ -58,5 +58,5 @@ Base price of the augmentation, before the player's price multiplier.
 
 RAM cost: 2.5 GB \* 16/4/1
 
-This excludes the player's price multiplier, but does include the relevant BitNode multipliers (e.g. the Shadows of Anarchy augmentation cost mult).
+This excludes the player's price multiplier, but does include the relevant BitNode multiplier (for all augs that aren't part of Shadows of Anarchy, which doesn't use BitNode multipliers).
 

--- a/markdown/bitburner.singularity.getaugmentationbaseprice.md
+++ b/markdown/bitburner.singularity.getaugmentationbaseprice.md
@@ -52,9 +52,11 @@ Name of Augmentation.
 
 number
 
-Base price of the augmentation, before price multiplier.
+Base price of the augmentation, before the player's price multiplier.
 
 ## Remarks
 
 RAM cost: 2.5 GB \* 16/4/1
+
+This excludes the player's price multiplier, but does include the relevant BitNode multipliers (e.g. the Shadows of Anarchy augmentation cost mult).
 

--- a/src/Augmentation/AugmentationHelpers.ts
+++ b/src/Augmentation/AugmentationHelpers.ts
@@ -14,7 +14,7 @@ import { mergeMultipliers } from "../PersonObjects/Multipliers";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { prestigeWorkerScripts } from "../NetscriptWorker";
 
-const soaAugmentationNames = [
+export const soaAugmentationNames = [
   AugmentationName.BeautyOfAphrodite,
   AugmentationName.ChaosOfDionysus,
   AugmentationName.FloodOfPoseidon,

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -5,7 +5,7 @@ import { CityName, CompletedProgramName, FactionWorkType, LocationName } from "@
 import { purchaseAugmentation, joinFaction, getFactionAugmentationsFiltered } from "../Faction/FactionHelpers";
 import { startWorkerScript } from "../NetscriptWorker";
 import { Augmentations } from "../Augmentation/Augmentations";
-import { getAugCost, installAugmentations } from "../Augmentation/AugmentationHelpers";
+import { getAugCost, installAugmentations, soaAugmentationNames } from "../Augmentation/AugmentationHelpers";
 import { CONSTANTS } from "../Constants";
 import { RunningScript } from "../Script/RunningScript";
 import { calculateAchievements } from "../Achievements/Achievements";
@@ -141,6 +141,11 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
       helpers.checkSingularityAccess(ctx);
       const augName = getEnumHelper("AugmentationName").nsGetMember(ctx, _augName);
       const aug = Augmentations[augName];
+      // SoA augmentations don't use the bitnode AugmentationMoneyCost multiplier;
+      // their cost only scales with the number of SoA augs already owned.
+      if (soaAugmentationNames.includes(augName)) {
+        return aug.baseCost;
+      }
       return aug.baseCost * currentNodeMults.AugmentationMoneyCost;
     },
     getAugmentationPrice: (ctx) => (_augName) => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2655,9 +2655,10 @@ export interface Singularity {
    * @remarks
    * RAM cost: 2.5 GB * 16/4/1
    *
+   * This excludes the player's price multiplier, but does include the relevant BitNode multipliers (e.g. the Shadows of Anarchy augmentation cost mult).
    *
    * @param augName - Name of Augmentation.
-   * @returns Base price of the augmentation, before price multiplier.
+   * @returns Base price of the augmentation, before the player's price multiplier.
    */
   getAugmentationBasePrice(augName: string): number;
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2655,7 +2655,7 @@ export interface Singularity {
    * @remarks
    * RAM cost: 2.5 GB * 16/4/1
    *
-   * This excludes the player's price multiplier, but does include the relevant BitNode multipliers (e.g. the Shadows of Anarchy augmentation cost mult).
+   * This excludes the player's price multiplier, but does include the relevant BitNode multiplier (for all augs that aren't part of Shadows of Anarchy, which doesn't use BitNode multipliers).
    *
    * @param augName - Name of Augmentation.
    * @returns Base price of the augmentation, before the player's price multiplier.


### PR DESCRIPTION
Fixes #2714.

SoA augmentations don't scale with the bitnode `AugmentationMoneyCost` multiplier; their cost is computed as `baseCost * SoACostMult^soaAugCount` in `getAugCost`. But `ns.singularity.getAugmentationBasePrice` was always multiplying by `currentNodeMults.AugmentationMoneyCost`, so it returned the wrong base price in any bitnode where that mult isn't 1 (e.g. BN11 = 2.0).

Exposed `soaAugmentationNames` from `AugmentationHelpers` and short-circuited the SoA case in `getAugmentationBasePrice` to return `aug.baseCost` directly, matching how `getAugCost` computes the SoA money cost.