### PR TITLE
API: more precise 'data' typing for TotalPrimesInRange contract

### DIFF
--- a/markdown/bitburner.codingcontractsignatures.md
+++ b/markdown/bitburner.codingcontractsignatures.md
@@ -37,7 +37,7 @@ export type CodingContractSignatures = {
   "Encryption I: Caesar Cipher": [[string, number], string];
   "Encryption II: Vigenère Cipher": [[string, string], string];
   "Square Root": [bigint, bigint, [string, string]];
-  "Total Number of Primes": [number[], number];
+  "Total Number of Primes": [[number, number], number];
   "Largest Rectangle in a Matrix": [(1 | 0)[][], [[number, number], [number, number]]];
 };
 ```

--- a/src/CodingContract/contracts/TotalPrimesInRange.ts
+++ b/src/CodingContract/contracts/TotalPrimesInRange.ts
@@ -1,10 +1,10 @@
 import { CodingContractName } from "@enums";
-import { CodingContractTypes } from "../ContractTypes";
 import { getRandomIntInclusive } from "../../utils/helpers/getRandomIntInclusive";
+import type { CodingContractTypes } from "../ContractTypes";
 
 export const totalPrimesInRange: Pick<CodingContractTypes, CodingContractName.TotalPrimesInRange> = {
   [CodingContractName.TotalPrimesInRange]: {
-    desc: (data: number[]): string => {
+    desc: (data: [number, number]): string => {
       return [
         `You are given two random non-negative integers: ${data}.\n`,
         `The first will be up to 5000000, and the second will be at most 1000000 greater.\n`,
@@ -14,7 +14,7 @@ export const totalPrimesInRange: Pick<CodingContractTypes, CodingContractName.To
       ].join(" ");
     },
     difficulty: 2,
-    generate: (): number[] => {
+    generate: (): [number, number] => {
       //The total range of values across all contracts, and minimum range for each contract is intended to make a pre-generated array of primes impractical,
       //and naive approaches for checking every value for primality slower but possible if well written.
       const low = getRandomIntInclusive(0, 5e6);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -9598,7 +9598,7 @@ export type CodingContractSignatures = {
   "Encryption I: Caesar Cipher": [[string, number], string];
   "Encryption II: Vigenère Cipher": [[string, string], string];
   "Square Root": [bigint, bigint, [string, string]];
-  "Total Number of Primes": [number[], number];
+  "Total Number of Primes": [[number, number], number];
   "Largest Rectangle in a Matrix": [(1 | 0)[][], [[number, number], [number, number]]];
 };
 


### PR DESCRIPTION
Updated the TS definition of 'data' for contracts of type 'Total Number of Primes' from number[] to [number, number], similar to other contracts. This better matches the actual provided data structure.