### PR TITLE
UI: Add hint for b1t_flum3.exe's "-q" option

### DIFF
--- a/src/BitNode/ui/BitFlumeModal.tsx
+++ b/src/BitNode/ui/BitFlumeModal.tsx
@@ -5,6 +5,7 @@ import { Page } from "../../ui/Router";
 import { EventEmitter } from "../../utils/EventEmitter";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
+import { CompletedProgramName } from "../../Enums";
 
 export const BitFlumeEvent = new EventEmitter<[]>();
 
@@ -24,6 +25,9 @@ export function BitFlumeModal(): React.ReactElement {
         <br />
         <br />
         Do you want to travel to the BitNode Nexus? This allows you to reset the current BitNode and select a new one.
+        <br />
+        <br />
+        You can use the "-q" option when running {CompletedProgramName.bitFlume} to skip this confirmation dialog.
       </Typography>
       <br />
       <br />


### PR DESCRIPTION
This option is not documented anywhere, so it's almost undiscoverable.

Before:

<img width="887" height="164" alt="before" src="https://github.com/user-attachments/assets/e4331bd2-3f71-4f02-8da5-5702ec7266d4" />

After:

<img width="889" height="201" alt="after" src="https://github.com/user-attachments/assets/81fcdcf8-1d7f-4cde-8999-e5d8e4eaaa02" />
