### PR TITLE
UI: Disable docs back button when no history

### DIFF
--- a/src/Documentation/ui/DocumentationRoot.tsx
+++ b/src/Documentation/ui/DocumentationRoot.tsx
@@ -82,7 +82,9 @@ export function DocumentationRoot({ docPage }: { docPage?: string }): React.Reac
         bgcolor={Settings.theme.backgroundprimary}
         alignItems="center"
       >
-        <Button onClick={() => history.pop()}>Back</Button>
+        <Button onClick={() => history.pop()} disabled={history.pages.length === 0}>
+          Back
+        </Button>
         <Button onClick={() => history.home()}>Home</Button>
         <DocumentationAutocomplete
           sx={{ marginLeft: "10px" }}


### PR DESCRIPTION
- [x] `npm run format`
- [x] `npm run lint`

<img width="1050" height="447" alt="image" src="https://github.com/user-attachments/assets/ddb13974-cf0a-40ed-8eed-2018e3c4c202" />
