### PR TITLE
BUGFIX: Fix an edge case with ram rounding

### DIFF
--- a/src/DarkNet/effects/ramblock.ts
+++ b/src/DarkNet/effects/ramblock.ts
@@ -103,7 +103,7 @@ export const getRamBlock = (maxRam: number): number => {
   }
 
   if (maxRam <= 64) {
-    return [16, 32, maxRam - 8][Math.floor(Math.random() * 3)];
+    return roundToTwo([16, 32, maxRam - 8][Math.floor(Math.random() * 3)]);
   }
 
   return roundToTwo([maxRam, maxRam - 8, maxRam - 64, maxRam / 2][Math.floor(Math.random() * 4)]);

--- a/test/jest/Darknet/Darknet.test.ts
+++ b/test/jest/Darknet/Darknet.test.ts
@@ -67,6 +67,8 @@ import { prestigeAugmentation } from "../../../src/Prestige";
 import { initStockMarket, StockMarket, SymbolToStockMap } from "../../../src/StockMarket/StockMarket";
 import { StockSymbol } from "@enums";
 import { GetAllServers } from "../../../src/Server/AllServers";
+import { roundToTwo } from "../../../src/utils/helpers/roundToTwo";
+import { getRamBlock } from "../../../src/DarkNet/effects/ramblock";
 
 beforeAll(() => {
   initGameEnvironment();
@@ -962,6 +964,26 @@ describe("CacheReward", () => {
       } else {
         expect(result.augmentationName).toBeUndefined();
       }
+    }
+  });
+});
+
+describe("ramblock", () => {
+  test.each([16, 16.01, 32.01, 64.01])("getRamBlock rounds %d correctly", (maxRam: number) => {
+    // This *must* be done within the function, Jest internally relies on
+    // Math.random so the mock must be restored immediately after.
+    const saved = Math.random;
+    let rng: number;
+    try {
+      Math.random = () => rng;
+      for (let i = 0; i < 1; i += 1.0 / 8.0) {
+        rng = i;
+        const result = getRamBlock(maxRam);
+        // We want *exact* equality
+        expect(result).toBe(roundToTwo(result));
+      }
+    } finally {
+      Math.random = saved;
     }
   });
 });

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -757,6 +757,9 @@ describe("darkweb", () => {
     if (!result.success) {
       throw new Error("Cannot add cache");
     }
+    if (result.cacheFilename == null) {
+      throw new Error("No cache filename");
+    }
     expect(darkweb.caches.length).toBe(1);
     expect(darkweb.caches[0]).toMatch(/test_[0-9]+\.cache/);
     ns.dnet.openCache(result.cacheFilename);
@@ -898,9 +901,12 @@ describe("Non-darkweb darknet server", () => {
   });
   test("openCache", () => {
     const ns = getNsOnNonDarkwebDarknetServer();
-    const result = addCacheToServer(getDarknetServerOrThrow(ns.getHostname()), "test.cache");
+    const result = addCacheToServer(getDarknetServerOrThrow(ns.getHostname()), false, "test.cache");
     if (!result.success) {
       throw new Error(result.message);
+    }
+    if (result.cacheFilename == null) {
+      throw new Error("No cache filename");
     }
     ns.dnet.openCache(result.cacheFilename);
   });


### PR DESCRIPTION
Because `maxRam` is not necessarily an integer, `maxRam- 8` will not necessarily be correctly rounded, *even if* `maxRam` is. For instance, `32 * 1.15 = 36.8` (rounds correctly naturally), but `36.8 - 8 = 28.799999999999997` (rounds "wrong.") This happens due to crossing precision boundaries at powers of two.

The correct answer is to *always* use `roundToTwo` whenever there's any chance of a fractional ram amount.