### PR TITLE
MISC: Request strict durability for save transactions

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -109,7 +109,7 @@ export async function save(saveData: SaveData): Promise<void> {
   }
   const db = await getDB();
   return new Promise((resolve, reject) => {
-    const transaction = db.transaction(["savestring"], "readwrite");
+    const transaction = db.transaction(["savestring"], "readwrite", { durability: "strict" });
     const rejectHandler = () => {
       reject(transaction.error ?? new Error("Cannot save game data. Transaction aborted or encountered an error."));
     };


### PR DESCRIPTION
## Change Description

Request strict IndexedDB transaction durability when saving game data. This asks the browser to flush outstanding changes to persistent storage before the save transaction reports completion, reducing the risk of an interrupted save leaving corrupted data behind.

Closes #2809

## Testing

- `npx tsc --noEmit`
- `npm run lint:report`
- `npx webpack --mode development`
- `npm run test` was run locally, but the existing Corporation and Sleeve floating-point assertions fail under Node `v23.11.0`. `CONTRIBUTING.md` documents these unrelated failures for Node versions older than v24.

## Screenshots

Not applicable: this change does not affect the UI.