### PR TITLE
CLEANUP: Removed WorkerScript.code property

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -23,9 +23,6 @@ export class WorkerScript {
   /** Script's arguments */
   args: ScriptArg[];
 
-  /** Copy of the script's code */
-  code = "";
-
   /**
    * Holds the timeoutID (numeric value) for whenever this script is blocked by a
    * timed Netscript function. i.e. Holds the return value of setTimeout()
@@ -98,7 +95,6 @@ export class WorkerScript {
     if (!script) {
       throw new Error(`WorkerScript constructed with invalid script filename: ${this.name}`);
     }
-    this.code = script.code;
     this.scriptRef = runningScriptObj;
     this.args = runningScriptObj.args.slice();
     this.env = new Environment();


### PR DESCRIPTION
While searching for entry points that could create duplicate script entries, I came upon this.  I believe it's old, unused code.  I cannot find anything that references it.  Even getting the script code from a `WorkerScript` calls `.getScript()` rather than referencing the .code field itself.  All it seems to do is keep `script.code` alive through a reference, and it doesn't need that.  It is also not used in the debugger, or in generating error messages.

After the change I ran my batcher for a while with 0 issues.