### PR TITLE
DNET: Fix issues in MathML puzzle

### DIFF
--- a/src/DarkNet/controllers/ServerGenerator.ts
+++ b/src/DarkNet/controllers/ServerGenerator.ts
@@ -514,7 +514,7 @@ export const parseSimpleArithmeticExpression = (expression: string): number => {
 
 export const generateSimpleArithmeticExpression = (difficulty: number): string => {
   const operators = ["+", "-", "*", "/"];
-  const operatorCount = Math.min(Math.floor(difficulty / 4), 1);
+  const operatorCount = Math.max(Math.floor(difficulty / 4), 1);
   const expression = [];
   for (let i = 0; i < operatorCount; i++) {
     expression.push(Math.ceil(Math.random() * 98));

--- a/src/DarkNet/controllers/ServerGenerator.ts
+++ b/src/DarkNet/controllers/ServerGenerator.ts
@@ -514,7 +514,7 @@ export const parseSimpleArithmeticExpression = (expression: string): number => {
 
 export const generateSimpleArithmeticExpression = (difficulty: number): string => {
   const operators = ["+", "-", "*", "/"];
-  const operatorCount = Math.floor(difficulty / 4);
+  const operatorCount = Math.min(Math.floor(difficulty / 4), 1);
   const expression = [];
   for (let i = 0; i < operatorCount; i++) {
     expression.push(Math.ceil(Math.random() * 98));

--- a/src/DarkNet/effects/authentication.ts
+++ b/src/DarkNet/effects/authentication.ts
@@ -155,7 +155,8 @@ export const isCloseToCorrectPassword = (
   logIfNotClose = false,
 ): boolean => {
   const difference = Math.abs(attemptedPassword - Number(correctPassword));
-  const result = difference < 0.01 || difference / Number(correctPassword) < 0.005;
+  const fractionalDiff = Math.abs(difference / Number(correctPassword));
+  const result = difference < 0.01 || fractionalDiff < 0.005;
 
   if (logIfNotClose && !result) {
     console.warn(`Attempted password ${attemptedPassword} is not close enough to correct password ${correctPassword}`);

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -247,7 +247,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
 
         if (Player.skills.charisma < server.requiredCharismaSkill) {
           logger(ctx)(
-            `You need a higher charisma level to extract data from ${server.hostname}. (${server.requiredHackingSkill} required)`,
+            `You need a higher charisma level to extract data from ${server.hostname}. (${server.requiredCharismaSkill} required)`,
           );
           return helpers.netscriptDelay(ctx, 100).then(() => ({
             success: false,


### PR DESCRIPTION
- Show correct stat in heartbleed error message about cha requirement
- Set a minimum in the MathML arithmatic expression puzzle to prevent a single number from being the hint and password
- Fix the "close enough" detection for floating point passwords to correctly handle if the password is negative