### PR TITLE
REFACTOR: Remove permanent reference to the saveObject

### DIFF
--- a/src/Electron.tsx
+++ b/src/Electron.tsx
@@ -5,7 +5,15 @@ import { Terminal } from "./Terminal";
 import { SnackbarEvents } from "./ui/React/Snackbar";
 import { ToastVariant } from "@enums";
 import { IReturnStatus, SaveData } from "./types";
-import { ImportPlayerData, ElectronGameData, saveObject } from "./SaveObject";
+import {
+  ImportPlayerData,
+  ElectronGameData,
+  saveGame,
+  getSaveFileName,
+  getSaveData,
+  getImportDataFromSaveData,
+  exportGame,
+} from "./SaveObject";
 import { exportScripts } from "./Terminal/commands/download";
 import { CONSTANTS } from "./Constants";
 import { commitHash } from "./utils/helpers/commitHash";
@@ -77,9 +85,9 @@ function initAppNotifier(): void {
 
 function initSaveFunctions(): void {
   const funcs = {
-    triggerSave: (): Promise<void> => saveObject.saveGame(true),
+    triggerSave: (): Promise<void> => saveGame(true),
     triggerGameExport: (): void => {
-      saveObject.exportGame().catch((error) => {
+      exportGame().catch((error) => {
         console.error(error);
         SnackbarEvents.emit("Could not export game.", ToastVariant.ERROR, 2000);
       });
@@ -87,13 +95,13 @@ function initSaveFunctions(): void {
     triggerScriptsExport: (): void => exportScripts("*", Player.getHomeComputer()),
     getSaveData: async (): Promise<{ save: SaveData; fileName: string }> => {
       return {
-        save: await saveObject.getSaveData(),
-        fileName: saveObject.getSaveFileName(),
+        save: await getSaveData(),
+        fileName: getSaveFileName(),
       };
     },
     getSaveInfo: async (saveData: SaveData): Promise<ImportPlayerData | undefined> => {
       try {
-        const importData = await saveObject.getImportDataFromSaveData(saveData);
+        const importData = await getImportDataFromSaveData(saveData);
         return importData.playerData;
       } catch (error) {
         console.error(error);

--- a/src/GameOptions/ui/GameOptionsSidebar.tsx
+++ b/src/GameOptions/ui/GameOptionsSidebar.tsx
@@ -12,7 +12,7 @@ import {
 import { Box, Button, List, ListItemButton, Paper, Tooltip, Typography } from "@mui/material";
 import { default as React, useRef, useState } from "react";
 import { FileDiagnosticModal } from "../../Diagnostic/FileDiagnosticModal";
-import { ImportData, saveObject } from "../../SaveObject";
+import { ImportData, getSaveDataFromFile, getImportDataFromSaveData, importGame } from "../../SaveObject";
 import { StyleEditorButton } from "../../Themes/ui/StyleEditorButton";
 import { ThemeEditorButton } from "../../Themes/ui/ThemeEditorButton";
 import { ConfirmationModal } from "../../ui/React/ConfirmationModal";
@@ -74,8 +74,8 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
 
   async function onImport(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
     try {
-      const saveData = await saveObject.getSaveDataFromFile(event.target.files);
-      const data = await saveObject.getImportDataFromSaveData(saveData);
+      const saveData = await getSaveDataFromFile(event.target.files);
+      const data = await getImportDataFromSaveData(saveData);
       setImportData(data);
       setImportSaveOpen(true);
       setSyncSteamAchievements(data.playerData?.syncSteamAchievements ?? true);
@@ -98,7 +98,7 @@ export const GameOptionsSidebar = (props: IProps): React.ReactElement => {
           SyncSteamAchievements: syncSteamAchievements,
         };
       }
-      await saveObject.importGame(importData.saveData, overrideSettings);
+      await importGame(importData.saveData, overrideSettings);
     } catch (e: unknown) {
       console.error(e);
       SnackbarEvents.emit(String(e), ToastVariant.ERROR, 5000);

--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -37,7 +37,7 @@ import { CreateProgramWork, isCreateProgramWork } from "../Work/CreateProgramWor
 import { FactionWork } from "../Work/FactionWork";
 import { CompanyWork } from "../Work/CompanyWork";
 import { canGetBonus } from "../ExportBonus";
-import { saveObject } from "../SaveObject";
+import { getSaveData, exportGame } from "../SaveObject";
 import { calculateCrimeWorkStats } from "../Work/Formulas";
 import { Engine } from "../engine";
 import { getEnumHelper } from "../utils/EnumHelper";
@@ -1202,7 +1202,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     },
     getSaveData: (ctx) => async () => {
       helpers.checkSingularityAccess(ctx);
-      const saveData = await saveObject.getSaveData();
+      const saveData = await getSaveData();
       if (typeof saveData === "string") {
         // saveData is the base64-encoded json save string. A base64-encoded string only uses ASCII characters, so it's
         // fine to use new TextEncoder().encode() to encode it to a Uint8Array.
@@ -1213,7 +1213,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
     },
     exportGame: (ctx) => () => {
       helpers.checkSingularityAccess(ctx);
-      return saveObject.exportGame();
+      return exportGame();
     },
     exportGameBonus: (ctx) => () => {
       helpers.checkSingularityAccess(ctx);

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -13,7 +13,7 @@ import {
 } from "./MessageDefinitions";
 
 import libSource from "../ScriptEditor/NetscriptDefinitions.d.ts?raw";
-import { saveObject } from "../SaveObject";
+import { getSaveData } from "../SaveObject";
 import { Player } from "@player";
 import type { BaseServer } from "../Server/BaseServer";
 import type { ContentFilePath } from "../Paths/ContentFile";
@@ -221,7 +221,7 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
   },
 
   getSaveFile: async function (msg: RFAMessage): Promise<RFAMessage> {
-    const saveData = await saveObject.getSaveData();
+    const saveData = await getSaveData();
 
     if (typeof saveData === "string") {
       return new RFAMessage({

--- a/src/SaveObject.ts
+++ b/src/SaveObject.ts
@@ -116,7 +116,7 @@ type ParsedSaveData = {
  * - "Optional 2": "loadGame" only loads these properties if they exist. The respective loaders require string values.
  * If saveObject has these properties, we check if their values are strings.
  */
-function assertBitburnerSaveObjectType(saveObject: unknown): asserts saveObject is BitburnerSaveObjectType {
+export function assertBitburnerSaveObjectType(saveObject: unknown): asserts saveObject is BitburnerSaveObjectType {
   assertObject(saveObject);
 
   const mandatoryKeysOfSaveObj = [
@@ -166,6 +166,244 @@ function assertParsedSaveData(parsedSaveData: unknown): asserts parsedSaveData i
   }
 }
 
+export async function getSaveData(forceExcludeRunningScripts = false): Promise<SaveData> {
+  const save = new BitburnerSaveObject();
+  save.PlayerSave = JSON.stringify(Player);
+
+  // For the servers save, overwrite the ExcludeRunningScripts setting if forced
+  const originalExcludeSetting = Settings.ExcludeRunningScriptsFromSave;
+  if (forceExcludeRunningScripts) Settings.ExcludeRunningScriptsFromSave = true;
+  save.AllServersSave = saveAllServers();
+  Settings.ExcludeRunningScriptsFromSave = originalExcludeSetting;
+
+  save.CompaniesSave = JSON.stringify(getCompaniesSave());
+  save.FactionsSave = JSON.stringify(getFactionsSave());
+  save.AliasesSave = JSON.stringify(Object.fromEntries(Aliases.entries()));
+  save.GlobalAliasesSave = JSON.stringify(Object.fromEntries(GlobalAliases.entries()));
+  save.StockMarketSave = JSON.stringify(StockMarket);
+  save.SettingsSave = JSON.stringify(Settings);
+  save.VersionSave = JSON.stringify(CONSTANTS.VersionNumber);
+  save.LastExportBonus = JSON.stringify(ExportBonus.LastExportBonus);
+  save.StaneksGiftSave = JSON.stringify(staneksGift);
+  save.GoSave = JSON.stringify(getGoSave());
+  save.DarknetSave = JSON.stringify(getDarkNetSave());
+  save.InfiltrationsSave = JSON.stringify(InfiltrationState);
+
+  if (Player.gang) save.AllGangsSave = JSON.stringify(AllGangs);
+
+  return await encodeJsonSaveString(JSON.stringify(save));
+}
+
+export async function saveGame(emitToastEvent = true): Promise<void> {
+  const savedOn = new Date().getTime();
+  Player.lastSave = savedOn;
+  let saveData;
+  try {
+    saveData = await getSaveData();
+  } catch (error) {
+    handleGetSaveDataInfoError(error);
+    return;
+  }
+  try {
+    await save(saveData);
+  } catch (error) {
+    console.error(error);
+    dialogBoxCreate(`Cannot save game: ${error}`);
+    return;
+  }
+  const electronGameData: ElectronGameData = {
+    playerIdentifier: Player.identifier,
+    fileName: getSaveFileName(),
+    save: saveData,
+    savedOn,
+  };
+  pushGameSaved(electronGameData);
+
+  if (emitToastEvent) {
+    SnackbarEvents.emit("Game Saved!", ToastVariant.INFO, 2000);
+  }
+}
+
+export function getSaveFileName(): string {
+  // Save file name is based on current timestamp and BitNode
+  const epochTime = Math.round(Date.now() / 1000);
+  const bn = Player.bitNodeN;
+  /**
+   * - Binary format: save file uses .json.gz extension. Save data is the compressed json save string.
+   * - Base64 format: save file uses .json extension. Save data is the base64-encoded json save string.
+   */
+  const extension = canUseBinaryFormat() ? "json.gz" : "json";
+  return `bitburnerSave_${epochTime}_BN${bn}x${getBitNodeLevel()}.${extension}`;
+}
+
+export async function exportGame(): Promise<void> {
+  // Give the export bonus before exporting the save data
+  giveExportBonus();
+  let saveData;
+  try {
+    saveData = await getSaveData();
+  } catch (error) {
+    handleGetSaveDataInfoError(error);
+    return;
+  }
+  const filename = getSaveFileName();
+  downloadContentAsFile(saveData, filename);
+}
+
+export async function importGame(
+  saveData: SaveData,
+  overrideSettings?: {
+    SyncSteamAchievements: boolean;
+  },
+): Promise<void> {
+  if (!saveData || saveData.length === 0) {
+    dialogBoxCreate("Invalid save data");
+    return;
+  }
+  // Modify settings in save data if needed (i.e., toggle SyncSteamAchievements before importing).
+  if (overrideSettings) {
+    let parsedSaveData;
+    try {
+      parsedSaveData = await getParsedSaveData(saveData);
+      // Validate SettingsSave
+      if (parsedSaveData.data.SettingsSave && typeof parsedSaveData.data.SettingsSave === "string") {
+        // Parse settings from data.SettingsSave
+        const settings: unknown = JSON.parse(parsedSaveData.data.SettingsSave);
+        assertObject(settings);
+        // Modify setting
+        settings.SyncSteamAchievements = overrideSettings.SyncSteamAchievements;
+        // Save modified data back to saveData
+        parsedSaveData.data.SettingsSave = JSON.stringify(settings);
+        saveData = await encodeJsonSaveString(JSON.stringify(parsedSaveData));
+      }
+    } catch (error) {
+      console.error(error);
+      dialogBoxCreate(`Cannot override settings: ${error}`);
+      return;
+    }
+  }
+  try {
+    await save(saveData);
+    /**
+     * Notify Electron code that the player imported a save file. "restoreIfNewerExists" will be disabled for a brief
+     * period of time.
+     */
+    pushImportResult(true);
+  } catch (error) {
+    console.error(error);
+    dialogBoxCreate(`Cannot import save data: ${error}`);
+    return;
+  }
+  setTimeout(() => location.reload(), 0);
+}
+
+export async function getSaveDataFromFile(files: FileList | null): Promise<SaveData> {
+  if (files === null) {
+    throw new Error("No file selected");
+  }
+  const file = files[0];
+  if (!file) {
+    throw new Error("Invalid file selected");
+  }
+
+  const rawData = new Uint8Array(await file.arrayBuffer());
+  if (isBinaryFormat(rawData)) {
+    return rawData;
+  }
+  if (isSteamCloudFormat(rawData)) {
+    return decodeBase64BytesToBytes(rawData);
+  }
+  return new TextDecoder().decode(rawData);
+}
+
+export async function getParsedSaveData(saveData: SaveData): Promise<ParsedSaveData> {
+  if (!saveData || saveData.length === 0) {
+    throw new Error("Invalid save data");
+  }
+
+  if (typeof saveData === "string" && saveData.startsWith(`{"ctor"`)) {
+    throw new Error(
+      "The save data is invalid. You must import the original save file. If it's a .gz file, don't decompress it.",
+    );
+  }
+
+  let decodedSaveData;
+  try {
+    decodedSaveData = await decodeSaveData(saveData);
+  } catch (error) {
+    console.error(error);
+    // Rethrow immediately if the error is SaveDataError; otherwise, handle it below.
+    if (error instanceof SaveDataError) {
+      throw error;
+    }
+  }
+
+  if (!decodedSaveData || decodedSaveData === "") {
+    console.error("decodedSaveData:", decodedSaveData);
+    console.error("saveData:", saveData);
+    throw new Error("The save data cannot be decoded.");
+  }
+
+  let parsedSaveData: unknown;
+  try {
+    parsedSaveData = JSON.parse(decodedSaveData);
+  } catch (error) {
+    console.error("decodedSaveData:", decodedSaveData);
+    throw new Error("The decoded save data is not valid.");
+  }
+
+  assertParsedSaveData(parsedSaveData);
+
+  return parsedSaveData;
+}
+
+export async function getImportDataFromSaveData(saveData: SaveData): Promise<ImportData> {
+  const parsedSaveData = await getParsedSaveData(saveData);
+
+  const data: ImportData = {
+    saveData: saveData,
+  };
+
+  const importedPlayer = loadPlayer(parsedSaveData.data.PlayerSave);
+
+  let syncSteamAchievements = true;
+  // Parse data.SettingsSave to get syncSteamAchievements.
+  if (parsedSaveData.data.SettingsSave && typeof parsedSaveData.data.SettingsSave === "string") {
+    try {
+      const settings: unknown = JSON.parse(parsedSaveData.data.SettingsSave);
+      assertObject(settings);
+      if (typeof settings.SyncSteamAchievements === "boolean") {
+        syncSteamAchievements = settings.SyncSteamAchievements;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  const playerData: ImportPlayerData = {
+    identifier: importedPlayer.identifier,
+    lastSave: importedPlayer.lastSave,
+    totalPlaytime: importedPlayer.totalPlaytime,
+
+    money: importedPlayer.money,
+    skills: importedPlayer.skills,
+
+    augmentations: importedPlayer.augmentations?.reduce<number>((total, current) => (total += current.level), 0) ?? 0,
+    factions: importedPlayer.factions?.length ?? 0,
+    achievements: importedPlayer.achievements?.length ?? 0,
+
+    bitNode: importedPlayer.bitNodeN,
+    bitNodeLevel: getBitNodeLevel(importedPlayer.bitNodeN, importedPlayer.activeSourceFileLvl(importedPlayer.bitNodeN)),
+    sourceFiles: [...importedPlayer.sourceFiles].reduce<number>((total, [__bn, lvl]) => (total += lvl), 0),
+    exploits: importedPlayer.exploits.length,
+
+    syncSteamAchievements,
+  };
+
+  data.playerData = playerData;
+  return data;
+}
+
 /**
  * We sometimes need the raw data in the loaded save object for debugging and showing useful error messages. This object
  * contains only what we need.
@@ -205,246 +443,6 @@ class BitburnerSaveObject implements BitburnerSaveObjectType {
   DarknetSave = "";
   InfiltrationsSave = "";
 
-  async getSaveData(forceExcludeRunningScripts = false): Promise<SaveData> {
-    this.PlayerSave = JSON.stringify(Player);
-
-    // For the servers save, overwrite the ExcludeRunningScripts setting if forced
-    const originalExcludeSetting = Settings.ExcludeRunningScriptsFromSave;
-    if (forceExcludeRunningScripts) Settings.ExcludeRunningScriptsFromSave = true;
-    this.AllServersSave = saveAllServers();
-    Settings.ExcludeRunningScriptsFromSave = originalExcludeSetting;
-
-    this.CompaniesSave = JSON.stringify(getCompaniesSave());
-    this.FactionsSave = JSON.stringify(getFactionsSave());
-    this.AliasesSave = JSON.stringify(Object.fromEntries(Aliases.entries()));
-    this.GlobalAliasesSave = JSON.stringify(Object.fromEntries(GlobalAliases.entries()));
-    this.StockMarketSave = JSON.stringify(StockMarket);
-    this.SettingsSave = JSON.stringify(Settings);
-    this.VersionSave = JSON.stringify(CONSTANTS.VersionNumber);
-    this.LastExportBonus = JSON.stringify(ExportBonus.LastExportBonus);
-    this.StaneksGiftSave = JSON.stringify(staneksGift);
-    this.GoSave = JSON.stringify(getGoSave());
-    this.DarknetSave = JSON.stringify(getDarkNetSave());
-    this.InfiltrationsSave = JSON.stringify(InfiltrationState);
-
-    if (Player.gang) this.AllGangsSave = JSON.stringify(AllGangs);
-
-    return await encodeJsonSaveString(JSON.stringify(this));
-  }
-
-  async saveGame(emitToastEvent = true): Promise<void> {
-    const savedOn = new Date().getTime();
-    Player.lastSave = savedOn;
-    let saveData;
-    try {
-      saveData = await this.getSaveData();
-    } catch (error) {
-      handleGetSaveDataInfoError(error);
-      return;
-    }
-    try {
-      await save(saveData);
-    } catch (error) {
-      console.error(error);
-      dialogBoxCreate(`Cannot save game: ${error}`);
-      return;
-    }
-    const electronGameData: ElectronGameData = {
-      playerIdentifier: Player.identifier,
-      fileName: this.getSaveFileName(),
-      save: saveData,
-      savedOn,
-    };
-    pushGameSaved(electronGameData);
-
-    if (emitToastEvent) {
-      SnackbarEvents.emit("Game Saved!", ToastVariant.INFO, 2000);
-    }
-  }
-
-  getSaveFileName(): string {
-    // Save file name is based on current timestamp and BitNode
-    const epochTime = Math.round(Date.now() / 1000);
-    const bn = Player.bitNodeN;
-    /**
-     * - Binary format: save file uses .json.gz extension. Save data is the compressed json save string.
-     * - Base64 format: save file uses .json extension. Save data is the base64-encoded json save string.
-     */
-    const extension = canUseBinaryFormat() ? "json.gz" : "json";
-    return `bitburnerSave_${epochTime}_BN${bn}x${getBitNodeLevel()}.${extension}`;
-  }
-
-  async exportGame(): Promise<void> {
-    // Give the export bonus before exporting the save data
-    giveExportBonus();
-    let saveData;
-    try {
-      saveData = await this.getSaveData();
-    } catch (error) {
-      handleGetSaveDataInfoError(error);
-      return;
-    }
-    const filename = this.getSaveFileName();
-    downloadContentAsFile(saveData, filename);
-  }
-
-  async importGame(
-    saveData: SaveData,
-    overrideSettings?: {
-      SyncSteamAchievements: boolean;
-    },
-  ): Promise<void> {
-    if (!saveData || saveData.length === 0) {
-      dialogBoxCreate("Invalid save data");
-      return;
-    }
-    // Modify settings in save data if needed (i.e., toggle SyncSteamAchievements before importing).
-    if (overrideSettings) {
-      let parsedSaveData;
-      try {
-        parsedSaveData = await this.getParsedSaveData(saveData);
-        // Validate SettingsSave
-        if (parsedSaveData.data.SettingsSave && typeof parsedSaveData.data.SettingsSave === "string") {
-          // Parse settings from data.SettingsSave
-          const settings: unknown = JSON.parse(parsedSaveData.data.SettingsSave);
-          assertObject(settings);
-          // Modify setting
-          settings.SyncSteamAchievements = overrideSettings.SyncSteamAchievements;
-          // Save modified data back to saveData
-          parsedSaveData.data.SettingsSave = JSON.stringify(settings);
-          saveData = await encodeJsonSaveString(JSON.stringify(parsedSaveData));
-        }
-      } catch (error) {
-        console.error(error);
-        dialogBoxCreate(`Cannot override settings: ${error}`);
-        return;
-      }
-    }
-    try {
-      await save(saveData);
-      /**
-       * Notify Electron code that the player imported a save file. "restoreIfNewerExists" will be disabled for a brief
-       * period of time.
-       */
-      pushImportResult(true);
-    } catch (error) {
-      console.error(error);
-      dialogBoxCreate(`Cannot import save data: ${error}`);
-      return;
-    }
-    setTimeout(() => location.reload(), 0);
-  }
-
-  async getSaveDataFromFile(files: FileList | null): Promise<SaveData> {
-    if (files === null) {
-      throw new Error("No file selected");
-    }
-    const file = files[0];
-    if (!file) {
-      throw new Error("Invalid file selected");
-    }
-
-    const rawData = new Uint8Array(await file.arrayBuffer());
-    if (isBinaryFormat(rawData)) {
-      return rawData;
-    }
-    if (isSteamCloudFormat(rawData)) {
-      return decodeBase64BytesToBytes(rawData);
-    }
-    return new TextDecoder().decode(rawData);
-  }
-
-  async getParsedSaveData(saveData: SaveData): Promise<ParsedSaveData> {
-    if (!saveData || saveData.length === 0) {
-      throw new Error("Invalid save data");
-    }
-
-    if (typeof saveData === "string" && saveData.startsWith(`{"ctor"`)) {
-      throw new Error(
-        "The save data is invalid. You must import the original save file. If it's a .gz file, don't decompress it.",
-      );
-    }
-
-    let decodedSaveData;
-    try {
-      decodedSaveData = await decodeSaveData(saveData);
-    } catch (error) {
-      console.error(error);
-      // Rethrow immediately if the error is SaveDataError; otherwise, handle it below.
-      if (error instanceof SaveDataError) {
-        throw error;
-      }
-    }
-
-    if (!decodedSaveData || decodedSaveData === "") {
-      console.error("decodedSaveData:", decodedSaveData);
-      console.error("saveData:", saveData);
-      throw new Error("The save data cannot be decoded.");
-    }
-
-    let parsedSaveData: unknown;
-    try {
-      parsedSaveData = JSON.parse(decodedSaveData);
-    } catch (error) {
-      console.error("decodedSaveData:", decodedSaveData);
-      throw new Error("The decoded save data is not valid.");
-    }
-
-    assertParsedSaveData(parsedSaveData);
-
-    return parsedSaveData;
-  }
-
-  async getImportDataFromSaveData(saveData: SaveData): Promise<ImportData> {
-    const parsedSaveData = await this.getParsedSaveData(saveData);
-
-    const data: ImportData = {
-      saveData: saveData,
-    };
-
-    const importedPlayer = loadPlayer(parsedSaveData.data.PlayerSave);
-
-    let syncSteamAchievements = true;
-    // Parse data.SettingsSave to get syncSteamAchievements.
-    if (parsedSaveData.data.SettingsSave && typeof parsedSaveData.data.SettingsSave === "string") {
-      try {
-        const settings: unknown = JSON.parse(parsedSaveData.data.SettingsSave);
-        assertObject(settings);
-        if (typeof settings.SyncSteamAchievements === "boolean") {
-          syncSteamAchievements = settings.SyncSteamAchievements;
-        }
-      } catch (error) {
-        console.error(error);
-      }
-    }
-
-    const playerData: ImportPlayerData = {
-      identifier: importedPlayer.identifier,
-      lastSave: importedPlayer.lastSave,
-      totalPlaytime: importedPlayer.totalPlaytime,
-
-      money: importedPlayer.money,
-      skills: importedPlayer.skills,
-
-      augmentations: importedPlayer.augmentations?.reduce<number>((total, current) => (total += current.level), 0) ?? 0,
-      factions: importedPlayer.factions?.length ?? 0,
-      achievements: importedPlayer.achievements?.length ?? 0,
-
-      bitNode: importedPlayer.bitNodeN,
-      bitNodeLevel: getBitNodeLevel(
-        importedPlayer.bitNodeN,
-        importedPlayer.activeSourceFileLvl(importedPlayer.bitNodeN),
-      ),
-      sourceFiles: [...importedPlayer.sourceFiles].reduce<number>((total, [__bn, lvl]) => (total += lvl), 0),
-      exploits: importedPlayer.exploits.length,
-
-      syncSteamAchievements,
-    };
-
-    data.playerData = playerData;
-    return data;
-  }
-
   toJSON(): IReviverValue {
     return Generic_toJSON("BitburnerSaveObject", this);
   }
@@ -454,7 +452,7 @@ class BitburnerSaveObject implements BitburnerSaveObjectType {
   }
 }
 
-async function loadGame(saveData: SaveData): Promise<boolean> {
+export async function loadGame(saveData: SaveData): Promise<boolean> {
   createScamUpdateText();
   if (!saveData) {
     console.error(
@@ -601,7 +599,3 @@ function createBetaUpdateText() {
 }
 
 constructorsForReviver.BitburnerSaveObject = BitburnerSaveObject;
-
-export { saveObject, loadGame };
-
-const saveObject = new BitburnerSaveObject();

--- a/src/ScriptEditor/ui/utils.ts
+++ b/src/ScriptEditor/ui/utils.ts
@@ -9,7 +9,7 @@ import { SnackbarEvents } from "../../ui/React/Snackbar";
 import { ToastVariant } from "../../Enums";
 import { EditorEvents } from "../EditorData";
 import { Settings } from "../../Settings/Settings";
-import { saveObject } from "../../SaveObject";
+import { saveGame } from "../../SaveObject";
 import { exceptionAlert } from "../../utils/helpers/exceptionAlert";
 
 export function getServerCode(scripts: OpenScript[], index: number): string | null {
@@ -95,6 +95,6 @@ export function saveScript(scriptToSave: OpenScript): void {
   EditorEvents.emit(scriptToSave.hostname, scriptToSave.path);
 
   if (Settings.SaveGameOnFileSave) {
-    saveObject.saveGame().catch((error) => exceptionAlert(error));
+    saveGame().catch((error) => exceptionAlert(error));
   }
 }

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -20,7 +20,7 @@ import { iTutorialStart } from "./InteractiveTutorial";
 import { checkForMessagesToSend } from "./Message/MessageHelpers";
 import { loadAllRunningScripts, updateOnlineScriptTimes } from "./NetscriptWorker";
 import { Player } from "@player";
-import { saveObject, loadGame } from "./SaveObject";
+import { saveGame, loadGame } from "./SaveObject";
 import { GetAllServers } from "./Server/AllServers";
 import { Settings } from "./Settings/Settings";
 import { FormatsNeedToChange } from "./ui/formatNumber";
@@ -61,10 +61,6 @@ declare global {
     GetAllServers: typeof GetAllServers;
     Factions: typeof Factions;
     Companies: typeof Companies;
-    SaveObject: {
-      saveObject: typeof saveObject;
-      loadGame: typeof loadGame;
-    };
   };
   // eslint-disable-next-line no-var
   var openDevMenu: () => void;
@@ -228,7 +224,7 @@ const Engine = {
         Engine.Counters.autoSaveCounter = 60 * 5; // Let's check back in a bit
       } else {
         Engine.Counters.autoSaveCounter = Settings.AutosaveInterval * 5;
-        saveObject.saveGame(!Settings.SuppressSavedGameToast).catch((error) => console.error(error));
+        saveGame(!Settings.SuppressSavedGameToast).catch((error) => console.error(error));
       }
     }
   },
@@ -399,11 +395,6 @@ const Engine = {
         // Manipulate data of Factions and Companies
         Factions: Factions,
         Companies: Companies,
-        // saveObject and loadGame can be used to create a custom save/load tool
-        SaveObject: {
-          saveObject: saveObject,
-          loadGame: loadGame,
-        },
       };
     }
     globalThis.openDevMenu = () => apr1();

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from "tss-react/mui";
 
 import { Player } from "@player";
 import { installAugmentations } from "../Augmentation/AugmentationHelpers";
-import { saveObject } from "../SaveObject";
+import { saveGame, exportGame } from "../SaveObject";
 import { CompletedProgramName, LocationName, SimplePage } from "@enums";
 import { ITutorial, iTutorialStart } from "../InteractiveTutorial";
 import { InteractiveTutorialRoot } from "./InteractiveTutorial/InteractiveTutorialRoot";
@@ -220,8 +220,7 @@ export function GameRoot(): React.ReactElement {
     for (const server of GetAllServers(true)) {
       server.runningScriptMap.clear();
     }
-    saveObject
-      .saveGame()
+    saveGame()
       .then(() => {
         setTimeout(() => htmlLocation.reload(), 0);
       })
@@ -441,10 +440,10 @@ export function GameRoot(): React.ReactElement {
         <GameOptionsRoot
           tab={pageWithContext.tab}
           save={() => {
-            saveObject.saveGame().catch((error) => exceptionAlert(error));
+            saveGame().catch((error) => exceptionAlert(error));
           }}
           export={() => {
-            saveObject.exportGame().catch((error) => exceptionAlert(error));
+            exportGame().catch((error) => exceptionAlert(error));
           }}
           forceKill={killAllScripts}
           softReset={softReset}
@@ -463,7 +462,7 @@ export function GameRoot(): React.ReactElement {
       mainPage = (
         <AugmentationsRoot
           exportGameFn={() => {
-            saveObject.exportGame().catch((error) => exceptionAlert(error));
+            exportGame().catch((error) => exceptionAlert(error));
           }}
           installAugmentationsFn={() => {
             installAugmentations();
@@ -535,7 +534,7 @@ export function GameRoot(): React.ReactElement {
                     <CharacterOverview
                       parentOpen={parentOpen}
                       save={() => {
-                        saveObject.saveGame().catch((error) => exceptionAlert(error));
+                        saveGame().catch((error) => exceptionAlert(error));
                       }}
                       killScripts={killAllScripts}
                     />

--- a/src/ui/React/ImportSaveComparison.tsx
+++ b/src/ui/React/ImportSaveComparison.tsx
@@ -28,7 +28,7 @@ import ThumbDownAlt from "@mui/icons-material/ThumbDownAlt";
 
 import { Skills } from "@nsdefs";
 
-import { ImportData, saveObject } from "../../SaveObject";
+import { ImportData, getSaveData, getImportDataFromSaveData, importGame } from "../../SaveObject";
 import { Settings } from "../../Settings/Settings";
 import { convertTimeMsToTimeElapsedString } from "../../utils/StringHelperFunctions";
 import { formatMoney, formatNumberNoSuffix } from "../formatNumber";
@@ -125,7 +125,7 @@ export const ImportSaveComparison = (props: { saveData: SaveData; automatic: boo
         SyncSteamAchievements: syncSteamAchievements,
       };
     }
-    await saveObject.importGame(props.saveData, overrideSettings);
+    await importGame(props.saveData, overrideSettings);
   };
 
   useEffect(() => {
@@ -143,8 +143,8 @@ export const ImportSaveComparison = (props: { saveData: SaveData; automatic: boo
 
   useEffect(() => {
     async function fetchData(): Promise<void> {
-      const dataBeingImported = await saveObject.getImportDataFromSaveData(props.saveData);
-      const dataCurrentlyInGame = await saveObject.getImportDataFromSaveData(await saveObject.getSaveData(true));
+      const dataBeingImported = await getImportDataFromSaveData(props.saveData);
+      const dataCurrentlyInGame = await getImportDataFromSaveData(await getSaveData(true));
 
       setImportData(dataBeingImported);
       setCurrentData(dataCurrentlyInGame);

--- a/src/utils/v2APIBreak.ts
+++ b/src/utils/v2APIBreak.ts
@@ -1,6 +1,6 @@
 import { isLegacyScript } from "../Paths/ScriptFilePath";
 import { TextFilePath } from "../Paths/TextFilePath";
-import { saveObject } from "../SaveObject";
+import { exportGame } from "../SaveObject";
 import { Script } from "../Script/Script";
 import { GetAllServers, GetServer } from "../Server/AllServers";
 import { IFileLine } from "./v1APIBreak";
@@ -239,7 +239,7 @@ export const v2APIBreak = () => {
   for (const server of GetAllServers()) {
     server.runningScriptMap = new Map();
   }
-  saveObject.exportGame().catch((e) => console.error(e));
+  exportGame().catch((e) => console.error(e));
 };
 
 const formatOffenders = (offenders: IFileLine[]): string => {

--- a/test/jest/FullSave.test.ts
+++ b/test/jest/FullSave.test.ts
@@ -1,9 +1,4 @@
-import {
-  type BitburnerSaveObjectType,
-  getSaveData,
-  getParsedSaveData,
-  assertBitburnerSaveObjectType,
-} from "../../src/SaveObject";
+import { getSaveData, getParsedSaveData, assertBitburnerSaveObjectType } from "../../src/SaveObject";
 import { Factions } from "../../src/Faction/Factions";
 import { Player, setPlayer } from "../../src/Player";
 import { PlayerObject } from "../../src/PersonObjects/Player/PlayerObject";

--- a/test/jest/FullSave.test.ts
+++ b/test/jest/FullSave.test.ts
@@ -1,4 +1,9 @@
-import { saveObject } from "../../src/SaveObject";
+import {
+  type BitburnerSaveObjectType,
+  getSaveData,
+  getParsedSaveData,
+  assertBitburnerSaveObjectType,
+} from "../../src/SaveObject";
 import { Factions } from "../../src/Faction/Factions";
 import { Player, setPlayer } from "../../src/Player";
 import { PlayerObject } from "../../src/PersonObjects/Player/PlayerObject";
@@ -10,15 +15,13 @@ import { Companies } from "../../src/Company/Companies";
 
 describe("Check Save File Continuity", () => {
   establishInitialConditions();
-  beforeAll(async () => {
-    // Calling getSaveString forces save info to update
-    await saveObject.getSaveData();
-  });
 
   const savesToTest = ["FactionsSave", "PlayerSave", "CompaniesSave", "GoSave"] as const;
   for (const saveToTest of savesToTest) {
-    test(`${saveToTest} continuity`, () => {
-      const parsed: unknown = JSON.parse(saveObject[saveToTest]);
+    test(`${saveToTest} continuity`, async () => {
+      const saveObject = (await getParsedSaveData(await getSaveData())).data;
+      assertBitburnerSaveObjectType(saveObject);
+      const parsed: unknown = JSON.parse(saveObject[saveToTest] as string);
       expect(parsed).toMatchSnapshot();
     });
   }

--- a/test/jest/Migration/Migration.test.ts
+++ b/test/jest/Migration/Migration.test.ts
@@ -1,7 +1,7 @@
 import { Player } from "@player";
 import fs from "node:fs";
 import type { ScriptFilePath } from "../../../src/Paths/ScriptFilePath";
-import { loadGame, saveObject } from "../../../src/SaveObject";
+import { loadGame, saveGame, getSaveData } from "../../../src/SaveObject";
 import * as db from "../../../src/db";
 import * as FileUtils from "../../../src/utils/FileUtils";
 import type { SaveData } from "../../../src/types";
@@ -88,8 +88,8 @@ describe("v3", () => {
     }
 
     // Save and reload.
-    await saveObject.saveGame();
-    await loadGameFromSaveData(await saveObject.getSaveData());
+    await saveGame();
+    await loadGameFromSaveData(await getSaveData());
     expect(Player.lastSave).not.toStrictEqual(lastSave);
 
     // Check if gained exp is saved correctly.


### PR DESCRIPTION
This moves almost all the functions out of BitburnerSaveObject and turns them into free functions instead. Most of them didn't need to be instance members at all, and the one that definitely used the fields is better off making a new instance every time. BitburnerSaveObject is new a dumb data object that exists only for serialization purposes, and all the functionality is accessed via importing the specific functions that are desired.

I also removed the permanent reference to save/load stuff in dev on the window object, since removing permanent references is sort of the point. It's not really needed given what we have in SF4 now, anyway.

This saves massively on persistent memory usage when the save is large. There is still a big memory spike when saving/loading, but it is at least reclaimable now.

# Testing
I used the createManyFiles script:
```js
/** @param {NS} ns */
function doScan(ns) {
  const servers = ns.scan("home");
  // The first entry connects back to the parent
  for (let i = 0; i < servers.length; ++i) {
    servers.push(...ns.scan(servers[i]).slice(1));
  }
  return servers;
}

/** @param {NS} ns */
function forEachFile(fn) {
  for (let i = 0; i < 3; ++i) {
    const fname = `manyScript-${i}.jsx`;
    fn(fname);
  }
}

/** @param {NS} ns */
export async function main(ns) {
  if (ns.args[0] === "delete") {
    let fCount = 0;
    let servers = doScan(ns);
    for (const server of servers) {
      forEachFile(fname => {fCount += ns.rm(fname, server)});
    }
    ns.tprint(`Removed ${fCount} files from ${servers.length} servers`);
  } else if (ns.args[0] == "run") {
    let servers = doScan(ns);
    const p = [];
    let count = 0;
    for (const server of servers) {
      ns.ftpcrack(server);
      ns.sqlinject(server);
      ns.brutessh(server);
      ns.relaysmtp(server);
      ns.httpworm(server);
      ns.nuke(server);
      count += ns.exec("manyScript-0.jsx", server) != 0;
    }
    ns.tprint(`Launched ${count} programs`);
  } else {
    const scriptSrc = `export function main(ns) {
  const p = [];
  for (let i = 0; i < 3; ++i) {
    const fname = "manyScript-" + i + ".jsx";
    p.push(ns.dynamicImport(fname));
  }
  return Promise.all(p);
} /*` + " ".repeat(1024*1024) + "*/";
    let fCount = 0;
    forEachFile(fname => {ns.write(fname, scriptSrc, "w")});
    let servers = doScan(ns);
    for (const server of servers) {
      forEachFile(fname => {fCount += ns.scp(fname, server)});
    }
    forEachFile(fname => {ns.rm(fname)});
    ns.tprint(`Copied ${fCount} files to ${servers.length} servers`);
  }
}
```
I did my testing on the Electron version (windows) to ensure no sneaky problems there. On save, memory usage spiked over 1GB, but GC dropped it down to 60MB.

On load, memory usage spiked even higher, up to 4GB at one point. After GC it dropped down to 300MB. Almost all of that was the 200MB of un-deduped script files.

Obviously, there are still memory opportunities in save/load, but this at least removes the permanent part.