### PR TITLE
GRAFTING: Change grafting time calculations to account of the augs power (percentage of all boosts) versus the amount of stats affected

### DIFF
--- a/src/PersonObjects/Grafting/GraftableAugmentation.ts
+++ b/src/PersonObjects/Grafting/GraftableAugmentation.ts
@@ -23,7 +23,8 @@ export class GraftableAugmentation {
 
   get time(): number {
     // Time = 1 hour * log_2(sum(aug multipliers) || 1) + 30 minutes
-    const antiLog = Math.max(sum(Object.values(this.augmentation.mults).filter((x) => x !== 1)), 1);
+    const augmentMults = Object.values(this.augmentation.mults).filter((x) => x !== 1);
+    const antiLog = Math.max(sum(Object.values(augmentMults))) - augmentMults.length + 1;
 
     const mult = Math.log2(antiLog);
     return (CONSTANTS.AugmentationGraftingTimeBase * mult + CONSTANTS.MillisecondsPerHalfHour) / 2;


### PR DESCRIPTION
Current grafting code favors the amount of stats modified by an aug instead of the total modification of stats of the aug.  This leads to some not very good augs, that modify many things, to have very long graft times that no one would want to wait for.

I changed the code to look at the sum of the total % of all stats modified instead.

Column on the left is new times, column on the right is old times

[GraftingTImes.xlsx](https://github.com/user-attachments/files/28356698/GraftingTImes.xlsx)

Opening as a draft PR 