### PR TITLE
BUGFIX: "The Void" location is not initialized properly

### DIFF
--- a/src/Locations/Location.ts
+++ b/src/Locations/Location.ts
@@ -6,12 +6,12 @@ interface IInfiltrationMetadata {
 }
 
 export interface IConstructorParams {
-  city?: CityName | null;
+  city: CityName | null;
   costMult?: number;
   expMult?: number;
   infiltrationData?: IInfiltrationMetadata;
-  name?: LocationName;
-  types?: LocationType[];
+  name: LocationName;
+  types: LocationType[];
   techVendorMaxRam?: number;
   techVendorMinRam?: number;
 }
@@ -37,13 +37,13 @@ export class Location {
   infiltrationData?: IInfiltrationMetadata;
 
   /** Identifier for location */
-  name: LocationName = LocationName.Void;
+  name: LocationName;
 
   /**
    * List of what type(s) this location is. A location can be multiple types
    * (e.g. company and tech vendor)
    */
-  types: LocationType[] = [];
+  types: LocationType[];
 
   /**
    * Tech vendors allow you to purchase servers.
@@ -58,6 +58,8 @@ export class Location {
   techVendorMinRam = 0;
 
   constructor(p: IConstructorParams) {
+    this.name = p.name;
+    this.types = p.types;
     if (p.city) {
       this.city = p.city;
     }
@@ -69,12 +71,6 @@ export class Location {
     }
     if (p.infiltrationData) {
       this.infiltrationData = p.infiltrationData;
-    }
-    if (p.name) {
-      this.name = p.name;
-    }
-    if (p.types) {
-      this.types = p.types;
     }
     if (p.techVendorMaxRam) {
       this.techVendorMaxRam = p.techVendorMaxRam;

--- a/src/Locations/data/LocationsMetadata.ts
+++ b/src/Locations/data/LocationsMetadata.ts
@@ -458,4 +458,9 @@ export const LocationsMetadata: IConstructorParams[] = [
     name: LocationName.ChongqingShadowedWalkway,
     types: [LocationType.Special],
   },
+  {
+    city: null,
+    name: LocationName.Void,
+    types: [LocationType.Special],
+  },
 ];

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -447,6 +447,10 @@ export function SpecialLocation(props: SpecialLocationProps): React.ReactElement
     case LocationName.ChongqingShadowedWalkway: {
       return renderShadowedWalkway();
     }
+    case LocationName.Void: {
+      // Reserved for special content such as easter eggs.
+      return <></>;
+    }
     default:
       console.error(`Location ${props.loc.name} doesn't have any special properties`);
       return <></>;


### PR DESCRIPTION
Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  console.log(
    ns.formulas.work.universityGains(ns.getPlayer(), "Algorithms", ns.enums.LocationName.Void)
  );
  console.log(ns.singularity.goToLocation(ns.enums.LocationName.Void));
}
```
Stack trace:
```
TypeError: Cannot read properties of undefined (reading 'expMult')
    at calculateClassEarnings (Formulas.ts:114:163)
    at eval (Formulas.ts:436:87)
    at Proxy.wrappedFunction (APIWrapper.ts:68:16)
    at main (test.js:5:22)
    at startNetscript2Script (NetscriptWorker.ts:88:9)
```

"The Void" was created as the default value of a location (`name: LocationName = LocationName.Void;`), but we don't actually need to use it. My changes in `src/Locations/Location.ts` allows us to remove this redundant location. However, I decided to keep it. We can use it later for easter eggs or future content.

Note that `ns.singularity.goToLocation(ns.enums.LocationName.Void)` now returns true and brings the UI to an empty page. I don't think it's an issue. We can add more content to this special location later.