### PR TITLE
REWORK: Lazy create atExit on WorkerScripts

### DIFF
--- a/src/Netscript/WorkerScript.ts
+++ b/src/Netscript/WorkerScript.ts
@@ -72,8 +72,8 @@ export class WorkerScript {
   /** hostname on which this script is running */
   hostname: string;
 
-  /**Map of functions called when the script ends. */
-  atExit: Map<string, () => void> = new Map();
+  /** Map of functions called when the script ends. Allocated lazily on the first ns.atExit call. */
+  atExit: Map<string, () => void> | null = null;
 
   constructor(runningScriptObj: RunningScript, pid: number, nsFuncsGenerator?: (ws: WorkerScript) => NSFull) {
     this.name = runningScriptObj.filename;

--- a/src/Netscript/killWorkerScript.ts
+++ b/src/Netscript/killWorkerScript.ts
@@ -65,13 +65,15 @@ function stopAndCleanUpWorkerScript(ws: WorkerScript): void {
   const atExit = ws.atExit;
   //Calling ns.exit inside ns.atExit can lead to recursion
   //so the map must be cleared before looping
-  ws.atExit = new Map();
+  ws.atExit = null;
 
-  for (const [id, callback] of atExit) {
-    try {
-      callback();
-    } catch (e: unknown) {
-      handleUnknownError(e, ws, `Error running atExit function with id ${id}.\n\n`);
+  if (atExit) {
+    for (const [id, callback] of atExit) {
+      try {
+        callback();
+      } catch (e: unknown) {
+        handleUnknownError(e, ws, `Error running atExit function with id ${id}.\n\n`);
+      }
     }
   }
 

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -1431,7 +1431,7 @@ export const ns: InternalAPI<NSFull> = {
   atExit: (ctx) => (callback, _id) => {
     const id = _id ? helpers.string(ctx, "id", _id) : "default";
     assertFunctionWithNSContext(ctx, "callback", callback);
-    ctx.workerScript.atExit.set(id, callback);
+    (ctx.workerScript.atExit ??= new Map()).set(id, callback);
   },
   mv: (ctx) => (_host, _source, _destination) => {
     const [server, host] = helpers.getServer(ctx, _host);


### PR DESCRIPTION
This will only create the atExit map on a WorkerScript if something actually registers an atExit.  The end result is a modest saving of memory for every WorkerScript that has no atExit registrations.

Tested with my darknet and batcher - no issues with atExit registrations or scripts with none.