### PR TITLE
UI: Show alert if browser is too outdated

### DIFF
--- a/src/utils/Protections.ts
+++ b/src/utils/Protections.ts
@@ -22,3 +22,10 @@ if (window.indexedDB) {
     writable: false,
   });
 }
+
+// Some players use really old browser versions on unsupported OSes such as Windows 7. Intl.Segmenter and other APIs are
+// not supported in these browsers, so they will only see a black screen when loading the game. We should show an alert
+// to notify them that they should update their browser, if possible.
+if (typeof Intl.Segmenter !== "function") {
+  alert(`Your browser is too outdated. Please update your browser.\n\nUserAgent: ${navigator.userAgent}`);
+}

--- a/src/utils/Protections.ts
+++ b/src/utils/Protections.ts
@@ -26,6 +26,18 @@ if (window.indexedDB) {
 // Some players use really old browser versions on unsupported OSes such as Windows 7. Intl.Segmenter and other APIs are
 // not supported in these browsers, so they will only see a black screen when loading the game. We should show an alert
 // to notify them that they should update their browser, if possible.
-if (typeof Intl.Segmenter !== "function") {
-  alert(`Your browser is too outdated. Please update your browser.\n\nUserAgent: ${navigator.userAgent}`);
+if (typeof Intl.Segmenter !== "function" || typeof String.prototype.toWellFormed !== "function") {
+  const errorMessage = `Your browser is too outdated. Please update your browser.\n\nUserAgent: ${navigator.userAgent}`;
+  alert(errorMessage);
+  const rootElement = document.getElementById("root");
+  if (rootElement) {
+    rootElement.innerText = errorMessage;
+    rootElement.style.color = "red";
+    rootElement.style.fontSize = "20px";
+    rootElement.style.justifyContent = "center";
+  }
+  // If the browser does not support Intl.Segmenter, initialization of graphemeSegmenter in StringHelperFunctions.ts
+  // will fail, so this throw is technically unnecessary. However, if toWellFormed is not supported, the game can still
+  // load normally while darknet initialization fails, potentially causing UI issues such as an empty darknet tab.
+  throw new Error(errorMessage);
 }


### PR DESCRIPTION
A player reported that the latest version only showed a black screen in Firefox. After investigating the report, I found that they were using a very old Firefox version that did not support `Intl.Segmenter`.

This PR adds a check that shows an alert informing players that their browser is too outdated and needs to be updated.

`Protections.ts` is the first script loaded by `index.tsx`, so I put this new check there.

Screenshot:

<img width="1309" height="605" alt="1" src="https://github.com/user-attachments/assets/998c20b8-8a1d-4dff-abd0-02bd9f7656b8" />

<img width="1307" height="696" alt="2" src="https://github.com/user-attachments/assets/26d5afa9-c66e-4572-a912-fbfb9a9a3b58" />
