### PR TITLE
UI: Follow up to #2886

### DIFF
--- a/src/DarkNet/ui/ServerSummary.tsx
+++ b/src/DarkNet/ui/ServerSummary.tsx
@@ -70,7 +70,7 @@ export function ServerSummary({
   const ramBlocked = showDetails ? ramBlockedDetails : formatNumber(server.blockedRam, 0);
 
   const components = [
-    <Tooltip key="runningScript" title={<>{runningScriptsTooltip}</>}>
+    <Tooltip key="runningScript" title={<>{runningScriptsTooltip}</>} style={{ cursor: "pointer" }}>
       <Typography
         color={runningScriptCount > 0 ? "primary" : "secondary"}
         onClick={() => Router.toPage(ComplexPage.ActiveScripts, { serverName: server.hostname })}
@@ -158,13 +158,11 @@ export function ServerSummary({
       </Tooltip>,
     );
   }
-  const maxIcons = showDetails ? components.length : 2;
+  const maxIcons = showDetails ? components.length : 3;
   const componentsToShow = components.slice(0, maxIcons);
 
   return (
-    <div
-      style={{ display: "inline-flex", flexDirection: "row-reverse", width: "100%", justifyContent: "space-between" }}
-    >
+    <div style={{ display: "inline-flex", flexDirection: "row", width: "100%", justifyContent: "space-between" }}>
       {componentsToShow}
     </div>
   );

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -187,7 +187,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
           files: new Map(),
           options: { vim: Settings.MonacoDefaultToVim, hostname: Player.currentServer },
         });
-      } else if (page == Page.Documentation || page == Page.Options) {
+      } else if (page === Page.Documentation || page === Page.Options || page === Page.ActiveScripts) {
         Router.toPage(page, {});
       } else if (isSimplePage(page)) {
         Router.toPage(page);

--- a/src/ui/ActiveScripts/ActiveScriptsPage.tsx
+++ b/src/ui/ActiveScripts/ActiveScriptsPage.tsx
@@ -15,7 +15,7 @@ import { isPositiveInteger } from "../../types";
 import { SpecialServers } from "../../Server/data/SpecialServers";
 
 interface IProps {
-  serverName?: string | null;
+  serverName?: string;
 }
 
 export function ActiveScriptsPage(props: IProps): React.ReactElement {

--- a/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
+++ b/src/ui/ActiveScripts/ActiveScriptsRoot.tsx
@@ -20,7 +20,7 @@ type ActiveScriptsTab = ComplexPage.ActiveScripts | SimplePage.RecentlyKilledScr
 
 export type ComponentProps = {
   page: ActiveScriptsTab;
-  serverName?: string | null;
+  serverName?: string;
 };
 
 export function ActiveScriptsRoot({ page, serverName }: ComponentProps): React.ReactElement {


### PR DESCRIPTION
I noticed some bugs and issues in #2886, but I hadn't finished my review before it was merged.

### The "Active Scripts" page is inaccessible.

MRE: Click on that sidebar item:
```
Uncaught Error: Can't handle click on Page Active Scripts
    at eval (SidebarRoot.tsx:235:13)
    at first.<computed> (SidebarAccordion.tsx:40:32)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:16)
    at invokeGuardedCallback (react-dom.development.js:4056:31)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:4070:25)
    at executeDispatch (react-dom.development.js:8243:3)
    at processDispatchQueueItemsInOrder (react-dom.development.js:8275:7)
    at processDispatchQueue (react-dom.development.js:8288:5)
    at dispatchEventsForPlugins (react-dom.development.js:8299:3)
```

### Incorrect max number of icons

<img width="224" height="137" alt="Capture" src="https://github.com/user-attachments/assets/e796a9f4-0d6a-4c4c-b9c5-7a39e52ab2d9" />

There are 3 icons here.

https://github.com/bitburner-official/bitburner-src/blob/0ebefa2c4591cb09580560a1f9c7f13ce04d3768/src/DarkNet/ui/ServerSummary.tsx#L161
This should be 3, not 2. Notice how `componentsToShow` is changed in #2886.

### Use pointer cursor when hovering the icon of running scripts

The UI should indicate that this icon is clickable; otherwise, nobody knows this feature exists.

### Change icon order

> The script icon on darknet server summaries is now always on the right side, to maintain consistency in finding it for quickly checking script count or getting to the Active Scripts page for that server

The goal is good (maintaining consistency), but the implementation is not (putting the icon on the right).

<img width="286" height="154" alt="1" src="https://github.com/user-attachments/assets/3d123efa-2fa2-41d5-9faf-13af6c20f538" />

This does not look too bad.

<img width="762" height="445" alt="2" src="https://github.com/user-attachments/assets/7a2b19b6-8184-4bfc-b075-d84f1b77ed82" />

However, without reading #2886's description, most people would think this is a bug. The icon looks like its left margin is set to a random large value.

Bitburner UI is left-to-right in most places (except for some popups in IPvGO; they weirdly place the "main" button on the right, but it's a separate issue), so the icon that is always present should be on the left, not the right.