### PR TITLE
MISC: Follow up to #2784

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -9,5 +9,6 @@ mkdir .app
 
 # Should be all the files needed.
 cp index.html .app
+cp export.html .app
 cp favicon.ico .app
 cp -r dist .app

--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -12,7 +12,6 @@ npm install
 cd ..
 
 # .app should have the fully built game already after npm run build
-cp export.html .package
 cp -r .app/* .package
 cp -r electron/* .package
 


### PR DESCRIPTION
When running `deploy-dev.yml`, everything in the generated `.app` folder is deployed to `https://bitburner-official.github.io/bitburner-src/`. This PR copies the top-level `export.html` in #2784 to the `.app` folder to ensure that `https://bitburner-official.github.io/bitburner-src/export.html` is deployed correctly.

This is only applied to the dev build, though. For the stable build, Snarling still needs to upload `export.html` manually.

Test:
- https://github.com/catloversg/bitburner-src/actions/runs/26092355335
- https://catloversg.github.io/bitburner-src/export.html