### PR TITLE
UI: Prevent accidental pastes when closing an editor tab with middle mouse button

### DIFF
--- a/src/ScriptEditor/ui/Tab.tsx
+++ b/src/ScriptEditor/ui/Tab.tsx
@@ -125,6 +125,14 @@ export function Tab({ provided, tabId, isActive, isExternal, isUnsaved, onClick,
               onClose();
             }
           }}
+          onMouseUp={(e) => {
+            // Some Linux DEs do a "paste" action on MMB (mouse up).
+            // Closing a tab with the editor in focus would cause a paste in the editor.
+            // This event handler prevents the paste in cases where another tab slides under the cursor
+            if (e.button === 1) {
+              e.preventDefault();
+            }
+          }}
           style={{
             minHeight: tabIconHeight,
             overflow: "hidden",

--- a/src/ScriptEditor/ui/Tab.tsx
+++ b/src/ScriptEditor/ui/Tab.tsx
@@ -125,14 +125,6 @@ export function Tab({ provided, tabId, isActive, isExternal, isUnsaved, onClick,
               onClose();
             }
           }}
-          onMouseUp={(e) => {
-            // Some Linux DEs do a "paste" action on MMB (mouse up).
-            // Closing a tab with the editor in focus would cause a paste in the editor.
-            // This event handler prevents the paste in cases where another tab slides under the cursor
-            if (e.button === 1) {
-              e.preventDefault();
-            }
-          }}
           style={{
             minHeight: tabIconHeight,
             overflow: "hidden",

--- a/src/ScriptEditor/ui/Tabs.tsx
+++ b/src/ScriptEditor/ui/Tabs.tsx
@@ -116,12 +116,16 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
               onWheel={handleScroll}
               onMouseUp={(e) => {
                 // Some Linux DEs do a "paste" action on MMB (mouse up).
-                // Closing a tab with the editor in focus would cause a paste in the editor
-                // This event handler prevents the paste in cases where the last tab is closed
+                // Closing a tab with the editor in focus would cause a paste in the editor.
+                // This event handler prevents the paste in cases where a tab is closed.
                 //
-                // It's important to mention that a regular MMB click on the tab container would
-                // also do nothing here, since the "mouse down" event changes the focus away from
+                // It's important to mention that a regular MMB click on the tab container itself
+                // (not one of the tabs) without this workaround would do nothing here,
+                // since the "mouse down" event changes the focus away from
                 // the editor before the "mouse up" attempts a paste, preventing it altogether.
+                //
+                // This handler also catches onMouseUp events originating from <Tab> (Tab.tsx), in cases
+                // where a tab is closed, and another one slides under the cursor before MMB is released.
                 if (e.button === 1) {
                   e.preventDefault();
                 }

--- a/src/ScriptEditor/ui/Tabs.tsx
+++ b/src/ScriptEditor/ui/Tabs.tsx
@@ -114,6 +114,18 @@ export function Tabs({ scripts, currentScript, onTabClick, onTabClose, onTabUpda
                 overflowX: "scroll",
               }}
               onWheel={handleScroll}
+              onMouseUp={(e) => {
+                // Some Linux DEs do a "paste" action on MMB (mouse up).
+                // Closing a tab with the editor in focus would cause a paste in the editor
+                // This event handler prevents the paste in cases where the last tab is closed
+                //
+                // It's important to mention that a regular MMB click on the tab container would
+                // also do nothing here, since the "mouse down" event changes the focus away from
+                // the editor before the "mouse up" attempts a paste, preventing it altogether.
+                if (e.button === 1) {
+                  e.preventDefault();
+                }
+              }}
             >
               {filteredScripts.map(({ script, originalIndex }, index) => {
                 const { path, hostname } = script;


### PR DESCRIPTION
PR for issue #2849 

closes #2849 

Tested with a native bitburner-linux-x64 build artifact, first replicated the issue once more on freshly cloned repository, then confirmed the issue is gone with the fix applied.

The issue was caused by the paste action happening OS-side (on mouse up). Usually, clicking somewhere with MMB moves away the focus from the editor (on mouse down), so the (mouse up) does not usually paste anything.

For some reason, on the electron build, the MMB on the button element in the \<Tab\> component doesn't move the focus away from the editor (on mouse down), so the paste still happened in the editor once MMB was released (and after the tab was correctly closed).

This PR kills any MMB (on mouse up) events happening within the \<Tab\>, and \<Tabs\> components. Since MMB is the standard non-remappable keybind for close/open tab in the context of tab containers, no users should be negatively impacted (no impact on potential custom keybinds).

Before:
[Screencast_20260604_131628.webm](https://github.com/user-attachments/assets/344161b9-a921-4821-8fab-ae2d4218ac8e)

After:
[Screencast_20260604_180833.webm](https://github.com/user-attachments/assets/622722c9-71ad-4c94-a252-283fc185b500)
