### PR TITLE
DNET: Add scaling depth each time you complete the bonus lab

### DIFF
--- a/src/DarkNet/Constants.ts
+++ b/src/DarkNet/Constants.ts
@@ -9,3 +9,13 @@ export const DarknetConstants = {
 } as const;
 
 export const MAX_PASSWORD_LENGTH = 50;
+export const VERTICAL_CONNECTION_CHANCE = 0.3;
+export const AIR_GAP_DEPTH = 8;
+export const NET_WIDTH = 8;
+export const MAX_NET_DEPTH = 100;
+export const SERVER_DENSITY = 0.6;
+export const LOW_LEVEL_SERVER_DENSITY = 0.7;
+export const MS_PER_MUTATION_PER_ROW = 30_000; // 30 seconds
+export const MAXIMUM_DNET_SERVER_COUNT = 120;
+export const MAXIMUM_DIFFICULTY = 36;
+export const MAX_MAZE_BONUS_SIZE = 50;

--- a/src/DarkNet/Enums.ts
+++ b/src/DarkNet/Enums.ts
@@ -5,10 +5,12 @@ export const HORIZONTAL_CONNECTION_CHANCE = 0.5;
 export const VERTICAL_CONNECTION_CHANCE = 0.3;
 export const AIR_GAP_DEPTH = 8;
 export const NET_WIDTH = 8;
-export const MAX_NET_DEPTH = 40;
+export const MAX_NET_DEPTH = 200;
 export const SERVER_DENSITY = 0.6;
 export const LOW_LEVEL_SERVER_DENSITY = 0.7;
 export const MS_PER_MUTATION_PER_ROW = 30_000; // 30 seconds
+export const MAXIMUM_DNET_SERVER_COUNT = 120;
+export const MAXIMUM_DIFFICULTY = 36;
 
 // each minigame needs to have a name that sounds like a device or browser or language model and version
 // (This list is not exposed to the player; they find them through discovery)

--- a/src/DarkNet/Enums.ts
+++ b/src/DarkNet/Enums.ts
@@ -2,15 +2,6 @@ import type { _ValueOf, DarknetServerDetails } from "@nsdefs";
 import type { DarknetServerData } from "./utils/darknetServerUtils";
 
 export const HORIZONTAL_CONNECTION_CHANCE = 0.5;
-export const VERTICAL_CONNECTION_CHANCE = 0.3;
-export const AIR_GAP_DEPTH = 8;
-export const NET_WIDTH = 8;
-export const MAX_NET_DEPTH = 200;
-export const SERVER_DENSITY = 0.6;
-export const LOW_LEVEL_SERVER_DENSITY = 0.7;
-export const MS_PER_MUTATION_PER_ROW = 30_000; // 30 seconds
-export const MAXIMUM_DNET_SERVER_COUNT = 120;
-export const MAXIMUM_DIFFICULTY = 36;
 
 // each minigame needs to have a name that sounds like a device or browser or language model and version
 // (This list is not exposed to the player; they find them through discovery)

--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -26,7 +26,7 @@ import {
   isLabyrinthServer,
 } from "../effects/labyrinth";
 import { DarknetServer, type DarknetServerConstructorParams } from "../../Server/DarknetServer";
-import { HORIZONTAL_CONNECTION_CHANCE, MAX_NET_DEPTH, ModelIds, NET_WIDTH, VERTICAL_CONNECTION_CHANCE } from "../Enums";
+import { HORIZONTAL_CONNECTION_CHANCE, ModelIds } from "../Enums";
 import { DarknetServerOptions, DnetServerBuilder } from "../models/DarknetServerOptions";
 import {
   getAllDarknetServers,
@@ -42,6 +42,7 @@ import type { ScriptFilePath } from "../../Paths/ScriptFilePath";
 import type { Script } from "../../Script/Script";
 import type { CodingContract } from "../../CodingContract/Contract";
 import { getTorRouter } from "../../Server/ServerHelpers";
+import { MAX_NET_DEPTH, NET_WIDTH, VERTICAL_CONNECTION_CHANCE } from "../Constants";
 
 export function initDarkwebServer(): void {
   const existingServer = GetServer(SpecialServers.DarkWeb);

--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -12,7 +12,8 @@ import {
   addRandomDarknetServers,
   balanceDarknetServers,
   deleteDarknetServer,
-  disconnectServer, getServerDensity,
+  disconnectServer,
+  getServerDensity,
 } from "./NetworkMovement";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 import { Player } from "@player";
@@ -25,13 +26,7 @@ import {
   isLabyrinthServer,
 } from "../effects/labyrinth";
 import { DarknetServer, type DarknetServerConstructorParams } from "../../Server/DarknetServer";
-import {
-  HORIZONTAL_CONNECTION_CHANCE,
-  MAX_NET_DEPTH,
-  ModelIds,
-  NET_WIDTH,
-  VERTICAL_CONNECTION_CHANCE,
-} from "../Enums";
+import { HORIZONTAL_CONNECTION_CHANCE, MAX_NET_DEPTH, ModelIds, NET_WIDTH, VERTICAL_CONNECTION_CHANCE } from "../Enums";
 import { DarknetServerOptions, DnetServerBuilder } from "../models/DarknetServerOptions";
 import {
   getAllDarknetServers,

--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -12,7 +12,7 @@ import {
   addRandomDarknetServers,
   balanceDarknetServers,
   deleteDarknetServer,
-  disconnectServer,
+  disconnectServer, getServerDensity,
 } from "./NetworkMovement";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 import { Player } from "@player";
@@ -30,7 +30,6 @@ import {
   MAX_NET_DEPTH,
   ModelIds,
   NET_WIDTH,
-  SERVER_DENSITY,
   VERTICAL_CONNECTION_CHANCE,
 } from "../Enums";
 import { DarknetServerOptions, DnetServerBuilder } from "../models/DarknetServerOptions";
@@ -98,7 +97,7 @@ export const populateDarknet = () => {
 
   clearDarknet();
   addLabyrinth();
-  addRandomDarknetServers(getNetDepth() * NET_WIDTH * SERVER_DENSITY - 10);
+  addRandomDarknetServers(getNetDepth() * NET_WIDTH * getServerDensity() - 10);
   addRandomDarknetServers(5 - DarknetState.Network[0].length);
   addRandomDarknetServers(5 - DarknetState.Network[1].length);
   balanceDarknetServers();

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -10,8 +10,14 @@ import { createDarknetServer } from "./ServerGenerator";
 import { addServerToNetwork, movePlayerIfNeeded } from "./NetworkGenerator";
 import { killServerScripts } from "../../Netscript/killWorkerScript";
 import { SpecialServers } from "../../Server/data/SpecialServers";
-import { getLabyrinthServerNames, getNetDepth, isLabyrinthServer } from "../effects/labyrinth";
-import { LOW_LEVEL_SERVER_DENSITY, MAX_NET_DEPTH, NET_WIDTH, SERVER_DENSITY } from "../Enums";
+import { getLabyrinthServerNames, getNetDepth, isLabyrinthServer, labData } from "../effects/labyrinth";
+import {
+  LOW_LEVEL_SERVER_DENSITY,
+  MAX_NET_DEPTH,
+  MAXIMUM_DNET_SERVER_COUNT,
+  NET_WIDTH,
+  SERVER_DENSITY,
+} from "../Enums";
 import {
   getAllAdjacentNeighbors,
   getAllDarknetServers,
@@ -190,15 +196,22 @@ export const deleteDarknetServer = (server: DarknetServer, force = false): void 
 };
 
 export const addRandomDarknetServers = (count = 1, difficulty?: number, fixedDepth?: boolean): void => {
+  if (getAllMovableDarknetServers().length >= MAXIMUM_DNET_SERVER_COUNT) {
+    return;
+  }
   for (let i = 0; i < count; i++) {
     const diff = difficulty ?? Math.floor(Math.random() * getNetDepth());
-    const newServer = createDarknetServer(diff, -1, -1);
+    const newServer = createDarknetServer(diff, diff, -1);
     const range = fixedDepth ? 0 : 3;
     moveDarknetServer(newServer, range, range);
   }
 };
 
 export const addLowLevelServersIfNeeded = (): void => {
+  if (getAllMovableDarknetServers().length >= MAXIMUM_DNET_SERVER_COUNT) {
+    return;
+  }
+  console.log("adding low level servers")
   const lowLevelServers = getAllDarknetServers().filter((s) => s.depth <= 3);
   const serversConnectedToDarkweb = getAllDarknetServers().filter((s) => s.depth === 0);
   if (serversConnectedToDarkweb.length <= 3) {
@@ -214,15 +227,23 @@ export const addLowLevelServersIfNeeded = (): void => {
 export const balanceDarknetServers = (): void => {
   const movableServers = getAllMovableDarknetServers();
   const netDepth = getNetDepth();
-  if (movableServers.length > netDepth * NET_WIDTH * SERVER_DENSITY) {
-    const serversToRemove = movableServers.length - netDepth * NET_WIDTH * SERVER_DENSITY;
+  const density = getServerDensity();
+  if (movableServers.length > netDepth * NET_WIDTH * density) {
+    const serversToRemove = movableServers.length - netDepth * NET_WIDTH * density;
     deleteRandomDarknetServers(serversToRemove);
   } else {
-    const serversToAdd = netDepth * NET_WIDTH * SERVER_DENSITY - movableServers.length;
+    const serversToAdd = netDepth * NET_WIDTH * density - movableServers.length;
     addRandomDarknetServers(serversToAdd);
   }
   addLowLevelServersIfNeeded();
 };
+
+export const getServerDensity = () => {
+  if (getNetDepth() <= labData[SpecialServers.BonusLab].depth) {
+    return SERVER_DENSITY;
+  }
+  return Math.max(SERVER_DENSITY - DarknetState.bonusLabCompletions * 0.01, SERVER_DENSITY * 0.4);
+}
 
 const isImmutable = (server: DarknetServer): boolean =>
   server === DarknetState.openServer || server.isConnectedTo || server.hasStasisLink;
@@ -231,7 +252,7 @@ export const moveDarknetServer = (
   server: DarknetServer,
   maxDepthDecrease = 3,
   maxDepthIncrease = 3,
-  startingDepth = server.difficulty,
+  startingDepth = server.depth,
 ): boolean => {
   if (server.hostname === SpecialServers.DarkWeb) {
     exceptionAlert(new Error("Something is trying to move darkweb"), true);

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -62,7 +62,7 @@ export const mutateDarknet = (): void => {
 
   // Limit mutation speed based on size of net
   const depth = getNetDepth();
-  const depthSpeedFactor = 16 / depth;
+  const depthSpeedFactor = Math.max(16 / depth, 0.3);
   if (Math.random() > depthSpeedFactor) {
     return;
   }
@@ -211,7 +211,7 @@ export const addLowLevelServersIfNeeded = (): void => {
   if (getAllMovableDarknetServers().length >= MAXIMUM_DNET_SERVER_COUNT) {
     return;
   }
-  console.log("adding low level servers")
+  console.log("adding low level servers");
   const lowLevelServers = getAllDarknetServers().filter((s) => s.depth <= 3);
   const serversConnectedToDarkweb = getAllDarknetServers().filter((s) => s.depth === 0);
   if (serversConnectedToDarkweb.length <= 3) {
@@ -242,8 +242,8 @@ export const getServerDensity = () => {
   if (getNetDepth() <= labData[SpecialServers.BonusLab].depth) {
     return SERVER_DENSITY;
   }
-  return Math.max(SERVER_DENSITY - DarknetState.bonusLabCompletions * 0.01, SERVER_DENSITY * 0.4);
-}
+  return Math.max(SERVER_DENSITY - DarknetState.bonusLabCompletions * 0.01, SERVER_DENSITY * 0.45);
+};
 
 const isImmutable = (server: DarknetServer): boolean =>
   server === DarknetState.openServer || server.isConnectedTo || server.hasStasisLink;

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -12,13 +12,6 @@ import { killServerScripts } from "../../Netscript/killWorkerScript";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 import { getLabyrinthServerNames, getNetDepth, isLabyrinthServer, labData } from "../effects/labyrinth";
 import {
-  LOW_LEVEL_SERVER_DENSITY,
-  MAX_NET_DEPTH,
-  MAXIMUM_DNET_SERVER_COUNT,
-  NET_WIDTH,
-  SERVER_DENSITY,
-} from "../Enums";
-import {
   getAllAdjacentNeighbors,
   getAllDarknetServers,
   getAllMovableDarknetServers,
@@ -27,7 +20,14 @@ import {
   getDarknetCyclesPerMutation,
   getIslands,
 } from "../utils/darknetNetworkUtils";
-import { DarknetConstants } from "../Constants";
+import {
+  DarknetConstants,
+  LOW_LEVEL_SERVER_DENSITY,
+  MAX_NET_DEPTH,
+  MAXIMUM_DNET_SERVER_COUNT,
+  NET_WIDTH,
+  SERVER_DENSITY,
+} from "../Constants";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { exceptionAlert } from "../../utils/helpers/exceptionAlert";
 
@@ -71,7 +71,7 @@ export const mutateDarknet = (): void => {
     const islands = getIslands();
     const island = islands[Math.floor(Math.random() * islands.length)];
     if (island) {
-      moveDarknetServer(island);
+      moveDarknetServer(island, 3, 3, island.difficulty);
     }
   }
 
@@ -196,10 +196,11 @@ export const deleteDarknetServer = (server: DarknetServer, force = false): void 
 };
 
 export const addRandomDarknetServers = (count = 1, difficulty?: number, fixedDepth?: boolean): void => {
-  if (getAllMovableDarknetServers().length >= MAXIMUM_DNET_SERVER_COUNT) {
-    return;
-  }
   for (let i = 0; i < count; i++) {
+    if (getAllMovableDarknetServers().length >= MAXIMUM_DNET_SERVER_COUNT) {
+      return;
+    }
+
     const diff = difficulty ?? Math.floor(Math.random() * getNetDepth());
     const newServer = createDarknetServer(diff, diff, -1);
     const range = fixedDepth ? 0 : 3;
@@ -211,7 +212,6 @@ export const addLowLevelServersIfNeeded = (): void => {
   if (getAllMovableDarknetServers().length >= MAXIMUM_DNET_SERVER_COUNT) {
     return;
   }
-  console.log("adding low level servers");
   const lowLevelServers = getAllDarknetServers().filter((s) => s.depth <= 3);
   const serversConnectedToDarkweb = getAllDarknetServers().filter((s) => s.depth === 0);
   if (serversConnectedToDarkweb.length <= 3) {

--- a/src/DarkNet/controllers/ServerGenerator.ts
+++ b/src/DarkNet/controllers/ServerGenerator.ts
@@ -10,8 +10,8 @@ import {
   numbers,
 } from "../models/dictionaryData";
 import { DarknetServer } from "../../Server/DarknetServer";
-import { ModelIds, MinigamesType, MAXIMUM_DIFFICULTY } from "../Enums";
-import { MAX_PASSWORD_LENGTH } from "../Constants";
+import { ModelIds, MinigamesType } from "../Enums";
+import { MAX_PASSWORD_LENGTH, MAXIMUM_DIFFICULTY } from "../Constants";
 import { clampNumber } from "../../utils/helpers/clampNumber";
 import { hasFullDarknetAccess } from "../effects/effects";
 

--- a/src/DarkNet/controllers/ServerGenerator.ts
+++ b/src/DarkNet/controllers/ServerGenerator.ts
@@ -10,7 +10,7 @@ import {
   numbers,
 } from "../models/dictionaryData";
 import { DarknetServer } from "../../Server/DarknetServer";
-import { ModelIds, MinigamesType } from "../Enums";
+import { ModelIds, MinigamesType, MAXIMUM_DIFFICULTY } from "../Enums";
 import { MAX_PASSWORD_LENGTH } from "../Constants";
 import { clampNumber } from "../../utils/helpers/clampNumber";
 import { hasFullDarknetAccess } from "../effects/effects";
@@ -62,7 +62,7 @@ const getRandomServerConfigBuilder = (difficulty: number) => {
 };
 
 export const createDarknetServer = (difficulty: number, depth: number, leftOffset: number): DarknetServer => {
-  const cappedDifficulty = clampNumber(difficulty, 0, MAX_PASSWORD_LENGTH);
+  const cappedDifficulty = clampNumber(difficulty, 0, MAXIMUM_DIFFICULTY);
   return serverFactory(getRandomServerConfigBuilder(cappedDifficulty), difficulty, depth, leftOffset);
 };
 

--- a/src/DarkNet/effects/SaveLoad.ts
+++ b/src/DarkNet/effects/SaveLoad.ts
@@ -26,10 +26,11 @@ export function loadDarkNet(saveString: unknown): void {
     if (typeof storedCycles !== "number" || !Number.isFinite(storedCycles)) {
       throw new Error(`Invalid storedCycles: ${storedCycles}`);
     }
-    const cleanedBonusLabCompletions = typeof bonusLabCompletions !== "number" || !Number.isFinite(bonusLabCompletions) ? 0 : bonusLabCompletions;
+    const cleanedBonusLabCompletions =
+      typeof bonusLabCompletions !== "number" || !Number.isFinite(bonusLabCompletions) ? 0 : bonusLabCompletions;
     DarknetState.storedCycles = storedCycles < 0 ? 0 : storedCycles;
     DarknetState.hasUsedHeartbleed = Boolean(hasUsedHeartbleed);
-    DarknetState.bonusLabCompletions = 50; // cleanedBonusLabCompletions < 0 ? 0 : cleanedBonusLabCompletions;
+    DarknetState.bonusLabCompletions = cleanedBonusLabCompletions < 0 ? 0 : cleanedBonusLabCompletions;
   } catch (error) {
     console.error(error);
     console.error("Invalid DarkNet data:", saveString);

--- a/src/DarkNet/effects/SaveLoad.ts
+++ b/src/DarkNet/effects/SaveLoad.ts
@@ -4,12 +4,14 @@ import { assertObject } from "../../utils/TypeAssertion";
 export type DarknetSaveFormat = {
   storedCycles: number;
   hasUsedHeartbleed: boolean;
+  bonusLabCompletions: number;
 };
 
 export function getDarkNetSave(): DarknetSaveFormat {
   return {
     storedCycles: Math.floor(DarknetState.storedCycles),
     hasUsedHeartbleed: DarknetState.hasUsedHeartbleed,
+    bonusLabCompletions: DarknetState.bonusLabCompletions,
   };
 }
 
@@ -20,12 +22,14 @@ export function loadDarkNet(saveString: unknown): void {
   try {
     const parsedData: unknown = JSON.parse(saveString);
     assertObject(parsedData);
-    const { storedCycles, hasUsedHeartbleed } = parsedData;
+    const { storedCycles, hasUsedHeartbleed, bonusLabCompletions } = parsedData;
     if (typeof storedCycles !== "number" || !Number.isFinite(storedCycles)) {
       throw new Error(`Invalid storedCycles: ${storedCycles}`);
     }
+    const cleanedBonusLabCompletions = typeof bonusLabCompletions !== "number" || !Number.isFinite(bonusLabCompletions) ? 0 : bonusLabCompletions;
     DarknetState.storedCycles = storedCycles < 0 ? 0 : storedCycles;
     DarknetState.hasUsedHeartbleed = Boolean(hasUsedHeartbleed);
+    DarknetState.bonusLabCompletions = 50; // cleanedBonusLabCompletions < 0 ? 0 : cleanedBonusLabCompletions;
   } catch (error) {
     console.error(error);
     console.error("Invalid DarkNet data:", saveString);

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -13,7 +13,7 @@ import { moveDarknetServer } from "../controllers/NetworkMovement";
 import { calculateIntelligenceBonus } from "../../PersonObjects/formulas/intelligence";
 import { addSessionToServer, DarknetState, hasDarknetBonusTime } from "../models/DarknetState";
 import { DarknetServer } from "../../Server/DarknetServer";
-import { GenericResponseMessage, ModelIds, NET_WIDTH, ResponseCodeEnum } from "../Enums";
+import { GenericResponseMessage, ModelIds, ResponseCodeEnum } from "../Enums";
 import { addCacheToServer } from "./cacheFiles";
 import { populateDarknet } from "../controllers/NetworkGenerator";
 import { type DarknetServerData, getDarknetServer } from "../utils/darknetServerUtils";
@@ -25,7 +25,7 @@ import {
 } from "../utils/darknetNetworkUtils";
 import { getTwoCharsInPassword } from "../utils/darknetAuthUtils";
 import { getTorRouter } from "../../Server/ServerHelpers";
-import { DarknetConstants } from "../Constants";
+import { DarknetConstants, NET_WIDTH } from "../Constants";
 import { isLabyrinthServer } from "./labyrinth";
 import { NetscriptContext } from "../../Netscript/APIWrapper";
 import { helpers } from "../../Netscript/NetscriptHelpers";

--- a/src/DarkNet/effects/labyrinth.ts
+++ b/src/DarkNet/effects/labyrinth.ts
@@ -308,11 +308,15 @@ export const handleLabyrinthPassword = (
   if (newLocation[0] == end[0] && newLocation[1] == end[1]) {
     Player.gainCharismaExp(calculatePasswordAttemptChaGain(server, 32, true));
     server.hasAdminRights = true;
-    const cacheCount = getLabyrinthDetails().name === SpecialServers.BonusLab ? 3 : 1;
+    const isBonusLab = getLabyrinthDetails().name === SpecialServers.BonusLab
+    const cacheCount = isBonusLab ? 3 : 1;
     for (let i = 0; i < cacheCount; i++) {
       addCacheToServer(server, false, LAB_CACHE_NAME);
     }
     addSessionToServer(labServer, pid);
+    if (isBonusLab) {
+      DarknetState.bonusLabCompletions ++;
+    }
 
     return {
       passwordAttempted: attemptedPassword,
@@ -364,7 +368,10 @@ const getOrdinalInput = (input: string): number[] | null => {
 export const getLabMaze = (): string[] => {
   if (!DarknetState.labyrinth) {
     const { mazeWidth, mazeHeight } = getLabyrinthDetails();
-    DarknetState.labyrinth = generateMaze(mazeWidth, mazeHeight);
+    DarknetState.labyrinth = generateMaze(
+      mazeWidth + DarknetState.bonusLabCompletions * 2,
+      mazeHeight + DarknetState.bonusLabCompletions * 2,
+    );
     const [offsetX, offsetY] = getRandomOffset();
     DarknetState.labEndpoint = [
       DarknetState.labyrinth[0].length - 2 - offsetX,
@@ -392,6 +399,9 @@ export const getLabyrinthChaRequirement = (name: string) => {
 
 export const getNetDepth = () => {
   const labDetails = getLabyrinthDetails();
+  if (labDetails.name === SpecialServers.BonusLab) {
+    return labDetails.depth + DarknetState.bonusLabCompletions * 2;
+  }
   return labDetails.depth ?? 10;
 };
 

--- a/src/DarkNet/effects/labyrinth.ts
+++ b/src/DarkNet/effects/labyrinth.ts
@@ -308,14 +308,14 @@ export const handleLabyrinthPassword = (
   if (newLocation[0] == end[0] && newLocation[1] == end[1]) {
     Player.gainCharismaExp(calculatePasswordAttemptChaGain(server, 32, true));
     server.hasAdminRights = true;
-    const isBonusLab = getLabyrinthDetails().name === SpecialServers.BonusLab
+    const isBonusLab = getLabyrinthDetails().name === SpecialServers.BonusLab;
     const cacheCount = isBonusLab ? 3 : 1;
     for (let i = 0; i < cacheCount; i++) {
       addCacheToServer(server, false, LAB_CACHE_NAME);
     }
     addSessionToServer(labServer, pid);
     if (isBonusLab) {
-      DarknetState.bonusLabCompletions ++;
+      DarknetState.bonusLabCompletions++;
     }
 
     return {

--- a/src/DarkNet/effects/labyrinth.ts
+++ b/src/DarkNet/effects/labyrinth.ts
@@ -11,6 +11,7 @@ import { addCacheToServer } from "./cacheFiles";
 import { getDarknetServer } from "../utils/darknetServerUtils";
 import { getFriendlyType, TypeAssertionError } from "../../utils/TypeAssertion";
 import type { SuccessResult } from "@nsdefs";
+import { MAX_MAZE_BONUS_SIZE, MAX_NET_DEPTH } from "../Constants";
 
 export const LAB_CACHE_NAME = "the_great_work";
 
@@ -368,10 +369,8 @@ const getOrdinalInput = (input: string): number[] | null => {
 export const getLabMaze = (): string[] => {
   if (!DarknetState.labyrinth) {
     const { mazeWidth, mazeHeight } = getLabyrinthDetails();
-    DarknetState.labyrinth = generateMaze(
-      mazeWidth + DarknetState.bonusLabCompletions * 2,
-      mazeHeight + DarknetState.bonusLabCompletions * 2,
-    );
+    const bonusSize = Math.min(DarknetState.bonusLabCompletions * 2, MAX_MAZE_BONUS_SIZE);
+    DarknetState.labyrinth = generateMaze(mazeWidth + bonusSize, mazeHeight + bonusSize);
     const [offsetX, offsetY] = getRandomOffset();
     DarknetState.labEndpoint = [
       DarknetState.labyrinth[0].length - 2 - offsetX,
@@ -400,7 +399,7 @@ export const getLabyrinthChaRequirement = (name: string) => {
 export const getNetDepth = () => {
   const labDetails = getLabyrinthDetails();
   if (labDetails.name === SpecialServers.BonusLab) {
-    return labDetails.depth + DarknetState.bonusLabCompletions * 2;
+    return Math.min(labDetails.depth + DarknetState.bonusLabCompletions * 2, MAX_NET_DEPTH);
   }
   return labDetails.depth ?? 10;
 };

--- a/src/DarkNet/effects/webstorm.ts
+++ b/src/DarkNet/effects/webstorm.ts
@@ -11,9 +11,9 @@ import {
 } from "../controllers/NetworkMovement";
 import { BaseServer } from "../../Server/BaseServer";
 import { getNetDepth } from "./labyrinth";
-import { NET_WIDTH } from "../Enums";
 import { sleep } from "../../utils/Utility";
 import { getAllMovableDarknetServers } from "../utils/darknetNetworkUtils";
+import { NET_WIDTH } from "../Constants";
 
 const validateDarknetNetworkAndEmitDarknetEvent = (): void => {
   validateDarknetNetwork();

--- a/src/DarkNet/models/DarknetServerOptions.ts
+++ b/src/DarkNet/models/DarknetServerOptions.ts
@@ -11,7 +11,7 @@ import {
 import { getLabyrinthDetails } from "../effects/labyrinth";
 import { DarknetServer } from "../../Server/DarknetServer";
 import type { DarknetResponseCode } from "@nsdefs";
-import { MinigamesType } from "../Enums";
+import type { MinigamesType } from "../Enums";
 import { DarknetState } from "./DarknetState";
 import { getRamBlock } from "../effects/ramblock";
 import { hasFullDarknetAccess } from "../effects/effects";

--- a/src/DarkNet/models/DarknetServerOptions.ts
+++ b/src/DarkNet/models/DarknetServerOptions.ts
@@ -11,7 +11,7 @@ import {
 import { getLabyrinthDetails } from "../effects/labyrinth";
 import { DarknetServer } from "../../Server/DarknetServer";
 import type { DarknetResponseCode } from "@nsdefs";
-import type { MinigamesType } from "../Enums";
+import { MAXIMUM_DIFFICULTY, MinigamesType } from "../Enums";
 import { DarknetState } from "./DarknetState";
 import { getRamBlock } from "../effects/ramblock";
 import { hasFullDarknetAccess } from "../effects/effects";

--- a/src/DarkNet/models/DarknetServerOptions.ts
+++ b/src/DarkNet/models/DarknetServerOptions.ts
@@ -11,7 +11,7 @@ import {
 import { getLabyrinthDetails } from "../effects/labyrinth";
 import { DarknetServer } from "../../Server/DarknetServer";
 import type { DarknetResponseCode } from "@nsdefs";
-import { MAXIMUM_DIFFICULTY, MinigamesType } from "../Enums";
+import { MinigamesType } from "../Enums";
 import { DarknetState } from "./DarknetState";
 import { getRamBlock } from "../effects/ramblock";
 import { hasFullDarknetAccess } from "../effects/effects";

--- a/src/DarkNet/models/DarknetState.ts
+++ b/src/DarkNet/models/DarknetState.ts
@@ -2,11 +2,11 @@ import { EventEmitter } from "../../utils/EventEmitter";
 import { BaseServer } from "../../Server/BaseServer";
 import { findRunningScriptByPid } from "../../Script/ScriptHelpers";
 import type { DarknetServer } from "../../Server/DarknetServer";
-import { MAX_NET_DEPTH, NET_WIDTH } from "../Enums";
 
 import { getDarknetCyclesPerMutation } from "../utils/darknetNetworkUtils";
 import type { PasswordResponse } from "./DarknetServerOptions";
 import { assertFiniteNumber, assertNonNullish } from "../../utils/TypeAssertion";
+import { MAX_NET_DEPTH, NET_WIDTH } from "../Constants";
 
 /** Event emitter to allow the UI to subscribe to Darknet gameplay updates in order to trigger rerenders properly */
 export const DarknetEvents = new EventEmitter<[]>();

--- a/src/DarkNet/models/DarknetState.ts
+++ b/src/DarkNet/models/DarknetState.ts
@@ -46,6 +46,7 @@ export const DarknetState = {
    * want to get data of alive PIDs.
    */
   labLocations: {} as Record<number, [number, number] | undefined>,
+  bonusLabCompletions: 0,
 
   lastPhishingCacheTime: new Date(),
   lastCctRewardTime: new Date(),
@@ -89,6 +90,7 @@ export function prestigeDarknetState(prestigeSourceFile: boolean): void {
     DarknetState.hasUsedHeartbleed = false;
   }
   DarknetState.cyclesSinceLastMutation = 0;
+  DarknetState.bonusLabCompletions = 0;
   DarknetState.Network = new Array(MAX_NET_DEPTH).fill(null).map(() => new Array<null>(NET_WIDTH).fill(null));
   DarknetState.labyrinth = null;
   DarknetState.labLocations = {};

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -10,7 +10,7 @@ import React, {
 import { Container, Typography, Button, Box, Tooltip } from "@mui/material";
 import { ZoomIn, ZoomOut } from "@mui/icons-material";
 import { throttle } from "lodash";
-import { ServerStatusBox } from "./ServerStatusBox";
+import { getServerStateSnapshot, ServerStatusBox } from "./ServerStatusBox";
 import { useRerender } from "../../ui/React/hooks";
 import { DarknetEvents, DarknetState } from "../models/DarknetState";
 import { SpecialServers } from "../../Server/data/SpecialServers";
@@ -110,7 +110,6 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     if (target.id === "draggableBackgroundTarget") {
       background?.releasePointerCapture(pointerEvent.pointerId);
     }
-    DarknetEvents.emit();
   };
 
   const handleDrag: PointerEventHandler<HTMLDivElement> = (pointerEvent) => {
@@ -279,18 +278,36 @@ export function NetworkDisplayWrapper(): React.ReactElement {
             height={DW_NET_HEIGHT}
             style={{ position: "absolute", zIndex: -1 }}
           ></canvas>
-          {darkWebRoot && <ServerStatusBox server={darkWebRoot} enableAuth={true} classes={classes} />}
+          {darkWebRoot && (
+            <ServerStatusBox
+              server={darkWebRoot}
+              enableAuth={true}
+              classes={classes}
+              stateSnapshot={getServerStateSnapshot(darkWebRoot)}
+            />
+          )}
           {DarknetState.Network.slice(0, netDisplayDepth).map((row) =>
             row.map(
               (server) =>
                 !!server && (
-                  <ServerStatusBox server={server} key={server.ip} enableAuth={allowAuth(server)} classes={classes} />
+                  <ServerStatusBox
+                    server={server}
+                    key={server.ip}
+                    enableAuth={allowAuth(server)}
+                    classes={classes}
+                    stateSnapshot={getServerStateSnapshot(server)}
+                  />
                 ),
             ),
           )}
 
           {!!labyrinth && netDisplayDepth > depth && (
-            <ServerStatusBox server={labyrinth} enableAuth={allowAuth(labyrinth)} classes={classes} />
+            <ServerStatusBox
+              server={labyrinth}
+              enableAuth={allowAuth(labyrinth)}
+              classes={classes}
+              stateSnapshot={getServerStateSnapshot(labyrinth)}
+            />
           )}
         </div>
       </div>

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -16,7 +16,7 @@ import { DarknetEvents, DarknetState } from "../models/DarknetState";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 import { drawOnCanvas, getPixelPosition } from "./networkCanvas";
 import { dnetStyles, DWServerLogStyles } from "./dnetStyles";
-import { getLabyrinthDetails, isLabyrinthServer } from "../effects/labyrinth";
+import { getLabyrinthDetails, getNetDepth, isLabyrinthServer } from "../effects/labyrinth";
 import { DarknetServer } from "../../Server/DarknetServer";
 import { getAllDarknetServers } from "../utils/darknetNetworkUtils";
 import { ServerDetailsModal } from "./ServerDetailsModal";
@@ -28,7 +28,6 @@ import { DocumentationLink } from "../../ui/React/DocumentationLink";
 import { Settings } from "../../Settings/Settings";
 
 const DW_NET_WIDTH = 6000;
-const DW_NET_HEIGHT = 12000;
 const initialSearchLabel = `Search:`;
 
 export function NetworkDisplayWrapper(): React.ReactElement {
@@ -43,6 +42,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
   const { classes } = dnetStyles({});
   const instability = getTimeoutChance();
   const instabilityText = instability > 0.01 ? `${(instability * 100).toFixed(1)}%` : "< 1%";
+  const DW_NET_HEIGHT = Math.max(getNetDepth() * 300, 5000);
 
   const scrollTo = useCallback(
     (top: number, left: number) => {
@@ -64,7 +64,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     }
     const visibilityMargin = DarknetState.showFullNetwork ? 99 : 3;
     const lab = getLabyrinthDetails().lab;
-    const startingDepth = lab && getServerLogs(lab, 1, true).length ? lab.depth : 0;
+    const startingDepth = lab && getServerLogs(lab, 1, true).length ? getNetDepth() : 0;
     const deepestServerDepth = DarknetState.Network.flat().reduce(
       (deepest, server) => (server?.hasAdminRights && server.depth > deepest ? server.depth : deepest),
       startingDepth,
@@ -94,7 +94,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
   const darkWebRoot = getDarknetServerOrThrow(SpecialServers.DarkWeb);
   const labDetails = getLabyrinthDetails();
   const labyrinth = labDetails.lab;
-  const depth = labDetails.depth;
+  const depth = getNetDepth();
 
   const handleDragStart: PointerEventHandler<HTMLDivElement> = (pointerEvent) => {
     const target = pointerEvent.target as HTMLDivElement;

--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -110,6 +110,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     if (target.id === "draggableBackgroundTarget") {
       background?.releasePointerCapture(pointerEvent.pointerId);
     }
+    DarknetEvents.emit();
   };
 
   const handleDrag: PointerEventHandler<HTMLDivElement> = (pointerEvent) => {

--- a/src/DarkNet/ui/ServerStatusBox.tsx
+++ b/src/DarkNet/ui/ServerStatusBox.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { Typography, SvgIcon, Tooltip } from "@mui/material";
+import React, { useState, memo } from "react";
 import { ServerDetailsModal } from "./ServerDetailsModal";
 import { getIcon } from "./ServerIcon";
 import { DarknetState } from "../models/DarknetState";
@@ -15,11 +14,12 @@ export type DWServerProps = {
   classes: {
     [key: string]: string;
   };
+  stateSnapshot: string;
 };
 
-export function ServerStatusBox({ server, enableAuth, classes }: DWServerProps): React.ReactElement {
+function ServerStatusBoxImpl({ server, enableAuth, classes }: DWServerProps): React.ReactElement {
   const [open, setOpen] = useState(false);
-  const icon = getIcon(server.modelId);
+  const Icon = getIcon(server.modelId);
 
   const authButtonHandler = () => {
     DarknetState.openServer = server;
@@ -31,41 +31,61 @@ export function ServerStatusBox({ server, enableAuth, classes }: DWServerProps):
     setOpen(false);
   };
 
-  const getServerStyles = (server: DarknetServer) => {
-    const position = getPixelPosition(server);
-    return {
-      ...DWServerStyles,
-      top: `${position.top}px`,
-      left: `${position.left}px`,
-      borderColor: server.hasStasisLink ? "gold" : server.hasAdminRights ? "green" : "grey",
-    };
+  const position = getPixelPosition(server);
+  const buttonStyle = {
+    ...DWServerStyles,
+    top: `${position.top}px`,
+    left: `${position.left}px`,
+    borderColor: server.hasStasisLink ? "gold" : server.hasAdminRights ? "green" : "grey",
+    position: "absolute" as const,
+    userSelect: "none" as const,
   };
+  const hostnameClass = server.hasAdminRights ? classes.txtPrimary : classes.txtSecondary;
 
   return (
     <>
-      {open ? <ServerDetailsModal open={open} onClose={handleClose} server={server} classes={classes} /> : ""}
-      <button
-        style={{ ...getServerStyles(server), position: "absolute", userSelect: "none" }}
-        className={classes.DWServer}
-        onClick={authButtonHandler}
-        disabled={!enableAuth}
-      >
+      {open ? <ServerDetailsModal open={open} onClose={handleClose} server={server} classes={classes} /> : null}
+      <button style={buttonStyle} className={classes.DWServer} onClick={authButtonHandler} disabled={!enableAuth}>
         <div style={{ padding: 0, margin: 0, width: "100%" }}>
           <div style={{ display: "inline-flex", flexDirection: "row", width: "100%", justifyContent: "space-between" }}>
-            <Tooltip title={`Server Model: ${server.modelId}`}>
-              <SvgIcon component={icon} color="secondary" />
-            </Tooltip>
-            <Typography color={server.hasAdminRights ? "primary" : "secondary"} sx={ServerName}>
+            <span title={`Server Model: ${server.modelId}`} style={{ display: "inline-flex" }}>
+              <Icon className={classes.txtSecondary} />
+            </span>
+            <span className={hostnameClass} style={ServerName}>
               {server.hostname}
-            </Typography>
+            </span>
           </div>
-          <Typography color="secondary" style={{ fontSize: "0.9em" }}>
+          <span className={classes.txtSecondary} style={{ display: "block", fontSize: "0.9em" }}>
             {server.ip} cha:{server.requiredCharismaSkill}
-          </Typography>
+          </span>
           <br />
           <ServerSummary server={server} enableAuth={enableAuth} classes={classes} />
         </div>
       </button>
     </>
   );
+}
+
+export const ServerStatusBox = memo(ServerStatusBoxImpl);
+
+/**
+ * Snapshot the mutable server fields that ServerStatusBox/ServerSummary render.
+ * This is used to avoid re-rendering the status box unless visible values change.
+ */
+export function getServerStateSnapshot(server: DarknetServer): string {
+  return [
+    server.hasAdminRights,
+    server.hasStasisLink,
+    server.backdoorInstalled,
+    server.depth,
+    server.leftOffset,
+    server.blockedRam,
+    server.requiredCharismaSkill,
+    server.caches.length,
+    server.contracts.length,
+    server.messages.length,
+    server.programs.length,
+    server.textFiles.size,
+    server.runningScriptMap.size,
+  ].join("|");
 }

--- a/src/DarkNet/ui/ServerSummary.tsx
+++ b/src/DarkNet/ui/ServerSummary.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { SvgIcon, Tooltip, Typography } from "@mui/material";
 import { Code, Description, Inventory2, LockPerson, Terminal, Bolt, DoorBackSharp } from "@mui/icons-material";
 import { formatNumber } from "../../ui/formatNumber";
 import { CompletedProgramName } from "@enums";
@@ -17,6 +16,11 @@ export type ServerSummaryProps = {
   };
 };
 
+const summaryItemStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+};
+
 export function ServerSummary({
   server,
   enableAuth,
@@ -24,10 +28,14 @@ export function ServerSummary({
   showDetails = false,
 }: ServerSummaryProps): React.ReactElement {
   if (!server.hasAdminRights && enableAuth) {
-    return <Typography>[ auth required ]</Typography>;
+    return <span style={{ display: "block" }}>[ auth required ]</span>;
   }
   if (!server.hasAdminRights && !enableAuth) {
-    return <Typography color="secondary">(no connection)</Typography>;
+    return (
+      <span className={classes.txtSecondary} style={{ display: "block" }}>
+        (no connection)
+      </span>
+    );
   }
 
   const cacheCount = server.caches.length;
@@ -69,90 +77,87 @@ export function ServerSummary({
   const ramBlocked = showDetails ? ramBlockedDetails : formatNumber(server.blockedRam, 0);
 
   const runningScriptsComponent = (
-    <Tooltip key="runningScript" title={<>{runningScriptsTooltip}</>}>
-      <Typography color={runningScriptCount > 0 ? "primary" : "secondary"}>
-        <SvgIcon component={Terminal} className={classes.serverStatusIcon} />
-        {runningScriptCount}
-      </Typography>
-    </Tooltip>
+    <span
+      key="runningScript"
+      title={runningScriptsTooltip}
+      className={runningScriptCount > 0 ? classes.txtPrimary : classes.txtSecondary}
+      style={summaryItemStyle}
+    >
+      <Terminal className={classes.serverStatusIcon} />
+      {runningScriptCount}
+    </span>
   );
 
   const components = [];
   if (cacheCount) {
     components.push(
-      <Tooltip key="cache" title={<>{dataCacheTooltip}</>}>
-        <Typography>
-          <SvgIcon component={Inventory2} className={`${classes.gold} ${classes.serverStatusIcon}`} />
-          {cacheCount}
-        </Typography>
-      </Tooltip>,
+      <span key="cache" title={dataCacheTooltip} style={summaryItemStyle}>
+        <Inventory2 className={`${classes.gold} ${classes.serverStatusIcon}`} />
+        {cacheCount}
+      </span>,
     );
   }
   if (hasStormSeed) {
     components.push(
-      <Tooltip key="stormSeed" title={<>A mysterious executable has been found here...</>}>
-        <Typography>
-          <SvgIcon component={Bolt} className={`${classes.gold} ${classes.serverStatusIcon}`} />?
-        </Typography>
-      </Tooltip>,
+      <span key="stormSeed" title="A mysterious executable has been found here..." style={summaryItemStyle}>
+        <Bolt className={`${classes.gold} ${classes.serverStatusIcon}`} />?
+      </span>,
     );
   }
   if (hasBackdoor) {
     components.push(
-      <Tooltip key="backdoor" title={<>Backdoor installed. Warning: this increases darknet instability.</>}>
-        <Typography>
-          <SvgIcon component={DoorBackSharp} className={`${classes.red} ${classes.serverStatusIcon}`} />
-        </Typography>
-      </Tooltip>,
+      <span
+        key="backdoor"
+        title="Backdoor installed. Warning: this increases darknet instability."
+        style={summaryItemStyle}
+      >
+        <DoorBackSharp className={`${classes.red} ${classes.serverStatusIcon}`} />
+      </span>,
     );
   }
   if (server.hasStasisLink) {
     components.push(
-      <Tooltip
-        key="backdoor"
-        title={
-          <>
-            Stasis link installed. This allows connecting to the server remotely, as well as ns.exec from any distance.
-          </>
-        }
+      <span
+        key="stasis"
+        title="Stasis link installed. This allows connecting to the server remotely, as well as ns.exec from any distance."
+        style={summaryItemStyle}
       >
-        <Typography>
-          <SvgIcon component={DoorBackSharp} className={`${classes.gold} ${classes.serverStatusIcon}`} />
-        </Typography>
-      </Tooltip>,
+        <DoorBackSharp className={`${classes.gold} ${classes.serverStatusIcon}`} />
+      </span>,
     );
   }
   if (contractCount) {
     components.push(
-      <Tooltip key="contract" title={<>Coding contract count: {contractCount}</>}>
-        <Typography>
-          <SvgIcon component={Code} className={classes.serverStatusIcon} />
-          {contractCount}
-        </Typography>
-      </Tooltip>,
+      <span key="contract" title={`Coding contract count: ${contractCount}`} style={summaryItemStyle}>
+        <Code className={classes.serverStatusIcon} />
+        {contractCount}
+      </span>,
     );
   }
   if (fileCount) {
     components.push(
-      <Tooltip key="file" title={<>{textFilesTooltip}</>}>
-        <Typography color={fileCount ? "primary" : "secondary"}>
-          <SvgIcon component={Description} className={classes.serverStatusIcon} />
-          {fileCount}
-        </Typography>
-      </Tooltip>,
+      <span
+        key="file"
+        title={textFilesTooltip}
+        className={fileCount ? classes.txtPrimary : classes.txtSecondary}
+        style={summaryItemStyle}
+      >
+        <Description className={classes.serverStatusIcon} />
+        {fileCount}
+      </span>,
     );
   }
   if (server.blockedRam) {
     components.push(
-      <Tooltip
+      <span
         key="ramBlocked"
-        title={<>Ram blocked by owner: {ramBlockedDetails}. This can be freed up using ns.dnet.memoryReallocation()</>}
+        title={`Ram blocked by owner: ${ramBlockedDetails}. This can be freed up using ns.dnet.memoryReallocation()`}
+        className={classes.txtSecondary}
+        style={summaryItemStyle}
       >
-        <Typography color={"secondary"}>
-          <SvgIcon component={LockPerson} className={classes.serverStatusIcon} />
-          {ramBlocked}
-        </Typography>
-      </Tooltip>,
+        <LockPerson className={classes.serverStatusIcon} />
+        {ramBlocked}
+      </span>,
     );
   }
   const maxIcons = showDetails ? components.length : 2;

--- a/src/DarkNet/ui/dnetStyles.ts
+++ b/src/DarkNet/ui/dnetStyles.ts
@@ -114,6 +114,12 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
     textIndent: "2em",
     color: "grey",
   },
+  txtPrimary: {
+    color: theme.palette.primary.main,
+  },
+  txtSecondary: {
+    color: theme.palette.secondary.main,
+  },
 }));
 
 /*
@@ -147,7 +153,7 @@ export const DWServerStyles = {
   fontSize: "0.875rem",
   lineHeight: 1.75,
   transition:
-    "background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
+    "background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
   color: "#0c0",
 };
 export const DWServerLogStyles = { fontFamily: 'JetBrainsMono, "Courier New", monospace', fontSize: "12px" };

--- a/src/DarkNet/ui/networkCanvas.ts
+++ b/src/DarkNet/ui/networkCanvas.ts
@@ -8,9 +8,9 @@ import {
 } from "./dnetStyles";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 import { getNetDepth, isLabyrinthServer } from "../effects/labyrinth";
-import { NET_WIDTH } from "../Enums";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { getDarknetServerOrThrow } from "../utils/darknetServerUtils";
+import { NET_WIDTH } from "../Constants";
 
 export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
   const ctx = canvas?.getContext("2d");

--- a/src/DarkNet/utils/darknetNetworkUtils.ts
+++ b/src/DarkNet/utils/darknetNetworkUtils.ts
@@ -1,10 +1,10 @@
 import { DarknetState } from "../models/DarknetState";
 import { DarknetServer } from "../../Server/DarknetServer";
-import { AIR_GAP_DEPTH, MS_PER_MUTATION_PER_ROW, NET_WIDTH } from "../Enums";
 import { GetAllServers } from "../../Server/AllServers";
 import { getNetDepth } from "../effects/labyrinth";
 import { CONSTANTS } from "../../Constants";
 import { Player } from "@player";
+import { AIR_GAP_DEPTH, MS_PER_MUTATION_PER_ROW, NET_WIDTH } from "../Constants";
 
 export const getDarknetCyclesPerMutation = () => {
   const depth = getNetDepth();

--- a/test/jest/Darknet/Labyrinth.test.ts
+++ b/test/jest/Darknet/Labyrinth.test.ts
@@ -13,12 +13,12 @@ import { Player } from "@player";
 import { DarknetState } from "../../../src/DarkNet/models/DarknetState";
 import { populateDarknet } from "../../../src/DarkNet/controllers/NetworkGenerator";
 import { SpecialServers } from "../../../src/Server/data/SpecialServers";
-import { MAX_NET_DEPTH, NET_WIDTH } from "../../../src/DarkNet/Enums";
 import type { DarknetServer } from "../../../src/Server/DarknetServer";
 import { PlayerOwnedAugmentation } from "../../../src/Augmentation/PlayerOwnedAugmentation";
 import { AugmentationName } from "@enums";
 import { getAuthResult } from "../../../src/DarkNet/effects/authentication";
 import { getMostRecentAuthLog } from "../../../src/DarkNet/models/packetSniffing";
+import { MAX_NET_DEPTH, NET_WIDTH } from "../../../src/DarkNet/Constants";
 
 beforeAll(() => {
   initGameEnvironment();


### PR DESCRIPTION
Players have been asking for darknet to take a bit longer at higher levels. Currently, as players get many augs, they can quickly reach the bottom of the 'net and repeatedly complete the bonus lab. I've had multiple people mention that it would be nice if the net got harder or deeper the more you completed it:
https://discord.com/channels/415207508303544321/415213435974975508/1496580682372087881

This pr increases the depth of the darknet each time you complete the bonus lab (up to a cap).
It also slightly decreases the overall server density and eventually caps the number of servers entirely, making later completions harder - both because there is more distance and because there are fewer servers/connections.
Finally, it increases the size of the lab maze (again, up to a cap)

In order to support this, I have also trimmed down some of the components and styling in the darknet, and made ore use of memoization, to ensure the UI is responsive enough to handle the largest nets.

This is deployed for testing at https://ficocelliguy.github.io/bitburner-src/