### PR TITLE
FIX: Autocompletion not working on scripts when autocompleting a filepath

### DIFF
--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -52,14 +52,14 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
 
   /** The directory portion of the current input */
   let relativeDir = "";
+  let path = baseDir;
   const slashIndex = currentText.lastIndexOf("/");
 
   if (slashIndex !== -1) {
     relativeDir = currentText.substring(0, slashIndex + 1);
-    const path = resolveDirectory(relativeDir, baseDir);
+    path = resolveDirectory(relativeDir, baseDir);
     // No valid terminal inputs contain a / that does not indicate a path
     if (path === null) return [];
-    baseDir = path;
     pathingRequiredMatch = currentText.replace(/^.*\//, path).toLowerCase();
   } else if (baseDir !== root) {
     pathingRequiredMatch = (baseDir + currentText).toLowerCase();
@@ -84,7 +84,7 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
     for (const member of iterable) {
       if (ignoreCurrent && member.length <= requiredStart.length) continue;
       if (member.toLowerCase().startsWith(requiredStart)) {
-        possibilities.push(usePathing ? relativeDir + member.substring(baseDir.length) : member);
+        possibilities.push(usePathing ? relativeDir + member.substring(path.length) : member);
       }
     }
   }

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -57,10 +57,11 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
 
   if (slashIndex !== -1) {
     relativeDir = currentText.substring(0, slashIndex + 1);
-    absoluteDir = resolveDirectory(relativeDir, baseDir);
+    const path = resolveDirectory(relativeDir, baseDir);
     // No valid terminal inputs contain a / that does not indicate a path
-    if (absoluteDir === null) return [];
-    pathingRequiredMatch = currentText.replace(/^.*\//, absoluteDir).toLowerCase();
+    if (path === null) return [];
+    absoluteDir = path;
+    pathingRequiredMatch = currentText.replace(/^.*\//, path).toLowerCase();
   } else if (baseDir !== root) {
     pathingRequiredMatch = (baseDir + currentText).toLowerCase();
   }

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -52,15 +52,15 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
 
   /** The directory portion of the current input */
   let relativeDir = "";
-  let path = baseDir;
+  let absoluteDir = baseDir;
   const slashIndex = currentText.lastIndexOf("/");
 
   if (slashIndex !== -1) {
     relativeDir = currentText.substring(0, slashIndex + 1);
-    path = resolveDirectory(relativeDir, baseDir);
+    absoluteDir = resolveDirectory(relativeDir, baseDir);
     // No valid terminal inputs contain a / that does not indicate a path
-    if (path === null) return [];
-    pathingRequiredMatch = currentText.replace(/^.*\//, path).toLowerCase();
+    if (absoluteDir === null) return [];
+    pathingRequiredMatch = currentText.replace(/^.*\//, absoluteDir).toLowerCase();
   } else if (baseDir !== root) {
     pathingRequiredMatch = (baseDir + currentText).toLowerCase();
   }
@@ -84,7 +84,7 @@ export async function getTabCompletionPossibilities(terminalText: string, baseDi
     for (const member of iterable) {
       if (ignoreCurrent && member.length <= requiredStart.length) continue;
       if (member.toLowerCase().startsWith(requiredStart)) {
-        possibilities.push(usePathing ? relativeDir + member.substring(path.length) : member);
+        possibilities.push(usePathing ? relativeDir + member.substring(absoluteDir.length) : member);
       }
     }
   }

--- a/test/jest/Terminal/tabCompletion.test.ts
+++ b/test/jest/Terminal/tabCompletion.test.ts
@@ -9,10 +9,11 @@ import { CodingContract } from "../../../src/CodingContract/Contract";
 import { asFilePath } from "../../../src/Paths/FilePath";
 import { Directory, isAbsolutePath, isDirectoryPath, root } from "../../../src/Paths/Directory";
 import { hasTextExtension } from "../../../src/Paths/TextFilePath";
-import { hasScriptExtension } from "../../../src/Paths/ScriptFilePath";
+import { hasScriptExtension, type ScriptFilePath } from "../../../src/Paths/ScriptFilePath";
 import { LiteratureName, MessageFilename } from "../../../src/Enums";
 import { Terminal } from "../../../src/Terminal";
 import { IPAddress } from "../../../src/Types/strings";
+import { LoadedModule, type ScriptURL } from "../../../src/Script/LoadedModule";
 
 describe("getTabCompletionPossibilities", function () {
   let closeServer: Server;
@@ -88,18 +89,7 @@ describe("getTabCompletionPossibilities", function () {
   it("completes the scp command", async () => {
     writeFiles();
     let options = await getTabCompletionPossibilities("scp ", root);
-    const filesToMatch = [
-      "note.txt",
-      "folder1/text.txt",
-      "folder1/text2.txt",
-      "hack.js",
-      "weaken.js",
-      "grow.js",
-      "old.script",
-      "folder1/test.js",
-      "anotherFolder/win.js",
-      LiteratureName.AGreenTomorrow,
-    ];
+    const filesToMatch = [...textFilePaths, ...scriptFilePaths, LiteratureName.AGreenTomorrow];
     expect(options.sort()).toEqual(filesToMatch.sort());
     // Test the second command argument (server name)
     options = await getTabCompletionPossibilities("scp note.txt ", root);
@@ -117,7 +107,13 @@ describe("getTabCompletionPossibilities", function () {
       // From a directory but with relative path .., show stuff in the resolved directory with the relative pathing included
       options = await getTabCompletionPossibilities(`${command} ../`, asDirectory("folder1/"));
       expect(options.sort()).toEqual(
-        [...scriptFilePaths.map((path) => "../" + path), "../folder1/", "../anotherFolder/"].sort(),
+        [
+          ...scriptFilePaths.map((path) => "../" + path),
+          "../folder1/",
+          "../anotherFolder/",
+          "../hack/",
+          "../hack/utils/",
+        ].sort(),
       );
       options = await getTabCompletionPossibilities(`${command} ../folder1/../anotherFolder/`, asDirectory("folder1/"));
       expect(options.sort()).toEqual(["../folder1/../anotherFolder/win.js"]);
@@ -152,8 +148,73 @@ describe("getTabCompletionPossibilities", function () {
     // Also check the same files
     options = await getTabCompletionPossibilities("./", root);
     expect(options.sort()).toEqual(
-      [...runnableFilePaths.map((path) => "./" + path), "./folder1/", "./anotherFolder/"].sort(),
+      [
+        ...runnableFilePaths.map((path) => "./" + path),
+        "./folder1/",
+        "./anotherFolder/",
+        "./hack/",
+        "./hack/utils/",
+      ].sort(),
     );
+  });
+
+  it("autocomplete function", async () => {
+    writeFiles();
+    const tempAutocomplete = setUpAutocompleteFunction("temp.js");
+    const scriptAutocomplete = setUpAutocompleteFunction("hack/script.js");
+    const listServersAutocomplete = setUpAutocompleteFunction("hack/utils/listServers.js");
+
+    expect(await getTabCompletionPossibilities("run temp.js ", root)).toStrictEqual(["temp.js_foo"]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+
+    // Only suggest directories
+    expect(await getTabCompletionPossibilities("run temp.js ./hac", root)).toStrictEqual(["./hack/", "./hack/utils/"]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+
+    // Only suggest directories
+    expect(await getTabCompletionPossibilities("run temp.js hack/", root)).toStrictEqual(["hack/utils/"]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+    // Suggest nothing
+    expect(await getTabCompletionPossibilities("run temp.js hack/scr", root)).toStrictEqual([]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+    // Only suggest directories
+    expect(await getTabCompletionPossibilities("run temp.js hack/util", root)).toStrictEqual(["hack/utils/"]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+
+    // Only suggest directories
+    expect(await getTabCompletionPossibilities("run /temp.js hack/", root)).toStrictEqual(["hack/utils/"]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+    // Suggest nothing
+    expect(await getTabCompletionPossibilities("run /temp.js hack/scr", root)).toStrictEqual([]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+    // Only suggest directories
+    expect(await getTabCompletionPossibilities("run /temp.js hack/util", root)).toStrictEqual(["hack/utils/"]);
+    expect(tempAutocomplete).toHaveBeenCalledTimes(1);
+    tempAutocomplete.mockClear();
+
+    const hackDirectory = asDirectory("hack/");
+    // Not suggest any directories because none match "hack/hack/sc".
+    // Suggest the result of the autocomplete function because "hack/script.js_foo" matches "hack/sc".
+    expect(await getTabCompletionPossibilities("run script.js hack/sc", hackDirectory)).toStrictEqual([
+      "hack/script.js_foo",
+    ]);
+    expect(scriptAutocomplete).toHaveBeenCalledTimes(1);
+    scriptAutocomplete.mockClear();
+
+    // Not suggest any directories because none match "hack/hack/uti".
+    // Suggest the result of the autocomplete function because "hack/utils/listServers.js_foo" matches "hack/uti".
+    expect(await getTabCompletionPossibilities("run utils/listServers.js hack/uti", hackDirectory)).toStrictEqual([
+      "hack/utils/listServers.js_foo",
+    ]);
+    expect(listServersAutocomplete).toHaveBeenCalledTimes(1);
+    listServersAutocomplete.mockClear();
   });
 
   it("completes the cat command", async () => {
@@ -182,7 +243,7 @@ describe("getTabCompletionPossibilities", function () {
     writeFiles();
     for (const command of ["ls", "cd", "upload"]) {
       const options = await getTabCompletionPossibilities(`${command} `, root);
-      expect(options.sort()).toEqual(["folder1/", "anotherFolder/"].sort());
+      expect(options.sort()).toEqual(["folder1/", "anotherFolder/", "hack/", "hack/utils/"].sort());
     }
   });
 });
@@ -220,6 +281,9 @@ const scriptFilePaths = [
   "old.script",
   "folder1/test.js",
   "anotherFolder/win.js",
+  "temp.js",
+  "hack/script.js",
+  "hack/utils/listServers.js",
 ].sort();
 const contractFilePaths = ["testContract.cct", "anothercontract.cct"];
 function writeFiles() {
@@ -240,4 +304,17 @@ function writeFiles() {
     home.contracts.push(new CodingContract(filename));
   }
   home.messages.push(LiteratureName.AGreenTomorrow, MessageFilename.TruthGazer);
+}
+
+function setUpAutocompleteFunction(filePath: string) {
+  const home = Player.getHomeComputer();
+  const script = home.scripts.get(filePath as ScriptFilePath);
+  if (!script) {
+    throw `${filePath} does not exist`;
+  }
+  const autocomplete = jest.fn(() => {
+    return [`${filePath}_foo`];
+  });
+  script.mod = new LoadedModule("" as ScriptURL, new Promise((r) => r({ autocomplete })));
+  return autocomplete;
 }


### PR DESCRIPTION
### The issue
Fix the autocompletion not calling the autocomplete function  of the script when trying to  run a script using relative path while typing a file path containing /

For example :
You have a server with the files
```
temp.js hack/script.js hack/utils/listServers.js
``` 
The autocomplete will run fine until you type the / and then it will stop working
```shell
/>run temp.js hack/
/>run temp.js hack/scr
/>run temp.js hack/util
``` 
All of those case will fail to fetch the script  because it is trying to find it at /hack/temp.js

If you use an absolute path like
```shell
/>run /temp.js hack/
/>run /hack/script.js ./util
``` 
It will works as it loads the script correctly

Also the next ones will also work since the autocomplete directory and the script directory are the same(until you change autocomplete directory by reaching the next /)
```shell
hack/>run script.js hack/sc
hack/>run utils/listServers.js hack/uti
/>run temp.js ./hac
``` 

### The root cause of the issue
The reason for the bug is that when the getTabCompletionPossibilities function is run, the working directory(baseDir) is passed as an argument.
But when completing a path(aka an input with a /) it is changed to be the absolute path until the last / of the current autocompletion item.
But that same working directory is later used to find the location of the script (to get it's autocomplete function)

### The fix
The working directory was decoupled from the path of the current autocomplete in order to avoid interference between the two

PS: I ran the lint and format but couldn't find how to run the game on my distribution so I tested it by modifying directly the main bundle on my game since it's a very small patch


