### PR TITLE
MISC: Allow killing scripts during tutorial

### DIFF
--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -8,20 +8,12 @@ import { workerScripts } from "./WorkerScripts";
 
 import { GetAllServers, GetServer } from "../Server/AllServers";
 import { AddRecentScript } from "./RecentScripts";
-import { ITutorial } from "../InteractiveTutorial";
-import { AlertEvents } from "../ui/React/AlertManager";
 import { handleUnknownError } from "../utils/ErrorHandler";
 import { roundToTwo } from "../utils/helpers/roundToTwo";
 import { BaseServer } from "../Server/BaseServer";
 
-export function killWorkerScript(ws: WorkerScript): boolean {
-  if (ITutorial.isRunning) {
-    AlertEvents.emit("Processes cannot be killed during the tutorial.");
-    return false;
-  }
+export function killWorkerScript(ws: WorkerScript): void {
   stopAndCleanUpWorkerScript(ws);
-
-  return true;
 }
 
 export function killWorkerScriptByPid(pid: number, killer?: WorkerScript): boolean {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -675,18 +675,15 @@ export const ns: InternalAPI<NSFull> = {
       }
 
       helpers.log(ctx, () => "About to exit...");
-      const killed = killWorkerScript(ctx.workerScript);
+      killWorkerScript(ctx.workerScript);
 
       if (runOpts.spawnDelay === 0) {
         helpers.log(ctx, () => `Executing '${path}' immediately`);
         spawnCb();
       }
-
-      if (killed) {
-        // This prevents error messages about statements after the spawn()
-        // trying to be executed when the script is dead.
-        throw new ScriptDeath(ctx.workerScript);
-      }
+      // This prevents error messages about statements after the spawn()
+      // trying to be executed when the script is dead.
+      throw new ScriptDeath(ctx.workerScript);
     },
   self: (ctx) => () => {
     const runningScript = helpers.getRunningScript(ctx, ctx.workerScript.pid);


### PR DESCRIPTION
While implementing a suggestion on Discord (make `spawn` return `never` instead of `void`), I find a strange and partially broken "feature".

During the tutorial, we try to prevent the player from killing scripts. In the `TerminalRunScript` step, the player runs the example script, and later steps expect that script to still be running. If the script is killed, some tutorial steps may no longer work as expected, such as the tail log step.

This feature was added in 2fc17423ffaa13a562bdfb273425a65d4b1fa74b. At the time, `killWorkerScript` was the only exported function for killing scripts. However, starting from #440, many functions began calling `killWorkerScriptByPid` instead of `killWorkerScript`, which means there are now many ways to kill scripts during the tutorial. For example, in the `ActiveScriptsPage` step, the player can kill the running script by using the button in the Active Scripts page.

Since this feature has not worked properly for a long time and we have not received complaints about it, I think we should remove it. Doing so removes a special case from the codebase and also allows us to make `spawn` return `never` instead of `void`.