### PR TITLE
BUGFIX: Remove duplicate running script code from memory, fix missed module cache lookups

### DIFF
--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -119,4 +119,5 @@ function removeWorkerScript(workerScript: WorkerScript): void {
   if (rs.temporary === false) {
     AddRecentScript(workerScript);
   }
+  workerScript.code = "";
 }

--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -160,7 +160,11 @@ function generateLoadedModule(script: Script, scripts: Map<ScriptFilePath, Scrip
   // preventing the ranges for other imports from being shifted.
   importNodes.sort((a, b) => b.start - a.start);
   let newCode = scriptCode;
-  // Loop through each node and replace the script name with a blob url.
+  let cacheKey = scriptCode;
+
+  // Runtime code needs blob URLs, but the module cache key does not.
+  // Blob URLs are unique per creation, so using them as the cache key makes
+  // identical imports miss the cache and create permanent duplicate modules.
   for (const node of importNodes) {
     const importedScript = getModuleScript(node.filename, script.filename, scripts);
     for (const scriptInSeenStack of seenStack) {
@@ -175,9 +179,10 @@ function generateLoadedModule(script: Script, scripts: Map<ScriptFilePath, Scrip
     importedScript.mod = generateLoadedModule(importedScript, scripts, seenStack);
     seenStack.pop();
     newCode = newCode.substring(0, node.start) + importedScript.mod.url + newCode.substring(node.end);
+    cacheKey = cacheKey.substring(0, node.start) + importedScript.mod.cacheKey + cacheKey.substring(node.end);
   }
 
-  const cachedMod = moduleCache.get(newCode);
+  const cachedMod = moduleCache.get(cacheKey);
   if (cachedMod) {
     script.mod = cachedMod;
   } else {
@@ -213,8 +218,8 @@ function generateLoadedModule(script: Script, scripts: Map<ScriptFilePath, Scrip
     // directly return the module, without even attempting to fetch, due to the way
     // modules work.
     URL.revokeObjectURL(url);
-    script.mod = new LoadedModule(url, module);
-    moduleCache.set(newCode, script.mod);
+    script.mod = new LoadedModule(url, module, cacheKey);
+    moduleCache.set(cacheKey, script.mod);
   }
 
   addDependencyInfo(script, seenStack);

--- a/src/Script/LoadedModule.ts
+++ b/src/Script/LoadedModule.ts
@@ -13,9 +13,11 @@ export interface ScriptModule {
 export class LoadedModule {
   url: ScriptURL;
   module: Promise<ScriptModule>;
+  cacheKey: string;
 
-  constructor(url: ScriptURL, module: Promise<ScriptModule>) {
+  constructor(url: ScriptURL, module: Promise<ScriptModule>, cacheKey: string) {
     this.url = url;
     this.module = module;
+    this.cacheKey = cacheKey;
   }
 }

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -7,10 +7,36 @@ import { RamCostConstants } from "../Netscript/RamCostGenerator";
 import type { ScriptFilePath } from "../Paths/ScriptFilePath";
 import { ContentFile } from "../Paths/ContentFile";
 
+//This caches script code for scripts with the same code but a different filename
+interface ScriptCodeCacheEntry {
+  code: string;
+  refs: number;
+}
+
+const scriptCodeCache = new Map<string, ScriptCodeCacheEntry>();
+
+function retainScriptCode(code: string): string {
+  const entry = scriptCodeCache.get(code);
+  if (entry) {
+    entry.refs++;
+    return entry.code;
+  }
+  scriptCodeCache.set(code, { code, refs: 1 });
+  return code;
+}
+
+function releaseScriptCode(code: string): void {
+  const entry = scriptCodeCache.get(code);
+  if (!entry) return;
+  entry.refs--;
+  if (entry.refs <= 0) scriptCodeCache.delete(code);
+}
+
 /** A script file as a file on a server.
  * For the execution of a script, see RunningScript and WorkerScript */
 export class Script extends ContentFile {
-  code: string;
+  private _code = "";
+  private codeRefRetained = false;
   filename: ScriptFilePath;
   server: string;
 
@@ -34,18 +60,31 @@ export class Script extends ContentFile {
     this.metadata.read();
     return this.code;
   }
+  get code(): string {
+    return this._code;
+  }
   set content(newCode: string) {
-    this.metadata.edit();
     if (this.code === newCode) return;
+    this.metadata.edit();
     this.code = newCode;
     this.invalidateModule();
   }
-
+  set code(newCode: string) {
+    if (this.codeRefRetained && this._code === newCode) return;
+    if (this.codeRefRetained) releaseScriptCode(this._code);
+    this._code = retainScriptCode(newCode);
+    this.codeRefRetained = true;
+  }
   constructor(filename = "default.js" as ScriptFilePath, code = "", server = "") {
     super();
     this.filename = filename;
     this.code = code;
     this.server = server; // hostname of server this script is on
+  }
+  dispose(): void {
+    if (this.codeRefRetained) releaseScriptCode(this._code);
+    this._code = "";
+    this.codeRefRetained = false;
   }
 
   /** Invalidates the current script module and related data, e.g. when modifying the file. */
@@ -93,6 +132,7 @@ export class Script extends ContentFile {
     if (this.server !== server.hostname || server.isRunning(this.filename)) return false;
     this.invalidateModule();
     server.scripts.delete(this.filename);
+    this.dispose();
     return true;
   }
 

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -64,8 +64,8 @@ export class Script extends ContentFile {
     return this._code;
   }
   set content(newCode: string) {
-    if (this.code === newCode) return;
     this.metadata.edit();
+    if (this.code === newCode) return;
     this.code = newCode;
     this.invalidateModule();
   }

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -190,6 +190,7 @@ export abstract class BaseServer implements IServer {
       if (this.isRunning(path)) return { res: false, msg: "Cannot delete a script that is currently running!" };
       script.invalidateModule();
       this.scripts.delete(path);
+      script.dispose();
       return { res: true };
     }
     if (hasProgramExtension(path)) {
@@ -256,6 +257,7 @@ export abstract class BaseServer implements IServer {
     // Check if the script already exists, and overwrite it if it does
     const script = this.scripts.get(filename);
     if (script) {
+      if (script.code === code) return { overwritten: false };
       // content setter handles module invalidation
       script.content = code;
       return { overwritten: true };
@@ -274,6 +276,7 @@ export abstract class BaseServer implements IServer {
     const existingFile = this.textFiles.get(textPath);
     // overWrite if already exists
     if (existingFile) {
+      if (existingFile.text === txt) return { overwritten: false };
       existingFile.content = txt;
       return { overwritten: true };
     }

--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -276,7 +276,7 @@ export abstract class BaseServer implements IServer {
     const existingFile = this.textFiles.get(textPath);
     // overWrite if already exists
     if (existingFile) {
-      if (existingFile.text === txt) return { overwritten: false };
+      if (existingFile.text === txt) return { overwritten: true };
       existingFile.content = txt;
       return { overwritten: true };
     }

--- a/src/TextFile.ts
+++ b/src/TextFile.ts
@@ -17,6 +17,7 @@ export class TextFile extends ContentFile {
     return this.text;
   }
   set content(text: string) {
+    if (this.text === text) return;
     this.metadata.edit();
     this.text = text;
   }


### PR DESCRIPTION
This PR aims to fix a few issues.

-Duplicate script content is present in memory when multiple scripts with the same content are running.
-Scripts can miss their module cache lookup due to their blob URL being unique
-Writing scripts could invalidate them and rewrite, even if the new content is identical


Lets start with the `newCode` variable.  It is created using `importedScript.mod.url`.  That string is unique, which can cause a cache lookup to fail.  To fix this, we add the `cacheKey` variable.  This represents a stable key for cache lookup.  This key can be used to lookup modules for multiple URL's.
In order to accommodate this new cacheKey variable, I've added it directly to LoadedModule.  We now set/get from the moduleCache using this cacheKey directly.

Next up is the scriptCodeCache.  I've added a get/set code function to Scripts.ts to retrieve the code.  The `refs` field is how many times it has been referenced.  Now, when you start a script, it's referenced code block gets cached, and each subsequent duplicate script (based on content) that is started adds to that count.  When a script is done, it is released which decrements the counter.  When the counter is at 0 the script code is released.  This should be a far cleaner life cycle path, which ends with the code being released, than relying on WeakRefs and GC.

The other minor fixes are mostly early returns, which show up as unneeded churn in the system.  If the contents have not changed when you write to it, don't invalidate and rewrite.

Pattern:

Pattern 1:  Same source code
Before
- New Script object / new string / new blob URL
- Cache sees a different identity
- New module or duplicated source
- Memory increases
After
- We have a stable source/cache identity key
- We reuse existing string/modules when possible by using this key
- We avoid invalidating anything when content has not changed
- Memory plateaus

We track 2 identities now.  Runtime still uses the blob URLs, but caches use the stable cacheKey

Patter 2: Each running script kept a copy of it's own source code in memory
Before
- Each running duplicate script would store it's own .code value
After
- Each running duplicate script stores 1 instance of it's code, and once the last script is done it is freed and can be GCd

The pattern for this becomes:
- script with source A runs
- Cache miss
- Store A, refs = 1
- script._code = A
- second script with source A runs
- cache hit
- refs = 2
- script._code = cached A

Before we could have 1000 Script objects with 1000 retained source strings.  Now, we can have 1000 Script objects with 1 retained source string and 1000 refs

Just added as a draft incase I think of something I've missed by the morning.

MRE:
```js
const SIZE = .5 //In MB
const COPIES = 32
const PREFIX = "mre-source-bloat/"
/**
 * Backup your save.  These tests can cause your game to fail to save or corrupt it
 * While I'm looking at fixing modules and caching code it still creates new Script instances
 * 
 * Key: Delete = 0, Unique = 1, Start = 2
 * 
 * General control:  0 = false, 1 = false, 2 = false
 * - Dev: memory will plateau
 * - Fix: same
 * 
 * Source/file object recreation:  0 = true, 1 = false, 2 = false
 * - Dev: Some churning, and memory should plateau at a higher level as each script uses it's own code
 * - Fix: Same, but less churning.  Memory should plateau earlier due to code sharing
 * - Increasing the file size or count should increase the gap between dev and this fix
 * 
 * Module Leak (Main test):  0 = true, 1 = false, 2 = true
 * - Dev: Memory should grow due to new modules being created from missed cache lookups
 * - Fix: Memory should plateau as module cache is now based on source/cacheKey
 * 
 * Save/file bloat: 0 = false, 1 = true, 2 = true
 * - Dev: Grows fast as new script code/modules accumulate
 * - Fix: Still grows from file/save data, but live source-string duplication should be lowered
 * - I ran this for both Dev and Fix and analyzed the memory dumps.  The results were great
 * - The fix had a lower dump size, ran longer, generated more unique names by over 4x, and a total of 1 Source-Code shared.
 *   The dev branch had 16k unique file names and 1,024 Source-Code shared
 * - The main bloat from this is the save data accumulation from all the files.
 */
const DELETE_BEFORE_SCP = false
const UNIQUE_FILE_NAMES = false
const START_SCRIPTS = false
/** @param {NS} ns */
export async function main(ns) {
  ns.disableLog("ALL")
  ns.ui.openTail()
  const files = Array.from({ length: COPIES }, (_, i) => `copy-${i}.js`)
  const targets = scanAll(ns)
    .filter((server) => ns.hasRootAccess(server))
    .filter((server) => ns.getServerMaxRam(server) >= 2)
  ns.atExit(() => {
    for (const target of targets)
      for (const file of ns.ls(target, PREFIX))
        ns.rm(file, target)
  })

  const victimBody = await makeLargeVictimScript(SIZE)
  let lastYield = performance.now()
  let generation = 0

  while (true) {
    generation++ //We can see this in the console
    const gen_prefix = UNIQUE_FILE_NAMES ? ns.sprintf(`-Gen-${generation}-`) : ""
    for (const file of files) {
      const fileName = `${PREFIX}${gen_prefix}${file}`
      ns.write(fileName, victimBody, "w")
      if (performance.now() - lastYield >= 200) {
        lastYield = performance.now()
        await ns.sleep(0)
      }
    }
    if (START_SCRIPTS) {
      //Give started scripts some time to finish.
      await ns.sleep(0)
    }
    for (const target of targets) {
      for (const file of files) {
        const fileName = `${PREFIX}${gen_prefix}${file}`
        if (DELETE_BEFORE_SCP) ns.rm(fileName, target)
        ns.scp(fileName, target, "home")
        if (START_SCRIPTS) {
          const threads = Math.floor(Math.max(0, ns.getServerMaxRam(target) - ns.getServerUsedRam(target) - target === "home" ? 32 : 0) / 1.6)
          if (threads) ns.exec(fileName, target, { temporary: true })
        }
        if (performance.now() - lastYield >= 200) {
          lastYield = performance.now()
          await ns.sleep(0)
        }
      }
    }
  }
}

function scanAll(ns) {
  const serverList = new Set(["home"])
  for (const server of serverList) {
    for (const connection of ns.scan(server)) {
      serverList.add(connection)
    }
  }
  return Array.from(serverList)
}

async function makeLargeVictimScript(sizeMb) {
  const targetBytes = sizeMb * 1024 * 1024;
  const line = "SOURCE_BLOAT_MRE_PAD_0123456789abcdef".repeat(32) + "\n"
  let pad = "";
  let lastYield = performance.now()

  while (pad.length < targetBytes) {
    pad += line;
    if (pad.length > 1024 * 1024 && pad.length * 2 < targetBytes) pad += pad
    if (performance.now() - lastYield >= 200) {
      lastYield = performance.now()
      await ns.sleep(0)
    }
  }

  pad = pad.slice(0, targetBytes)

  return `/*
${pad}
*/
export async function main(ns) {
  ns.disableLog("ALL");
  await ns.sleep(50)
}`
    ;
}
```