### PR TITLE
DOCS: Fix a few ram costs that are incorrect in the ns docs

### DIFF
--- a/markdown/bitburner.singularity.getdarkwebprograms.md
+++ b/markdown/bitburner.singularity.getdarkwebprograms.md
@@ -19,7 +19,7 @@ getDarkwebPrograms(): ProgramName[];
 
 ## Remarks
 
-RAM cost: 1 GB \* 16/4/1
+RAM cost: 0.5 GB \* 16/4/1
 
 This function allows the player to get a list of programs available for purchase on the dark web. Players MUST have purchased Tor to get the list of programs available. If Tor has not been purchased yet, this function will return an empty list.
 

--- a/markdown/bitburner.singularity.hospitalize.md
+++ b/markdown/bitburner.singularity.hospitalize.md
@@ -17,5 +17,5 @@ void
 
 ## Remarks
 
-RAM cost: 0.25 GB \* 16/4/1
+RAM cost: 0.5 GB \* 16/4/1
 

--- a/markdown/bitburner.stanek.getfragment.md
+++ b/markdown/bitburner.stanek.getfragment.md
@@ -72,5 +72,5 @@ The fragment at \[rootX, rootY\], if any.
 
 ## Remarks
 
-RAM cost: 5 GB
+RAM cost: 2 GB
 

--- a/markdown/bitburner.userinterface.clearterminal.md
+++ b/markdown/bitburner.userinterface.clearterminal.md
@@ -17,5 +17,5 @@ void
 
 ## Remarks
 
-RAM cost: 0.2 GB
+RAM cost: 0 GB
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2717,7 +2717,7 @@ export interface Singularity {
   /**
    * Hospitalize the player.
    * @remarks
-   * RAM cost: 0.25 GB * 16/4/1
+   * RAM cost: 0.5 GB * 16/4/1
    */
   hospitalize(): void;
 
@@ -2820,7 +2820,7 @@ export interface Singularity {
   /**
    * Get a list of programs offered on the dark web.
    * @remarks
-   * RAM cost: 1 GB * 16/4/1
+   * RAM cost: 0.5 GB * 16/4/1
    *
    *
    * This function allows the player to get a list of programs available for purchase
@@ -6709,7 +6709,7 @@ interface Stanek {
   /**
    * Get placed fragment at location.
    * @remarks
-   * RAM cost: 5 GB
+   * RAM cost: 2 GB
    *
    * @param rootX - X against which to align the top left of the fragment.
    * @param rootY - Y against which to align the top left of the fragment.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7014,7 +7014,7 @@ interface UserInterface {
   /**
    * Clear the Terminal window, as if the player ran `clear` in the terminal
    * @remarks
-   * RAM cost: 0.2 GB
+   * RAM cost: 0 GB
    */
   clearTerminal(): void;
 }


### PR DESCRIPTION
When looking into the mis-labeled ram costs in #2830 , I identified a few more that are incorrect.

` Singularity.hospitalize` is `SF4Cost(RamCostConstants.SingularityFn1 / 4)`  - 2/4 or 0.5gig base, incorrectly labelled as 0.25

`Singularity.getDarkwebPrograms`  is `SF4Cost(RamCostConstants.SingularityFn1 / 4)`  - 2/4 or 0.5gig base, incorrectly labelled as 1

`Stanek.getFragment` is `RamCostConstants.StanekFragmentAt` - 2gig, incorrectly labelled as 5

`UserInterface.clearTerminal` - 0gig, incorrectly labelled as 0.2