### PR TITLE
OPTIMIZATION: Script.code interning and transform caching

### DIFF
--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -93,7 +93,7 @@ function generateLoadedModule(script: Script, scripts: Map<ScriptFilePath, Scrip
     case FileType.JSX:
     case FileType.TS:
     case FileType.TSX:
-      ({ scriptCode, sourceMap } = transformScript(script.code, fileType));
+      ({ scriptCode, sourceMap } = transformScript(script.internedCode, fileType));
       break;
     default:
       throw new Error(`Invalid file type: ${fileType}. Filename: ${script.filename}, server: ${script.server}.`);

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -6,11 +6,21 @@ import { roundToTwo } from "../utils/helpers/roundToTwo";
 import { RamCostConstants } from "../Netscript/RamCostGenerator";
 import type { ScriptFilePath } from "../Paths/ScriptFilePath";
 import { ContentFile } from "../Paths/ContentFile";
+import { internString, type InternedString } from "../utils/helpers/internString";
 
 /** A script file as a file on a server.
  * For the execution of a script, see RunningScript and WorkerScript */
 export class Script extends ContentFile {
-  code: string;
+  private _code = internString("");
+  get code(): string {
+    return this._code.value;
+  }
+  set code(value: string) {
+    this._code = internString(value);
+  }
+  get internedCode(): InternedString {
+    return this._code;
+  }
   filename: ScriptFilePath;
   server: string;
 

--- a/src/utils/ScriptTransformer.ts
+++ b/src/utils/ScriptTransformer.ts
@@ -3,6 +3,7 @@ import { transformSync, type ParserConfig } from "@swc/wasm-web";
 import * as acorn from "acorn";
 import { resolveScriptFilePath, validScriptExtensions, type ScriptFilePath } from "../Paths/ScriptFilePath";
 import type { Script } from "../Script/Script";
+import { internString, type InternedString } from "./helpers/internString";
 
 export type AcornASTProgram = acorn.Program;
 export type BabelASTProgram = object;
@@ -27,6 +28,12 @@ export interface FileTypeFeature {
 export class ModuleResolutionError extends Error {}
 
 const supportedFileTypes = [FileType.JSX, FileType.TS, FileType.TSX] as const;
+
+type TransformCacheEntry = {
+  scriptCode: InternedString;
+  sourceMap?: InternedString;
+};
+const transformCache = new WeakMap<InternedString, Partial<Record<FileType, TransformCacheEntry>>>();
 
 export function getFileType(filename: string): FileType {
   const extension = filename.substring(filename.lastIndexOf(".") + 1);
@@ -159,11 +166,18 @@ export function getModuleScript(
  * for more information.
  */
 export function transformScript(
-  code: string,
+  internedCode: InternedString,
   fileType: FileType,
 ): { scriptCode: string; sourceMap: string | undefined } {
   if (supportedFileTypes.every((v) => v !== fileType)) {
     throw new Error(`Invalid file type: ${fileType}`);
+  }
+  const cached = transformCache.get(internedCode)?.[fileType];
+  if (cached) {
+    return {
+      scriptCode: cached.scriptCode.value,
+      sourceMap: cached.sourceMap?.value,
+    };
   }
   const fileTypeFeature = getFileTypeFeature(fileType);
   let parserConfig: ParserConfig;
@@ -182,7 +196,7 @@ export function transformScript(
       parserConfig.jsx = true;
     }
   }
-  const result = transformSync(code, {
+  const result = transformSync(internedCode.value, {
     jsc: {
       parser: parserConfig,
       // @ts-expect-error -- jsc supports "esnext" target, but the definition in wasm-web.d.ts is outdated. Ref: https://github.com/swc-project/swc/issues/9495
@@ -190,8 +204,19 @@ export function transformScript(
     },
     sourceMaps: true,
   });
+  const entry: TransformCacheEntry = {
+    scriptCode: internString(result.code),
+    sourceMap: result.map === undefined ? undefined : internString(result.map),
+  };
+  let byFileType = transformCache.get(internedCode);
+  if (!byFileType) {
+    byFileType = {};
+    transformCache.set(internedCode, byFileType);
+  }
+  byFileType[fileType] = entry;
+
   return {
-    scriptCode: result.code,
-    sourceMap: result.map,
+    scriptCode: entry.scriptCode.value,
+    sourceMap: entry.sourceMap?.value,
   };
 }

--- a/src/utils/helpers/internString.ts
+++ b/src/utils/helpers/internString.ts
@@ -1,0 +1,29 @@
+export type InternedString = {
+  readonly value: string;
+};
+
+class InternedStringValue implements InternedString {
+  constructor(readonly value: string) {}
+}
+
+const emptyInternedString = new InternedStringValue("");
+const internedStrings = new Map<string, WeakRef<InternedStringValue>>();
+
+const finalizer = new FinalizationRegistry<string>((value) => {
+  const ref = internedStrings.get(value);
+  if (!ref?.deref()) internedStrings.delete(value);
+});
+
+//Keep 1 copy of the string in memory.  Remove once there are no more references.
+export function internString(value: string): InternedString {
+  //Each script starts with a "" for code.  Don't intern "", just return the default emptyInternedString
+  if (value === "") return emptyInternedString;
+
+  const existing = internedStrings.get(value)?.deref();
+  if (existing) return existing;
+
+  const interned = new InternedStringValue(value);
+  internedStrings.set(value, new WeakRef(interned));
+  finalizer.register(interned, value);
+  return interned;
+}


### PR DESCRIPTION
This is a proof of concept for the benefits of interning large, reused strings such as Script.code.

My tests on darknet, which is my largest script, is as follows:

Darknet - big script - big savings over ~180 darknet servers
Observed over time
(dev) - stable at around 720-820mb. Jumps to 1150mb at times.
(fix) - stable at around 280-420mb. Jumps to 770mb at times.


All you need to do is test it with a large number identical scripts all running on their own server.  Since each Script instance has it's own .code field, every script that is started from that instance essentially shares the same .code, but it adds up over 180 darknet servers.