### PR TITLE
BUGFIX: Duplicate .lit and .cache files can be generated in dnet

### DIFF
--- a/src/DarkNet/effects/cacheFiles.ts
+++ b/src/DarkNet/effects/cacheFiles.ts
@@ -25,6 +25,9 @@ export const addCacheToServer = (server: DarknetServer, isPhishingCache: boolean
   if (!cacheFilename) {
     return { success: false, message: `Cannot generate path. prefix: ${prefix}` };
   }
+  if (server.caches.includes(cacheFilename)) {
+    return { success: false, message: `Duplicate cache file: ${cacheFilename}` };
+  }
   server.caches.push(cacheFilename);
   return { success: true, cacheFilename };
 };

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -125,7 +125,7 @@ export const addClue = (server: DarknetServer) => {
   // Basic mechanics hints
   if ((Math.random() < 0.7 && server.difficulty <= 3) || Math.random() < 0.1) {
     const hint: LiteratureName = hintLiterature[Math.floor(Math.random() * hintLiterature.length)];
-    if (hint) {
+    if (hint && !server.messages.includes(hint)) {
       server.messages.push(hint);
     }
   }

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -322,6 +322,12 @@ export abstract class BaseServer implements IServer {
     if (value.data.runningScripts != null && Array.isArray(value.data.runningScripts)) {
       server.savedScripts = value.data.runningScripts;
     }
+    // Remove duplicate .lit and .msg files.
+    const messageSet = new Set(server.messages);
+    if (messageSet.size !== server.messages.length) {
+      console.warn("Found duplicate messages in ", server.messages);
+      server.messages = [...messageSet];
+    }
     // If textFiles is not an array, we've already done the 2.3 migration to textFiles and scripts as maps + path changes.
     if (!Array.isArray(server.textFiles)) return server;
 

--- a/src/Server/DarknetServer.ts
+++ b/src/Server/DarknetServer.ts
@@ -89,7 +89,14 @@ export class DarknetServer extends BaseServer implements DarknetServerData {
   }
 
   static fromJSON(value: IReviverValue): DarknetServer {
-    return BaseServer.fromJSONBase(value, DarknetServer, includedKeys);
+    const server = BaseServer.fromJSONBase(value, DarknetServer, includedKeys);
+    // Remove duplicate .cache files.
+    const cacheSet = new Set(server.caches);
+    if (cacheSet.size !== server.caches.length) {
+      console.warn("Found duplicate cache files in ", server.caches);
+      server.caches = [...cacheSet];
+    }
+    return server;
   }
 }
 


### PR DESCRIPTION
MRE: Run test code and check the console log.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  Player.gainCharismaExp(1e100);
  for (let i = 0; i < 1000; ++i) {
    GetServer("darkweb").hasAdminRights = false;
    await ns.dnet.authenticate("darkweb", "");
  }
  const items = ns.ls("darkweb");
  const seen = new Set();
  const duplicates = new Set();
  for (const item of items) {
    if (seen.has(item)) {
      duplicates.add(item);
    } else {
      seen.add(item);
    }
  }
  console.log([...duplicates]);
}
```

This is the minimal fix. I can change `generateCacheFilename` to make it never generate duplicate cache files, but I'm not sure if it's necessary.