### PR TITLE
TOOLS: Follow up to #2882

### DIFF
--- a/tools/package-electron.sh
+++ b/tools/package-electron.sh
@@ -24,7 +24,7 @@ packageLinux() {
 }
 
 packageMac() {
-  electron-packager .package bitburner --platform darwin --arch universal --osx-universal.x64ArchFiles="Contents/Resources/app/node_modules/@catloversg/steamworks.js/dist/osx/*" --out .build --asar.unpack='**/node_modules/@catloversg/steamworks.js/**/*.{dylib,node}' --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2025 Bitburner"
+  electron-packager .package bitburner --platform darwin --arch universal --osx-universal.x64ArchFiles="Contents/Resources/app.asar.unpacked/node_modules/@catloversg/steamworks.js/dist/osx/*.node" --out .build --asar.unpack='**/node_modules/@catloversg/steamworks.js/**/*.{dylib,node}' --overwrite --icon .package/icon.icns --app-copyright "Copyright (C) 2025 Bitburner"
 }
 
 BUILD_PLATFORM="${1:-"all"}"


### PR DESCRIPTION
When enabling ASAR, we need to update the path of `x64ArchFiles`.

Note that I change `*` to `*.node`. `libsteam_api.dylib` is a universal binary. We only need to take care of `.node` files (`Detected file "Contents/Resources/app.asar.unpacked/node_modules/@catloversg/steamworks.js/dist/osx/steamworksjs.darwin-arm64.node" that's the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule: "undefined"`).

Sample run: https://github.com/catloversg/bitburner-src/actions/runs/27497688972/job/81274718891

I also asked for help testing on Discord.