### PR TITLE
UI: correct text for kidnap crime description and update work header

### DIFF
--- a/src/Crime/Crimes.ts
+++ b/src/Crime/Crimes.ts
@@ -186,7 +186,7 @@ export const Crimes: Record<CrimeType, Crime> = {
 
   [CrimeType.kidnap]: new Crime(
     "to kidnap",
-    "Attempt to kidnap and ransom a high-profile-target",
+    "Attempt to kidnap and ransom a high-profile target",
     CrimeType.kidnap,
     120e3,
     3.6e6,

--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -300,7 +300,7 @@ function Work(): React.ReactElement {
     const perc = (Player.currentWork.unitCompleted / crime.time) * 100;
 
     details = <>{Player.currentWork.crimeType}</>;
-    header = <>You are attempting to {Player.currentWork.crimeType}</>;
+    header = <>You are attempting {Player.currentWork.getCrime().workName}</>;
     innerText = <>{perc.toFixed(2)}%</>;
   }
   if (isClassWork(Player.currentWork)) {


### PR DESCRIPTION
# UI: correct text for kidnap crime description and update work header in CharacterOverview

Before:
<img width="2241" height="884" alt="Screenshot from 2026-05-27 19-53-17" src="https://github.com/user-attachments/assets/fea21a0f-8ed7-4c1c-96dd-fdce4589b7f7" />
<img width="1747" height="638" alt="Screenshot from 2026-05-27 19-53-07" src="https://github.com/user-attachments/assets/6eed1f9a-4132-40df-a4e4-2b9bc832178d" />

After:
<img width="2240" height="875" alt="Screenshot from 2026-05-27 19-51-46" src="https://github.com/user-attachments/assets/460939b9-0a46-46dd-b7ca-670cf3357f3e" />
<img width="1731" height="659" alt="Screenshot from 2026-05-27 19-51-29" src="https://github.com/user-attachments/assets/0aa96496-cf90-4e8b-b69e-d50f58a67478" />

Notice that when the work is not focused, the crime name changes. This is due to line 303 in `ui/React/CharacterOverview` that states `header = <>You are attempting to {Player.currentWork.crimeType}</>;`. This is incorrect, `crimeType` is the name that is showed in the slums screen (where you choose which crime to commit). The correct value is `workName`, which is the one displayed on the focus tab.


PS: I ran all the steps in CONTRIBUTING.md except the ones that say to "update version", "update changelog"... because I didn't know where to edit it. If I have to do so, please tell me.
