### PR TITLE
BUGFIX: Stock market UI crashes when using long currency symbol

### DIFF
--- a/src/StockMarket/ui/StockTickerHeaderText.tsx
+++ b/src/StockMarket/ui/StockTickerHeaderText.tsx
@@ -13,6 +13,7 @@ import { Settings } from "../../Settings/Settings";
 import { formatMoney, formatPercent } from "../../ui/formatNumber";
 import Typography from "@mui/material/Typography";
 import { getDarknetVolatilityMult } from "../../DarkNet/effects/effects";
+import { clampNumber } from "../../utils/helpers/clampNumber";
 
 interface IProps {
   stock: Stock;
@@ -31,7 +32,7 @@ export function StockTickerHeaderText(props: IProps): React.ReactElement {
       stock.name.length +
       (TickerHeaderFormatData.longestSymbol - stock.symbol.length),
   );
-  const spacesBeforePrice = " ".repeat(spacesAllottedForStockPrice - stockPriceFormat.length);
+  const spacesBeforePrice = " ".repeat(clampNumber(spacesAllottedForStockPrice - stockPriceFormat.length, 0));
 
   let hdrText = `${stock.name}${spacesAfterStockName}${stock.symbol} -${spacesBeforePrice}${stockPriceFormat}`;
   if (Player.has4SData) {
@@ -42,9 +43,6 @@ export function StockTickerHeaderText(props: IProps): React.ReactElement {
       plusOrMinus = !plusOrMinus;
     }
     hdrText += (plusOrMinus ? "+" : "-").repeat(Math.floor(Math.abs(stock.otlkMag) / 10) + 1);
-
-    // Debugging:
-    // hdrText += ` - ${stock.getAbsoluteForecast()} / ${stock.otlkMagForecast}`;
   }
 
   let color = Settings.theme.success;


### PR DESCRIPTION
MRE: Set "foofoofoofoofoofoo" as the currency symbol and open the Stock Market tab.

Stack trace:
```
RangeError: Invalid count value: -13
    at String.repeat (<anonymous>)
    at StockTickerHeaderText (webpack://bitburner/./src/StockMarket/ui/StockTickerHeaderText.tsx?:29:33)
    at renderWithHooks (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:14985:18)
    at mountIndeterminateComponent (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:17811:13)
    at beginWork (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:19049:16)
    at HTMLUnknownElement.callCallback (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:3945:14)
    at Object.invokeGuardedCallbackDev (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:3994:16)
    at invokeGuardedCallback (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:4056:31)
    at beginWork$1 (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:23960:7)
    at performUnitOfWork (webpack://bitburner/./node_modules/react-dom/cjs/react-dom.development.js?:22775:12)
```

This is the minimal fix. `localesWithLongPriceFormat` is not really useful, but I left it as-is.

Fixes #2799.