### PR TITLE
MISC: Partially revert #2841

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Player } from "@player";
 import { AugmentationName, CityName, CompletedProgramName, FactionName } from "@enums";
 import { BitNodeMultipliers, replaceCurrentNodeMults } from "./BitNodeMultipliers";
-import { formatMoney } from "../ui/formatNumber";
+
 class BitNode {
   // A short description, or tagline, about the BitNode
   tagline: string;
@@ -37,10 +37,11 @@ class BitNode {
 }
 
 export const BitNodes: Record<string, BitNode> = {};
+
 function upgradeTextForBN(sourceFileNum: number) {
-  const sourceFileText = `Destroying this BitNode will give you Source-File ${sourceFileNum}, or if you already have this Source-File, it will upgrade its level up to a maximum of 3.`;
-  return sourceFileText;
+  return `Destroying this BitNode will give you Source-File ${sourceFileNum}, or if you already have this Source-File, it will upgrade its level up to a maximum of 3.`;
 }
+
 export function initBitNodes() {
   BitNodes.BitNode1 = new BitNode(
     1,
@@ -285,7 +286,10 @@ export function initBitNodes() {
         <br />
         In this BitNode:
         <ul>
-          <li>Your starting money is ${formatMoney(250e6)}.</li>
+          {/* Do NOT call formatMoney. formatMoney applies the player-defined currency symbol settings, but BitNode data
+          is initialized before the save data is loaded, so it always uses the default settings. If we cannot apply the
+          player's settings, just don't call formatMoney. */}
+          <li>Your starting money is 250e6.</li>
           <li>You start with a WSE membership and access to the TIX API.</li>
           <li>You can short stocks and place different types of orders (limit/stop).</li>
         </ul>

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -289,7 +289,7 @@ export function initBitNodes() {
           {/* Do NOT call formatMoney. formatMoney applies the player-defined currency symbol settings, but BitNode data
           is initialized before the save data is loaded, so it always uses the default settings. If we cannot apply the
           player's settings, just don't call formatMoney. */}
-          <li>Your starting money is 250e6.</li>
+          <li>Your starting money is 250 million.</li>
           <li>You start with a WSE membership and access to the TIX API.</li>
           <li>You can short stocks and place different types of orders (limit/stop).</li>
         </ul>

--- a/src/Documentation/doc/en/advanced/bitnodes.md
+++ b/src/Documentation/doc/en/advanced/bitnodes.md
@@ -157,7 +157,7 @@ You are trying to make a name for yourself as an up-and-coming hedge fund manage
 
 In this BitNode:
 
-- You start with $250 million
+- Your starting money is 250 million.
 - You start with a WSE membership and access to the TIX API
 - You are able to short stocks and place different types of orders (limit/stop)
 


### PR DESCRIPTION
There are two issues in #2841:
- `${formatMoney(250e6)}` evaluates to `$$250.000m` (notice the double `$`).
- Using `formatMoney` does not work the way you are expecting. Please check my comments and https://github.com/bitburner-official/bitburner-src/pull/2453#issuecomment-3810566785 for more information.

Refactor our codebase to use `formatMoney` here is doable, but it's not worth the effort. I'll do it when there is sufficient benefit.