### PR TITLE
API: Make ns.spawn return never instead of void

### DIFF
--- a/markdown/bitburner.ns.spawn.md
+++ b/markdown/bitburner.ns.spawn.md
@@ -9,7 +9,7 @@ Terminate current script and start another in a defined number of milliseconds.
 **Signature:**
 
 ```typescript
-spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: ScriptArg[]): void;
+spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: ScriptArg[]): never;
 ```
 
 ## Parameters
@@ -82,7 +82,7 @@ Additional arguments to pass into the new script that is being run.
 
 **Returns:**
 
-void
+never
 
 ## Remarks
 

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -8,20 +8,12 @@ import { workerScripts } from "./WorkerScripts";
 
 import { GetAllServers, GetServer } from "../Server/AllServers";
 import { AddRecentScript } from "./RecentScripts";
-import { ITutorial } from "../InteractiveTutorial";
-import { AlertEvents } from "../ui/React/AlertManager";
 import { handleUnknownError } from "../utils/ErrorHandler";
 import { roundToTwo } from "../utils/helpers/roundToTwo";
 import { BaseServer } from "../Server/BaseServer";
 
-export function killWorkerScript(ws: WorkerScript): boolean {
-  if (ITutorial.isRunning) {
-    AlertEvents.emit("Processes cannot be killed during the tutorial.");
-    return false;
-  }
+export function killWorkerScript(ws: WorkerScript): void {
   stopAndCleanUpWorkerScript(ws);
-
-  return true;
 }
 
 export function killWorkerScriptByPid(pid: number, killer?: WorkerScript): boolean {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -675,18 +675,15 @@ export const ns: InternalAPI<NSFull> = {
       }
 
       helpers.log(ctx, () => "About to exit...");
-      const killed = killWorkerScript(ctx.workerScript);
+      killWorkerScript(ctx.workerScript);
 
       if (runOpts.spawnDelay === 0) {
         helpers.log(ctx, () => `Executing '${path}' immediately`);
         spawnCb();
       }
-
-      if (killed) {
-        // This prevents error messages about statements after the spawn()
-        // trying to be executed when the script is dead.
-        throw new ScriptDeath(ctx.workerScript);
-      }
+      // This prevents error messages about statements after the spawn()
+      // trying to be executed when the script is dead.
+      throw new ScriptDeath(ctx.workerScript);
     },
   self: (ctx) => () => {
     const runningScript = helpers.getRunningScript(ctx, ctx.workerScript.pid);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7950,7 +7950,7 @@ export interface NS {
    * @param threadOrOptions - Either an integer number of threads for new script, or a {@link SpawnOptions} object. Threads defaults to 1 and spawnDelay defaults to 10,000 ms.
    * @param args - Additional arguments to pass into the new script that is being run.
    */
-  spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: ScriptArg[]): void;
+  spawn(script: string, threadOrOptions?: number | SpawnOptions, ...args: ScriptArg[]): never;
 
   /**
    * Returns the currently running script.


### PR DESCRIPTION
`ns.exit` returns `never`, so it's useful in situation like this:

```ts
function getLength(ns: NS, x: string | null) {
  if (x === null) {
    ns.exit();
  }

  // x is narrowed to string
  return x.length;
}
```
`ns.spawn` also terminates the current script, similar to `ns.exit`. However, it currently returns `void`, so it cannot be used in the same way.

Note that this PR needs to be merged after #2797.