### PR TITLE
SCRIPT: fix bugs in static ram cost calculations caused by user-declared identifiers and destructuring

### DIFF
--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -332,14 +332,16 @@ function parseOnlyCalculateDeps(
 
   // References get added pessimistically. They are added for thisModule.name, name, and for
   // any aliases.
-  function addRef(key: string, name: string, module = currentModule): void {
+  function addRef(key: string, name: string, memberRhs = false, module = currentModule): void {
     const s = dependencyMap[key] || (dependencyMap[key] = new Set());
     const external = internalToExternal[name];
     if (external !== undefined) {
       s.add(external);
     }
     s.add(module + "." + name);
-    s.add(name); // For builtins like hack.
+    if (memberRhs) {
+      s.add(name); // For builtins like hack.
+    }
   }
 
   //A list of identifiers that resolve to "native Javascript code"
@@ -436,6 +438,9 @@ function parseOnlyCalculateDeps(
       MemberExpression: (node: acorn.MemberExpression, st: State, walkDeeper: walk.WalkerCallback<State>) => {
         node.object && walkDeeper(node.object, st);
         node.property && walkDeeper(node.property, st);
+        if (node.property?.type === "Identifier" && !objectPrototypeProperties.includes(node.property.name)) {
+          addRef(st.key, node.property.name, true);
+        }
       },
     };
   }
@@ -514,7 +519,7 @@ function parseOnlyCalculateDeps(
              */
             if (node.source != null && typeof node.source.value === "string" && specifier.local.type === "Identifier") {
               // if this is true, we are re-exporting something
-              addRef(exportedDepName, specifier.local.name, node.source.value as ScriptFilePath);
+              addRef(exportedDepName, specifier.local.name, false, node.source.value as ScriptFilePath);
               additionalModules.push(node.source.value as ScriptFilePath);
             } else if (specifier.local.type === "Identifier" && specifier.exported.name !== specifier.local.name) {
               // this makes sure we are not referring to ourselves

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -442,6 +442,20 @@ function parseOnlyCalculateDeps(
           addRef(st.key, node.property.name, true);
         }
       },
+      ObjectPattern: (node: acorn.ObjectPattern, st: State, walkDeeper: walk.WalkerCallback<State>) => {
+        for (const property of node.properties) {
+          if (property.type === "RestElement") continue;
+          const assignmentProperty = property;
+          assignmentProperty.key && walkDeeper(assignmentProperty.key, st);
+          assignmentProperty.value && walkDeeper(assignmentProperty.value, st);
+          if (
+            assignmentProperty.key?.type === "Identifier" &&
+            !objectPrototypeProperties.includes(assignmentProperty.key.name)
+          ) {
+            addRef(st.key, assignmentProperty.key.name, true);
+          }
+        }
+      },
     };
   }
 

--- a/test/jest/Netscript/RamCalculation.test.ts
+++ b/test/jest/Netscript/RamCalculation.test.ts
@@ -70,7 +70,7 @@ describe("Netscript RAM Calculation/Generation Tests", function () {
     expectedRamCost: number,
     extraLayerCost = 0,
   ) {
-    const code = `${fnPath.join(".")}();\n`.repeat(3);
+    const code = `ns.${fnPath.join(".")}();\n`.repeat(3);
     const fnName = fnPath[fnPath.length - 1];
     const server = "testserver";
 

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -134,6 +134,53 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
       const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
       expectCost(calculated, HackCost);
     });
+
+    it("Simple base NS function in a renamed variable", function () {
+      const code = `
+        export async function main(ns) {
+          const _ns = ns;
+          ns.hack("joesguns");
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, HackCost);
+    });
+
+    it("Simple base NS function in a renamed variable", function () {
+      const code = `
+        export async function main(ns) {
+          const _ns = ns;
+          ns.hack("joesguns");
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, HackCost);
+    });
+
+    it("Simple base NS function in destructuring renamed to another base NS function", function () {
+      const code = `
+        export async function main(ns) {
+          const { grow: hack } = ns;  // same as const hack = ns.grow;
+          hack();
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, GrowCost);
+    });
+
+    it("Simple base NS function in destructuring as function parameter", function () {
+      const code = `
+        export async function main(ns) {
+          doHack(ns);
+        }
+
+        function doHack({ hack }) {
+          hack();
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, HackCost);
+    });
   });
 
   describe("Functions that can be confused with NS functions", function () {
@@ -148,13 +195,23 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
       expectCost(calculated, 0);
     });
 
-    // TODO: once we fix static parsing this should pass
     it("Function 'getTask' that can be confused with Sleeve.getTask", function () {
       const code = `
         export async function main(ns) {
           getTask();
         }
         function getTask() { return 0; }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, 0);
+    });
+
+    it("Variable 'attempt' that can be confused with CodingContract.attempt", function () {
+      const code = `
+        export async function main(ns) {
+          const attempt = 0;
+          attempt = attempt + 1;
+        }
       `;
       const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
       expectCost(calculated, 0);
@@ -176,6 +233,50 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
       const code = `
         export async function main(ns) {
           ns.sleeve.getTask(3);
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, SleeveGetTaskCost);
+    });
+
+    it("Sleeve functions using a namespace alias", function () {
+      const code = `
+        export async function main(ns) {
+          const s = ns.sleeve;
+          s.getTask(3);
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, SleeveGetTaskCost);
+    });
+
+    it("Sleeve functions from destructuring", function () {
+      const code = `
+        export async function main(ns) {
+          const { getTask } = ns.sleeve;
+          getTask(3);
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, SleeveGetTaskCost);
+    });
+
+    it("Sleeve functions from destructuring with renaming", function () {
+      const code = `
+        export async function main(ns) {
+          const { getTask: gt } = ns.sleeve;
+          gt(3);
+        }
+      `;
+      const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
+      expectCost(calculated, SleeveGetTaskCost);
+    });
+
+    it("Sleeve function from nested destructuring with renaming", function () {
+      const code = `
+        export async function main(ns) {
+          const { sleeve: { getTask: gt } } = ns;
+          gt(3);
         }
       `;
       const calculated = calculateRamUsage(code, filename, server, new Map()).cost;
@@ -452,6 +553,25 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
           [incorrect_libNameTwo, incorrect_libScriptTwo],
         ]),
       ).cost;
+      expectCost(calculated, HackCost);
+    });
+    it("Importing a function that returns a reference to NS", function () {
+      const libName = "lib.js" as ScriptFilePath;
+      const libCode = `
+        export function getNS() {
+          return globalThis.ns;
+        }
+      `;
+      const lib = new Script(libName, libCode);
+      const code = `
+        import { getNS } from "lib";
+
+        export async function main(ns) {
+          globalThis.ns = ns;
+          getNS().hack();
+        }
+      `;
+      const calculated = calculateRamUsage(code, folderFilename, server, new Map([[libName, lib]])).cost;
       expectCost(calculated, HackCost);
     });
   });

--- a/test/jest/Netscript/StaticRamParsingCalculation.test.ts
+++ b/test/jest/Netscript/StaticRamParsingCalculation.test.ts
@@ -149,7 +149,7 @@ describe("Parsing NetScript code to work out static RAM costs", function () {
     });
 
     // TODO: once we fix static parsing this should pass
-    it.skip("Function 'getTask' that can be confused with Sleeve.getTask", function () {
+    it("Function 'getTask' that can be confused with Sleeve.getTask", function () {
       const code = `
         export async function main(ns) {
           getTask();


### PR DESCRIPTION
This tries to address the same kind of issues as #2758, but using a completely different approach. Multiple of the new tests added directly come from the discussion that happened there.

## Summary of the change

Previously, the static ram cost analysis was considering any identifier as possibly being a match for a costly ns function. With the new logic, only identifiers in the right hand side of member access will be considered. For this purpose, destructuring is considered as just syntactic sugar for member access.

The new logic is still very easy to explain to players if they encounter false positives. Instead of the current suggestion of having to rename any identifier, they only have to rename members of their own objects.

## Example 1

```js
/** @param {NS} ns */
export async function main(ns) {
  const target = "joesguns";
  let run = true;
  let exec = (hack) => hack("joesguns");
  while (run) {
    // ns.hack => triggers cost check for "hack"
    if (!await attempt(ns, exec, ns.hack, target)) {
      run = false;
    }
  }
}

/** @param {NS} ns */
async function attempt(ns, exec, hack, target) {
  // triggers cost check for all 4 getServer* identifiers.
  const {
    getServerSecurityLevel: sec,
    getServerMinSecurityLevel,
    getServerMoneyAvailable: money,
    getServerMaxMoney,
  } = ns;
  if (sec(target) > getServerMinSecurityLevel(target) ||
      money(target) > getServerMaxMoney(target)) {
    return false
  }
  await exec(hack);
  return true;
}
```

The previous logic would flag `run`, `attempt` and `exec` as being `ns.run`, `ns.codingcontract.attempt` and `ns.exec` respectively.

Before:
<img width="1125" height="936" alt="image" src="https://github.com/user-attachments/assets/f4f963f0-8827-4143-b84a-505b0b1ed373" />

After:
<img width="556" height="789" alt="image" src="https://github.com/user-attachments/assets/a28a1918-eac2-4496-83f3-99ecee74e766" />

## Example 2

Additionally, while doing some manual testing for this change, I realized that the previous logic was *not* counting destructuring identifiers when they get renamed, which the new logic handles properly:

```js
/** @param {NS} ns */
// static ram cost on v3.0.1 is 1.6GB instead of the actual 3.6GB.
export async function main(ns) {
  const { getServer: srv } = ns;
  ns.print(srv("joesguns"));
}
```

Before:
<img width="489" height="342" alt="image" src="https://github.com/user-attachments/assets/0d45808e-dfad-400b-81d5-6d1732ddf239" />

After:
<img width="489" height="348" alt="image" src="https://github.com/user-attachments/assets/f5f18692-f148-489e-a397-d0984642b746" />

## Related issues

This doesn't actually fix #875 since that issue is about the .hack field in the GangMemberInfo object. As I mentioned in #2758, I don't think it's possible to differentiate `gangMemberInfo.hack` from `ns.hack` without a fully-fledged type inference analysis.

## Testing

The new version is passing all the existing tests, with the only change in one test, which was testing the ram cost of things like `hack()`, which was changed to `ns.hack()`.

One of the existing skipped test is now unskipped since this PR fixes the issue highlighted by the test.

Many additional tests have been added.

I tested the change on my personal save and everything seems to work as expected. However, the only "normal" (not ram-dodged) I have is part of my batcher and the darkweb handler, so it's not saying all that much that it works.

## Possible further improvements

For the purpose of identifying the imported functions that are called, the current logic (which is not changed by the current PR) also considers rhs of member access as possible match for the imported functions, but I don't think that can ever be the case:

```js
import { costlyFunction } from "lib.js";
export async main(ns) {
  // I don't think this costlyFunction identifier can possibly directly reference the imported one, without a previous `foo.costlyFunction = costlyFunction`, which is where we should trigger the dependency.
  foo.costlyFunction();
}
```

I would prefer to keep this out of scope for the current PR.