### PR TITLE
UI: Make tutorial content scrollable

### DIFF
--- a/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
+++ b/src/ui/InteractiveTutorial/InteractiveTutorialRoot.tsx
@@ -593,32 +593,32 @@ export async function main(ns) {
 
   const step = ITutorial.currStep;
   const content = contents[step];
-  if (content === undefined) throw new Error("error in the tutorial");
+  if (content === undefined) {
+    throw new Error(`Invalid step in the tutorial: ${step}`);
+  }
   return (
-    <>
-      <Paper square sx={{ maxWidth: "70vw", p: 2 }}>
-        {content.content}
-        <br />
-        {step !== iTutorialSteps.DocumentationPageInfo && (
-          <>
-            {step !== iTutorialSteps.Start && (
-              <Button onClick={iTutorialPrevStep} aria-label="previous" style={{ marginRight: "1em" }}>
-                Previous
-              </Button>
-            )}
-            {(content.canNext || ITutorial.stepIsDone[step]) && (
-              <Button onClick={iTutorialNextStep} aria-label="next">
-                Next
-              </Button>
-            )}
-          </>
-        )}
-        <br />
-        <br />
-        <Button onClick={iTutorialEnd}>
-          {step !== iTutorialSteps.DocumentationPageInfo ? "Exit Tutorial" : "Finish Tutorial"}
-        </Button>
-      </Paper>
-    </>
+    <Paper square sx={{ maxWidth: "70vw", p: 2 }}>
+      {content.content}
+      <br />
+      {step !== iTutorialSteps.DocumentationPageInfo && (
+        <>
+          {step !== iTutorialSteps.Start && (
+            <Button onClick={iTutorialPrevStep} aria-label="previous" style={{ marginRight: "1em" }}>
+              Previous
+            </Button>
+          )}
+          {(content.canNext || ITutorial.stepIsDone[step]) && (
+            <Button onClick={iTutorialNextStep} aria-label="next">
+              Next
+            </Button>
+          )}
+        </>
+      )}
+      <br />
+      <br />
+      <Button onClick={iTutorialEnd}>
+        {step !== iTutorialSteps.DocumentationPageInfo ? "Exit Tutorial" : "Finish Tutorial"}
+      </Button>
+    </Paper>
   );
 }

--- a/src/ui/React/Overview.tsx
+++ b/src/ui/React/Overview.tsx
@@ -123,7 +123,7 @@ export function Overview({ children, mode }: IProps): React.ReactElement {
     return <></>;
   return (
     <Draggable handle=".drag" bounds="body" onStop={handleStop} defaultPosition={{ x, y }}>
-      <Paper className={classes.overviewContainer} square>
+      <Paper className={classes.overviewContainer} square style={{ maxHeight: "100vh", overflowY: "auto" }}>
         <Box className="drag" onDoubleClick={() => setOpen((old) => !old)} ref={draggableRef}>
           <Box className={classes.header}>
             <LeftIcon color="secondary" className={classes.icon} sx={{ padding: "2px" }} />


### PR DESCRIPTION
When using a very low resolution and a high window size scaling factor, the tutorial content can become taller than the viewport. As a result, some buttons may be inaccessible, including the "Finish Tutorial" button.

<img width="1173" height="821" alt="Capture" src="https://github.com/user-attachments/assets/68e6fde5-00a3-4d78-9de5-8f7df0da7b66" />

This PR makes the tutorial content scrollable so players can scroll through it and access all buttons. Technically, this change makes the entire overview container scrollable, including both the tutorial content and the overview panel. However, this should not cause any issues.