### PR TITLE
CCT: Follow up to #2603

### DIFF
--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -106,7 +106,7 @@ export const HashUpgradesMetadata: HashUpgradeParams[] = [
     value: 10,
   },
   {
-    costPerLevel: 200,
+    costPerLevel: 65,
     desc: "Generate a random Coding Contract somewhere on the network",
     name: HashUpgradeEnum.GenerateCodingContract,
     effectText: (level: number): JSX.Element | null => <>Generated {level} contracts.</>,

--- a/src/Hacknet/data/HashUpgradesMetadata.tsx
+++ b/src/Hacknet/data/HashUpgradesMetadata.tsx
@@ -106,7 +106,7 @@ export const HashUpgradesMetadata: HashUpgradeParams[] = [
     value: 10,
   },
   {
-    costPerLevel: 65,
+    costPerLevel: 25,
     desc: "Generate a random Coding Contract somewhere on the network",
     name: HashUpgradeEnum.GenerateCodingContract,
     effectText: (level: number): JSX.Element | null => <>Generated {level} contracts.</>,


### PR DESCRIPTION
In #2603 we rebalanced ccts to spawn 3x more, and reduce the rewards by the same factor of 3.

The hash exchange multipliers were unchanged, resulting in a 3x nerf to hashnet's cct generation.

In this PR I change the cost per level to (almost) a third of the current cost - noting 200/3 is ugly and no other scaling factor changes by a non multiple of 10 currently. It could be `70` instead of `65`, but I feel this slight buff is not excessive for being a closer "round value". 

Another alternative is to spawn 3x ccts at per hash-exchange, and change the description to reflect that as well. I chose this option as the least "invasive" to player perceptions, but I'm ambivalent about which is preferable.