### PR TITLE
MISC: fix deprecated `nFormat` replacement text

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1529,7 +1529,7 @@ setRemovedFunctions(ns, {
   getServerRam: { version: "2.2.0", replacement: "getServerMaxRam and getServerUsedRam" },
   nFormat: {
     version: "3.0.0",
-    replacement: "ns.formatNumber, ns.formatRam, ns.formatPercent, or JS built-in objects/functions",
+    replacement: "ns.format.number(), ns.format.ram(), ns.format.percent(), or JS built-in objects/functions",
   },
   getTimeSinceLastAug: {
     version: "3.0.0",


### PR DESCRIPTION
Improves a fairly minor bit of awkwardness:
Scripts which use `nFormat` get a deprecation error that tells them to use another deprecated function (visible a few lines below).

It might as well just tell them the latest functions instead.

---

I have just edited this in github's UI because it seems likely sufficient from a skim and brief search, but I'm not sure off-hand if there are other steps needed (e.g. rebuild docs?).

I'm happy to do so if there is, I'm just hoping to avoid it unless necessary :)  I'm a complete first-timer for this repo, so I may be missing something extremely obvious.