### PR TITLE
API: Let `singularity.destroyW0r1dD43m0n` travel to Bitverse

### DIFF
--- a/markdown/bitburner.singularity.destroyw0r1dd43m0n.md
+++ b/markdown/bitburner.singularity.destroyw0r1dd43m0n.md
@@ -42,7 +42,7 @@ number
 
 </td><td>
 
-_(Optional)_ BN number to jump to. Undefined leaves you on the BitVerse selection screen.
+_(Optional)_ BN number to jump to. Passing undefined leaves you on the BitVerse screen.
 
 
 </td></tr>
@@ -90,5 +90,5 @@ RAM cost: 32 GB \* 16/4/1
 
 You must have the special augment installed and the required hacking level OR Completed the final black op.
 
-Although this function can be used to take you to the BitVerse screen, that can usually be accomplished more cheaply with @<!-- -->link<!-- -->{<!-- -->\#installBackdoor<!-- -->}<!-- -->.
+If you do not want to move on to the next BN and instead stay on the BitVerse screen, you can set nextBN to undefined. Note that with the hacking route, using [installBackdoor](./bitburner.singularity.installbackdoor.md) is a cheaper way to do this.
 

--- a/markdown/bitburner.singularity.destroyw0r1dd43m0n.md
+++ b/markdown/bitburner.singularity.destroyw0r1dd43m0n.md
@@ -9,7 +9,7 @@ Destroy the w0r1d\_d43m0n and move on to the next BN.
 **Signature:**
 
 ```typescript
-destroyW0r1dD43m0n(nextBN: number, callbackScript?: string, bitNodeOptions?: BitNodeOptions): void;
+destroyW0r1dD43m0n(nextBN?: number, callbackScript?: string, bitNodeOptions?: BitNodeOptions): void;
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ number
 
 </td><td>
 
-BN number to jump to
+_(Optional)_ BN number to jump to. undefined leads you to the BitVerse
 
 
 </td></tr>

--- a/markdown/bitburner.singularity.destroyw0r1dd43m0n.md
+++ b/markdown/bitburner.singularity.destroyw0r1dd43m0n.md
@@ -42,7 +42,7 @@ number
 
 </td><td>
 
-_(Optional)_ BN number to jump to. undefined leads you to the BitVerse
+_(Optional)_ BN number to jump to. Undefined leaves you on the BitVerse selection screen.
 
 
 </td></tr>
@@ -89,4 +89,6 @@ void
 RAM cost: 32 GB \* 16/4/1
 
 You must have the special augment installed and the required hacking level OR Completed the final black op.
+
+Although this function can be used to take you to the BitVerse screen, that can usually be accomplished more cheaply with @<!-- -->link<!-- -->{<!-- -->\#installBackdoor<!-- -->}<!-- -->.
 

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1155,31 +1155,31 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     },
     destroyW0r1dD43m0n: (ctx) => (_nextBN, _cbScript, _bitNodeOptions) => {
       helpers.checkSingularityAccess(ctx);
-      const nextBN = helpers.number(ctx, "nextBN", _nextBN);
+      const { shouldStopOnBitVerse, nextBN } = _nextBN
+        ? { shouldStopOnBitVerse: false, nextBN: helpers.number(ctx, "nextBN", _nextBN) }
+        : { shouldStopOnBitVerse: true, nextBN: 0 };
+      // Checks if nextBN is undefined and either 2nd or 3rd param have been declared
       if (!nextBN && (_cbScript || _bitNodeOptions)) {
         throw helpers.errorMessage(
           ctx,
           `Invalid call: When nextBN is undefined, all other params should not be declared`,
         );
-      } else {
-        const wd = GetServer(SpecialServers.WorldDaemon);
-        if (!(wd instanceof Server)) {
-          throw new Error("WorldDaemon is not a normal server. This is a bug. Please contact developers.");
-        } else {
-          wd.backdoorInstalled = true;
+      }
+      // Only runs if nextBN !== 0 (jumping to a valid BN)
+      let cbScript;
+      if (shouldStopOnBitVerse) {
+        if (!validBitNodes.includes(nextBN)) {
+          throw new Error(`Invalid BitNode: ${_nextBN}.`);
         }
-        Router.toPage(Page.BitVerse, { flume: false, quick: false });
-      }
-      if (!validBitNodes.includes(nextBN)) {
-        throw new Error(`Invalid BitNode: ${_nextBN}.`);
-      }
-      const cbScript = _cbScript
-        ? resolveScriptFilePath(helpers.string(ctx, "cbScript", _cbScript), ctx.workerScript.name)
-        : false;
-      if (cbScript === null) {
-        throw helpers.errorMessage(ctx, `Could not resolve file path. callbackScript is null.`);
+        cbScript = _cbScript
+          ? resolveScriptFilePath(helpers.string(ctx, "cbScript", _cbScript), ctx.workerScript.name)
+          : false;
+        if (cbScript === null) {
+          throw helpers.errorMessage(ctx, `Could not resolve file path. callbackScript is null.`);
+        }
       }
 
+      // General checks
       const wd = GetServer(SpecialServers.WorldDaemon);
       if (!(wd instanceof Server)) {
         throw new Error("WorldDaemon is not a normal server. This is a bug. Please contact developers.");
@@ -1204,9 +1204,13 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
 
       wd.backdoorInstalled = true;
       calculateAchievements();
-      enterBitNode(false, Player.bitNodeN, nextBN, helpers.validateBitNodeOptions(ctx, _bitNodeOptions));
-      if (cbScript) {
-        setTimeout(() => runAfterReset(cbScript), 500);
+      if (shouldStopOnBitVerse) {
+        enterBitNode(false, Player.bitNodeN, nextBN, helpers.validateBitNodeOptions(ctx, _bitNodeOptions));
+        if (cbScript) {
+          setTimeout(() => runAfterReset(cbScript), 500);
+        }
+      } else {
+        Router.toPage(Page.BitVerse, { flume: false, quick: false });
       }
     },
     getCurrentWork: (ctx) => () => {

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1156,6 +1156,20 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     destroyW0r1dD43m0n: (ctx) => (_nextBN, _cbScript, _bitNodeOptions) => {
       helpers.checkSingularityAccess(ctx);
       const nextBN = helpers.number(ctx, "nextBN", _nextBN);
+      if (!nextBN && (_cbScript || _bitNodeOptions)) {
+        throw helpers.errorMessage(
+          ctx,
+          `Invalid call: When nextBN is undefined, all other params should not be declared`,
+        );
+      } else {
+        const wd = GetServer(SpecialServers.WorldDaemon);
+        if (!(wd instanceof Server)) {
+          throw new Error("WorldDaemon is not a normal server. This is a bug. Please contact developers.");
+        } else {
+          wd.backdoorInstalled = true;
+        }
+        Router.toPage(Page.BitVerse, { flume: false, quick: false });
+      }
       if (!validBitNodes.includes(nextBN)) {
         throw new Error(`Invalid BitNode: ${_nextBN}.`);
       }

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1155,21 +1155,25 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     },
     destroyW0r1dD43m0n: (ctx) => (_nextBN, _cbScript, _bitNodeOptions) => {
       helpers.checkSingularityAccess(ctx);
-      const { shouldStopOnBitVerse, nextBN } = _nextBN
-        ? { shouldStopOnBitVerse: false, nextBN: helpers.number(ctx, "nextBN", _nextBN) }
-        : { shouldStopOnBitVerse: true, nextBN: 0 };
+      let nextBN;
+      if (_nextBN == null) {
+        nextBN = 0;
+      } else {
+        nextBN = helpers.number(ctx, "nextBN", _nextBN);
+      }
+
       // Checks if nextBN is undefined and either 2nd or 3rd param have been declared
-      if (!nextBN && (_cbScript || _bitNodeOptions)) {
+      if (!_nextBN && (_cbScript || _bitNodeOptions)) {
         throw helpers.errorMessage(
           ctx,
           `Invalid call: When nextBN is undefined, all other params should not be declared`,
         );
       }
-      // Only runs if nextBN !== 0 (jumping to a valid BN)
-      let cbScript;
-      if (shouldStopOnBitVerse) {
+
+      let cbScript: ScriptFilePath | false | null | undefined;
+      if (!(_nextBN == null)) {
         if (!validBitNodes.includes(nextBN)) {
-          throw new Error(`Invalid BitNode: ${_nextBN}.`);
+          throw new Error(`Invalid BitNode: ${nextBN}.`);
         }
         cbScript = _cbScript
           ? resolveScriptFilePath(helpers.string(ctx, "cbScript", _cbScript), ctx.workerScript.name)
@@ -1204,7 +1208,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
 
       wd.backdoorInstalled = true;
       calculateAchievements();
-      if (shouldStopOnBitVerse) {
+      if (_nextBN) {
         enterBitNode(false, Player.bitNodeN, nextBN, helpers.validateBitNodeOptions(ctx, _bitNodeOptions));
         if (cbScript) {
           setTimeout(() => runAfterReset(cbScript), 500);

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1156,7 +1156,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     destroyW0r1dD43m0n: (ctx) => (_nextBN, _cbScript, _bitNodeOptions) => {
       helpers.checkSingularityAccess(ctx);
       const nextBN = _nextBN != null ? helpers.number(ctx, "nextBN", _nextBN) : null;
-      if (nextBN != null) {
+      if (nextBN !== null) {
         // If _nextBN was provided, check that it is a valid BitNode.
         if (!validBitNodes.includes(nextBN)) {
           throw new Error(`Invalid BitNode: ${_nextBN}.`);

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -1155,35 +1155,23 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     },
     destroyW0r1dD43m0n: (ctx) => (_nextBN, _cbScript, _bitNodeOptions) => {
       helpers.checkSingularityAccess(ctx);
-      let nextBN;
-      if (_nextBN == null) {
-        nextBN = 0;
-      } else {
-        nextBN = helpers.number(ctx, "nextBN", _nextBN);
-      }
-
-      // Checks if nextBN is undefined and either 2nd or 3rd param have been declared
-      if (!_nextBN && (_cbScript || _bitNodeOptions)) {
-        throw helpers.errorMessage(
-          ctx,
-          `Invalid call: When nextBN is undefined, all other params should not be declared`,
-        );
-      }
-
-      let cbScript: ScriptFilePath | false | null | undefined;
-      if (!(_nextBN == null)) {
+      const nextBN = _nextBN != null ? helpers.number(ctx, "nextBN", _nextBN) : null;
+      if (nextBN != null) {
+        // If _nextBN was provided, check that it is a valid BitNode.
         if (!validBitNodes.includes(nextBN)) {
-          throw new Error(`Invalid BitNode: ${nextBN}.`);
+          throw new Error(`Invalid BitNode: ${_nextBN}.`);
         }
-        cbScript = _cbScript
-          ? resolveScriptFilePath(helpers.string(ctx, "cbScript", _cbScript), ctx.workerScript.name)
-          : false;
-        if (cbScript === null) {
-          throw helpers.errorMessage(ctx, `Could not resolve file path. callbackScript is null.`);
-        }
+      } else if (_cbScript != null || _bitNodeOptions != null) {
+        // If _nextBN was not provided, the other parameters must also be nullish.
+        throw helpers.errorMessage(ctx, `When nextBN is nullish, other parameters must be nullish.`);
+      }
+      const cbScript = _cbScript
+        ? resolveScriptFilePath(helpers.string(ctx, "cbScript", _cbScript), ctx.workerScript.name)
+        : false;
+      if (cbScript === null) {
+        throw helpers.errorMessage(ctx, `Could not resolve file path. callbackScript is null.`);
       }
 
-      // General checks
       const wd = GetServer(SpecialServers.WorldDaemon);
       if (!(wd instanceof Server)) {
         throw new Error("WorldDaemon is not a normal server. This is a bug. Please contact developers.");
@@ -1208,13 +1196,13 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
 
       wd.backdoorInstalled = true;
       calculateAchievements();
-      if (_nextBN) {
-        enterBitNode(false, Player.bitNodeN, nextBN, helpers.validateBitNodeOptions(ctx, _bitNodeOptions));
-        if (cbScript) {
-          setTimeout(() => runAfterReset(cbScript), 500);
-        }
-      } else {
+      if (nextBN === null) {
         Router.toPage(Page.BitVerse, { flume: false, quick: false });
+        return;
+      }
+      enterBitNode(false, Player.bitNodeN, nextBN, helpers.validateBitNodeOptions(ctx, _bitNodeOptions));
+      if (cbScript) {
+        setTimeout(() => runAfterReset(cbScript), 500);
       }
     },
     getCurrentWork: (ctx) => () => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2887,6 +2887,9 @@ export interface Singularity {
    *   OR
    * Completed the final black op.
    *
+   * Although this function can be used to take you to the BitVerse screen, that can usually be accomplished
+   * more cheaply with @link{#installBackdoor}.
+   *
    * @param nextBN - BN number to jump to. Undefined leaves you on the BitVerse selection screen.
    * @param callbackScript - Name of the script to launch in the next BN.
    * @param bitNodeOptions - BitNode options for the next BN.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2887,7 +2887,7 @@ export interface Singularity {
    *   OR
    * Completed the final black op.
    *
-   * @param nextBN - BN number to jump to
+   * @param nextBN - BN number to jump to. undefined leads you to the BitVerse
    * @param callbackScript - Name of the script to launch in the next BN.
    * @param bitNodeOptions - BitNode options for the next BN.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2887,10 +2887,11 @@ export interface Singularity {
    *   OR
    * Completed the final black op.
    *
-   * Although this function can be used to take you to the BitVerse screen, that can usually be accomplished
-   * more cheaply with @link{#installBackdoor}.
+   * If you do not want to move on to the next BN and instead stay on the BitVerse screen, you can set nextBN
+   * to undefined. Note that with the hacking route, using {@link Singularity.installBackdoor | installBackdoor} is a
+   * cheaper way to do this.
    *
-   * @param nextBN - BN number to jump to. Undefined leaves you on the BitVerse selection screen.
+   * @param nextBN - BN number to jump to. Passing undefined leaves you on the BitVerse screen.
    * @param callbackScript - Name of the script to launch in the next BN.
    * @param bitNodeOptions - BitNode options for the next BN.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2887,7 +2887,7 @@ export interface Singularity {
    *   OR
    * Completed the final black op.
    *
-   * @param nextBN - BN number to jump to. undefined leads you to the BitVerse
+   * @param nextBN - BN number to jump to. Undefined leaves you on the BitVerse selection screen.
    * @param callbackScript - Name of the script to launch in the next BN.
    * @param bitNodeOptions - BitNode options for the next BN.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2891,7 +2891,7 @@ export interface Singularity {
    * @param callbackScript - Name of the script to launch in the next BN.
    * @param bitNodeOptions - BitNode options for the next BN.
    */
-  destroyW0r1dD43m0n(nextBN: number, callbackScript?: string, bitNodeOptions?: BitNodeOptions): void;
+  destroyW0r1dD43m0n(nextBN?: number, callbackScript?: string, bitNodeOptions?: BitNodeOptions): void;
 
   /**
    * Get the current work the player is doing.

--- a/test/jest/Netscript/Singularity.test.ts
+++ b/test/jest/Netscript/Singularity.test.ts
@@ -31,6 +31,9 @@ import { getTorRouter } from "../../../src/Server/ServerHelpers";
 import * as exceptionAlertModule from "../../../src/utils/helpers/exceptionAlert";
 import { numberOfBlackOperations } from "../../../src/Bladeburner/data/BlackOperations";
 import type { SleeveTask, Task } from "@nsdefs";
+import { Router } from "../../../src/ui/GameRoot";
+import { Page } from "../../../src/ui/Router";
+import { getDefaultBitNodeOptions } from "../../../src/BitNode/BitNodeUtils";
 
 const nextBN = 4;
 
@@ -285,6 +288,20 @@ describe("b1tflum3", () => {
   });
 });
 
+// Make sure that the player is in the next BN and received SF rewards.
+const expectSucceedInJumpingToNextBN = () => {
+  expect(Player.bitNodeN).toStrictEqual(nextBN);
+  expect(Player.augmentations.length).toStrictEqual(0);
+  expect(Player.sourceFileLvl(1)).toStrictEqual(1);
+};
+
+// Make sure that the player is still in the same BN without SF rewards.
+const expectFailToJumpToNextBN = () => {
+  expect(Player.bitNodeN).toStrictEqual(1);
+  expect(Player.augmentations.length).toStrictEqual(1);
+  expect(Player.sourceFileLvl(1)).toStrictEqual(0);
+};
+
 describe("destroyW0r1dD43m0n", () => {
   beforeEach(() => {
     setupBasicTestingEnvironment();
@@ -292,17 +309,11 @@ describe("destroyW0r1dD43m0n", () => {
   });
 
   describe("Success", () => {
-    // Make sure that the player is in the next BN and received SF rewards.
-    const expectSucceedInDestroyingWD = () => {
-      expect(Player.bitNodeN).toStrictEqual(nextBN);
-      expect(Player.augmentations.length).toStrictEqual(0);
-      expect(Player.sourceFileLvl(1)).toStrictEqual(1);
-    };
     test("Hacking route", () => {
       setNumBlackOpsComplete(0);
       const ns = getNS();
       ns.singularity.destroyW0r1dD43m0n(nextBN);
-      expectSucceedInDestroyingWD();
+      expectSucceedInJumpingToNextBN();
     });
     test("Hacking route with BN options", () => {
       setNumBlackOpsComplete(0);
@@ -312,13 +323,13 @@ describe("destroyW0r1dD43m0n", () => {
         sourceFileOverrides: new Map(),
         intelligenceOverride: 1,
       });
-      expectSucceedInDestroyingWD();
+      expectSucceedInJumpingToNextBN();
     });
     test("Bladeburner route", () => {
       Player.skills.hacking = 0;
       const ns = getNS();
       ns.singularity.destroyW0r1dD43m0n(nextBN);
-      expectSucceedInDestroyingWD();
+      expectSucceedInJumpingToNextBN();
     });
     test("Bladeburner route with BN options", () => {
       Player.skills.hacking = 0;
@@ -328,26 +339,31 @@ describe("destroyW0r1dD43m0n", () => {
         sourceFileOverrides: new Map(),
         intelligenceOverride: 1,
       });
-      expectSucceedInDestroyingWD();
+      expectSucceedInJumpingToNextBN();
     });
     test("intelligenceOverride", () => {
-      testIntelligenceOverride(getNS(), "destroyW0r1dD43m0n", expectSucceedInDestroyingWD, setUpBeforeDestroyingWD);
+      testIntelligenceOverride(getNS(), "destroyW0r1dD43m0n", expectSucceedInJumpingToNextBN, setUpBeforeDestroyingWD);
+    });
+    test("nullish nextBN", () => {
+      setNumBlackOpsComplete(0);
+      const ns = getNS();
+      const spiedRouterToPage = jest.spyOn(Router, "toPage");
+      ns.singularity.destroyW0r1dD43m0n(undefined);
+
+      expect(GetServerOrThrow(SpecialServers.WorldDaemon).backdoorInstalled).toBe(true);
+      expectFailToJumpToNextBN();
+      expect(spiedRouterToPage).toHaveBeenCalledWith(Page.BitVerse, { flume: false, quick: false });
+      spiedRouterToPage.mockRestore();
     });
   });
 
   describe("Failure", () => {
-    // Make sure that the player is still in the same BN without SF rewards.
-    const expectFailToDestroyWD = () => {
-      expect(Player.bitNodeN).toStrictEqual(1);
-      expect(Player.augmentations.length).toStrictEqual(1);
-      expect(Player.sourceFileLvl(1)).toStrictEqual(0);
-    };
     test("Do not have enough hacking level and numBlackOpsComplete", () => {
       Player.skills.hacking = 0;
       setNumBlackOpsComplete(0);
       const ns = getNS();
       ns.singularity.destroyW0r1dD43m0n(nextBN);
-      expectFailToDestroyWD();
+      expectFailToJumpToNextBN();
     });
     test("Do not have admin rights on WD and do not have enough numBlackOpsComplete", () => {
       const wdServer = GetServerOrThrow(SpecialServers.WorldDaemon);
@@ -355,7 +371,7 @@ describe("destroyW0r1dD43m0n", () => {
       setNumBlackOpsComplete(0);
       const ns = getNS();
       ns.singularity.destroyW0r1dD43m0n(nextBN);
-      expectFailToDestroyWD();
+      expectFailToJumpToNextBN();
     });
     test("Invalid intelligenceOverride", () => {
       const ns = getNS();
@@ -365,7 +381,7 @@ describe("destroyW0r1dD43m0n", () => {
           intelligenceOverride: -1,
         });
       }).toThrow();
-      expectFailToDestroyWD();
+      expectFailToJumpToNextBN();
     });
     test("Invalid sourceFileOverrides", () => {
       const ns = getNS();
@@ -375,11 +391,29 @@ describe("destroyW0r1dD43m0n", () => {
           sourceFileOverrides: [] as unknown as Map<number, number>,
         });
       }).toThrow();
-      expectFailToDestroyWD();
+      expectFailToJumpToNextBN();
     });
     test("Invalid nextBN", () => {
       const ns = getNS();
+      expect(() => ns.singularity.destroyW0r1dD43m0n(0)).toThrow("Invalid BitNode");
       expect(() => ns.singularity.destroyW0r1dD43m0n(-1)).toThrow("Invalid BitNode");
+    });
+    test.each([
+      ["1", undefined, getDefaultBitNodeOptions()],
+      ["2", "test.js", undefined],
+      ["3", "test.js", getDefaultBitNodeOptions()],
+    ])("nextBN is nullish but other parameters are not - %s", (__, callbackScript, bitNodeOptions) => {
+      setNumBlackOpsComplete(0);
+      const ns = getNS();
+      const spiedRouterToPage = jest.spyOn(Router, "toPage");
+      expect(() => ns.singularity.destroyW0r1dD43m0n(undefined, callbackScript, bitNodeOptions)).toThrow(
+        "When nextBN is nullish, other parameters must be nullish.",
+      );
+
+      expect(GetServerOrThrow(SpecialServers.WorldDaemon).backdoorInstalled).toBe(false);
+      expectFailToJumpToNextBN();
+      expect(spiedRouterToPage).not.toHaveBeenCalled();
+      spiedRouterToPage.mockRestore();
     });
   });
 });


### PR DESCRIPTION
Context in and closes #2854 
This PR makes `singularity.destroyW0r1dD43m0n` travel to Bitverse by setting `nextBN` to 0.
MRE:
1.1: **Classic:** Set yourself hacking exp enough to destroy w0r1d_d43m0n, root the server
1.2: **Bladeburner:** Join Bladeburner, complete all blackops.
2. Create a script on home and paste `ns.singularity.destroyW0r1dD43m0n(0)`. Run it.

You should travel to the bitverse. Once there, enter a BN of your choice to ensure that `nextBN` hasn't been set

Edit: Added MRE