### PR TITLE
REWORK: lazy assign disableLogs on every script to save memory

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -32,8 +32,8 @@ export class WorkerScript {
   /** Holds the Promise reject() function while the script is "blocked" by an async op */
   delayReject: ((reason?: ScriptDeath) => void) | undefined = undefined;
 
-  /** Stores names of all functions that have logging disabled */
-  disableLogs: Record<string, boolean> = {};
+  /** Stores names of all functions that have logging disabled. Allocated lazily; null means none disabled. */
+  disableLogs: Record<string, boolean> | null = null;
 
   /**
    * Used for dynamic RAM calculation. Stores names of all functions that have
@@ -127,7 +127,7 @@ export class WorkerScript {
   }
 
   shouldLog(fn: string): boolean {
-    return !(this.disableLogs.ALL || this.disableLogs[fn]);
+    return !(this.disableLogs?.ALL || this.disableLogs?.[fn]);
   }
 
   log(func: string, txt: () => string): void {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -476,8 +476,8 @@ export const ns: InternalAPI<NSFull> = {
       // No need to log here, it's been disabled.
     } else {
       // We don't track individual log entries when all are disabled.
-      if (!ctx.workerScript.disableLogs["ALL"]) {
-        ctx.workerScript.disableLogs[fn] = true;
+      if (!ctx.workerScript.disableLogs?.["ALL"]) {
+        (ctx.workerScript.disableLogs ??= {})[fn] = true;
         helpers.log(ctx, () => `Disabled logging for ${fn}`);
       }
     }
@@ -488,15 +488,15 @@ export const ns: InternalAPI<NSFull> = {
       throw helpers.errorMessage(ctx, `Invalid argument: ${fn}.`);
     }
     if (fn === "ALL") {
-      ctx.workerScript.disableLogs = {};
+      ctx.workerScript.disableLogs = null;
       helpers.log(ctx, () => `Enabled logging for all functions`);
     } else {
-      if (ctx.workerScript.disableLogs["ALL"]) {
+      if (ctx.workerScript.disableLogs?.["ALL"]) {
         // As an optimization, we normally store only that key, but we have to
         // expand it out to all keys at this point.
         // Conveniently, possibleLogs serves as a model for "all keys disabled."
         ctx.workerScript.disableLogs = Object.assign({}, possibleLogs, { ALL: false, [fn]: false });
-      } else {
+      } else if (ctx.workerScript.disableLogs) {
         ctx.workerScript.disableLogs[fn] = false;
       }
       helpers.log(ctx, () => `Enabled logging for ${fn}`);


### PR DESCRIPTION
This only creates the disableLogs object on each WorkerScript if it needs to.  Saving ~10mb for 300k WorkerScripts.  It will only create it when a specific disableLog("specific") is called.  If ALL is specified, it still gets the reference object and skips the disabling of all other logs.

Tested by running some scripts with disableLogs("ALL"), and just for "exec".  No issues.