### PR TITLE
API: Follow up to #2806

### DIFF
--- a/markdown/bitburner.userinterface.alias.md
+++ b/markdown/bitburner.userinterface.alias.md
@@ -9,7 +9,7 @@ Programmatically sets an alias.
 **Signature:**
 
 ```typescript
-alias(alias: string, substitution: string, global?: boolean): void;
+alias(alias: string, substitution: string, isGlobal?: boolean): void;
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-The keyword to set.
+The alias name to set.
 
 
 </td></tr>
@@ -64,7 +64,7 @@ The substitution to run.
 </td></tr>
 <tr><td>
 
-global
+isGlobal
 
 
 </td><td>
@@ -74,7 +74,7 @@ boolean
 
 </td><td>
 
-_(Optional)_ Whether the alias should be set as a global alias. Global aliases replace all examples of the alias with the substitution string.
+_(Optional)_ Whether the alias should be set as a global alias. Global aliases replace all occurrences of the alias with the substitution string.
 
 
 </td></tr>
@@ -88,18 +88,19 @@ void
 
 RAM cost: 0 GB
 
-Programmatically sets an alias. This is functionally equivalent to if you typed \`\`<!-- -->alias $<!-- -->{<!-- -->alias<!-- -->}<!-- -->=$<!-- -->{<!-- -->substitution<!-- -->}<!-- -->\`\` in the terminal. This function throws an error if alias/substitution are empty strings after leading and trailing whitespace are removed. It also throws if alias has any invalid characters (not alphanum or `|!%,@-`<!-- -->).
+This is functionally equivalent to typing `alias ${alias}=${substitution}` in the terminal.
 
-Only one alias can be set for a particular context; global aliases will overwrite nonglobal aliases silently and vice versa.
+This function throws an error if `alias` is an empty string or contains any invalid characters (only alphanumeric characters and `_|!%,@-` are allowed).
+
+Only one alias may be defined for a given context. Setting a global alias will silently overwrite an existing non-global alias with the same name, and vice versa.
 
 ## Example
 
-File: script.js
 
 ```js
-export async function main(ns){
-   ns.alias("nuke", "run NUKE.exe"); // Equivalent to typing "alias nuke="run NUKE.exe"
-   ns.alias("worm", "HTTPWorm.exe", true); // Equivalent to typing "alias -g worm="HTTPWorm.exe"
+export async function main(ns) {
+  ns.ui.alias("nuke", "run NUKE.exe"); // Equivalent to typing `alias nuke="run NUKE.exe"`
+  ns.ui.alias("worm", "HTTPWorm.exe", true); // Equivalent to typing `alias -g worm="HTTPWorm.exe"`
 }
 
 ```

--- a/markdown/bitburner.userinterface.md
+++ b/markdown/bitburner.userinterface.md
@@ -27,7 +27,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-[alias(alias, substitution, global)](./bitburner.userinterface.alias.md)
+[alias(alias, substitution, isGlobal)](./bitburner.userinterface.alias.md)
 
 
 </td><td>

--- a/src/NetscriptFunctions/UserInterface.ts
+++ b/src/NetscriptFunctions/UserInterface.ts
@@ -19,11 +19,13 @@ import { assertStringWithNSContext } from "../Netscript/TypeAssertion";
 
 /** Converts the provided value to a string and ensures it satisfies the alias condition, throwing if it is not  */
 export function parseAsAlias(ctx: NetscriptContext, argName: string, v: unknown): string {
-  if (typeof v === "number") v = helpers.string(ctx, argName, v); // cast to string;
   assertStringWithNSContext(ctx, argName, v);
   const matches = v.match(aliasRegex);
-  if (matches == null || matches.length !== 1 || matches[0] !== v) {
-    throw helpers.errorMessage(ctx, `'${argName}' must only contain letters, numbers, or any of these symbols: |!%,@-`);
+  if (matches === null || matches.length !== 1 || matches[0] !== v) {
+    throw helpers.errorMessage(
+      ctx,
+      `'${argName}' must not be an empty string and must contain only alphanumeric characters or any of these symbols: _|!%,@-`,
+    );
   }
   return v;
 }
@@ -226,18 +228,11 @@ export function NetscriptUserInterface(): InternalAPI<IUserInterface> {
       );
     },
 
-    alias: (ctx) => (_alias, _substitution, _global) => {
+    alias: (ctx) => (_alias, _substitution, _isGlobal) => {
       const alias = parseAsAlias(ctx, "alias", _alias);
       const substitution = helpers.string(ctx, "substitution", _substitution);
-      const global = helpers.boolean(ctx, "global", _global ?? false);
-      if (!alias) {
-        throw helpers.errorMessage(ctx, `'alias' cannot be an empty string.`);
-      }
-      if (!substitution) {
-        throw helpers.errorMessage(ctx, `'substitution' cannot be an empty string or only contain whitespace.`);
-      }
-
-      if (global) {
+      const isGlobal = helpers.boolean(ctx, "global", _isGlobal ?? false);
+      if (isGlobal) {
         addGlobalAlias(alias, substitution);
         helpers.log(ctx, () => `Added global alias ${alias}: ${substitution}`);
       } else {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -7039,27 +7039,28 @@ interface UserInterface {
    * @remarks
    * RAM cost: 0 GB
    *
-   * Programmatically sets an alias. This is functionally equivalent to if you typed ``alias ${alias}=${substitution}`` in the terminal.
-   * This function throws an error if alias/substitution are empty strings after leading and trailing whitespace are removed. It also throws if
-   * alias has any invalid characters (not alphanum or `|!%,@-`).
+   * This is functionally equivalent to typing `alias ${alias}=${substitution}` in the terminal.
    *
-   * Only one alias can be set for a particular context; global aliases will overwrite nonglobal aliases silently and vice versa.
+   * This function throws an error if `alias` is an empty string or contains any invalid characters (only alphanumeric
+   * characters and `_|!%,@-` are allowed).
+   *
+   * Only one alias may be defined for a given context. Setting a global alias will silently overwrite an existing
+   * non-global alias with the same name, and vice versa.
    *
    * @example
-   * File: script.js
    * ```js
-   * export async function main(ns){
-   *    ns.alias("nuke", "run NUKE.exe"); // Equivalent to typing "alias nuke="run NUKE.exe"
-   *    ns.alias("worm", "HTTPWorm.exe", true); // Equivalent to typing "alias -g worm="HTTPWorm.exe"
+   * export async function main(ns) {
+   *   ns.ui.alias("nuke", "run NUKE.exe"); // Equivalent to typing `alias nuke="run NUKE.exe"`
+   *   ns.ui.alias("worm", "HTTPWorm.exe", true); // Equivalent to typing `alias -g worm="HTTPWorm.exe"`
    * }
    *
    * ```
-   * @param alias - The keyword to set.
+   * @param alias - The alias name to set.
    * @param substitution - The substitution to run.
-   * @param global - Whether the alias should be set as a global alias. Global aliases replace all examples of the alias with the substitution string.
-   *
+   * @param isGlobal - Whether the alias should be set as a global alias. Global aliases replace all occurrences of the
+   * alias with the substitution string.
    */
-  alias(alias: string, substitution: string, global?: boolean): void;
+  alias(alias: string, substitution: string, isGlobal?: boolean): void;
 
   /**
    * Clears an existing alias.

--- a/test/jest/Netscript/UserInterface.test.ts
+++ b/test/jest/Netscript/UserInterface.test.ts
@@ -11,9 +11,12 @@ beforeAll(() => {
   initGameEnvironment();
 });
 
+beforeEach(() => {
+  setupBasicTestingEnvironment();
+});
+
 describe("setTheme", () => {
   beforeEach(() => {
-    setupBasicTestingEnvironment();
     Settings.theme = { ...defaultTheme };
   });
 
@@ -88,7 +91,6 @@ describe("setTheme", () => {
 
 describe("setStyles", () => {
   beforeEach(() => {
-    setupBasicTestingEnvironment();
     Settings.styles = { ...defaultStyles };
   });
 
@@ -159,4 +161,20 @@ describe("setStyles", () => {
       spyConErr.mockRestore();
     });
   });
+});
+
+test("alias", () => {
+  const ns = getNS();
+  ns.ui.alias("foo", "run foo.js");
+  expect(ns.ui.getAllAliases().get("foo")?.substitution).toBe("run foo.js");
+
+  ns.ui.alias("foo", "   run foo.js   ");
+  expect(ns.ui.getAllAliases().get("foo")?.substitution).toBe("run foo.js");
+
+  ns.ui.alias("foo", "   ");
+  expect(ns.ui.getAllAliases().get("foo")?.substitution).toBe("");
+
+  expect(() => ns.ui.alias("", "bar")).toThrow();
+  expect(() => ns.ui.alias("   ", "bar")).toThrow();
+  expect(() => ns.ui.alias("^", "bar")).toThrow();
 });


### PR DESCRIPTION
While running `npm run doc`, api-extractor prints some warnings related to the new `ns.ui.alias` API. While fixing the TSDoc for that API, I found some issues in #2806. This PR is basically the review that vivian-wei requested in that PR.

The biggest issue is this part in the TSDoc:
```
   * This function throws an error if alias/substitution are empty strings after leading and trailing whitespace are removed. It also throws if
   * alias has any invalid characters (not alphanum or `|!%,@-`).
```
Currently, the substitution can actually be an empty string. For example, running `alias foo="    "` in the terminal will alias `foo` to an empty string. This may not be the desired behavior, but as long as this API works nearly identically to the CLI command, the docs should accurately describe the current behavior.

```
alias has any invalid characters (not alphanum or `|!%,@-`)
```
This part is also incorrect.

The next issue is the implementation:
https://github.com/bitburner-official/bitburner-src/blob/763bd6c93ac297ffd30fcb66220676a0d91fb68c/src/NetscriptFunctions/UserInterface.ts#L230-L238

The first check is unnecessary. `parseAsAlias` already handles the empty string case.

The second check is wrong and outdated. As I said above, `substitution` should be able to be an empty string. If we want to change this behavior, we need to do that in a separate PR.

The phrase "only contain whitespace" is outdated. In https://github.com/bitburner-official/bitburner-src/pull/2806/changes/31a01c230c0fc3bd44aaa94f7d2a4c48ee7eba3c, there was a `trim()` call when parsing `_substitution`. That call was removed later due to https://github.com/bitburner-official/bitburner-src/pull/2806/changes/31a01c230c0fc3bd44aaa94f7d2a4c48ee7eba3c#r3365850789. However, the error message was not updated.