### PR TITLE
UI: Improve visual effect of "SoA - Flood of Poseidon" augmentation

### DIFF
--- a/src/Infiltration/ui/Cyberpunk2077Game.tsx
+++ b/src/Infiltration/ui/Cyberpunk2077Game.tsx
@@ -43,7 +43,7 @@ export function Cyberpunk2077Game({ stage }: IProps): React.ReactElement {
         <Typography variant="h5" color={Settings.theme.primary}>
           Targets:{" "}
           {stage.answers.map((a, i) => {
-            if (i == stage.currentAnswerIndex)
+            if (i === stage.currentAnswerIndex)
               return (
                 <span key={`${i}`} style={{ fontSize: "1em", color: Settings.theme.infolight }}>
                   {a}&nbsp;
@@ -70,7 +70,13 @@ export function Cyberpunk2077Game({ stage }: IProps): React.ReactElement {
               sx={{
                 fontSize: fontSize,
                 color: item.color,
-                border: item.selected ? `2px solid ${Settings.theme.infolight}` : "unset",
+                // Always use a 2px border to avoid small symbol position shifts caused by size changes (element vs
+                // element + 2px border).
+                border: item.selected
+                  ? `2px solid ${Settings.theme.infolight}`
+                  : hasAugment && item.content === stage.answers[stage.currentAnswerIndex]
+                  ? `2px solid ${Settings.theme.warning}`
+                  : "2px solid transparent",
                 lineHeight: "unset",
                 p: item.selected ? "2px" : "4px",
               }}

--- a/src/Infiltration/ui/Cyberpunk2077Game.tsx
+++ b/src/Infiltration/ui/Cyberpunk2077Game.tsx
@@ -64,26 +64,32 @@ export function Cyberpunk2077Game({ stage }: IProps): React.ReactElement {
             gap: 1,
           }}
         >
-          {flatGrid.map((item, idx) => (
-            <Typography
-              key={idx}
-              sx={{
-                fontSize: fontSize,
-                color: item.color,
-                // Always use a 2px border to avoid small symbol position shifts caused by size changes (element vs
-                // element + 2px border).
-                border: item.selected
-                  ? `2px solid ${Settings.theme.infolight}`
-                  : hasAugment && item.content === stage.answers[stage.currentAnswerIndex]
-                  ? `2px solid ${Settings.theme.warning}`
-                  : "2px solid transparent",
-                lineHeight: "unset",
-                p: item.selected ? "2px" : "4px",
-              }}
-            >
-              {item.content}
-            </Typography>
-          ))}
+          {flatGrid.map((item, idx) => {
+            let borderStyle = "solid";
+            let borderColor = "transparent";
+            if (item.selected) {
+              borderColor = Settings.theme.infolight;
+            } else if (hasAugment && item.content === stage.answers[stage.currentAnswerIndex]) {
+              borderStyle = "dashed";
+              borderColor = Settings.theme.warning;
+            }
+            return (
+              <Typography
+                key={idx}
+                sx={{
+                  fontSize: fontSize,
+                  color: item.color,
+                  // Always use a 2px border to avoid small symbol position shifts caused by size changes (element vs
+                  // element + 2px border).
+                  border: `2px ${borderStyle} ${borderColor}`,
+                  lineHeight: "unset",
+                  p: item.selected ? "2px" : "4px",
+                }}
+              >
+                {item.content}
+              </Typography>
+            );
+          })}
         </Box>
       </Paper>
     </>


### PR DESCRIPTION
A player asked why the "SoA - Flood of Poseidon" augmentation did not provide any hints. I did not understand what they meant until they mentioned that they are color-blind. The UI hint provided by this augmentation relies on the ability to distinguish colors, which is problematic for color-blind players.

This PR adds a border around the target symbol so that color-blind players can still identify it. The goal is similar to #1380, but applied to the "Match the symbols" game.

Before:

<img width="935" height="362" alt="before" src="https://github.com/user-attachments/assets/65c75ec3-b050-45aa-8a1a-f64ab5e459de" />

After:

<img width="940" height="369" alt="after" src="https://github.com/user-attachments/assets/d094fa4e-dd5d-4cf2-aef7-272c11b209ec" />

