### PR TITLE
UI: Unify default color handling between `ns.print` and `ns.tprint`

### DIFF
--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -86,6 +86,7 @@ export const helpers = {
   hostReturnOptions,
   returnServerID,
   argsToString,
+  getTextColor,
   errorMessage,
   validateHGWOptions,
   checkEnvFlags,
@@ -365,6 +366,23 @@ function argsToString(args: unknown[]): string {
 
     return (out += String(nativeArg));
   }, "");
+}
+
+/** Determine what default color a string should have for tprint/print. */
+function getTextColor(str: string): "error" | "success" | "warn" | "info" | "primary" {
+  if (str.match(/^(\[[^\]]+\] )?ERROR/) || str.match(/(^\[[^\]]+\] )?FAIL/)) {
+    return "error";
+  }
+  if (str.match(/^(\[[^\]]+\] )?SUCCESS/)) {
+    return "success";
+  }
+  if (str.match(/^(\[[^\]]+\] )?WARN/)) {
+    return "warn";
+  }
+  if (str.match(/^(\[[^\]]+\] )?INFO/)) {
+    return "info";
+  }
+  return "primary";
 }
 
 function validateHGWOptions(ctx: NetscriptContext, opts: unknown): CompleteHGWOptions {

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -370,6 +370,8 @@ function argsToString(args: unknown[]): string {
 
 /** Determine what default color a string should have for tprint/print. */
 function getTextColor(str: string): "error" | "success" | "warn" | "info" | "primary" {
+  // Match a tag at the start-of-line with an optional bracket part (primarily for timestamps)
+  // Example: "[13:10] ERROR: Too much regex"
   if (str.match(/^(\[[^\]]+\] )?ERROR/) || str.match(/^(\[[^\]]+\] )?FAIL/)) {
     return "error";
   }

--- a/src/Netscript/NetscriptHelpers.tsx
+++ b/src/Netscript/NetscriptHelpers.tsx
@@ -370,7 +370,7 @@ function argsToString(args: unknown[]): string {
 
 /** Determine what default color a string should have for tprint/print. */
 function getTextColor(str: string): "error" | "success" | "warn" | "info" | "primary" {
-  if (str.match(/^(\[[^\]]+\] )?ERROR/) || str.match(/(^\[[^\]]+\] )?FAIL/)) {
+  if (str.match(/^(\[[^\]]+\] )?ERROR/) || str.match(/^(\[[^\]]+\] )?FAIL/)) {
     return "error";
   }
   if (str.match(/^(\[[^\]]+\] )?SUCCESS/)) {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -430,20 +430,11 @@ export const ns: InternalAPI<NSFull> = {
       const str = helpers.argsToString(args);
       const color = helpers.getTextColor(str);
       switch (color) {
-        case "error": {
-          Terminal.error(`${ctx.workerScript.name}: ${str}`);
-          break;
-        }
-        case "success": {
-          Terminal.success(`${ctx.workerScript.name}: ${str}`);
-          break;
-        }
-        case "warn": {
-          Terminal.warn(`${ctx.workerScript.name}: ${str}`);
-          break;
-        }
+        case "error":
+        case "success":
+        case "warn":
         case "info": {
-          Terminal.info(`${ctx.workerScript.name}: ${str}`);
+          Terminal[color](`${ctx.workerScript.name}: ${str}`);
           break;
         }
         case "primary": {
@@ -459,20 +450,11 @@ export const ns: InternalAPI<NSFull> = {
       const str = vsprintf(format, args);
       const color = helpers.getTextColor(str);
       switch (color) {
-        case "error": {
-          Terminal.error(`${str}`);
-          break;
-        }
-        case "success": {
-          Terminal.success(`${str}`);
-          break;
-        }
-        case "warn": {
-          Terminal.warn(`${str}`);
-          break;
-        }
+        case "error":
+        case "success":
+        case "warn":
         case "info": {
-          Terminal.info(`${str}`);
+          Terminal[color](`${str}`);
           break;
         }
         case "primary": {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -428,47 +428,16 @@ export const ns: InternalAPI<NSFull> = {
         throw helpers.errorMessage(ctx, "Takes at least 1 argument.");
       }
       const str = helpers.argsToString(args);
-      if (str.startsWith("ERROR") || str.startsWith("FAIL")) {
-        Terminal.error(`${ctx.workerScript.name}: ${str}`);
-        return;
-      }
-      if (str.startsWith("SUCCESS")) {
-        Terminal.success(`${ctx.workerScript.name}: ${str}`);
-        return;
-      }
-      if (str.startsWith("WARN")) {
-        Terminal.warn(`${ctx.workerScript.name}: ${str}`);
-        return;
-      }
-      if (str.startsWith("INFO")) {
-        Terminal.info(`${ctx.workerScript.name}: ${str}`);
-        return;
-      }
-      Terminal.print(`${ctx.workerScript.name}: ${str}`);
+      const color = helpers.getTextColor(str);
+      Terminal.print(`${ctx.workerScript.name}: ${str}`, color);
     },
   tprintf:
     (ctx) =>
     (_format, ...args) => {
       const format = helpers.string(ctx, "format", _format);
       const str = vsprintf(format, args);
-
-      if (str.startsWith("ERROR") || str.startsWith("FAIL")) {
-        Terminal.error(`${str}`);
-        return;
-      }
-      if (str.startsWith("SUCCESS")) {
-        Terminal.success(`${str}`);
-        return;
-      }
-      if (str.startsWith("WARN")) {
-        Terminal.warn(`${str}`);
-        return;
-      }
-      if (str.startsWith("INFO")) {
-        Terminal.info(`${str}`);
-        return;
-      }
-      Terminal.print(`${str}`);
+      const color = helpers.getTextColor(str);
+      Terminal.print(`${str}`, color);
     },
   clearLog: (ctx) => () => {
     ctx.workerScript.scriptRef.clearLog();

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -429,7 +429,28 @@ export const ns: InternalAPI<NSFull> = {
       }
       const str = helpers.argsToString(args);
       const color = helpers.getTextColor(str);
-      Terminal.print(`${ctx.workerScript.name}: ${str}`, color);
+      switch (color) {
+        case "error": {
+          Terminal.error(`${ctx.workerScript.name}: ${str}`);
+          break;
+        }
+        case "success": {
+          Terminal.success(`${ctx.workerScript.name}: ${str}`);
+          break;
+        }
+        case "warn": {
+          Terminal.warn(`${ctx.workerScript.name}: ${str}`);
+          break;
+        }
+        case "info": {
+          Terminal.info(`${ctx.workerScript.name}: ${str}`);
+          break;
+        }
+        case "primary": {
+          Terminal.print(`${ctx.workerScript.name}: ${str}`);
+          break;
+        }
+      }
     },
   tprintf:
     (ctx) =>
@@ -437,7 +458,28 @@ export const ns: InternalAPI<NSFull> = {
       const format = helpers.string(ctx, "format", _format);
       const str = vsprintf(format, args);
       const color = helpers.getTextColor(str);
-      Terminal.print(`${str}`, color);
+      switch (color) {
+        case "error": {
+          Terminal.error(`${str}`);
+          break;
+        }
+        case "success": {
+          Terminal.success(`${str}`);
+          break;
+        }
+        case "warn": {
+          Terminal.warn(`${str}`);
+          break;
+        }
+        case "info": {
+          Terminal.info(`${str}`);
+          break;
+        }
+        case "primary": {
+          Terminal.print(`${str}`);
+          break;
+        }
+      }
     },
   clearLog: (ctx) => () => {
     ctx.workerScript.scriptRef.clearLog();

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -176,8 +176,8 @@ export class Terminal {
     TerminalEvents.emit();
   }
 
-  print(s: string, color: "primary" | "error" | "success" | "info" | "warn" = "primary"): void {
-    this.append(new Output(s, color));
+  print(s: string): void {
+    this.append(new Output(s, "primary"));
   }
 
   printRaw(node: React.ReactNode): void {

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -176,8 +176,8 @@ export class Terminal {
     TerminalEvents.emit();
   }
 
-  print(s: string): void {
-    this.append(new Output(s, "primary"));
+  print(s: string, color: "primary" | "error" | "success" | "info" | "warn" = "primary"): void {
+    this.append(new Output(s, color));
   }
 
   printRaw(node: React.ReactNode): void {

--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -28,6 +28,7 @@ import { dialogBoxCreate } from "./DialogBox";
 import { makeStyles } from "tss-react/mui";
 import { logBoxBaseZIndex } from "./Constants";
 import { clampNumber } from "../../utils/helpers/clampNumber";
+import { helpers } from "../../Netscript/NetscriptHelpers";
 
 let layerCounter = 0;
 
@@ -271,22 +272,6 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
     propsRef.current.setMinimized(!propsRef.current.minimized);
   }
 
-  function lineColor(s: string): "error" | "success" | "warn" | "info" | "primary" {
-    if (s.match(/(^\[[^\]]+\] )?ERROR/) || s.match(/(^\[[^\]]+\] )?FAIL/)) {
-      return "error";
-    }
-    if (s.match(/(^\[[^\]]+\] )?SUCCESS/)) {
-      return "success";
-    }
-    if (s.match(/(^\[[^\]]+\] )?WARN/)) {
-      return "warn";
-    }
-    if (s.match(/(^\[[^\]]+\] )?INFO/)) {
-      return "info";
-    }
-    return "primary";
-  }
-
   const onWindowResize = useMemo(
     () =>
       debounce((): void => {
@@ -429,7 +414,7 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
                       <ANSIITypography
                         key={i}
                         text={line}
-                        color={lineColor(line)}
+                        color={helpers.getTextColor(line)}
                         styles={{
                           fontSize: propsRef.current.fontSize ?? Settings.styles.tailFontSize,
                         }}


### PR DESCRIPTION
In Ye Olden Days, both `print` and `tprint` decided which color a line should be by checking `.startsWith` against the various strings ("ERROR", "FAIL", "SUCCESS", "WARN", and "INFO"). While `tprint` still does this, `print` was at some point changed to use regular expressions designed to skip an optional prefix in brackets (basically, the optional timestamp). However, these regular expressions include the "start of string" marker inside the optional portion, which means they now flag a string that contains the relevant text *anywhere*, rather than just at the beginning.

This commit corrects this error in the regexps and splits the color-determination logic into a helper function that is now also used by `tprint` (and `tprintf`), so default color handling is once again the same whether you're printing to a tail log or the terminal.

Tested by simply running a test script that `print`ed and `tprint`ed the same five lines of text, before and after my changes.

`tprint` before:
<img width="471" height="165" alt="image" src="https://github.com/user-attachments/assets/ff91fa40-edde-4dbb-8f54-27178dab9229" />
`tprint` after:
<img width="475" height="168" alt="image" src="https://github.com/user-attachments/assets/e5c7d850-ed48-4cd0-b51a-57a5b651b214" />
`print` before:
<img width="387" height="192" alt="image" src="https://github.com/user-attachments/assets/379c553d-38f4-4009-9a87-3460ac67029f" />
`print` after:
<img width="392" height="194" alt="image" src="https://github.com/user-attachments/assets/bce94703-0949-4d94-a99d-6a218a966d1d" />
