### PR TITLE
UI: Fix sell division window profit display

### DIFF
--- a/src/Corporation/ui/modals/SellDivisionModal.tsx
+++ b/src/Corporation/ui/modals/SellDivisionModal.tsx
@@ -62,10 +62,7 @@ export function SellDivisionModal(props: IProps): React.ReactElement {
           rows={[
             [
               "Profit:",
-              <MoneyRate
-                key="profit"
-                money={(divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses) / 10}
-              />,
+              <MoneyRate key="profit" money={divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses} />,
             ],
             ["Cities:", getRecordKeys(divisionToSell.offices).length],
             ["Warehouses:", getRecordKeys(divisionToSell.warehouses).length],


### PR DESCRIPTION
<img width="383" height="221" alt="image" src="https://github.com/user-attachments/assets/06421bf7-fdc9-4856-aee8-ea53446054ec" />
<img width="370" height="201" alt="image" src="https://github.com/user-attachments/assets/5126ff78-40f0-452f-bc0b-17663f6e4534" />

The profit shown in the Sell division windows was 10 times lower than the actual profit.

The source of the bug was that the profit (`divisionToSell.lastCycleRevenue - divisionToSell.lastCycleExpenses`) was divided by 10. But the calculation for revenue/expenses already includes cycle length: https://github.com/bitburner-official/bitburner-src/blob/09e85517704ea81adb448a9f5345af031fe90ed7/src/Corporation/Division.ts#L173