### PR TITLE
CLEANUP: Removed dead property

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -48,12 +48,6 @@ export class WorkerScript {
   /** Netscript Environment for this script */
   env: Environment;
 
-  /**
-   * Used for static RAM calculation. Stores names of all functions that have
-   * already been checked by this script
-   */
-  loadedFns: Record<string, boolean> = {};
-
   /** Filename of script */
   name: ScriptFilePath;
 


### PR DESCRIPTION
It looks like this property is no longer in use.  It may have been at one point in time, but not anymore.

There is only one other reference to loadedFns, and it's in the static ram calculations.  But that one is a local variable and does not reference this property at all.

Should save another ~10MB for 300k scripts
