### PR TITLE
MISC: Change random server selection when generating coding contracts

### DIFF
--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -190,29 +190,18 @@ export function getRandomReward(): ICodingContractReward {
   return { type: getRandomIntInclusive(0, validRewardTypes.length - 1) };
 }
 
-function getRandomServer(): BaseServer | null {
-  const servers = GetAllServers().filter((server: BaseServer) => server.serversOnNetwork.length !== 0);
+export function getRandomServer(): BaseServer | null {
+  const servers = GetAllServers().filter(
+    (server: BaseServer) =>
+      server instanceof Server &&
+      !server.purchasedByPlayer &&
+      server.hostname !== SpecialServers.WorldDaemon &&
+      server.serversOnNetwork.length !== 0,
+  );
   if (servers.length === 0) {
     return null;
   }
-  let randIndex = getRandomIntInclusive(0, servers.length - 1);
-  let randServer = servers[randIndex];
-
-  // An infinite loop shouldn't ever happen, but to be safe we'll use
-  // a for loop with a limited number of tries
-  for (let i = 0; i < 200; ++i) {
-    if (
-      randServer instanceof Server &&
-      !randServer.purchasedByPlayer &&
-      randServer.hostname !== SpecialServers.WorldDaemon
-    ) {
-      break;
-    }
-    randIndex = getRandomIntInclusive(0, servers.length - 1);
-    randServer = servers[randIndex];
-  }
-
-  return randServer;
+  return servers[getRandomIntInclusive(0, servers.length - 1)];
 }
 
 /**

--- a/src/Documentation/doc/en/basic/codingcontracts.md
+++ b/src/Documentation/doc/en/basic/codingcontracts.md
@@ -9,7 +9,8 @@ Each contract has a limited number of attempts.
 If you provide the wrong answer too many times and exceed the number of attempts, the contract will self-destruct (delete itself).
 
 Coding Contracts are randomly generated and spawn over time. Initially, you'll only see a small range of the easier contracts, but as you progress further through the game more challenging ones will unlock.
-They can appear on any [server](servers.md) (including your home computer), except for your purchased [servers](servers.md).
+
+They can appear on non-darknet [servers](servers.md) that are not owned by the player (`Server.purchasedByPlayer` is false).
 
 ## Contract generation
 

--- a/test/jest/CodingContract/ContractGenerator.test.ts
+++ b/test/jest/CodingContract/ContractGenerator.test.ts
@@ -21,6 +21,7 @@ import { Companies } from "../../../src/Company/Companies";
 import { CodingContractTypes } from "../../../src/CodingContract/ContractTypes";
 import { getRecordEntries } from "../../../src/Types/Record";
 import { Server } from "../../../src/Server/Server";
+import { getDarkscapeNavigator } from "../../../src/DarkNet/effects/effects";
 
 beforeAll(() => {
   initGameEnvironment();
@@ -61,6 +62,7 @@ describe("Generator", () => {
   });
   test("getRandomServer", () => {
     Player.sourceFiles.set(9, 3);
+    getDarkscapeNavigator();
     const ns = getNS();
     for (let i = 0; i < ns.cloud.getServerLimit(); ++i) {
       ns.cloud.purchaseServer(`pserver-${i}`, 2);
@@ -68,20 +70,34 @@ describe("Generator", () => {
     for (let i = 0; i < ns.hacknet.maxNumNodes(); ++i) {
       ns.hacknet.purchaseNode();
     }
+    const isValidTargetServerForGeneratingContract = (server: BaseServer) => {
+      return (
+        server instanceof Server &&
+        !server.purchasedByPlayer &&
+        server.hostname !== SpecialServers.WorldDaemon &&
+        server.serversOnNetwork.length !== 0
+      );
+    };
+
     for (let i = 0; i < 10000; ++i) {
       const server = getRandomServer();
       if (server === null) {
         throw new Error(`getRandomServer does not return a server`);
       }
-      if (
-        !(server instanceof Server) ||
-        server.purchasedByPlayer ||
-        server.hostname === SpecialServers.WorldDaemon ||
-        server.serversOnNetwork.length === 0
-      ) {
+      if (!isValidTargetServerForGeneratingContract(server)) {
         throw new Error(`getRandomServer returns an invalid server: ${server.hostname}`);
       }
     }
+
+    const spiedMathRandom = jest.spyOn(Math, "random").mockReturnValue(0);
+    const server = getRandomServer();
+    if (server === null) {
+      throw new Error(`getRandomServer does not return a server`);
+    }
+    if (!isValidTargetServerForGeneratingContract(server)) {
+      throw new Error(`getRandomServer returns an invalid server: ${server.hostname}`);
+    }
+    spiedMathRandom.mockRestore();
   });
 });
 

--- a/test/jest/CodingContract/ContractGenerator.test.ts
+++ b/test/jest/CodingContract/ContractGenerator.test.ts
@@ -70,34 +70,27 @@ describe("Generator", () => {
     for (let i = 0; i < ns.hacknet.maxNumNodes(); ++i) {
       ns.hacknet.purchaseNode();
     }
-    const isValidTargetServerForGeneratingContract = (server: BaseServer) => {
-      return (
-        server instanceof Server &&
-        !server.purchasedByPlayer &&
-        server.hostname !== SpecialServers.WorldDaemon &&
-        server.serversOnNetwork.length !== 0
-      );
-    };
-
-    for (let i = 0; i < 10000; ++i) {
+    const testRandomServer = () => {
       const server = getRandomServer();
       if (server === null) {
         throw new Error(`getRandomServer does not return a server`);
       }
-      if (!isValidTargetServerForGeneratingContract(server)) {
+      if (
+        !(server instanceof Server) ||
+        server.purchasedByPlayer ||
+        server.hostname === SpecialServers.WorldDaemon ||
+        server.serversOnNetwork.length === 0
+      ) {
         throw new Error(`getRandomServer returns an invalid server: ${server.hostname}`);
       }
-    }
+    };
 
     const spiedMathRandom = jest.spyOn(Math, "random").mockReturnValue(0);
-    const server = getRandomServer();
-    if (server === null) {
-      throw new Error(`getRandomServer does not return a server`);
-    }
-    if (!isValidTargetServerForGeneratingContract(server)) {
-      throw new Error(`getRandomServer returns an invalid server: ${server.hostname}`);
-    }
+    testRandomServer();
     spiedMathRandom.mockRestore();
+    for (let i = 0; i < 10000; ++i) {
+      testRandomServer();
+    }
   });
 });
 

--- a/test/jest/CodingContract/ContractGenerator.test.ts
+++ b/test/jest/CodingContract/ContractGenerator.test.ts
@@ -6,6 +6,7 @@ import {
   generateRandomContractOnHome,
   getRandomFilename,
   getRandomReward,
+  getRandomServer,
 } from "../../../src/CodingContract/ContractGenerator";
 import { CodingContractName, CompanyName, JobField, JobName } from "../../../src/Enums";
 import { GetAllServers } from "../../../src/Server/AllServers";
@@ -19,6 +20,7 @@ import { Factions } from "../../../src/Faction/Factions";
 import { Companies } from "../../../src/Company/Companies";
 import { CodingContractTypes } from "../../../src/CodingContract/ContractTypes";
 import { getRecordEntries } from "../../../src/Types/Record";
+import { Server } from "../../../src/Server/Server";
 
 beforeAll(() => {
   initGameEnvironment();
@@ -56,6 +58,30 @@ describe("Generator", () => {
   test("generateContract - random server", () => {
     generateContract({});
     assertNumberOfContracts(1, GetAllServers());
+  });
+  test("getRandomServer", () => {
+    Player.sourceFiles.set(9, 3);
+    const ns = getNS();
+    for (let i = 0; i < ns.cloud.getServerLimit(); ++i) {
+      ns.cloud.purchaseServer(`pserver-${i}`, 2);
+    }
+    for (let i = 0; i < ns.hacknet.maxNumNodes(); ++i) {
+      ns.hacknet.purchaseNode();
+    }
+    for (let i = 0; i < 10000; ++i) {
+      const server = getRandomServer();
+      if (server === null) {
+        throw new Error(`getRandomServer does not return a server`);
+      }
+      if (
+        !(server instanceof Server) ||
+        server.purchasedByPlayer ||
+        server.hostname === SpecialServers.WorldDaemon ||
+        server.serversOnNetwork.length === 0
+      ) {
+        throw new Error(`getRandomServer returns an invalid server: ${server.hostname}`);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
The implementation of `getRandomServer` is awkward.

The documentation and the retry loop imply that coding contracts are intended to be generated only on NPC servers. However, with the current implementation, there is a very small chance that a contract will be generated on home, a cloud server, or a hacknet server.

The documentation is also incorrect. It states that the chosen server can be home, but `home.purchasedByPlayer` is true, so home can only be selected when the loop reaches its extremely unlikely fallback case.