### PR TITLE
DOCUMENTATION: Update type definitions of ns.flags and AutocompleteData.flags

### DIFF
--- a/markdown/bitburner.autocompletedata.flags.md
+++ b/markdown/bitburner.autocompletedata.flags.md
@@ -9,7 +9,10 @@ Parses the flags schema on the already inputted flags
 **Signature:**
 
 ```typescript
-flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg | string[] };
+flags(schema: [string, any][]): {
+    [key: string]: any;
+    _: ScriptArg[];
+  };
 ```
 
 ## Parameters
@@ -37,7 +40,7 @@ schema
 
 </td><td>
 
-\[string, string \| number \| boolean \| string\[\]\]\[\]
+\[string, any\]\[\]
 
 
 </td><td>
@@ -48,5 +51,5 @@ schema
 
 **Returns:**
 
-{ \[key: string\]: [ScriptArg](./bitburner.scriptarg.md) \| string\[\] }
+{ \[key: string\]: any; \_: [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\]; }
 

--- a/markdown/bitburner.ns.flags.md
+++ b/markdown/bitburner.ns.flags.md
@@ -9,7 +9,10 @@ Parse command line flags.
 **Signature:**
 
 ```typescript
-flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg | string[] };
+flags(schema: [string, any][]): {
+    [key: string]: any;
+    _: ScriptArg[];
+  };
 ```
 
 ## Parameters
@@ -37,7 +40,7 @@ schema
 
 </td><td>
 
-\[string, string \| number \| boolean \| string\[\]\]\[\]
+\[string, any\]\[\]
 
 
 </td><td>
@@ -48,7 +51,7 @@ schema
 
 **Returns:**
 
-{ \[key: string\]: [ScriptArg](./bitburner.scriptarg.md) \| string\[\] }
+{ \[key: string\]: any; \_: [ScriptArg](./bitburner.scriptarg.md)<!-- -->\[\]; }
 
 ## Remarks
 

--- a/src/NetscriptFunctions/Flags.ts
+++ b/src/NetscriptFunctions/Flags.ts
@@ -1,11 +1,11 @@
 import type { ScriptArg } from "@nsdefs";
 import { toNative } from "./toNative";
 import libarg from "arg";
-import { NetscriptContext } from "../Netscript/APIWrapper";
+import type { NetscriptContext } from "../Netscript/APIWrapper";
 
 export type Schema = [string, string | number | boolean | string[]][];
 type FlagType = StringConstructor | NumberConstructor | BooleanConstructor | StringConstructor[];
-type FlagsRet = Record<string, ScriptArg | string[]>;
+type FlagsRet = Record<string, unknown> & { _: ScriptArg[] };
 export function Flags(ctx: NetscriptContext | string[], permissive: boolean): (data: unknown) => FlagsRet {
   const vargs = Array.isArray(ctx) ? ctx : ctx.workerScript.scriptRef.args;
   return (schema: unknown): FlagsRet => {

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -9189,7 +9189,10 @@ export interface NS {
    * ```
    * `bar` in the last example is `"false"` (a string), not `false` (a boolean). `data.bar` is truthy, not falsy.
    */
-  flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg | string[] };
+  flags(schema: [string, any][]): {
+    [key: string]: any;
+    _: ScriptArg[];
+  };
 
   /**
    * Share the server's ram with your factions to increase the reputation gain rate of faction work. This boost is
@@ -11168,7 +11171,10 @@ interface AutocompleteData {
   /** Netscript Enums */
   enums: NSEnums;
   /** Parses the flags schema on the already inputted flags */
-  flags(schema: [string, string | number | boolean | string[]][]): { [key: string]: ScriptArg | string[] };
+  flags(schema: [string, any][]): {
+    [key: string]: any;
+    _: ScriptArg[];
+  };
   /** The hostname of the server the script would be running on */
   hostname: string;
   /** The filename of the script about to be run */

--- a/src/Terminal/getTabCompletionPossibilities.ts
+++ b/src/Terminal/getTabCompletionPossibilities.ts
@@ -6,7 +6,7 @@ import { parseCommand, parseCommands } from "./Parser";
 import { HelpTexts } from "./HelpText";
 import { compile } from "../NetscriptJSEvaluator";
 import { Flags } from "../NetscriptFunctions/Flags";
-import { AutocompleteData } from "@nsdefs";
+import type { AutocompleteData } from "@nsdefs";
 import libarg from "arg";
 import { getAllDirectories, resolveDirectory, root } from "../Paths/Directory";
 import { isLegacyScript, resolveScriptFilePath } from "../Paths/ScriptFilePath";


### PR DESCRIPTION
This PR fixes two issues.

First, `flags()._` is undocumented. Quote from https://www.npmjs.com/package/arg:
```
All parameters that aren't consumed by options (commonly referred to as "extra" parameters) are added to result._, which is always an array (even if no extra parameters are passed, in which case an empty array is returned).
```

Second, in the schema type, the type of the default value should be `any`.
```ts
export async function main(ns: NS) {
  console.clear();
  const result = ns.flags([
    ["foo1", 1],
    ["foo2", "str"],
    ["foo3", true],
    ["foo4", { bar: "baz" }],
    ["foo5", null],
    ["foo6", undefined]
  ]);
  console.log(result);
}
```