### PR TITLE
feat(ui): add ns.ui.openPage/closePage for script-created sidebar pages

### DIFF
--- a/src/Netscript/RamCostGenerator.ts
+++ b/src/Netscript/RamCostGenerator.ts
@@ -457,6 +457,8 @@ const ui = {
   alias: 0,
   unalias: 0,
   getAllAliases: 0,
+  openPage: 0,
+  closePage: 0,
 } as const;
 
 // Grafting API

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -11,6 +11,7 @@ import { AddRecentScript } from "./RecentScripts";
 import { handleUnknownError } from "../utils/ErrorHandler";
 import { roundToTwo } from "../utils/helpers/roundToTwo";
 import { BaseServer } from "../Server/BaseServer";
+import { CustomPageManager } from "../ui/CustomPageManager";
 
 export function killWorkerScript(ws: WorkerScript): void {
   stopAndCleanUpWorkerScript(ws);
@@ -119,4 +120,5 @@ function removeWorkerScript(workerScript: WorkerScript): void {
   if (rs.temporary === false) {
     AddRecentScript(workerScript);
   }
+  CustomPageManager.closePagesByPid(workerScript.pid);
 }

--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -16,6 +16,7 @@ import { hasTextExtension } from "../Paths/TextFilePath";
 import { errorMessage } from "../Netscript/ErrorMessages";
 import { addGlobalAlias, addAlias, removeAlias, Aliases, GlobalAliases, aliasRegex } from "../Alias";
 import { assertStringWithNSContext } from "../Netscript/TypeAssertion";
+import { CustomPageManager } from "../ui/CustomPageManager";
 
 /** Converts the provided value to a string and ensures it satisfies the alias condition, throwing if it is not  */
 export function parseAsAlias(ctx: NetscriptContext, argName: string, v: unknown): string {
@@ -277,5 +278,22 @@ export function NetscriptUserInterface(): InternalAPI<IUserInterface> {
 
       return returnMap;
     },
+
+    openPage:
+      (ctx) =>
+      (_title, _content = "") => {
+        const title = helpers.string(ctx, "title", _title);
+        const content = helpers.string(ctx, "content", _content);
+        if (!title) throw helpers.errorMessage(ctx, "'title' cannot be empty.");
+        CustomPageManager.openPage(ctx.workerScript.pid, title, content);
+      },
+
+    closePage:
+      (ctx) =>
+      (_title) => {
+        const title = helpers.string(ctx, "title", _title);
+        if (!title) throw helpers.errorMessage(ctx, "'title' cannot be empty.");
+        CustomPageManager.closePage(title);
+      },
   };
 }

--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -283,8 +283,8 @@ export function NetscriptUserInterface(): InternalAPI<IUserInterface> {
       (ctx) =>
       (_title, _content = "") => {
         const title = helpers.string(ctx, "title", _title);
-        const content = helpers.string(ctx, "content", _content);
         if (!title) throw helpers.errorMessage(ctx, "'title' cannot be empty.");
+        const content = typeof _content === "string" ? _content : wrapUserNode(_content);
         CustomPageManager.openPage(ctx.workerScript.pid, title, content);
       },
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7080,6 +7080,48 @@ interface UserInterface {
    * @returns A map of alias names to an object containing the substitution string and if the alias was set to global.
    */
   getAllAliases(): Map<string, { substitution: string; isGlobal: boolean }>;
+
+  /**
+   * Open or update a custom sidebar page.
+   *
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * Creates a new page that appears in the game's sidebar under a "Scripts" section.
+   * If a page with the given title already exists, its content is updated in place.
+   * The page is automatically removed when the script that created it exits.
+   *
+   * Call this function repeatedly (e.g. in a loop with `await ns.sleep()`) to update
+   * the displayed content.
+   *
+   * @example
+   * ```js
+   * export async function main(ns) {
+   *   while (true) {
+   *     const info = `Money: ${ns.formatNumber(ns.getServerMoneyAvailable("n00dles"))}`;
+   *     ns.ui.openPage("My Dashboard", info);
+   *     await ns.sleep(1000);
+   *   }
+   * }
+   * ```
+   *
+   * @param title - The page title shown in the sidebar (must be unique across all scripts).
+   * @param content - Optional text to display on the page.
+   */
+  openPage(title: string, content?: string): void;
+
+  /**
+   * Close a custom sidebar page.
+   *
+   * @remarks
+   * RAM cost: 0 GB
+   *
+   * Removes the page with the given title from the sidebar. Has no effect if no such
+   * page exists. Pages are also automatically removed when the owning script exits.
+   *
+   * @param title - The title of the page to close.
+   */
+  closePage(title: string): void;
 }
 
 /**

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7096,6 +7096,7 @@ interface UserInterface {
    *
    * @example
    * ```js
+   * // Plain string (renders in monospace pre-formatted style)
    * export async function main(ns) {
    *   while (true) {
    *     const info = `Money: ${ns.formatNumber(ns.getServerMoneyAvailable("n00dles"))}`;
@@ -7105,10 +7106,28 @@ interface UserInterface {
    * }
    * ```
    *
+   * ```js
+   * // React JSX (full control over layout and styling)
+   * export async function main(ns) {
+   *   while (true) {
+   *     const money = ns.getServerMoneyAvailable("n00dles");
+   *     ns.ui.openPage("My Dashboard",
+   *       <div>
+   *         <h2>n00dles</h2>
+   *         <p>Money: {ns.formatNumber(money)}</p>
+   *       </div>
+   *     );
+   *     await ns.sleep(1000);
+   *   }
+   * }
+   * ```
+   *
    * @param title - The page title shown in the sidebar (must be unique across all scripts).
-   * @param content - Optional text to display on the page.
+   * @param content - Optional content to display. Accepts a plain string (rendered
+   *   in monospace pre-formatted style) or a React node (rendered as-is, giving
+   *   full control over layout and styling). See {@link ReactNode}.
    */
-  openPage(title: string, content?: string): void;
+  openPage(title: string, content?: ReactNode): void;
 
   /**
    * Close a custom sidebar page.

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -43,7 +43,9 @@ import BiotechIcon from "@mui/icons-material/Biotech"; // Grafting
 
 import { Router } from "../../ui/GameRoot";
 import { ComplexPage, SimplePage } from "../../ui/Enums";
-import { Page, isSimplePage } from "../../ui/Router";
+import { Page, PageWithContext, isSimplePage } from "../../ui/Router";
+import { CustomPageManager, type CustomPage } from "../../ui/CustomPageManager";
+import ArticleIcon from "@mui/icons-material/Article";
 import { SidebarAccordion } from "./SidebarAccordion";
 import { Player } from "@player";
 import { CONSTANTS } from "../../Constants";
@@ -122,7 +124,11 @@ const useStyles = makeStyles()((theme: Theme) => ({
   listitem: {},
 }));
 
-export function SidebarRoot(props: { page: Page }): React.ReactElement {
+export function SidebarRoot(props: { pageWithContext: PageWithContext }): React.ReactElement {
+  const page = props.pageWithContext.page;
+  const scriptPageId = props.pageWithContext.page === ComplexPage.ScriptPage
+    ? (props.pageWithContext as { page: ComplexPage.ScriptPage; id: string }).id
+    : null;
   const isSettingUpKeyBindings = useRef(false);
   useCycleRerender();
 
@@ -307,7 +313,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
 
     document.addEventListener("keydown", handleShortcuts);
     return () => document.removeEventListener("keydown", handleShortcuts);
-  }, [canGoToPage, clickPage, props.page]);
+  }, [canGoToPage, clickPage, page]);
 
   const { classes } = useStyles();
   const [open, setOpen] = useState(Settings.IsSidebarOpened);
@@ -345,7 +351,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
       <List>
         <SidebarAccordion
           key_="Hacking"
-          page={props.page}
+          page={page}
           clickPage={clickPage}
           flash={flash}
           icon={ComputerIcon}
@@ -368,7 +374,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
         <Divider />
         <SidebarAccordion
           key_="Character"
-          page={props.page}
+          page={page}
           clickPage={clickPage}
           flash={flash}
           icon={AccountBoxIcon}
@@ -379,7 +385,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
             canOpenFactions && {
               key_: Page.Factions,
               icon: ContactsIcon,
-              active: [Page.Factions, Page.Faction].includes(props.page),
+              active: [Page.Factions, Page.Faction].includes(page),
               count: invitationsCount,
             },
             canOpenAugmentations && {
@@ -396,7 +402,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
         <Divider />
         <SidebarAccordion
           key_="World"
-          page={props.page}
+          page={page}
           clickPage={clickPage}
           flash={flash}
           icon={PublicIcon}
@@ -406,7 +412,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
             {
               key_: Page.City,
               icon: LocationCityIcon,
-              active: [Page.City, Page.Location].includes(props.page),
+              active: [Page.City, Page.Location].includes(page),
             },
             { key_: Page.Travel, icon: AirplanemodeActiveIcon },
             canJob && { key_: Page.Job, icon: WorkIcon },
@@ -422,7 +428,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
         <Divider />
         <SidebarAccordion
           key_="Help"
-          page={props.page}
+          page={page}
           clickPage={clickPage}
           flash={flash}
           icon={LiveHelpIcon}
@@ -436,8 +442,51 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
             process.env.NODE_ENV === "development" && { key_: Page.DevMenu, icon: DeveloperBoardIcon },
           ]}
         />
+        <ScriptPageItems activeId={scriptPageId} classes={classes} sidebarOpen={open} />
         <Typography id="sidebar-extra-hook-3"></Typography>
       </List>
     </Drawer>
+  );
+}
+
+// ── Script-created custom pages ───────────────────────────────────────────────
+
+interface ScriptPageItemsProps {
+  activeId: string | null;
+  classes: Record<"listitem" | "active", string>;
+  sidebarOpen: boolean;
+}
+
+function ScriptPageItems({ activeId, classes, sidebarOpen }: ScriptPageItemsProps): React.ReactElement | null {
+  const [customPages, setCustomPages] = useState<readonly CustomPage[]>(() => CustomPageManager.getSnapshot());
+  useEffect(() => CustomPageManager.subscribe(() => setCustomPages(CustomPageManager.getSnapshot())), []);
+  if (customPages.length === 0) return null;
+
+  return (
+    <>
+      <Divider />
+      {customPages.map((cp) => {
+        const isActive = activeId === cp.id;
+        const color = isActive ? "primary" : "secondary";
+        return (
+          <ListItem
+            key={cp.id}
+            classes={{ root: classes.listitem }}
+            button
+            className={isActive ? classes.active : ""}
+            onClick={() => Router.toPage(ComplexPage.ScriptPage, { id: cp.id })}
+          >
+            <ListItemIcon>
+              <Tooltip title={!sidebarOpen ? cp.title : ""}>
+                <ArticleIcon color={color} />
+              </Tooltip>
+            </ListItemIcon>
+            <ListItemText>
+              <Typography color={color}>{cp.title}</Typography>
+            </ListItemText>
+          </ListItem>
+        );
+      })}
+    </>
   );
 }

--- a/src/ui/CustomPageManager.ts
+++ b/src/ui/CustomPageManager.ts
@@ -1,10 +1,12 @@
 /** Registry for script-created sidebar pages. */
 
+import type { ReactNode } from "react";
+
 export interface CustomPage {
   /** Unique identifier — same as title. */
   id: string;
   title: string;
-  content: string;
+  content: ReactNode;
   /** PID of the script that created this page. */
   pid: number;
 }
@@ -19,7 +21,7 @@ class CustomPageRegistry {
   private snapshot: readonly CustomPage[] = [];
 
   /** Open a page or update its content.  Called by ns.ui.openPage(). */
-  openPage(pid: number, title: string, content = ""): void {
+  openPage(pid: number, title: string, content: ReactNode = ""): void {
     const existing = this.pages.get(title);
     if (existing) {
       existing.content = content;

--- a/src/ui/CustomPageManager.ts
+++ b/src/ui/CustomPageManager.ts
@@ -1,0 +1,73 @@
+/** Registry for script-created sidebar pages. */
+
+export interface CustomPage {
+  /** Unique identifier — same as title. */
+  id: string;
+  title: string;
+  content: string;
+  /** PID of the script that created this page. */
+  pid: number;
+}
+
+type Listener = () => void;
+
+class CustomPageRegistry {
+  private readonly pages = new Map<string, CustomPage>();
+  private readonly listeners = new Set<Listener>();
+  // Cached snapshot array — only replaced on mutation so useSyncExternalStore
+  // can bail out on unchanged renders.
+  private snapshot: readonly CustomPage[] = [];
+
+  /** Open a page or update its content.  Called by ns.ui.openPage(). */
+  openPage(pid: number, title: string, content = ""): void {
+    const existing = this.pages.get(title);
+    if (existing) {
+      existing.content = content;
+    } else {
+      this.pages.set(title, { id: title, title, content, pid });
+    }
+    this.invalidate();
+  }
+
+  /** Close a page.  Called by ns.ui.closePage() and on script exit. */
+  closePage(title: string): void {
+    if (this.pages.delete(title)) this.invalidate();
+  }
+
+  /** Remove all pages owned by the given PID.  Called on script termination. */
+  closePagesByPid(pid: number): void {
+    let changed = false;
+    for (const [id, page] of this.pages) {
+      if (page.pid === pid) {
+        this.pages.delete(id);
+        changed = true;
+      }
+    }
+    if (changed) this.invalidate();
+  }
+
+  /** Retrieve a page by its id/title. */
+  getPage(id: string): CustomPage | undefined {
+    return this.pages.get(id);
+  }
+
+  // ── useSyncExternalStore interface ─────────────────────────────────────────
+
+  /** Stable subscribe function for useSyncExternalStore. */
+  readonly subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  /** Stable snapshot getter — same array reference while nothing has changed. */
+  readonly getSnapshot = (): readonly CustomPage[] => this.snapshot;
+
+  // ── private ────────────────────────────────────────────────────────────────
+
+  private invalidate(): void {
+    this.snapshot = [...this.pages.values()];
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const CustomPageManager = new CustomPageRegistry();

--- a/src/ui/CustomPages/CustomPageRoot.tsx
+++ b/src/ui/CustomPages/CustomPageRoot.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { CustomPageManager, type CustomPage } from "../CustomPageManager";
+import { Settings } from "../../Settings/Settings";
 import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
 
 interface Props {
   id: string;
@@ -22,22 +24,27 @@ export function CustomPageRoot({ id }: Props): React.ReactElement {
     return <Typography>This page no longer exists.</Typography>;
   }
 
-  // Typography as="pre" so MUI's theme text color is applied — bare <pre>
-  // does not inherit the theme color and renders invisible on dark backgrounds.
-  return (
-    <Typography
-      component="pre"
-      sx={{
-        fontFamily: "monospace",
-        fontSize: "1rem",
-        whiteSpace: "pre-wrap",
-        wordBreak: "break-word",
-        m: 0,
-        p: 0,
-        lineHeight: 1.4,
-      }}
-    >
-      {page.content}
-    </Typography>
-  );
+  // String content: render in a Typography pre so the player's configured
+  // monospace font/size is applied and column-padded text aligns correctly.
+  // ReactNode content: render directly inside a plain container so the
+  // caller's JSX controls its own layout and styling.
+  if (typeof page.content === "string") {
+    return (
+      <Typography
+        component="pre"
+        sx={{
+          fontFamily: Settings.styles.fontFamily,
+          fontSize: `${Settings.styles.fontSize}px`,
+          lineHeight: Settings.styles.lineHeight,
+          whiteSpace: "pre",
+          m: 0,
+          p: 1,
+        }}
+      >
+        {page.content}
+      </Typography>
+    );
+  }
+
+  return <Box sx={{ p: 1 }}>{page.content}</Box>;
 }

--- a/src/ui/CustomPages/CustomPageRoot.tsx
+++ b/src/ui/CustomPages/CustomPageRoot.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from "react";
+import { CustomPageManager, type CustomPage } from "../CustomPageManager";
+import Typography from "@mui/material/Typography";
+
+interface Props {
+  id: string;
+}
+
+/**
+ * Renders the content of a script-created custom page.
+ * Re-renders automatically whenever the script calls ns.ui.openPage() with
+ * updated content.
+ */
+export function CustomPageRoot({ id }: Props): React.ReactElement {
+  const [pages, setPages] = useState<readonly CustomPage[]>(() => CustomPageManager.getSnapshot());
+
+  useEffect(() => CustomPageManager.subscribe(() => setPages(CustomPageManager.getSnapshot())), []);
+
+  const page = pages.find((p: CustomPage) => p.id === id);
+
+  if (!page) {
+    return <Typography>This page no longer exists.</Typography>;
+  }
+
+  return (
+    <pre
+      style={{
+        fontFamily: "monospace",
+        fontSize: "inherit",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+        margin: 0,
+        padding: 0,
+        lineHeight: 1.4,
+      }}
+    >
+      {page.content}
+    </pre>
+  );
+}

--- a/src/ui/CustomPages/CustomPageRoot.tsx
+++ b/src/ui/CustomPages/CustomPageRoot.tsx
@@ -22,19 +22,22 @@ export function CustomPageRoot({ id }: Props): React.ReactElement {
     return <Typography>This page no longer exists.</Typography>;
   }
 
+  // Typography as="pre" so MUI's theme text color is applied — bare <pre>
+  // does not inherit the theme color and renders invisible on dark backgrounds.
   return (
-    <pre
-      style={{
+    <Typography
+      component="pre"
+      sx={{
         fontFamily: "monospace",
-        fontSize: "inherit",
+        fontSize: "1rem",
         whiteSpace: "pre-wrap",
         wordBreak: "break-word",
-        margin: 0,
-        padding: 0,
+        m: 0,
+        p: 0,
         lineHeight: 1.4,
       }}
     >
       {page.content}
-    </pre>
+    </Typography>
   );
 }

--- a/src/ui/Enums.ts
+++ b/src/ui/Enums.ts
@@ -44,6 +44,7 @@ export enum SimplePage {
 }
 
 export enum ComplexPage {
+  ScriptPage = "Script Page",
   BitVerse = "BitVerse",
   Faction = "Faction",
   FactionAugmentations = "Faction Augmentations",

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -79,6 +79,7 @@ import { SpecialServers } from "../Server/data/SpecialServers";
 import { ErrorModal } from "../ErrorHandling/ErrorModal";
 import { DWRoot } from "../DarkNet/DWRoot";
 import { DocumentationPopUp } from "../Documentation/ui/DocumentationPopUp";
+import { CustomPageRoot } from "./CustomPages/CustomPageRoot";
 
 const htmlLocation = location;
 
@@ -488,6 +489,10 @@ export function GameRoot(): React.ReactElement {
       mainPage = <ThemeBrowser />;
       break;
     }
+    case Page.ScriptPage: {
+      mainPage = <CustomPageRoot id={pageWithContext.id} />;
+      break;
+    }
     case Page.ImportSave: {
       mainPage = <ImportSaveComparison saveData={pageWithContext.saveData} automatic={!!pageWithContext.automatic} />;
       withSidebar = false;
@@ -546,7 +551,7 @@ export function GameRoot(): React.ReactElement {
               </Overview>
               {withSidebar ? (
                 <Box display="flex" flexDirection="row" width="100%">
-                  <SidebarRoot page={pageWithContext.page} />
+                  <SidebarRoot pageWithContext={pageWithContext} />
                   <Box className={classes.root}>{mainPage}</Box>
                 </Box>
               ) : (

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -11,7 +11,9 @@ import { ComplexPage, SimplePage } from "./Enums";
 export type Page = SimplePage | ComplexPage;
 export const Page = { ...SimplePage, ...ComplexPage };
 
-export type PageContext<T extends Page> = T extends ComplexPage.BitVerse
+export type PageContext<T extends Page> = T extends ComplexPage.ScriptPage
+  ? { id: string }
+  : T extends ComplexPage.BitVerse
   ? { flume: boolean; quick: boolean }
   : T extends ComplexPage.Faction
   ? { faction: Faction }
@@ -30,6 +32,7 @@ export type PageContext<T extends Page> = T extends ComplexPage.BitVerse
   : never;
 
 export type PageWithContext =
+  | ({ page: ComplexPage.ScriptPage } & PageContext<ComplexPage.ScriptPage>)
   | ({ page: ComplexPage.BitVerse } & PageContext<ComplexPage.BitVerse>)
   | ({ page: ComplexPage.Faction } & PageContext<ComplexPage.Faction>)
   | ({ page: ComplexPage.FactionAugmentations } & PageContext<ComplexPage.FactionAugmentations>)


### PR DESCRIPTION
## Summary

This PR adds two new functions to the `ns.ui` namespace that allow scripts to create named pages in the game sidebar:

- **`ns.ui.openPage(title, content?)`** — creates a page in the sidebar (or updates its content if it already exists). Calling this in a loop is the intended update pattern.
- **`ns.ui.closePage(title)`** — removes the page. Pages are also automatically removed when the owning script exits or is killed.

Both functions cost **0 GB RAM**.

### Motivation

Currently, scripts that want to display persistent status information have to use `ns.ui.openTail()` and a floating log window. This works, but tail windows:
- Float over game content
- Don't feel like a native part of the UI
- Have to be manually positioned/resized
- Show script log output rather than structured content

`openPage` lets scripts render content as a first-class game page, appearing in the sidebar just like Terminal, Stats, or Hacknet.

### Example usage — plain string

Strings are rendered in a `<pre>` block using the player's configured monospace font, so column-aligned text works the same as in tail windows:

```js
export async function main(ns) {
  while (true) {
    const lines = [
      `Money:  ${ns.formatNumber(ns.getServerMoneyAvailable("home"))}`,
      `RAM:    ${ns.getServerUsedRam("home").toFixed(1)} / ${ns.getServerMaxRam("home")} GB`,
      `Hacks:  ${ns.getHackingLevel()}`,
    ].join("\n");

    ns.ui.openPage("Status", lines);
    await ns.sleep(1000);
  }
}
```

### Example usage — React JSX (*.jsx / *.tsx)

`content` also accepts a `ReactNode`, giving full control over layout and styling — the same model as `ns.printRaw` / `ns.tprintRaw`:

```jsx
export async function main(ns) {
  while (true) {
    const money = ns.getServerMoneyAvailable("home");
    ns.ui.openPage("Status",
      <div style={{ padding: "1rem" }}>
        <h2>Home Server</h2>
        <p>Money: {ns.formatNumber(money)}</p>
      </div>
    );
    await ns.sleep(1000);
  }
}
```

## Implementation

| File | Change |
|------|--------|
| `src/ui/CustomPageManager.ts` | New singleton registry — stores pages by title, notifies React subscribers on mutation. `content` typed as `ReactNode`. |
| `src/ui/CustomPages/CustomPageRoot.tsx` | New React component — subscribes to the manager and re-renders on content updates. Strings render in a Typography `pre`; React nodes render directly in a Box. |
| `src/ui/Enums.ts` | `ComplexPage.ScriptPage = "Script Page"` |
| `src/ui/Router.ts` | `PageContext<ScriptPage> = { id: string }`, added to `PageWithContext` union |
| `src/ui/GameRoot.tsx` | `case Page.ScriptPage` renders `<CustomPageRoot>`, passes full `pageWithContext` to sidebar |
| `src/Sidebar/ui/SidebarRoot.tsx` | `ScriptPageItems` — dynamic section hidden when no pages exist, shows one item per registered page |
| `src/Netscript/killWorkerScript.ts` | `CustomPageManager.closePagesByPid(pid)` called on script termination |
| `src/NetscriptFunctions/UserInterface.ts` | `openPage` and `closePage` implementation. Strings passed through; other values wrapped with `wrapUserNode` for error-boundary protection. |
| `src/Netscript/RamCostGenerator.ts` | `openPage: 0, closePage: 0` |
| `src/ScriptEditor/NetscriptDefinitions.d.ts` | Full JSDoc public API types with both string and JSX examples |

## Test plan

- [ ] `run test_page.js` creates a sidebar entry and shows updating content
- [ ] Killing the script removes the sidebar entry automatically
- [ ] `ns.ui.closePage()` removes the entry from a running script
- [ ] Calling `openPage` with the same title updates content without creating a duplicate
- [ ] Multiple scripts can register different pages simultaneously
- [ ] Navigating to another page and back preserves content
- [ ] Plain string content renders in monospace pre-formatted style
- [ ] React JSX content (in a .jsx file) renders with full layout control
- [ ] TypeScript types are correct and JSDoc appears in the script editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
