### PR TITLE
BUGFIX: nano and vim open and save files on wrong servers in edge cases

### DIFF
--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -182,7 +182,12 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
 
   const clickPage = useCallback(
     (page: Page) => {
-      if (page == Page.ScriptEditor || page == Page.Documentation || page == Page.Options) {
+      if (page == Page.ScriptEditor) {
+        Router.toPage(page, {
+          files: new Map(),
+          options: { vim: Settings.MonacoDefaultToVim, hostname: Player.currentServer },
+        });
+      } else if (page == Page.Documentation || page == Page.Options) {
         Router.toPage(page, {});
       } else if (isSimplePage(page)) {
         Router.toPage(page);

--- a/src/Terminal/commands/common/editor.ts
+++ b/src/Terminal/commands/common/editor.ts
@@ -1,9 +1,9 @@
 import { Terminal } from "../../../Terminal";
-import { ScriptEditorRouteOptions, Page } from "../../../ui/Router";
+import { Page } from "../../../ui/Router";
 import { Router } from "../../../ui/GameRoot";
-import { BaseServer } from "../../../Server/BaseServer";
+import type { BaseServer } from "../../../Server/BaseServer";
 import { type ScriptFilePath, hasScriptExtension, isLegacyScript } from "../../../Paths/ScriptFilePath";
-import { TextFilePath, hasTextExtension } from "../../../Paths/TextFilePath";
+import { type TextFilePath, hasTextExtension } from "../../../Paths/TextFilePath";
 import { getGlobbedFileMap } from "../../../Paths/GlobbedFiles";
 import { sendDeprecationNotice } from "./deprecation";
 import { getFileType, getFileTypeFeature } from "../../../utils/ScriptTransformer";
@@ -14,6 +14,7 @@ import { hasCacheExtension } from "../../../Paths/CacheFilePath";
 interface EditorParameters {
   args: (string | number | boolean)[];
   server: BaseServer;
+  vim: boolean;
 }
 
 function getScriptTemplate(path: string): string {
@@ -33,11 +34,7 @@ export async function main(ns) {
   }
 }
 
-export function commonEditor(
-  command: string,
-  { args, server }: EditorParameters,
-  options?: ScriptEditorRouteOptions,
-): void {
+export function commonEditor(command: string, { args, server, vim }: EditorParameters): void {
   if (args.length < 1) return Terminal.error(`Incorrect usage of ${command} command. Usage: ${command} [scriptname]`);
   const files = new Map<ScriptFilePath | TextFilePath, string>();
   let hasLegacyScript = false;
@@ -76,5 +73,5 @@ export function commonEditor(
   if (hasLegacyScript) {
     sendDeprecationNotice();
   }
-  Router.toPage(Page.ScriptEditor, { files, options });
+  Router.toPage(Page.ScriptEditor, { files, options: { vim, hostname: server.hostname } });
 }

--- a/src/Terminal/commands/nano.ts
+++ b/src/Terminal/commands/nano.ts
@@ -1,7 +1,7 @@
-import { BaseServer } from "../../Server/BaseServer";
+import type { BaseServer } from "../../Server/BaseServer";
 
 import { commonEditor } from "./common/editor";
 
 export function nano(args: (string | number | boolean)[], server: BaseServer): void {
-  return commonEditor("nano", { args, server }, { vim: false });
+  return commonEditor("nano", { args, server, vim: false });
 }

--- a/src/Terminal/commands/vim.ts
+++ b/src/Terminal/commands/vim.ts
@@ -1,7 +1,7 @@
-import { BaseServer } from "../../Server/BaseServer";
+import type { BaseServer } from "../../Server/BaseServer";
 
 import { commonEditor } from "./common/editor";
 
 export function vim(args: (string | number | boolean)[], server: BaseServer): void {
-  return commonEditor("vim", { args, server }, { vim: true });
+  return commonEditor("vim", { args, server, vim: true });
 }

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -351,9 +351,9 @@ export function GameRoot(): React.ReactElement {
     case Page.ScriptEditor: {
       mainPage = (
         <ScriptEditorRoot
-          files={pageWithContext.files ?? new Map()}
-          hostname={pageWithContext.options?.hostname ?? Player.getCurrentServer().hostname}
-          vim={pageWithContext.options === undefined ? Settings.MonacoDefaultToVim : pageWithContext.options.vim}
+          files={pageWithContext.files}
+          hostname={pageWithContext.options.hostname}
+          vim={pageWithContext.options.vim}
         />
       );
       break;

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -72,7 +72,6 @@ import { V2Modal } from "../utils/V2Modal";
 import { useRerender } from "./React/hooks";
 import { HistoryProvider } from "./React/Documentation";
 import { GoRoot } from "../Go/ui/GoRoot";
-import { Settings } from "../Settings/Settings";
 import { isBitNodeFinished } from "../BitNode/BitNodeUtils";
 import { UIEventEmitter, UIEventType } from "./UIEventEmitter";
 import { exceptionAlert } from "../utils/helpers/exceptionAlert";

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -18,7 +18,7 @@ export type PageContext<T extends Page> = T extends ComplexPage.BitVerse
   : T extends ComplexPage.FactionAugmentations
   ? { faction: Faction }
   : T extends ComplexPage.ScriptEditor
-  ? { files?: Map<ScriptFilePath | TextFilePath, string>; options?: ScriptEditorRouteOptions }
+  ? { files: Map<ScriptFilePath | TextFilePath, string>; options: ScriptEditorRouteOptions }
   : T extends ComplexPage.Location
   ? { location: Location }
   : T extends ComplexPage.ImportSave
@@ -43,7 +43,7 @@ export type PageWithContext =
 
 export interface ScriptEditorRouteOptions {
   vim: boolean;
-  hostname?: string;
+  hostname: string;
 }
 
 /** The router keeps track of player navigation/routing within the game. */


### PR DESCRIPTION
MRE:
- Ensure you are connecting to home
- Expose `nano` and `GetServer`
- `globalThis.nano(["foo.txt"], globalThis.GetServer("n00dles"))`
- The editor shows `home:/foo.txt` instead of `n00dles:/foo.txt`
- Save `foo.txt` and go back to the terminal. Use `ls` to check the file list. `foo.txt` is saved on home instead of n00dles.

This bug can only be triggered with module raid. It is similar to #1051. `src/Terminal/commands/common/editor.ts` needs to use the `hostname` option added in #1062.