### PR TITLE
DOC: fix incorrect namespace for getCheatSuccessChance in several function descriptions

### DIFF
--- a/markdown/bitburner.gocheat.destroynode.md
+++ b/markdown/bitburner.gocheat.destroynode.md
@@ -6,7 +6,7 @@
 
 Attempts to destroy an empty node, leaving an offline dead space that does not count as territory or provide open node access to adjacent routers.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 

--- a/markdown/bitburner.gocheat.md
+++ b/markdown/bitburner.gocheat.md
@@ -34,7 +34,7 @@ Description
 
 Attempts to destroy an empty node, leaving an offline dead space that does not count as territory or provide open node access to adjacent routers.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 
@@ -73,7 +73,7 @@ Warning: if you fail to play a cheat move, your turn will be skipped. After your
 
 Attempts to place two routers at once on empty nodes. Note that this ignores other move restrictions, so you can suicide your own routers if they have no access to empty ports and do not capture any enemy routers.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 
@@ -88,7 +88,7 @@ Warning: if you fail to play a cheat move, your turn will be skipped. After your
 
 Attempts to remove an existing router, leaving an empty node behind.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 
@@ -103,7 +103,7 @@ Warning: if you fail to play a cheat move, your turn will be skipped. After your
 
 Attempts to repair an offline node, leaving an empty playable node behind.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 

--- a/markdown/bitburner.gocheat.playtwomoves.md
+++ b/markdown/bitburner.gocheat.playtwomoves.md
@@ -6,7 +6,7 @@
 
 Attempts to place two routers at once on empty nodes. Note that this ignores other move restrictions, so you can suicide your own routers if they have no access to empty ports and do not capture any enemy routers.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 

--- a/markdown/bitburner.gocheat.removerouter.md
+++ b/markdown/bitburner.gocheat.removerouter.md
@@ -6,7 +6,7 @@
 
 Attempts to remove an existing router, leaving an empty node behind.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 

--- a/markdown/bitburner.gocheat.repairofflinenode.md
+++ b/markdown/bitburner.gocheat.repairofflinenode.md
@@ -6,7 +6,7 @@
 
 Attempts to repair an offline node, leaving an empty playable node behind.
 
-Success chance can be seen via ns.go.getCheatSuccessChance()
+Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
 
 Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a small (\~10%) chance you will instantly be ejected from the subnet.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -5438,7 +5438,7 @@ export interface GoCheat {
   /**
    * Attempts to remove an existing router, leaving an empty node behind.
    *
-   * Success chance can be seen via ns.go.getCheatSuccessChance()
+   * Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
    *
    * Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a
    * small (~10%) chance you will instantly be ejected from the subnet.
@@ -5466,7 +5466,7 @@ export interface GoCheat {
    * Attempts to place two routers at once on empty nodes. Note that this ignores other move restrictions, so you can
    * suicide your own routers if they have no access to empty ports and do not capture any enemy routers.
    *
-   * Success chance can be seen via ns.go.getCheatSuccessChance()
+   * Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
    *
    * Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a
    * small (~10%) chance you will instantly be ejected from the subnet.
@@ -5498,7 +5498,7 @@ export interface GoCheat {
   /**
    * Attempts to repair an offline node, leaving an empty playable node behind.
    *
-   * Success chance can be seen via ns.go.getCheatSuccessChance()
+   * Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
    *
    * Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a
    * small (~10%) chance you will instantly be ejected from the subnet.
@@ -5527,7 +5527,7 @@ export interface GoCheat {
    * Attempts to destroy an empty node, leaving an offline dead space that does not count as territory or
    * provide open node access to adjacent routers.
    *
-   * Success chance can be seen via ns.go.getCheatSuccessChance()
+   * Success chance can be seen via ns.go.cheat.getCheatSuccessChance()
    *
    * Warning: if you fail to play a cheat move, your turn will be skipped. After your first cheat attempt, if you fail, there is a
    * small (~10%) chance you will instantly be ejected from the subnet.


### PR DESCRIPTION
Here is an example of the new documentation:
<img width="859" height="187" alt="image" src="https://github.com/user-attachments/assets/384ef8fc-7a93-4ef0-9343-63bf40640eb6" />