### PR TITLE
BUGFIX: Fixed MathML darknet nodes with negative valued passwords would incorrectly allow wrong passwords

### DIFF
--- a/markdown/bitburner.hackingformulas.md
+++ b/markdown/bitburner.hackingformulas.md
@@ -134,7 +134,7 @@ Calculate hack time.
 
 </td><td>
 
-Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is `1 + (cores - 1) / 16}`<!-- -->.
+Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is `1 + (cores - 1) / 16`<!-- -->.
 
 
 </td></tr>

--- a/markdown/bitburner.hackingformulas.weakeneffect.md
+++ b/markdown/bitburner.hackingformulas.weakeneffect.md
@@ -4,7 +4,7 @@
 
 ## HackingFormulas.weakenEffect() method
 
-Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is `1 + (cores - 1) / 16}`<!-- -->.
+Calculate the security decrease from a weaken operation. Unlike other hacking formulas, weaken effect depends only on thread count and core count, not on server or player properties. The core bonus formula is `1 + (cores - 1) / 16`<!-- -->.
 
 **Signature:**
 

--- a/src/DarkNet/effects/authentication.ts
+++ b/src/DarkNet/effects/authentication.ts
@@ -155,7 +155,7 @@ export const isCloseToCorrectPassword = (
   logIfNotClose = false,
 ): boolean => {
   const difference = Math.abs(attemptedPassword - Number(correctPassword));
-  const result = difference < 0.01 || difference / Number(correctPassword) < 0.005;
+  const result = difference < 0.01 || Math.abs(difference / Number(correctPassword)) < 0.005;
 
   if (logIfNotClose && !result) {
     console.warn(`Attempted password ${attemptedPassword} is not close enough to correct password ${correctPassword}`);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6296,7 +6296,7 @@ interface HackingFormulas {
    * Calculate the security decrease from a weaken operation.
    * Unlike other hacking formulas, weaken effect depends only on thread count and
    * core count, not on server or player properties. The core bonus formula is
-   * `1 + (cores - 1) / 16}`.
+   * `1 + (cores - 1) / 16`.
    * @param threads - Number of threads running weaken.
    * @param cores - Number of cores on the host server. Default 1.
    * @returns The security decrease amount.


### PR DESCRIPTION
Fixed bug where MathML darknet nodes with negative valued math expressions would incorrectly allow wrong passwords