### PR TITLE
UI: improve explanation of highest charge on Stanek fragment boost

### DIFF
--- a/src/CotMG/ui/FragmentInspector.tsx
+++ b/src/CotMG/ui/FragmentInspector.tsx
@@ -38,6 +38,8 @@ export function FragmentInspector(props: IProps): React.ReactElement {
           <br />
           Charge: N/A
           <br />
+          Highest charge: N/A
+          <br />
           root [X, Y] N/A
           <br />
         </Typography>
@@ -47,10 +49,12 @@ export function FragmentInspector(props: IProps): React.ReactElement {
   const f = props.fragment.fragment();
 
   let charge = formatStaneksGiftCharge(props.fragment.highestCharge * props.fragment.numCharge);
+  let highestCharge = formatStaneksGiftCharge(props.fragment.highestCharge);
   let effect = "N/A";
   // Boosters cannot be charged.
   if (f.type === FragmentTypeEnum.Booster) {
     charge = "N/A";
+    highestCharge = "N/A";
     effect = `${f.power}x adjacent fragment power`;
   } else if (Effect(f.type).includes("+x%")) {
     effect = Effect(f.type).replace(/-*x%/, formatPercent(props.gift.effect(props.fragment) - 1));
@@ -73,6 +77,8 @@ export function FragmentInspector(props: IProps): React.ReactElement {
         Base Power: {formatStaneksGiftPower(f.power)}
         <br />
         Charge: {charge}
+        <br />
+        Highest Charge: {highestCharge}
         <br />
         root [X, Y] {props.fragment.x}, {props.fragment.y}
         <br />

--- a/src/CotMG/ui/StaneksGiftRoot.tsx
+++ b/src/CotMG/ui/StaneksGiftRoot.tsx
@@ -170,12 +170,12 @@ export function StaneksGiftRoot({ staneksGift }: IProps): React.ReactElement {
                   Stat Fragments are charged using the stanek.chargeFragment(rootX, rootY) NetScript API function. The
                   charging process ordinarily takes 1000ms to complete, but only takes 200ms during bonus time. When the
                   function finishes executing, the fragment's charge levels will be raised by an amount corresponding to
-                  the number of threads that were used. Note that it is generally more effective to charge a fragment a
-                  few times with many threads than to charge it many times with few threads, so there is a benefit to
-                  combining charging jobs into fewer scripts. As a Stat Fragment's charge level is increased, its
-                  bonuses will increase, but there will be diminishing returns. As such, it is generally most efficient
-                  to charge all of the placed fragments equally. The charge level of a fragment will not decrease over
-                  time, but it will be reset to 0 upon removing it from the board or installing augmentations.
+                  the number of threads that were used. The maximum number of threads used in a single call to
+                  chargeFragment is also recorded as its highest charge. As a Stat Fragment's charge level and highest
+                  charge are increased, its bonuses will increase, but there will be diminishing returns. As such, it is
+                  generally most efficient to charge all of the placed fragments equally. The charge level of a fragment
+                  will not decrease over time, but it will be reset to 0 upon removing it from the board or installing
+                  augmentations.
                 </Typography>
               </>,
             )


### PR DESCRIPTION
This change updates the help text that describes how the fragments get their charge and the UI to display the highest charge.

Before:
<img width="1029" height="352" alt="image" src="https://github.com/user-attachments/assets/a88e3cd2-442a-4de8-83a4-f7d86dbd8dbf" />

After:
<img width="553" height="236" alt="image" src="https://github.com/user-attachments/assets/b61c26ab-0c44-446a-bc57-a0960412e48a" />

For completeness sake, the new description and UI where no fragment is selected:
<img width="2044" height="131" alt="image" src="https://github.com/user-attachments/assets/fa0802ba-89f0-4751-8e6a-fe94be3de2f4" />
<img width="526" height="281" alt="image" src="https://github.com/user-attachments/assets/52886b72-c0ee-44fc-be88-7166239988e5" />

As a side note, there is some documentation about Stanek in two places: the info button on "Stanek's Gift" page and one in the documentation itself. The later has very little info, so maybe we should instead move the current help into the documentation and have the info button redirect towards the documentation?