### PR TITLE
DOCUMENTATION: Remove incorrect description of ns.spawn

### DIFF
--- a/markdown/bitburner.ns.spawn.md
+++ b/markdown/bitburner.ns.spawn.md
@@ -96,8 +96,6 @@ Because this function immediately terminates the script, it does not have a retu
 
 Running this function with 0 or fewer threads will cause a runtime error.
 
-For password-protected servers (such as darknet servers), a session must be established with the destination server before using this function.
-
 ## Example
 
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -8044,8 +8044,6 @@ export interface NS {
    *
    * Running this function with 0 or fewer threads will cause a runtime error.
    *
-   * For password-protected servers (such as darknet servers), a session must be established with the destination server before using this function.
-   *
    * @example
    * ```js
    * //The following example will execute the script ‘foo.js’ with 10 threads, in 500 milliseconds and the arguments ‘foodnstuff’ and 90:


### PR DESCRIPTION
Quote from fico:
> That documentation is copy-pasted from exec, and shouldn't be on spawn.
