### PR TITLE
DOCUMENTATION: Use @example for examples

### DIFF
--- a/markdown/bitburner.ns.md
+++ b/markdown/bitburner.ns.md
@@ -12,9 +12,8 @@ Collection of all functions passed to scripts
 export interface NS 
 ```
 
-## Remarks
+## Example
 
-<b>Basic usage example:</b>
 
 ```js
 export async function main(ns) {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7025,8 +7025,7 @@ interface UserInterface {
 /**
  * Collection of all functions passed to scripts
  * @public
- * @remarks
- * <b>Basic usage example:</b>
+ * @example
  * ```js
  * export async function main(ns) {
  *  // Basic ns functions can be accessed on the ns object


### PR DESCRIPTION
`@example` is the standard tag for showing examples.