### PR TITLE
BUGFIX: Steam version fails to launch on Windows without VC++ and on old Linux distros

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-process-exit */
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { app, dialog, BrowserWindow, ipcMain, protocol, net } = require("electron");
+const { app, dialog, BrowserWindow, ipcMain, protocol, net, shell } = require("electron");
 
 const log = require("electron-log");
 log.catchErrors();
@@ -19,7 +19,7 @@ app.on("window-all-closed", () => {
   process.exit(0);
 });
 
-require("./steamworksUtils");
+const { MissingVcRuntimeError } = require("./steamworksUtils");
 const gameWindow = require("./gameWindow");
 const utils = require("./utils");
 const storage = require("./storage");
@@ -261,13 +261,20 @@ app.on("ready", async () => {
   } else {
     window = await startWindow(process.argv.includes("--no-scripts"));
     if (global.steamworksError) {
-      await dialog.showMessageBox(window, {
+      const buttons = ["OK"];
+      if (global.steamworksError instanceof MissingVcRuntimeError) {
+        buttons.push("Download Visual C++ v14 Redistributable");
+      }
+      const { response } = await dialog.showMessageBox(window, {
         title: "Bitburner",
         message: "Could not connect to Steam",
-        detail: `${global.steamworksError.message}\n\nYou won't be able to receive achievements until this is resolved and you restart the game.`,
+        detail: `${global.steamworksError.message}\n\nSteam Cloud and Steam achievements won't work until this is resolved and you restart the game.`,
         type: "warning",
-        buttons: ["OK"],
+        buttons,
       });
+      if (response === 1) {
+        await shell.openExternal("https://aka.ms/vc14/vc_redist.x64.exe");
+      }
     }
   }
 });

--- a/electron/steamworksUtils.js
+++ b/electron/steamworksUtils.js
@@ -1,12 +1,93 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const steamworks = require("@catloversg/steamworks.js");
+const { app } = require("electron");
+const fs = require("node:fs");
+const path = require("node:path");
 const log = require("electron-log");
+
+class MissingVcRuntimeError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+function isVcRuntimeInstalled() {
+  // Electron only supports 64-bit Windows on modern versions, so checking the 64-bit runtime DLL in System32 is
+  // sufficient. SysWOW64 and registry checks are unnecessary.
+  return fs.existsSync(path.join(process.env.SystemRoot || "C:\\Windows", "System32", "vcruntime140.dll"));
+}
+
+function verifyLibraryFiles() {
+  const basePath = path.join(app.getAppPath(), "node_modules", "@catloversg", "steamworks.js", "dist");
+  let folderPath;
+  let requiredFiles;
+  switch (process.platform) {
+    case "win32": {
+      folderPath = path.join(basePath, "win64");
+      requiredFiles = ["steam_api64.dll", "steamworksjs.win32-x64-msvc.node"];
+      break;
+    }
+    case "linux": {
+      folderPath = path.join(basePath, "linux64");
+      requiredFiles = ["libsteam_api.so", "steamworksjs.linux-x64-gnu.node"];
+      break;
+    }
+    case "darwin": {
+      folderPath = path.join(basePath, "osx");
+      requiredFiles = ["libsteam_api.dylib", "steamworksjs.darwin-x64.node", "steamworksjs.darwin-arm64.node"];
+      break;
+    }
+    default:
+      return { success: false, error: new Error(`Invalid platform: ${process.platform}`) };
+  }
+  const missingFiles = [];
+  for (const file of requiredFiles) {
+    const filePath = path.join(folderPath, file);
+    if (fs.existsSync(filePath)) {
+      continue;
+    }
+    missingFiles.push(file);
+  }
+  if (missingFiles.length > 0) {
+    return { success: false, error: new Error(`Cannot find ${missingFiles.join(",")}`) };
+  }
+  return { success: true };
+}
+
+let steamworks;
+try {
+  steamworks = require("@catloversg/steamworks.js");
+} catch (error) {
+  log.error(error);
+  log.info(
+    process.report.getReport().header.osName,
+    process.report.getReport().header.osRelease,
+    process.report.getReport().header.osVersion,
+    process.report.getReport().header.osMachine,
+  );
+  // Check whether required native library files exist, in case the installation is incomplete or corrupted.
+  const result = verifyLibraryFiles();
+  if (!result.success) {
+    global.steamworksError = result.error;
+  } else if (process.platform === "win32" && !isVcRuntimeInstalled()) {
+    // steamworksjs.win32-x64-msvc.node depends on vcruntime140.dll.
+    global.steamworksError = new MissingVcRuntimeError("You need to install Visual C++ v14 Redistributable.");
+  } else if (process.platform === "linux" && error instanceof Error && error.message.includes("GLIBC_")) {
+    // The native module depends on newer glibc versions that are unavailable on some older Linux distributions,
+    // including still-supported RHEL8-based systems.
+    global.steamworksError = new Error(
+      `Your OS version is too outdated: ${process.report.getReport().header.osRelease}.`,
+    );
+  } else {
+    global.steamworksError = error;
+  }
+}
 
 /** @type {ReturnType<typeof import("@catloversg/steamworks.js").init> | undefined} */
 let steamworksClient = undefined;
 try {
   // 1812820 is our Steam App ID.
-  steamworksClient = steamworks.init(1812820);
+  steamworksClient = steamworks?.init(1812820);
 } catch (error) {
   if (error instanceof Error) {
     log.warn(error.message);
@@ -20,5 +101,6 @@ try {
 }
 
 module.exports = {
+  MissingVcRuntimeError,
   steamworksClient,
 };


### PR DESCRIPTION
The Steam version fails to launch because it crashes at `require("@catloversg/steamworks.js")`.

On Windows:
```
[error] Unhandled Exception Error: The specified module could not be found.
\\?\C:\Users\username\Downloads\bitburner-win32-x64\resources\app\node_modules\@catloversg\steamworks.js\dist\win64\steamworksjs.win32-x64-msvc.node
    at process.func [as dlopen] (node:electron/js2c/node_init:2:2630)
    at Module._extensions..node (node:internal/modules/cjs/loader:1998:18)
    at Object.func [as .node] (node:electron/js2c/node_init:2:2630)
    at Module.load (node:internal/modules/cjs/loader:1560:32)
    at Module._load (node:internal/modules/cjs/loader:1362:12)
    at c._load (node:electron/js2c/node_init:2:18060)
    at wrapModuleLoad (node:internal/modules/cjs/loader:262:19)
    at Module.require (node:internal/modules/cjs/loader:1583:12)
    at require (node:internal/modules/helpers:153:16)
    at Object.<anonymous> (C:\Users\username\Downloads\bitburner-win32-x64\resources\app\node_modules\@catloversg\steamworks.js\index.js:8:21)
```
The error message is misleading. `steamworksjs.win32-x64-msvc.node` depends on `vcruntime140.dll`.

On AlmaLinux 8:
```
[error] Error: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /home/username/Documents/bitburner-linux-x64/resources/app/node_modules/@catloversg/steamworks.js/dist/linux64/steamworksjs.linux-x64-gnu.node)
    at process.func [as dlopen] (node:electron/js2c/node_init:2:2630)
    at Module._extensions..node (node:internal/modules/cjs/loader:1998:18)
    at Object.func [as .node] (node:electron/js2c/node_init:2:2630)
    at Module.load (node:internal/modules/cjs/loader:1560:32)
    at Module._load (node:internal/modules/cjs/loader:1362:12)
    at c._load (node:electron/js2c/node_init:2:18060)
    at wrapModuleLoad (node:internal/modules/cjs/loader:262:19)
    at Module.require (node:internal/modules/cjs/loader:1583:12)
    at require (node:internal/modules/helpers:153:16)
    at Object.<anonymous> (/home/username/Documents/bitburner-linux-x64/resources/app/node_modules/@catloversg/steamworks.js/index.js:10:21)
```
RHEL 8 only supports glibc 2.28.

After applying the fix:

<img width="550" height="252" alt="windows" src="https://github.com/user-attachments/assets/5af7abf1-e687-4caf-9764-c69b99c32229" />

<img width="537" height="235" alt="linux" src="https://github.com/user-attachments/assets/f7eb2364-87a0-408c-9643-d30d2c7c4699" />
