### PR TITLE
MISC: Follow up to #2830

### DIFF
--- a/markdown/bitburner.userinterface.opencodeeditor.md
+++ b/markdown/bitburner.userinterface.opencodeeditor.md
@@ -74,7 +74,8 @@ RAM cost: 0 GB
 
 This opens files from the server the script is running on, which may be different than the server the terminal is connected to.
 
-<b>Usage examples:</b>
+## Example
+
 
 ```js
   ns.ui.openCodeEditor("foo.js");

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -69,7 +69,7 @@ import { Programs } from "../Programs/Programs";
 import { getRecordKeys } from "../Types/Record";
 import { DarknetServer } from "../Server/DarknetServer";
 import { DarknetState } from "../DarkNet/models/DarknetState";
-import { getFriendlyType } from "../utils/TypeAssertion";
+import { getFriendlyType, isObject } from "../utils/TypeAssertion";
 
 export const helpers = {
   string,
@@ -233,15 +233,18 @@ function editorOptions(ctx: NetscriptContext, _options: unknown): EditorOptions 
   if (!_options) {
     return {};
   }
-  if (typeof _options !== "object") {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    throw errorMessage(ctx, `editorOptions must be an object, was ${_options}`);
+  if (!isObject(_options)) {
+    throw errorMessage(
+      ctx,
+      `editorOptions must be an object. Its type is ${getFriendlyType(_options)}. Its string value is ${String(
+        _options,
+      )}`,
+    );
   }
   // Safe assertion since _options type has been narrowed to a non-null object
   const options = _options as Unknownify<EditorOptions>;
   if (Object.hasOwn(options, "vim") && typeof options.vim !== "boolean") {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    throw errorMessage(ctx, `editorOptions.vim must be a boolean, was ${_options}`);
+    throw errorMessage(ctx, `editorOptions.vim must be a boolean, was ${options.vim}`);
   }
   return _options;
 }

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7005,19 +7005,19 @@ interface UserInterface {
   /**
    * Opens the specified file(s) in the code editor.
    *
-   * @param files - Optional. The file(s) to open in the editor. If not provided, opens the editor to the last edited file, if any.
-   * @param editorOptions - Optional. Settings for opening the editor, such as `vim` mode
-   *
    * @remarks
    * RAM cost: 0 GB
    *
    * This opens files from the server the script is running on, which may be different than the server the terminal is connected to.
    *
-   * <b>Usage examples:</b>
+   * @example
    * ```js
    *   ns.ui.openCodeEditor("foo.js");
    *   ns.ui.openCodeEditor(["bar.js", "data.json"], { vim: true });
    * ```
+   *
+   * @param files - Optional. The file(s) to open in the editor. If not provided, opens the editor to the last edited file, if any.
+   * @param editorOptions - Optional. Settings for opening the editor, such as `vim` mode
    */
   openCodeEditor(files?: string | string[], editorOptions?: EditorOptions): void;
 }


### PR DESCRIPTION
- The first check does not handle the case in which `_options` is an array: `ns.ui.openCodeEditor(undefined, [])`
- The second check prints `editorOptions.vim must be a boolean, was [object Object]`: `ns.ui.openCodeEditor(undefined, { vim: "foo" })`
- Use `@example` instead of `<b>Usage examples:</b>`. I think fico copied TSDoc of `NS`. I'll open a separate PR for that.