### PR TITLE
BLADEBURNER: Revert #2611

### DIFF
--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -81,9 +81,6 @@ export class Skill {
   }
 
   calculateMaxUpgradeCount(currentLevel: number, cost: PositiveNumber): number {
-    // At extreme levels, floating-point precision loss makes currentLevel + 1 === currentLevel,
-    // causing calculateCost to return 0. No upgrade is possible in this case.
-    if (this.calculateCost(currentLevel, 1 as PositiveInteger) <= 0) return 0;
     /**
      * Define:
      * - x = count

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -1,18 +1,12 @@
-import { BladeburnerMultName, BladeburnerSkillName } from "@enums";
-import { Skill } from "../../../src/Bladeburner/Skill";
-import { PositiveNumber } from "../../../src/types";
+import { BladeburnerSkillName } from "@enums";
+import { Skills } from "../../../src/Bladeburner/data/Skills";
+import type { PositiveNumber } from "../../../src/types";
 
-const hyperdrive = new Skill({
-  name: BladeburnerSkillName.Hyperdrive,
-  desc: "test",
-  baseCost: 1,
-  costInc: 2.5,
-  mults: { [BladeburnerMultName.ExpGain]: 10 },
-});
+const hyperdrive = Skills[BladeburnerSkillName.Hyperdrive];
 
 describe("Bladeburner Skill", () => {
   describe("calculateMaxUpgradeCount", () => {
-    it("should return 0 when currentLevel is too high for floating-point precision", () => {
+    it.skip("should return 0 when currentLevel is too high for floating-point precision", () => {
       // At level 1e50, adding 1 is below float64 precision: 1e50 + 1 === 1e50
       // So calculateCost returns 0 for any count, and no upgrade is possible
       const result = hyperdrive.calculateMaxUpgradeCount(1e50, 1 as PositiveNumber);


### PR DESCRIPTION
MRE:
```js
/** @param {NS} ns */
export async function main(ns) {
  console.log(ns.formulas.bladeburner.skillMaxUpgradeCount("Hyperdrive", Number.MAX_SAFE_INTEGER + 1, 1e100));
}
```
#2611 incorrectly tried to fix #1693. With the check in that PR, if `currentLevel` is higher than `Number.MAX_SAFE_INTEGER`, `skillMaxUpgradeCount` always returns 0.

The old code has issues, but players can double-check the result of `skillMaxUpgradeCount` and ignore it when they know it's wrong. However, with the wrong fix, `skillMaxUpgradeCount` is now useless when `currentLevel` is higher than `Number.MAX_SAFE_INTEGER`.

Fixing #1693 is not easy. I have some ideas, but it will take a while to test them. The current "fix" is wrong and causes more harm than good, IMO. I think we should revert it and find another fix later.