### PR TITLE
BUGFIX: Darknet UI allows authentication of hidden servers

### DIFF
--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -171,9 +171,10 @@ export function NetworkDisplayWrapper(): React.ReactElement {
   };
 
   const search = (selection: string, options: string[], searchTerm: string) => {
+    // Ignore single character searches
     if (searchTerm.length === 1) {
       return;
-    } // Ignore single character searches
+    }
     if (!searchTerm) {
       setSearchLabel(initialSearchLabel);
       return;
@@ -183,12 +184,11 @@ export function NetworkDisplayWrapper(): React.ReactElement {
       servers.find((s) => s.hostname.toLowerCase() === selection.toLowerCase()) ||
       servers.find((s) => s.hostname.toLowerCase() === options[0]?.toLowerCase());
 
-    if (!foundServer) {
+    if (!foundServer || foundServer.depth >= netDisplayDepth) {
       setSearchLabel(`(No results)`);
       return;
-    } else {
-      setSearchLabel(initialSearchLabel);
     }
+    setSearchLabel(initialSearchLabel);
 
     const position = getPixelPosition(foundServer, true);
 


### PR DESCRIPTION
MRE:
- Follow the steps in #2868 to get a test save file.
- Use `DarknetState.Network` to get a server connected to the authenticated lab. With the test save file attached in #2868, use `g1gahub`.
- Type the hostname you found into the search tool and press enter. The darknet UI will open the server detail popup for `g1gahub` even though this server is hidden.

This bug is similar to #2868. The `search` function needs to check the server depth.