### PR TITLE
CLEANUP: Removing unneeded items from WorkerScript

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -54,11 +54,10 @@ export class WorkerScript {
    */
   loadedFns: Record<string, boolean> = {};
 
-  /** Filename of script */
-  name: ScriptFilePath;
-
-  /** Script's output/return value. Currently not used or implemented */
-  output = "";
+  /** Filename of script. Mirrors the RunningScript, so we don't store a second copy. */
+  get name(): ScriptFilePath {
+    return this.scriptRef.filename;
+  }
 
   /**
    * Process ID. Must be an integer. Used for efficient script
@@ -69,15 +68,17 @@ export class WorkerScript {
   /** Reference to underlying RunningScript object */
   scriptRef: RunningScript;
 
-  /** hostname on which this script is running */
-  hostname: string;
+  /** hostname on which this script is running. Mirrors the RunningScript. */
+  get hostname(): string {
+    return this.scriptRef.server;
+  }
 
   /**Map of functions called when the script ends. */
   atExit: Map<string, () => void> = new Map();
 
   constructor(runningScriptObj: RunningScript, pid: number, nsFuncsGenerator?: (ws: WorkerScript) => NSFull) {
-    this.name = runningScriptObj.filename;
-    this.hostname = runningScriptObj.server;
+    // Assign first: the name/hostname getters read through scriptRef.
+    this.scriptRef = runningScriptObj;
 
     const sanitizedPid = Math.round(pid);
     if (typeof sanitizedPid !== "number" || isNaN(sanitizedPid)) {
@@ -86,7 +87,7 @@ export class WorkerScript {
     this.pid = sanitizedPid;
     runningScriptObj.pid = sanitizedPid;
 
-    // Get the underlying script's code
+    // Verify the server and underlying script exist
     const server = GetServer(this.hostname);
     if (server == null) {
       throw new Error(`WorkerScript constructed with invalid server ip: ${this.hostname}`);
@@ -95,7 +96,6 @@ export class WorkerScript {
     if (!script) {
       throw new Error(`WorkerScript constructed with invalid script filename: ${this.name}`);
     }
-    this.scriptRef = runningScriptObj;
     this.args = runningScriptObj.args.slice();
     this.env = new Environment();
     if (typeof nsFuncsGenerator === "function") {

--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -86,7 +86,6 @@ export class WorkerScript {
     if (!script) {
       throw new Error(`WorkerScript constructed with invalid script filename: ${this.name}`);
     }
-    this.args = runningScriptObj.args.slice();
     this.env = new Environment();
     if (typeof nsFuncsGenerator === "function") {
       this.env.vars = nsFuncsGenerator(this);

--- a/src/Server/ServerPurchases.ts
+++ b/src/Server/ServerPurchases.ts
@@ -11,7 +11,6 @@ import { Player } from "@player";
 
 import { dialogBoxCreate } from "../ui/React/DialogBox";
 import { isPowerOfTwo } from "../utils/helpers/isPowerOfTwo";
-import { workerScripts } from "../Netscript/WorkerScripts";
 import { isIPAddress } from "../Types/strings";
 
 // Returns the cost of purchasing a server with the given RAM
@@ -83,9 +82,6 @@ export const renameCloudServer = (hostname: string, newName: string): void => {
   for (const byPid of server.runningScriptMap.values()) {
     for (const r of byPid.values()) {
       r.server = newName;
-      const ws = workerScripts.get(r.pid);
-      if (!ws) continue;
-      ws.hostname = newName;
     }
   }
   server.scripts.forEach((r) => (r.server = newName));


### PR DESCRIPTION
WorkerScript already has access to the hostname property from its RunningScript.  The only real game interaction I found was in renaming servers.  I ran a simple script below and got the expected output.  The new server name was returned when I got the running script by pid.

Test Script:
```js
/** @param {NS} ns */
export async function main(ns) {
  //Give yourself lots of money first.
  const hostname = "test-"
  const startingRam = 256
  const filename = "workerscript_hostname_stability_test.js"

  ns.write(filename, testFile, "w")

  for (const server of ns.cloud.getServerNames()) {
    ns.cloud.deleteServer(server)
  }

  let count = 0
  while (ns.cloud.purchaseServer(hostname + String(count >= 10 ? count++ : "0" + String(count++)), startingRam) !== "") { }

  for (const server of ns.cloud.getServerNames()) {
    ns.scp(filename, server)
    ns.exec(filename, server)
  }

  await ns.sleep(100)

  for (const server of ns.cloud.getServerNames()) {
    ns.cloud.renameServer(server, server + "-rename")
  }

  await ns.sleep(100)

  for (const server of ns.cloud.getServerNames()) {
    const processes = ns.ps(server)
    for (const proc of processes)
      ns.tprintf(ns.getRunningScript(proc.pid).server)
  }
}
const testFile = `
export async function main(ns) {
  ns.disableLog("ALL");
  await ns.sleep(20000)
}`;
```