### PR TITLE
MISC: Allow exporting save data even if game fails to load

### DIFF
--- a/export.html
+++ b/export.html
@@ -27,6 +27,12 @@
     </div>
     <!-- Use esm for top-level await -->
     <script type="module">
+      if (!window.indexedDB || typeof window.indexedDB.databases !== "function") {
+        const errorMessage = `Your browser is too outdated. Please update your browser.\n\nUserAgent: ${navigator.userAgent}`;
+        alert(errorMessage);
+        // This is the simplest way to stop execution in top-level code without using a labeled block or IIFE.
+        throw new Error(errorMessage);
+      }
       const databaseName = "bitburnerSave";
       // Check src/db.ts to see why the current max version is 2. If the database version is greater than this value, it
       // means that the code in this file is outdated.
@@ -35,7 +41,6 @@
       const database = databases.find((info) => info.name === databaseName);
       if (!database) {
         alert("There is no save data");
-        // This is the simplest way to stop execution in top-level code without using a labeled block or IIFE.
         throw new Error("There is no save data");
       }
       if (database.version === undefined || database.version > maxDatabaseVersion) {

--- a/src/ui/LoadingScreen.tsx
+++ b/src/ui/LoadingScreen.tsx
@@ -61,6 +61,8 @@ export function LoadingScreen(): React.ReactElement {
         <Grid item>
           <Typography>
             If the game fails to load, consider <a href="?noScripts">killing all scripts</a>
+            <br />
+            You can export your save data at <a href="./export.html">export.html</a>
           </Typography>
         </Grid>
       )}

--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -12,6 +12,7 @@ npm install
 cd ..
 
 # .app should have the fully built game already after npm run build
+cp export.html .package
 cp -r .app/* .package
 cp -r electron/* .package
 


### PR DESCRIPTION
In the Steam version, players can use `--export-save` flag to load `export.html` and export their save data. This is useful if the game fails to load for an unknown reason. This PR adds the same feature to the web version.
- Stable: https://bitburner-official.github.io/export.html
- Dev: https://bitburner-official.github.io/bitburner-src/export.html

After merging this PR, I'll ask Snarling to upload `export.html` to https://github.com/bitburner-official/bitburner-official.github.io.