### PR TITLE
API: Change log message when calling ns.stanek.acceptGift repeatedly

### DIFF
--- a/src/NetscriptFunctions/Stanek.ts
+++ b/src/NetscriptFunctions/Stanek.ts
@@ -119,10 +119,15 @@ export function NetscriptStanek(): InternalAPI<IStanek> {
     },
     acceptGift: (ctx) => () => {
       const cotmgFaction = Factions[FactionName.ChurchOfTheMachineGod];
+      // Return early if the player is already a member
+      if (cotmgFaction.isMember && Player.hasAugmentation(AugmentationName.StaneksGift1, true)) {
+        helpers.log(ctx, () => `You are already a member of ${FactionName.ChurchOfTheMachineGod}.`);
+        return true;
+      }
       // Check if the player is eligible to join the church
       const checkResult = canAcceptStaneksGift();
       if (checkResult.success) {
-        // Join the CotMG factionn
+        // Join the CotMG faction
         joinFaction(cotmgFaction);
         // Install the first Stanek aug
         applyAugmentation({ name: AugmentationName.StaneksGift1, level: 1 });


### PR DESCRIPTION
When running `ns.stanek.acceptGift` more than once, it returns true but prints this log message:
```
stanek.acceptGift: You already purchased or installed augmentations that are not NeuroFlux Governor.
```

If the player is already a member of CotMG, we should return early and print a corresponding log message.