### PR TITLE
FIX: Cover move RecoveryRoot cases with the newer version check

### DIFF
--- a/src/ui/React/RecoveryRoot.tsx
+++ b/src/ui/React/RecoveryRoot.tsx
@@ -109,14 +109,8 @@ export function RecoveryRoot({ softReset, crashReport, resetError }: IProps): Re
         Please update your browser.
       </Typography>
     );
-  } else if (sourceError instanceof InvalidSaveData) {
-    instructions = (
-      <Typography variant="h4" color={Settings.theme.warning}>
-        Your save data is invalid. Please import a valid backup save file.
-      </Typography>
-    );
   } else if (
-    (sourceError instanceof JSONReviverError && isSaveDataFromNewerVersions(loadedSaveObjectMiniDump.VersionSave)) ||
+    isSaveDataFromNewerVersions(loadedSaveObjectMiniDump.VersionSave) ||
     sourceError instanceof IndexedDBVersionError
   ) {
     instructions = (
@@ -130,6 +124,12 @@ export function RecoveryRoot({ softReset, crashReport, resetError }: IProps): Re
         )}
         Please check if you are using the correct build. This may happen when you load the save data of the dev build
         (Steam Beta or https://bitburner-official.github.io/bitburner-src) on the stable build.
+      </Typography>
+    );
+  } else if (sourceError instanceof InvalidSaveData || sourceError instanceof JSONReviverError) {
+    instructions = (
+      <Typography variant="h4" color={Settings.theme.warning}>
+        Your save data is invalid. Please import a valid backup save file.
       </Typography>
     );
   } else {

--- a/src/ui/React/RecoveryRoot.tsx
+++ b/src/ui/React/RecoveryRoot.tsx
@@ -104,6 +104,7 @@ export function RecoveryRoot({ softReset, crashReport, resetError }: IProps): Re
 
   let instructions;
   if (sourceError instanceof UnsupportedSaveData) {
+    // This specifically is thrown only from needing CompressionStream and not having it.
     instructions = (
       <Typography variant="h4" color={Settings.theme.warning}>
         Please update your browser.
@@ -113,6 +114,9 @@ export function RecoveryRoot({ softReset, crashReport, resetError }: IProps): Re
     isSaveDataFromNewerVersions(loadedSaveObjectMiniDump.VersionSave) ||
     sourceError instanceof IndexedDBVersionError
   ) {
+    // We check broadly for the version being mismatched. If the version is
+    // newer than we expect, an unknown/unanticipated change to the save
+    // format may have occured, which could result in almost any error type.
     instructions = (
       <Typography variant="h5" color={Settings.theme.warning}>
         {loadedSaveObjectMiniDump.VersionSave !== undefined && (
@@ -127,12 +131,15 @@ export function RecoveryRoot({ softReset, crashReport, resetError }: IProps): Re
       </Typography>
     );
   } else if (sourceError instanceof InvalidSaveData || sourceError instanceof JSONReviverError) {
+    // These error types are mostly already covered by the version check above.
+    // If they occur while on the same version, it indicates bad save editing.
     instructions = (
       <Typography variant="h4" color={Settings.theme.warning}>
         Your save data is invalid. Please import a valid backup save file.
       </Typography>
     );
   } else {
+    // If we get this far, we don't know what's going on.
     instructions = (
       <Box>
         <Typography>It is recommended to alert a developer.</Typography>


### PR DESCRIPTION
In cases of save data changes, the errors we throw can be varied - and SaveObject itself has lots of paths that just throw a plain Error. This broadens the test to check for newer versions first, regarless of Error type.

Here is what loading the data from my other PR looks like now, if I artificially drop the current version to emulate a release:
<img width="1464" height="687" alt="image" src="https://github.com/user-attachments/assets/f440375b-e1cc-44be-946c-bfd9270ec54f" />

Unfortunately, this won't make it in soon enough to help with beta testers for *this* release, but it will help going forward.