### PR TITLE
BUGFIX: ns.singularity.b1tflum3 does not validate nextBN

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1139,6 +1139,9 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     b1tflum3: (ctx) => (_nextBN, _cbScript, _bitNodeOptions) => {
       helpers.checkSingularityAccess(ctx);
       const nextBN = helpers.number(ctx, "nextBN", _nextBN);
+      if (!validBitNodes.includes(nextBN)) {
+        throw new Error(`Invalid BitNode: ${_nextBN}.`);
+      }
       const cbScript = _cbScript
         ? resolveScriptFilePath(helpers.string(ctx, "cbScript", _cbScript), ctx.workerScript.name)
         : false;

--- a/src/RedPill.tsx
+++ b/src/RedPill.tsx
@@ -12,6 +12,7 @@ import { getDefaultBitNodeOptions, setBitNodeOptions } from "./BitNode/BitNodeUt
 import { prestigeWorkerScripts } from "./NetscriptWorker";
 import { exceptionAlert } from "./utils/helpers/exceptionAlert";
 import { ActivateRecoveryMode } from "./ui/React/RecoveryRoot";
+import { validBitNodes } from "./BitNode/Constants";
 
 function giveSourceFile(bitNodeNumber: number): void {
   const sourceFileKey = "SourceFile" + bitNodeNumber.toString();
@@ -56,6 +57,9 @@ export function enterBitNode(
   newBitNode: number,
   bitNodeOptions: BitNodeOptions,
 ): void {
+  if (!validBitNodes.includes(newBitNode)) {
+    throw new Error(`Invalid BitNode: ${newBitNode}.`);
+  }
   // We must kill all scripts before setting up BitNode data and performing the prestige.
   prestigeWorkerScripts();
 

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -278,6 +278,10 @@ describe("b1tflum3", () => {
       }).toThrow();
       expectFailToB1tflum3();
     });
+    test("Invalid nextBN", () => {
+      const ns = getNS();
+      expect(() => ns.singularity.b1tflum3(-1)).toThrow("Invalid BitNode");
+    });
   });
 });
 
@@ -372,6 +376,10 @@ describe("destroyW0r1dD43m0n", () => {
         });
       }).toThrow();
       expectFailToDestroyWD();
+    });
+    test("Invalid nextBN", () => {
+      const ns = getNS();
+      expect(() => ns.singularity.destroyW0r1dD43m0n(-1)).toThrow("Invalid BitNode");
     });
   });
 });


### PR DESCRIPTION
MRE: `ns.singularity.b1tflum3(-1)`

Without validation, an invalid nextBN will be written to `Player.bitNodeN`.