### PR TITLE
DEVMENU: Add tool to set SF12 level

### DIFF
--- a/src/DevMenu/ui/SourceFilesDev.tsx
+++ b/src/DevMenu/ui/SourceFilesDev.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 
-import { AccordionSummary, AccordionDetails, Button, ButtonGroup, Typography } from "@mui/material";
+import { AccordionSummary, AccordionDetails, Button, ButtonGroup, Typography, TextField } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { makeStyles } from "tss-react/mui";
 
@@ -15,6 +15,7 @@ import { DeleteServer, GetAllServers } from "../../Server/AllServers";
 import { HacknetServer } from "../../Hacknet/HacknetServer";
 import { AutoExpandAccordion } from "../../ui/AutoExpand/AutoExpandAccordion";
 import { getDarkscapeNavigator } from "../../DarkNet/effects/effects";
+import { dialogBoxCreate } from "../../ui/React/DialogBox";
 
 const useStyles = makeStyles()({
   group: {
@@ -32,6 +33,10 @@ export function SourceFilesDev({ parentRerender }: { parentRerender: () => void 
 
   const setSF = useCallback(
     (sfN: number, sfLvl: number) => () => {
+      if (!Number.isInteger(sfLvl) || sfLvl < 0) {
+        dialogBoxCreate(`Invalid SF level: ${sfLvl}`);
+        return;
+      }
       if (sfN === 9) {
         if (sfLvl === 0) {
           // Make sure that Player.hacknetNodes contains only HackNode and there is no hacknet server in "AllServers".
@@ -88,9 +93,10 @@ export function SourceFilesDev({ parentRerender }: { parentRerender: () => void 
 
   const devLvls = [0, 1, 2, 3];
 
-  const buttonRow = (sfN?: number) => {
+  const ButtonRow = (sfN?: number) => {
     const title = sfN ? `SF-${sfN}` : "Set All";
     const level = sfN ? Player.sourceFileLvl(sfN) : 0;
+    const [newSf12Level, setNewSf12Level] = useState(Player.sourceFileLvl(12));
     return (
       <tr key={title}>
         <td>
@@ -103,12 +109,16 @@ export function SourceFilesDev({ parentRerender }: { parentRerender: () => void 
                 {lvl}
               </Button>
             ))}
-            {sfN === 12 &&
-              [1, 10, 100].map((numLevels) => (
-                <Button key={numLevels} onClick={setSF(12, level + numLevels)}>
-                  +{numLevels}
-                </Button>
-              ))}
+            {sfN === 12 && (
+              <>
+                <TextField
+                  style={{ maxWidth: "90px" }}
+                  value={newSf12Level}
+                  onChange={(x) => setNewSf12Level(Number(x.target.value))}
+                />
+                <Button onClick={setSF(12, newSf12Level)}>Set</Button>
+              </>
+            )}
             {sfN && <Typography className={classes.extraInfo}>{`Level: ${level}`}</Typography>}
             {sfN === 10 && (
               <>
@@ -151,7 +161,7 @@ export function SourceFilesDev({ parentRerender }: { parentRerender: () => void 
                 <Button onClick={clearExploits}>Clear</Button>
               </td>
             </tr>
-            {[undefined, ...validBitNodes].map((sfN) => buttonRow(sfN))}
+            {[undefined, ...validBitNodes].map((sfN) => ButtonRow(sfN))}
           </tbody>
         </table>
       </AccordionDetails>


### PR DESCRIPTION
This is a suggestion from Discord:
```
Suggestion: remove the SF12 +1, +10, +100 buttons in the dev menu and replace them with a number field to set it at any non negative integer (possibly < 35846)
```
This tool is useful when testing issues that occurs at a high and specific SF12 level (e.g., #2667).

Before:

<img width="610" height="563" alt="before" src="https://github.com/user-attachments/assets/1c0f0c4e-8cf9-418e-9582-b30b64e72692" />

After:

<img width="599" height="564" alt="after" src="https://github.com/user-attachments/assets/33a15cc0-bb5a-48f7-8241-c016f314754d" />