### PR TITLE
DEVMENU: Initialize dark net data when adding darknet program

### DIFF
--- a/src/DevMenu/ui/ProgramsDev.tsx
+++ b/src/DevMenu/ui/ProgramsDev.tsx
@@ -11,6 +11,7 @@ import { Player } from "@player";
 import MenuItem from "@mui/material/MenuItem";
 import { CompletedProgramName } from "@enums";
 import { AutoExpandAccordion } from "../../ui/AutoExpand/AutoExpandAccordion";
+import { populateDarknet } from "../../DarkNet/controllers/NetworkGenerator";
 
 export function ProgramsDev(): React.ReactElement {
   const [program, setProgram] = useState(CompletedProgramName.bruteSsh);
@@ -19,12 +20,18 @@ export function ProgramsDev(): React.ReactElement {
   }
   function addProgram(): void {
     Player.getHomeComputer().pushProgram(program);
+    if (program === CompletedProgramName.darkscape) {
+      populateDarknet();
+    }
   }
 
   function addAllPrograms(): void {
     const home = Player.getHomeComputer();
     for (const name of Object.values(CompletedProgramName)) {
       home.pushProgram(name);
+      if (name === CompletedProgramName.darkscape) {
+        populateDarknet();
+      }
     }
   }
 


### PR DESCRIPTION
MRE:
- Load a clean save file.
- Dev menu => Programs => Add: All.
- Save and reload.
- Wait a few seconds: `Caught an exception: Error: The connection between darkweb and home is unidirectional.`

This bug is similar to #2632.

Originally, I planned to refactor the darknet code and other related code to make sure this issue won't happen again. However, there are many ways to do that, and each comes with its own pros and cons. I'm also worried that the refactor could introduce regressions.

Let's apply this minimal fix and discuss a better solution later.