### PR TITLE
BASE: Replace expr-eval with expr-eval-fork due to security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "clsx": "^1.2.1",
         "convert-source-map": "^2.0.0",
         "date-fns": "^2.30.0",
-        "expr-eval": "^2.0.2",
+        "expr-eval-fork": "^3.0.3",
         "fast-dice-coefficient": "1.0.3",
         "hast-util-from-dom": "^5.0.1",
         "hast-util-to-text": "^4.0.2",
@@ -9333,11 +9333,14 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/expr-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
-      "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
-      "license": "MIT"
+    "node_modules/expr-eval-fork": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+      "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/express": {
       "version": "4.22.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clsx": "^1.2.1",
     "convert-source-map": "^2.0.0",
     "date-fns": "^2.30.0",
-    "expr-eval": "^2.0.2",
+    "expr-eval-fork": "^3.0.3",
     "fast-dice-coefficient": "1.0.3",
     "hast-util-from-dom": "^5.0.1",
     "hast-util-to-text": "^4.0.2",

--- a/src/Corporation/helpers.ts
+++ b/src/Corporation/helpers.ts
@@ -8,7 +8,7 @@ import * as corpConstants from "./data/Constants";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { CreatingCorporationCheckResultEnum } from "@enums";
 import { throwIfReachable } from "../utils/helpers/throwIfReachable";
-import { Parser } from "expr-eval";
+import { Parser } from "expr-eval-fork";
 
 // Configure a restricted parser by disabling unnecessary features.
 const corpFormulaParser = new Parser({


### PR DESCRIPTION
The npm package `expr-eval` ([Github](https://github.com/silentmatt/expr-eval)) suffers from a high severity security [flaw] due to ~~not~~ insufficient input sanitization. [Github Advisory: CVE-2025-12735](https://github.com/advisories/GHSA-jc85-fpwf-qm7x)

This switches to a forked version ([expr-eval-fork](https://www.npmjs.com/package/expr-eval-fork) on npm) and the code changes are on [GitHub](https://github.com/jorenbroekema/expr-eval).

The trivial Bitburner code change is simply that the new package is called `expr-eval-fork` rather than `expr-eval` in an import statement.

Passes `npm test`, `npm run format:report`, `npm run lint:report`, and appears functional for 
random contracts (1 or 2) via `npm run start:dev`.
