### PR TITLE
Fix tutorial blocking on n00dles.js filename casing

### DIFF
--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -718,6 +718,7 @@ export class Terminal {
       }
       const errorMessageForBadCommand =
         "Bad command. Please follow the tutorial or click 'Exit Tutorial' if you'd like to skip it.";
+      const tutorialArg = (arg: string | number | boolean) => String(arg).toLowerCase();
       switch (ITutorial.currStep) {
         case iTutorialSteps.TerminalHelp:
           if (commandArray.length === 1 && commandArray[0] === "help") {
@@ -817,10 +818,16 @@ export class Terminal {
           }
           break;
         case iTutorialSteps.TerminalCreateScript:
-          if (commandArray.length === 2 && commandArray[0] === "nano" && commandArray[1] === "n00dles.js") {
+          if (
+            commandArray.length === 2 &&
+            tutorialArg(commandArray[0]) === "nano" &&
+            tutorialArg(commandArray[1]) === "n00dles.js"
+          ) {
             iTutorialNextStep();
+            commandArray[0] = "nano";
+            commandArray[1] = "n00dles.js";
           } else {
-            this.error(errorMessageForBadCommand);
+            this.error("Bad command. Enter: nano n00dles.js (check case).");
             return;
           }
           break;
@@ -833,18 +840,30 @@ export class Terminal {
           }
           break;
         case iTutorialSteps.TerminalRunScript:
-          if (commandArray.length === 2 && commandArray[0] === "run" && commandArray[1] === "n00dles.js") {
+          if (
+            commandArray.length === 2 &&
+            tutorialArg(commandArray[0]) === "run" &&
+            tutorialArg(commandArray[1]) === "n00dles.js"
+          ) {
             iTutorialNextStep();
+            commandArray[0] = "run";
+            commandArray[1] = "n00dles.js";
           } else {
-            this.error(errorMessageForBadCommand);
+            this.error("Bad command. Enter: run n00dles.js (check case).");
             return;
           }
           break;
         case iTutorialSteps.ActiveScriptsToTerminal:
-          if (commandArray.length === 2 && commandArray[0] === "tail" && commandArray[1] === "n00dles.js") {
+          if (
+            commandArray.length === 2 &&
+            tutorialArg(commandArray[0]) === "tail" &&
+            tutorialArg(commandArray[1]) === "n00dles.js"
+          ) {
             iTutorialNextStep();
+            commandArray[0] = "tail";
+            commandArray[1] = "n00dles.js";
           } else {
-            this.error(errorMessageForBadCommand);
+            this.error("Bad command. Enter: tail n00dles.js (check case).");
             return;
           }
           break;

--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -323,14 +323,11 @@ export function InteractiveTutorialRoot(): React.ReactElement {
             hacking manually the entire time. You can automate your hacking by writing scripts!
             <br />
             <br />
-            To create a new script or edit an existing one, you can use{" "}
+            Scripts must end with a script extension (.js, .jsx, .ts, .tsx). Create your first script by entering
           </Typography>
-          <Typography classes={{ root: classes.textfield }}>{"[home /]> nano"}</Typography>
-
-          <Typography>
-            Scripts must end with a script extension (.js, .jsx, .ts, .tsx). Let's make a script now by entering
+          <Typography classes={{ root: classes.textfield }}>
+            {`[home /]> nano ${tutorialScriptName} (check case)`}
           </Typography>
-          <Typography classes={{ root: classes.textfield }}>{`[home /]> nano ${tutorialScriptName}`}</Typography>
         </>
       ),
       canNext: false,


### PR DESCRIPTION
## Summary

- Tutorial terminal gate accepts case-insensitive nano/run/tail with n00dles.js and normalizes the filename before the command runs.
- Create-script tutorial text shows a single command with (check case) instead of a misleading nano-only step.
- Step-specific error messages for those tutorial steps.

Fixes #2789

## Test plan

- [ ] Start a new game, reach the create-script tutorial step after home.
- [ ] nano n00dles.js advances and opens the editor.
- [ ] nano N00dles.js also advances and opens n00dles.js.
- [ ] nano alone shows: Enter: nano n00dles.js (check case).
- [ ] Later tutorial run/tail steps accept mixed-case n00dles.js.