### PR TITLE
DOCUMENTATION: Clarify ns.singularity.getOwnedSourceFiles

### DIFF
--- a/markdown/bitburner.singularity.getownedsourcefiles.md
+++ b/markdown/bitburner.singularity.getownedsourcefiles.md
@@ -27,3 +27,5 @@ For example, let's say you have SF 1.3, but you overrode the active level of SF1
 
 If the active level of a source file is 0, that source file won't be included in the result.
 
+This function does not require owning Source-File 4 or being in BitNode 4. You can also use [ResetInfo.ownedSF](./bitburner.resetinfo.ownedsf.md) as a lower-RAM alternative.
+

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2592,6 +2592,9 @@ export interface Singularity {
    *
    * If the active level of a source file is 0, that source file won't be included in the result.
    *
+   * This function does not require owning Source-File 4 or being in BitNode 4. You can also use
+   * {@link ResetInfo.ownedSF | ResetInfo.ownedSF} as a lower-RAM alternative.
+   *
    * @returns Array containing an object with number and level of the source file.
    */
   getOwnedSourceFiles(): SourceFileLvl[];


### PR DESCRIPTION
Among all Singularity APIs, this is the only API that bypasses the SF requirement. This PR documents that behavior. It also mentions the lower-RAM alternative.