### PR TITLE
DNET: Improve script visibility and searchability in the darknet

### DIFF
--- a/src/DarkNet/ui/ServerStatusBox.tsx
+++ b/src/DarkNet/ui/ServerStatusBox.tsx
@@ -33,11 +33,12 @@ export function ServerStatusBox({ server, enableAuth, classes }: DWServerProps):
 
   const getServerStyles = (server: DarknetServer) => {
     const position = getPixelPosition(server);
+    const hasRunningScripts = !!server.runningScriptMap.size;
     return {
       ...DWServerStyles,
       top: `${position.top}px`,
       left: `${position.left}px`,
-      borderColor: server.hasStasisLink ? "gold" : server.hasAdminRights ? "green" : "grey",
+      borderColor: server.hasStasisLink ? "gold" : hasRunningScripts ? "green" : "grey",
     };
   };
 

--- a/src/DarkNet/ui/ServerSummary.tsx
+++ b/src/DarkNet/ui/ServerSummary.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { SvgIcon, Tooltip, Typography } from "@mui/material";
-import { Code, Description, Inventory2, LockPerson, Terminal, Bolt, DoorBackSharp } from "@mui/icons-material";
+import { Bolt, Code, Description, DoorBackSharp, Inventory2, LockPerson, Terminal } from "@mui/icons-material";
 import { formatNumber } from "../../ui/formatNumber";
-import { CompletedProgramName } from "@enums";
+import { CompletedProgramName, ComplexPage } from "@enums";
 import { formatToMaxDigits } from "./uiUtilities";
 
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { DarknetConstants } from "../Constants";
+import { Router } from "../../ui/GameRoot";
 
 export type ServerSummaryProps = {
   server: DarknetServer;
@@ -24,7 +25,7 @@ export function ServerSummary({
   showDetails = false,
 }: ServerSummaryProps): React.ReactElement {
   if (!server.hasAdminRights && enableAuth) {
-    return <Typography>[ auth required ]</Typography>;
+    return <Typography color="secondary">[ auth required ]</Typography>;
   }
   if (!server.hasAdminRights && !enableAuth) {
     return <Typography color="secondary">(no connection)</Typography>;
@@ -68,16 +69,18 @@ export function ServerSummary({
   const ramBlockedDetails = formatToMaxDigits(server.blockedRam, 2) + "GB";
   const ramBlocked = showDetails ? ramBlockedDetails : formatNumber(server.blockedRam, 0);
 
-  const runningScriptsComponent = (
+  const components = [
     <Tooltip key="runningScript" title={<>{runningScriptsTooltip}</>}>
-      <Typography color={runningScriptCount > 0 ? "primary" : "secondary"}>
+      <Typography
+        color={runningScriptCount > 0 ? "primary" : "secondary"}
+        onClick={() => Router.toPage(ComplexPage.ActiveScripts, { serverName: server.hostname })}
+      >
         <SvgIcon component={Terminal} className={classes.serverStatusIcon} />
         {runningScriptCount}
       </Typography>
-    </Tooltip>
-  );
+    </Tooltip>,
+  ];
 
-  const components = [];
   if (cacheCount) {
     components.push(
       <Tooltip key="cache" title={<>{dataCacheTooltip}</>}>
@@ -156,10 +159,12 @@ export function ServerSummary({
     );
   }
   const maxIcons = showDetails ? components.length : 2;
-  const componentsToShow = [...components.slice(0, maxIcons), runningScriptsComponent];
+  const componentsToShow = components.slice(0, maxIcons);
 
   return (
-    <div style={{ display: "inline-flex", flexDirection: "row", width: "100%", justifyContent: "space-between" }}>
+    <div
+      style={{ display: "inline-flex", flexDirection: "row-reverse", width: "100%", justifyContent: "space-between" }}
+    >
       {componentsToShow}
     </div>
   );

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -209,7 +209,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
       switch (keyBindingType) {
         case SimplePage.Terminal:
         case ComplexPage.ScriptEditor:
-        case SimplePage.ActiveScripts:
+        case ComplexPage.ActiveScripts:
         case SimplePage.CreateProgram:
         case SimplePage.Stats:
         case SimplePage.Hacknet:

--- a/src/ui/ActiveScripts/ActiveScriptsPage.tsx
+++ b/src/ui/ActiveScripts/ActiveScriptsPage.tsx
@@ -14,10 +14,14 @@ import { Settings } from "../../Settings/Settings";
 import { isPositiveInteger } from "../../types";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 
-export function ActiveScriptsPage(): React.ReactElement {
+interface IProps {
+  serverName?: string | null;
+}
+
+export function ActiveScriptsPage(props: IProps): React.ReactElement {
   const [scriptsPerPage, setScriptsPerPage] = useState(Settings.ActiveScriptsScriptPageSize);
   const [serversPerPage, setServersPerPage] = useState(Settings.ActiveScriptsServerPageSize);
-  const [filter, setFilter] = useState("");
+  const [filter, setFilter] = useState(props.serverName ?? "");
   const [page, setPage] = useState(0);
 
   function changeScriptsPerPage(e: SelectChangeEvent<number>) {
@@ -146,7 +150,7 @@ export function ActiveScriptsPage(): React.ReactElement {
       </div>
       <List dense={true}>
         {dataToShow.map(([server, scripts]) => (
-          <ServerAccordion key={server.hostname} server={server} scripts={scripts} />
+          <ServerAccordion key={server.hostname} server={server} scripts={scripts} startOpen={!!props.serverName} />
         ))}
       </List>
     </>

--- a/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
+++ b/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
@@ -2,8 +2,8 @@
  * Root React Component for the "Active Scripts" UI page. This page displays
  * and provides information about all of the player's scripts that are currently running
  */
-import React, { useState, useEffect } from "react";
-import { Button, Tabs, Tab } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { Button, Tab, Tabs } from "@mui/material";
 
 import { ActiveScriptsPage } from "./ActiveScriptsPage";
 import { RecentScriptsPage } from "./RecentScriptsPage";
@@ -12,17 +12,18 @@ import { useRerender } from "../React/hooks";
 import { errorModalsAreSuppressed, ErrorState, toggleSuppressErrorModals } from "../../ErrorHandling/ErrorState";
 import { OptionSwitch } from "../React/OptionSwitch";
 import { killAllScripts } from "../../Netscript/killWorkerScript";
-import { SimplePage } from "@enums";
+import { ComplexPage, SimplePage } from "@enums";
 import { Router } from "../GameRoot";
 import { Settings } from "../../Settings/Settings";
 
-type ActiveScriptsTab = SimplePage.ActiveScripts | SimplePage.RecentlyKilledScripts | SimplePage.RecentErrors;
+type ActiveScriptsTab = ComplexPage.ActiveScripts | SimplePage.RecentlyKilledScripts | SimplePage.RecentErrors;
 
 export type ComponentProps = {
   page: ActiveScriptsTab;
+  serverName?: string | null;
 };
 
-export function ActiveScriptsRoot({ page }: ComponentProps): React.ReactElement {
+export function ActiveScriptsRoot({ page, serverName }: ComponentProps): React.ReactElement {
   const [tab, setTab] = useState<ActiveScriptsTab>(page);
   useRerender(400);
 
@@ -34,10 +35,14 @@ export function ActiveScriptsRoot({ page }: ComponentProps): React.ReactElement 
 
   function handleChange(
     __event: React.SyntheticEvent | null,
-    tab: SimplePage.ActiveScripts | SimplePage.RecentlyKilledScripts | SimplePage.RecentErrors,
+    tab: ComplexPage.ActiveScripts | SimplePage.RecentlyKilledScripts | SimplePage.RecentErrors,
   ): void {
     setTab(tab);
-    Router.toPage(tab);
+    if (tab === ComplexPage.ActiveScripts) {
+      Router.toPage(tab, {});
+    } else {
+      Router.toPage(tab);
+    }
   }
 
   function errorTabText(): string {
@@ -63,7 +68,7 @@ export function ActiveScriptsRoot({ page }: ComponentProps): React.ReactElement 
             },
           }}
         >
-          <Tab label={"Active"} value={SimplePage.ActiveScripts} />
+          <Tab label={"Active"} value={ComplexPage.ActiveScripts} />
           <Tab label={"Recently Killed"} value={SimplePage.RecentlyKilledScripts} />
           <Tab label={errorTabText()} value={SimplePage.RecentErrors} />
         </Tabs>
@@ -88,7 +93,7 @@ export function ActiveScriptsRoot({ page }: ComponentProps): React.ReactElement 
         </Button>
       </div>
 
-      {tab === SimplePage.ActiveScripts && <ActiveScriptsPage />}
+      {tab === ComplexPage.ActiveScripts && <ActiveScriptsPage serverName={serverName} />}
       {tab === SimplePage.RecentlyKilledScripts && <RecentScriptsPage />}
       {tab === SimplePage.RecentErrors && <RecentErrorsPage />}
     </>

--- a/src/ui/ActiveScripts/ServerAccordion.tsx
+++ b/src/ui/ActiveScripts/ServerAccordion.tsx
@@ -13,10 +13,11 @@ import { createProgressBarText } from "../../utils/helpers/createProgressBarText
 interface ServerAccordionProps {
   server: BaseServer;
   scripts: WorkerScript[];
+  startOpen: boolean;
 }
 
-export function ServerAccordion({ server, scripts }: ServerAccordionProps): React.ReactElement {
-  const [open, setOpen] = React.useState(false);
+export function ServerAccordion({ server, scripts, startOpen }: ServerAccordionProps): React.ReactElement {
+  const [open, setOpen] = React.useState(startOpen);
 
   // Accordion's header text
   const longestHostnameLength = 26;

--- a/src/ui/Enums.ts
+++ b/src/ui/Enums.ts
@@ -11,7 +11,6 @@ export enum ToastVariant {
  * transition to. You can use setPage() with these.
  */
 export enum SimplePage {
-  ActiveScripts = "Active Scripts",
   RecentlyKilledScripts = "Recently Killed Scripts",
   RecentErrors = "Recent Errors",
   Augmentations = "Augmentations",
@@ -44,6 +43,7 @@ export enum SimplePage {
 }
 
 export enum ComplexPage {
+  ActiveScripts = "Active Scripts",
   BitVerse = "BitVerse",
   Faction = "Faction",
   FactionAugmentations = "Faction Augmentations",

--- a/src/ui/GameRoot.tsx
+++ b/src/ui/GameRoot.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from "tss-react/mui";
 import { Player } from "@player";
 import { installAugmentations } from "../Augmentation/AugmentationHelpers";
 import { saveObject } from "../SaveObject";
-import { CompletedProgramName, LocationName, SimplePage } from "@enums";
+import { CompletedProgramName, LocationName, SimplePage, ComplexPage } from "@enums";
 import { ITutorial, iTutorialStart } from "../InteractiveTutorial";
 import { InteractiveTutorialRoot } from "./InteractiveTutorial/InteractiveTutorialRoot";
 import { ITutorialEvents } from "./InteractiveTutorial/ITutorialEvents";
@@ -16,7 +16,6 @@ import { dialogBoxCreate } from "./React/DialogBox";
 import { GetAllServers } from "../Server/AllServers";
 import { StockMarket } from "../StockMarket/StockMarket";
 
-import type { ComplexPage } from "./Enums";
 import type { IRouter, PageContext, PageWithContext } from "./Router";
 import { isSimplePage, Page } from "./Router";
 import { Overview } from "./React/Overview";
@@ -359,7 +358,7 @@ export function GameRoot(): React.ReactElement {
       break;
     }
     case Page.ActiveScripts: {
-      mainPage = <ActiveScriptsRoot page={SimplePage.ActiveScripts} />;
+      mainPage = <ActiveScriptsRoot page={ComplexPage.ActiveScripts} serverName={pageWithContext.serverName} />;
       break;
     }
     case Page.RecentlyKilledScripts: {

--- a/src/ui/Router.ts
+++ b/src/ui/Router.ts
@@ -30,6 +30,8 @@ export type PageContext<T extends Page> = T extends ComplexPage.BitVerse
   ? { tab?: OptionsTabName }
   : T extends ComplexPage.CustomPage
   ? { content: ReactElement }
+  : T extends ComplexPage.ActiveScripts
+  ? { serverName?: string }
   : never;
 
 export type PageWithContext =
@@ -42,6 +44,7 @@ export type PageWithContext =
   | ({ page: ComplexPage.Documentation } & PageContext<ComplexPage.Documentation>)
   | ({ page: ComplexPage.Options } & PageContext<ComplexPage.Options>)
   | ({ page: ComplexPage.CustomPage } & PageContext<ComplexPage.CustomPage>)
+  | ({ page: ComplexPage.ActiveScripts } & PageContext<ComplexPage.ActiveScripts>)
   | { page: ComplexPage.LoadingScreen }
   | { page: SimplePage };
 

--- a/src/utils/KeyBindingUtils.ts
+++ b/src/utils/KeyBindingUtils.ts
@@ -21,7 +21,7 @@ export const SpoilerKeyBindingTypes = [
 export const GoToPageKeyBindingTypes = [
   SimplePage.Terminal,
   ComplexPage.ScriptEditor,
-  SimplePage.ActiveScripts,
+  ComplexPage.ActiveScripts,
   SimplePage.CreateProgram,
   SimplePage.Stats,
   SimplePage.Factions,
@@ -84,7 +84,7 @@ export const DefaultKeyBindings: Record<KeyBindingType, [KeyCombination | null, 
     },
     null,
   ],
-  [SimplePage.ActiveScripts]: [
+  [ComplexPage.ActiveScripts]: [
     {
       control: false,
       alt: true,


### PR DESCRIPTION
This PR improves how easy it is to see and interact with scripts running on darknet servers through the UI, ased on player feedback and requests.

- Darknet servers will now only have a green outline if a script is actively running there. (They maintain their green name and green connections, and status icons, so that authenticated servers are still visibly identifiable at a glance)

- The script icon on darknet servers, when clicked, will navigate to the Active Scripts page with that server's name in the search bar, so that players can quickly see the running scripts and their details or logs

- The script icon on darknet server summaries is now always on the right side, to maintain consistency in finding it for quickly checking script count or getting to the Active Scripts page for that server