### PR TITLE
UI: Remove extra semicolon in Job page

### DIFF
--- a/src/Locations/ui/JobRoot.tsx
+++ b/src/Locations/ui/JobRoot.tsx
@@ -19,7 +19,7 @@ export function JobRoot(): React.ReactElement {
     }
     return (
       <Box key={companyName} sx={{ marginBottom: "20px" }}>
-        <GenericLocation location={location} showBackButton={false} />;
+        <GenericLocation location={location} showBackButton={false} />
       </Box>
     );
   });


### PR DESCRIPTION
The semi-colon was visible when selecting text that includes it, rendering the game LiterallyUnplayble™

## Before
<img width="928" height="405" alt="image" src="https://github.com/user-attachments/assets/aab03698-a928-46be-886e-583e6cb96f13" />

## After
<img width="897" height="386" alt="image" src="https://github.com/user-attachments/assets/193bd72d-cf2d-43cf-b2ee-e93929f64d51" />