### PR TITLE
BUGFIX: Darknet UI draws connections between hidden servers

### DIFF
--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -72,8 +72,8 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     setNetDisplayDepth(deepestServerDepth + visibilityMargin);
 
     rerender();
-    drawOnCanvas(canvas.current);
-  }, [rerender]);
+    drawOnCanvas(canvas.current, netDisplayDepth);
+  }, [rerender, netDisplayDepth]);
 
   useEffect(() => {
     const clearSubscription = DarknetEvents.subscribe(() => updateDisplay());

--- a/src/DarkNet/ui/networkCanvas.ts
+++ b/src/DarkNet/ui/networkCanvas.ts
@@ -12,7 +12,7 @@ import { NET_WIDTH } from "../Enums";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { getDarknetServerOrThrow } from "../utils/darknetServerUtils";
 
-export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
+export const drawOnCanvas = (canvas: HTMLCanvasElement, netDisplayDepth: number) => {
   const ctx = canvas?.getContext("2d");
   if (!ctx || !canvas) {
     console.error("Could not get canvas context");
@@ -23,6 +23,7 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
   for (const server of DarknetState.Network.flat()) {
     if (
       !server ||
+      server.depth >= netDisplayDepth ||
       (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights))
     ) {
       continue;
@@ -32,7 +33,7 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement) => {
     for (const connectedServerName of server.serversOnNetwork) {
       const connectedServer = getDarknetServerOrThrow(connectedServerName);
       if (
-        !connectedServer ||
+        connectedServer.depth >= netDisplayDepth ||
         (!connectedServer.hasAdminRights &&
           !connectedServer.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights))
       ) {


### PR DESCRIPTION
MRE:
- Load a clean save file and bitflume to BN15.
- Dev => "Gain admin access to all darknet servers" + "Gain admin access to labyrinth server".
- Run webstorm a few times.

<img width="839" height="745" alt="Capture" src="https://github.com/user-attachments/assets/7aa5a2fa-9ed7-431a-b7b0-dbf4d5362acb" />

You can load this save file to test this bug:
[bitburnerSave_1781103964_BN15x1.json.gz](https://github.com/user-attachments/files/28801773/bitburnerSave_1781103964_BN15x1.json.gz)

The Darknet UI hides all servers with a depth greater than or equal to `netDisplayDepth`, but when drawing the connections, the filters in `networkCanvas.ts` do not check the server depth.