### PR TITLE
CITY: Add BN hint to special locations

### DIFF
--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -158,13 +158,28 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
     );
   }
 
+  function specialLocationNextBNHint(bn_number: number): React.ReactElement {
+    if (knowAboutBitverse()) {
+      return (
+        <>
+          <br />
+          <br />
+          <Typography>You should check out BN-{bn_number} to uncover more details about this place.</Typography>
+        </>
+      )
+    }
+    return <></>;
+  }
+
   function CreateCorporation(): React.ReactElement {
     const [open, setOpen] = useState(false);
     if (!Player.canAccessCorporation()) {
+
       return (
         <>
           <Typography>
             <i>A businessman is yelling at a clerk. You should come back later.</i>
+            {specialLocationNextBNHint(3)}
           </Typography>
         </>
       );
@@ -181,7 +196,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
 
   function renderGrafting(): React.ReactElement {
     if (!Player.canAccessGrafting()) {
-      return <></>;
+      { specialLocationNextBNHint(10) };
     }
     return (
       <Button onClick={handleGrafting} sx={{ my: 5 }}>
@@ -293,6 +308,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
             <br />
             <br />A symbol is carved in the altar.
           </Typography>
+
           <br />
           {symbol}
         </>

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -51,6 +51,20 @@ interface SpecialLocationProps {
 export function SpecialLocation(props: SpecialLocationProps): React.ReactElement {
   const rerender = useRerender();
 
+  // Special Location Hints
+  function specialLocationNextBNHint(bn_number: number): React.ReactElement {
+    if (knowAboutBitverse()) {
+      return (
+        <>
+          <br />
+          <br />
+          <Typography>You should check out BN-{bn_number} to uncover more details about this place.</Typography>
+        </>
+      )
+    }
+    return <></>;
+  }
+
   // Apply for Bladeburner division
   const joinBladeburnerDivision = useCallback(() => {
     Player.startBladeburner();
@@ -104,7 +118,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
 
   function renderBladeburner(): React.ReactElement {
     if (!Player.canAccessBladeburner() || currentNodeMults.BladeburnerRank === 0) {
-      return <></>;
+      { specialLocationNextBNHint(6) };
     }
     const text = Player.bladeburner ? "Enter Bladeburner Headquarters" : "Apply to Bladeburner Division";
     return (
@@ -156,19 +170,6 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
         <Button onClick={EatNoodles}>Eat noodles</Button>
       </>
     );
-  }
-
-  function specialLocationNextBNHint(bn_number: number): React.ReactElement {
-    if (knowAboutBitverse()) {
-      return (
-        <>
-          <br />
-          <br />
-          <Typography>You should check out BN-{bn_number} to uncover more details about this place.</Typography>
-        </>
-      )
-    }
-    return <></>;
   }
 
   function CreateCorporation(): React.ReactElement {
@@ -307,6 +308,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
             A decrepit altar stands in the middle of a dilapidated church.
             <br />
             <br />A symbol is carved in the altar.
+            {specialLocationNextBNHint(13)}
           </Typography>
 
           <br />

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -181,8 +181,8 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
         <>
           <Typography>
             <i>A businessman is yelling at a clerk. You should come back later.</i>
-            {specialLocationNextBNHint(3)}
           </Typography>
+          {specialLocationNextBNHint(3)}
         </>
       );
     }

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -60,7 +60,7 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
           <br />
           <Typography>You should check out BN-{bn_number} to uncover more details about this place.</Typography>
         </>
-      )
+      );
     }
     return <></>;
   }
@@ -118,7 +118,9 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
 
   function renderBladeburner(): React.ReactElement {
     if (!Player.canAccessBladeburner() || currentNodeMults.BladeburnerRank === 0) {
-      { specialLocationNextBNHint(6) };
+      {
+        return specialLocationNextBNHint(6);
+      }
     }
     const text = Player.bladeburner ? "Enter Bladeburner Headquarters" : "Apply to Bladeburner Division";
     return (
@@ -175,7 +177,6 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
   function CreateCorporation(): React.ReactElement {
     const [open, setOpen] = useState(false);
     if (!Player.canAccessCorporation()) {
-
       return (
         <>
           <Typography>
@@ -197,7 +198,9 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
 
   function renderGrafting(): React.ReactElement {
     if (!Player.canAccessGrafting()) {
-      { specialLocationNextBNHint(10) };
+      {
+        return specialLocationNextBNHint(10);
+      }
     }
     return (
       <Button onClick={handleGrafting} sx={{ my: 5 }}>
@@ -308,11 +311,11 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
             A decrepit altar stands in the middle of a dilapidated church.
             <br />
             <br />A symbol is carved in the altar.
-            {specialLocationNextBNHint(13)}
           </Typography>
 
           <br />
           {symbol}
+          <Typography>{specialLocationNextBNHint(13)}</Typography>
         </>
       );
     }


### PR DESCRIPTION
closes #2819 

Add BN hints to special locations. For example, Sector-12's City Hall now has the following text when the player discovers the Bitverse:
<img width="2245" height="1581" alt="Screenshot from 2026-05-29 21-37-05" src="https://github.com/user-attachments/assets/97a0debc-0922-4ee6-a06e-422f16496033" />

Places that changed and now contain the hint:
**Sector-12:** City Hall (Corp)
**Sector-12:** NSA (Bladeburner)
**Chongqing:** Church (CotMG)
**New Tokyo:** Vitalife (Sleeves)

@catloversg I was thinking maybe we can use `CorruptibleText` for those texts. What do you think?
