### PR TITLE
FIX: Make skillMaxUpgradeCount work in all cases

### DIFF
--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -35,12 +35,16 @@ export class Skill {
     for (const [multName, mult] of getRecordEntries(params.mults)) this.mults[multName] = mult;
   }
 
-  calculateCost(currentLevel: number, count = 1 as PositiveInteger): number {
+  getActualUpgradeCount(currentLevel: number, count: number): number {
     // This avoids an exploit where at high currentLevels, skills can be bought more cheaply by manipulating
     // rounding. Adding "count" to "currentLevel" will round in these circumstances because not all integer values
     // are representable; this leads to potentially getting more levels than we asked for. By performing the same
     // rounding here, we calculate the cost for the number of levels we will actually get.
-    const actualCount = currentLevel + count - currentLevel;
+    return currentLevel + count - currentLevel;
+  }
+
+  calculateCost(currentLevel: number, count = 1 as PositiveInteger): number {
+    const actualCount = this.getActualUpgradeCount(currentLevel, count);
     /**
      * The cost of the next level: (baseCost + currentLevel * costInc) * mult. The cost needs to be an integer, so we
      * need to use Math.floor or Math.round.
@@ -132,7 +136,15 @@ export class Skill {
      *
      * x_2 = -Delta - m
      *
-     * a, c and y are always greater than 0, so x_2 is always less than 0. Therefore, x_1 is the only solution.
+     * Since a, c, and y are all greater than 0:
+     *
+     * Delta = sqrt(m^2 + 2y/(a*c)) > |m|
+     *
+     * Therefore:
+     *
+     * x_2 = -Delta - m < -|m| - m <= 0
+     *
+     * Since the first inequality is strict, x_2 < 0. Thus, x_1 is the only non-negative solution.
      *
      * However, calculating it directly in this form will lead to catastrophic cancellation when m gets large.
      * So, multiply top and bottom by (Delta + m):
@@ -182,9 +194,149 @@ export class Skill {
     return r0;
   }
 
+  calculateMaxUpgradeCountNew(currentLevel: number, cost: PositiveNumber): number {
+    // Sanity checks for bnMult and skill settings. Callers should already check currentLevel and cost.
+    if (currentNodeMults.BladeburnerSkillCost <= 0 || this.baseCost <= 0 || this.costInc <= 0) {
+      throw new Error(
+        `Invalid bnMult or skill settings. BladeburnerSkillCost: ${currentNodeMults.BladeburnerSkillCost}, baseCost: ${this.baseCost}, costInc: ${this.costInc}`,
+      );
+    }
+
+    // Find the smallest count that registers a real, nonzero level change. The dead zone below this can span more than
+    // one count, so this needs its own search, not a single fixed check at count = 1.
+    let lo = 0;
+    let hi = 1;
+    while (this.getActualUpgradeCount(currentLevel, hi) === 0) {
+      lo = hi;
+      hi *= 2;
+    }
+    // At extreme magnitudes, the gap between adjacent representable doubles can exceed 1, so "hi - lo > 1" would never
+    // become false and the loop would spin indefinitely. The "mid === lo || mid === hi" check would break the loop in
+    // that case.
+    while (hi - lo > 1) {
+      const mid = lo + Math.floor((hi - lo) / 2);
+      // Granularity floor, can't narrow further
+      if (mid === lo || mid === hi) {
+        break;
+      }
+      if (this.getActualUpgradeCount(currentLevel, mid) === 0) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    const countMin = hi;
+
+    const isAffordable = (count: number) =>
+      count >= countMin && this.calculateCost(currentLevel, count as PositiveInteger) <= cost;
+
+    // Return early if even the cheapest viable request is not affordable.
+    if (!isAffordable(countMin)) {
+      return 0;
+    }
+
+    /**
+     * Define:
+     * - x = count
+     * - a = currentNodeMults.BladeburnerSkillCost
+     * - b = this.baseCost
+     * - c = this.costInc
+     * - d = currentLevel
+     * - y = cost
+     *
+     * We have:
+     *
+     * y = round(x*a*(b + c*(d + (x - 1)/2)))
+     *
+     * To simplify the calculation, let's ignore the Math.round part:
+     *
+     * y = x*a*(b + c*(d + (x - 1)/2))
+     *
+     * Divide by a and c to simplify things, multiply by 2 to help complete the square:
+     *
+     * 2y/(a*c) = 2x*(b/c + d + (x - 1)/2)
+     *          = x^2 + 2x*(b/c + d - 1/2)
+     *
+     * Solve for x in terms of everything else:
+     *
+     * Define:
+     *
+     * m = b/c + d - 1/2
+     *
+     * 2y/(a*c) = x^2 + 2x*m
+     * m^2 + 2y/(a*c) = x^2 + 2xm + m^2 = (x + m)^2
+     *
+     * Define:
+     *
+     * Delta = sqrt(m^2 + 2y/(a*c))
+     *
+     * Solutions:
+     *
+     * x_1 = Delta - m
+     *
+     * x_2 = -Delta - m
+     *
+     * Since a, c, and y are all greater than 0:
+     *
+     * Delta = sqrt(m^2 + 2y/(a*c)) > |m|
+     *
+     * Therefore:
+     *
+     * x_2 = -Delta - m < -|m| - m <= 0
+     *
+     * Since the first inequality is strict, x_2 < 0. Thus, x_1 is the only non-negative solution.
+     *
+     * However, calculating it directly in this form will lead to catastrophic cancellation when m gets large.
+     * So, multiply top and bottom by (Delta + m):
+     *
+     * x_1 = (Delta - m)(Delta + m)/(Delta + m)
+     *     = (Delta^2 - m^2)/(Delta + m)
+     *     = (m^2 + 2y/(a*c) - m^2)/(Delta + m)
+     *     = (2y/(a*c))/(Delta + m)
+     */
+    const m = this.baseCost / this.costInc + currentLevel - 0.5;
+    const yac = (2 * cost) / (currentNodeMults.BladeburnerSkillCost * this.costInc);
+    const delta = Math.sqrt(m * m + yac);
+    const numericallyStableEstimate = yac / (delta + m);
+
+    let seed = Math.round(numericallyStableEstimate);
+    if (!Number.isFinite(seed) || seed < countMin) {
+      seed = countMin;
+    }
+
+    // Expand outward from the seed to bracket the true boundary.
+    // After this step, it's guaranteed that lower is affordable and upper is not.
+    let lower = countMin;
+    let upper = seed;
+    let step = Math.max(1, seed - countMin);
+    // This loop cannot be infinite. If upper is a too high finite value (not affordable) or Infinity, isAffordable will
+    // return false.
+    while (isAffordable(upper)) {
+      lower = upper;
+      upper += step;
+      step *= 2;
+    }
+
+    // Binary search the exact boundary.
+    // Same comment about the "upper - lower > 1" case and the "mid === lower || mid === upper" check as above.
+    while (upper - lower > 1) {
+      const mid = lower + Math.floor((upper - lower) / 2);
+      if (mid === lower || mid === upper) {
+        break;
+      }
+      if (isAffordable(mid)) {
+        lower = mid;
+      } else {
+        upper = mid;
+      }
+    }
+
+    return lower;
+  }
+
   canUpgrade(bladeburner: Bladeburner, count = 1): Availability<{ actualCount: number; cost: number }> {
     const currentLevel = bladeburner.skills[this.name] ?? 0;
-    const actualCount = currentLevel + count - currentLevel;
+    const actualCount = this.getActualUpgradeCount(currentLevel, count);
     if (actualCount === 0) {
       return {
         error: `Cannot upgrade ${this.name}: Due to floating-point inaccuracy and the small value of specified "count", your skill cannot be upgraded.`,

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -44,7 +44,11 @@ export class Skill {
   }
 
   calculateCost(currentLevel: number, count = 1 as PositiveInteger): number {
+    if (!isFinite(count) || !isFinite(currentLevel)) return Number.POSITIVE_INFINITY;
+
     const actualCount = this.getActualUpgradeCount(currentLevel, count);
+    // Edge case: If currentLevel is too high, the calculation below can result in NaN.
+    if (actualCount === 0) return 0;
     /**
      * The cost of the next level: (baseCost + currentLevel * costInc) * mult. The cost needs to be an integer, so we
      * need to use Math.floor or Math.round.
@@ -95,6 +99,19 @@ export class Skill {
   }
 
   calculateMaxUpgradeCount(currentLevel: number, cost: PositiveNumber): number {
+    // Check edge cases.
+    if (Number.isNaN(currentLevel) || Number.isNaN(cost)) {
+      return Number.NaN;
+    }
+    if (cost < 1) {
+      return 0;
+    }
+    if (!Number.isFinite(cost)) {
+      return Number.POSITIVE_INFINITY;
+    }
+    if (!Number.isFinite(currentLevel)) {
+      return 0;
+    }
     /**
      * Define:
      * - x = count
@@ -153,10 +170,17 @@ export class Skill {
      *     = (Delta^2 - m^2)/(Delta + m)
      *     = (m^2 + 2y/(a*c) - m^2)/(Delta + m)
      *     = (2y/(a*c))/(Delta + m)
+     *
+     * Both y and d can be very large numbers, ranging up to MAX_VALUE.
+     * However, they are never *small* numbers - we don't have to worry about underflow.
+     * So, we multiply top and bottom of the final equation by 2^-500 to shift the ranges of the exponent from
+     * [0, 1024] to [-500, 524], such that we don't have to worry about overflows.
+     * Note that it is still possible for the expression "m * m" to overflow to Infinity if d > 2**1012, since
+     * at this range m > 2**512. However, for all d > ~2**537 the result will be zero anyway, so this is not an issue.
      */
-    const m = this.baseCost / this.costInc + currentLevel - 0.5;
-    const yac = (2 * cost) / (currentNodeMults.BladeburnerSkillCost * this.costInc);
-    const delta = Math.sqrt(m * m + yac);
+    const m = 2 ** -500 * (this.baseCost / this.costInc) + 2 ** -500 * currentLevel - 2 ** -501;
+    const yac = (2 ** -499 * cost) / (currentNodeMults.BladeburnerSkillCost * this.costInc);
+    const delta = Math.sqrt(m * m + 2 ** -500 * yac);
     const result = yac / (delta + m);
     /**
      * Now we have to find the actual answer. We search a window that includes the (rounded) result as well as the next

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -3,7 +3,8 @@ import type { BladeburnerMultName, BladeburnerSkillName } from "@enums";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
 import { Bladeburner } from "./Bladeburner";
 import { Availability } from "./Types";
-import { PositiveInteger, PositiveNumber, isPositiveInteger } from "../types";
+import { nextafter } from "../utils/NextAfter";
+import { type PositiveInteger, type PositiveNumber, isPositiveInteger } from "../types";
 import { PartialRecord, getRecordEntries } from "../Types/Record";
 
 interface SkillParams {
@@ -35,6 +36,10 @@ export class Skill {
   }
 
   calculateCost(currentLevel: number, count = 1 as PositiveInteger): number {
+    // This avoids an exploit where at high currentLevels, skills can be bought more cheaply by manipulating
+    // rounding. Adding "count" to "currentLevel" will round in these circumstances because not all integer values
+    // are representable; this leads to potentially getting more levels than we asked for. By performing the same
+    // rounding here, we calculate the cost for the number of levels we will actually get.
     const actualCount = currentLevel + count - currentLevel;
     /**
      * The cost of the next level: (baseCost + currentLevel * costInc) * mult. The cost needs to be an integer, so we
@@ -63,7 +68,7 @@ export class Skill {
      *
      * This means that we do the flooring/rounding at the end instead of each iterative step.
      *
-     * [3] and [4] are not equivalent to [1] and [2] respectively, but it's much easier to find the close forms of [3]
+     * [3] and [4] are not equivalent to [1] and [2] respectively, but it's much easier to find the closed forms of [3]
      * and [4] than [1] and [2]. After testing, we conclude that the cost calculated by [4] is a good approximation of
      * [2], so we choose [4] to calculate the cost. In order to calculate the cost with a big "count", we accept the
      * slight inaccuracy.
@@ -72,11 +77,16 @@ export class Skill {
      *
      * $$Cost = \mathrm{Round}(Count \ast Mult \ast (BaseCost + (CostInc \ast (CurrentLevel + \frac{Count - 1}{2}))))$$
      *
+     * We rearrange slightly for greater accuracy, because CurrentLevel is often much higher than Count but Count and
+     * BaseCost are usually closer in magnitude:
+     *
+     * $$Cost = \mathrm{Round}(Count \ast Mult \ast (BaseCost + CostInc \ast \frac{Count - 1}{2} + CostInc \ast CurrentLevel))$$
+     *
      */
     return Math.round(
       actualCount *
         currentNodeMults.BladeburnerSkillCost *
-        (this.baseCost + this.costInc * (currentLevel + (actualCount - 1) / 2)),
+        (this.baseCost + this.costInc * (actualCount - 1) * 0.5 + this.costInc * currentLevel),
     );
   }
 
@@ -92,47 +102,84 @@ export class Skill {
      *
      * We have:
      *
-     * $$ y = \mathrm{Round}(x \ast a \ast (b + c \ast (d + \frac{x - 1}{2})))$$
+     * y = round(x*a*(b + c*(d + (x - 1)/2)))
      *
      * To simplify the calculation, let's ignore the Math.round part:
      *
-     * $$ y = x \ast a \ast (b + c \ast (d + \frac{x - 1}{2}))$$
+     * y = x*a*(b + c*(d + (x - 1)/2))
      *
-     * Solve for x in terms of y:
+     * Divide by a and c to simplify things, multiply by 2 to help complete the square:
+     *
+     * 2y/(a*c) = 2x*(b/c + d + (x - 1)/2)
+     *          = x^2 + 2x*(b/c + d - 1/2)
+     *
+     * Solve for x in terms of everything else:
      *
      * Define:
      *
-     * $$ m = -b - c \ast d + \frac{c}{2} $$
+     * m = b/c + d - 1/2
      *
-     * $$ Delta = \sqrt{{m ^ 2} + \frac{2 \ast c \ast y}{a}} $$
+     * 2y/(a*c) = x^2 + 2x*m
+     * m^2 + 2y/(a*c) = x^2 + 2xm + m^2 = (x + m)^2
+     *
+     * Define:
+     *
+     * Delta = sqrt(m^2 + 2y/(a*c))
      *
      * Solutions:
      *
-     * $$ x_1 = \frac{m + Delta}{c} $$
+     * x_1 = Delta - m
      *
-     * $$ x_2 = \frac{m - Delta}{c} $$
+     * x_2 = -Delta - m
      *
-     * $a$, $c$ and $y$ are always greater than 0, so $x_2$ is always less than 0. Therefore, $x_1$ is the only
-     * solution.
+     * a, c and y are always greater than 0, so x_2 is always less than 0. Therefore, x_1 is the only solution.
+     *
+     * However, calculating it directly in this form will lead to catastrophic cancellation when m gets large.
+     * So, multiply top and bottom by (Delta + m):
+     *
+     * x_1 = (Delta - m)(Delta + m)/(Delta + m)
+     *     = (Delta^2 - m^2)/(Delta + m)
+     *     = (m^2 + 2y/(a*c) - m^2)/(Delta + m)
+     *     = (2y/(a*c))/(Delta + m)
      */
-    const m = -this.baseCost - this.costInc * currentLevel + this.costInc / 2;
-    const delta = Math.sqrt(m * m + (2 * this.costInc * cost) / currentNodeMults.BladeburnerSkillCost);
-    const result = Math.round((m + delta) / this.costInc);
+    const m = this.baseCost / this.costInc + currentLevel - 0.5;
+    const yac = (2 * cost) / (currentNodeMults.BladeburnerSkillCost * this.costInc);
+    const delta = Math.sqrt(m * m + yac);
+    const result = yac / (delta + m);
     /**
-     * Due to floating-point rounding and edge-cases, we cannot ensure that rounding x_1 will give us the correct
-     * integer. In other words, we cannot be sure that x_1 is within 0.5 of the integer value we want. However, we can
-     * be sure that it is within 1 of the value we want, which means that checking the numbers above and below the
-     * rounded value are sufficient to find our correct integer.
+     * Now we have to find the actual answer. We search a window that includes the (rounded) result as well as the next
+     * higher and lower numbers. For reasons that I believe can be proven but am only handwaving here, the true result
+     * will lie in this window, so checking these three values will be sufficient.
      */
-    const costOfResultPlus1 = this.calculateCost(currentLevel, (result + 1) as PositiveInteger);
-    if (costOfResultPlus1 <= cost) {
-      return result + 1;
+    let r0, r1, r2;
+    const nextLevel = currentLevel + result;
+    // MAX_SAFE_INTEGER (+1) is the first point where intervals between numbers become 2, so not all integers are
+    // representable. Half this value is the first point where intervals between numbers become *1*, which is very
+    // important for rounding.
+    const HALF_SAFE = (Number.MAX_SAFE_INTEGER + 1) / 2;
+    if (nextLevel > HALF_SAFE) {
+      // Because the result is *strictly greater* than HALF_SAFE, we know that both the successor and predecessor
+      // will also be integers. So we use nextafter() to find these values to
+      // form our window. The simple addition will correctly round nextLevel, the middle of our range.
+      r1 = nextLevel - currentLevel;
+      r2 = nextafter(nextLevel, Number.POSITIVE_INFINITY) - currentLevel;
+      r0 = nextafter(nextLevel, 0) - currentLevel;
+    } else {
+      // Since the (rounded) sum is <= HALF_SAFE, we know the rounded result alone is also <= HALF_SAFE.
+      // So we can operate directly on the rounded result, +-1.
+      r1 = Math.round(result);
+      r2 = r1 + 1;
+      r0 = r1 - 1;
     }
-    const costOfResult = this.calculateCost(currentLevel, result as PositiveInteger);
+    const costOfResultPlus = this.calculateCost(currentLevel, r2 as PositiveInteger);
+    if (costOfResultPlus <= cost) {
+      return r2;
+    }
+    const costOfResult = this.calculateCost(currentLevel, r1 as PositiveInteger);
     if (costOfResult <= cost) {
-      return result;
+      return r1;
     }
-    return result - 1;
+    return r0;
   }
 
   canUpgrade(bladeburner: Bladeburner, count = 1): Availability<{ actualCount: number; cost: number }> {

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -100,10 +100,16 @@ export class Skill {
 
   calculateMaxUpgradeCount(currentLevel: number, cost: PositiveNumber): number {
     // Check edge cases.
+    // Sanity checks for bnMult and skill settings.
+    if (currentNodeMults.BladeburnerSkillCost <= 0 || this.baseCost <= 0 || this.costInc <= 0) {
+      throw new Error(
+        `Invalid bnMult or skill settings. BladeburnerSkillCost: ${currentNodeMults.BladeburnerSkillCost}, baseCost: ${this.baseCost}, costInc: ${this.costInc}`,
+      );
+    }
     if (Number.isNaN(currentLevel) || Number.isNaN(cost)) {
       return Number.NaN;
     }
-    if (cost < this.baseCost) {
+    if (cost < currentNodeMults.BladeburnerSkillCost * this.baseCost) {
       return 0;
     }
     if (!Number.isFinite(cost)) {
@@ -181,7 +187,19 @@ export class Skill {
     const m = 2 ** -500 * (this.baseCost / this.costInc) + 2 ** -500 * currentLevel - 2 ** -501;
     const yac = (2 ** -499 * cost) / (currentNodeMults.BladeburnerSkillCost * this.costInc);
     const delta = Math.sqrt(m * m + 2 ** -500 * yac);
-    const result = yac / (delta + m);
+    const estimate = yac / (delta + m);
+    // Defensive coding.
+    // This never happens as long as the math above is correct and we do not remove the sanity checks for bnMult and
+    // skill settings.
+    // If estimate is not finite, the downward search will enter an infinite loop:
+    // - Infinity: "x" (a variable in that loop) will "step down" from Infinity to 1.7976931348623157e+308
+    // (Number.MAX_VALUE) and then gradually decrease from there, which practically never ends.
+    // - NaN: x is NaN and nextafter(NaN, 0) is also NaN, so the loop is obviously infinite.
+    if (!Number.isFinite(estimate)) {
+      throw new Error(
+        `Invalid estimate: ${estimate}. BladeburnerSkillCost: ${currentNodeMults.BladeburnerSkillCost}, baseCost: ${this.baseCost}, costInc: ${this.costInc}, currentLevel: ${currentLevel}, cost: ${cost}`,
+      );
+    }
     /**
      * Now we have to find the actual answer. We use the perspective of "final level" rather than amount, because that
      * has the property that at large values it rounds correctly - the available amounts that can be used aren't the
@@ -191,7 +209,7 @@ export class Skill {
      * changes result. The speed (but not correctness) relies on the fact that our initial guess will be very close -
      * almost always within 1 (or 1 ulp for large values) of the correct answer.
      */
-    const finalLevel = Math.round(currentLevel + result);
+    const finalLevel = Math.round(currentLevel + estimate);
     let x = finalLevel;
     if (this.calculateCost(currentLevel, (finalLevel - currentLevel) as PositiveInteger) <= cost) {
       // Search upwards. This loop *will* terminate because eventually calculateCost will return Infinity,

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -178,7 +178,7 @@ export class Skill {
      *     = (2y/(a*c))/(Delta + m)
      *
      * Both y and d can be very large numbers, ranging up to MAX_VALUE.
-     * However, they are never *small* numbers - we don't have to worry about underflow.
+     * However, they are never *small* numbers - we don't have to worry about underflow for *them*.
      * So, we multiply top and bottom of the final equation by 2^-500 to shift the ranges of the exponent from
      * [0, 1024] to [-500, 524], such that we don't have to worry about overflows.
      * Note that it is still possible for the expression "m * m" to overflow to Infinity if d > 2**1012, since
@@ -186,15 +186,15 @@ export class Skill {
      */
     const m = 2 ** -500 * (this.baseCost / this.costInc) + 2 ** -500 * currentLevel - 2 ** -501;
     const yac = (2 ** -499 * cost) / (currentNodeMults.BladeburnerSkillCost * this.costInc);
-    let estimate;
-    if (m === 0) {
-      // Divide-by-zero avoidance: If m is zero, it is possible for the normal calculation of estimate to divide-by-zero,
-      // so we use a simplified version without that problem.
-      estimate = Math.sqrt(yac) * 2 ** 250;
-    } else {
-      const delta = Math.sqrt(m * m + 2 ** -500 * yac);
-      estimate = yac / (delta + m);
-    }
+    const delta = Math.sqrt(m * m + 2 ** -500 * yac);
+    // Divide-by-zero/underflow avoidance: If m is sufficiently small, we can run into underflow issues in the
+    // calculations. If m is *negative*, then we can run into catastrophic cancellation. The solution to both issues is
+    // to revert to the original formula of "delta - m". Note that underflows to 0 are a non-issue here for the same
+    // reason that overflows to Infinity are a non-issue for the other form: Having an initial estimate of 0 is fine.
+    //
+    // Also note that it is technically possible for the simple form to give an Infinite result, but only if m < -(2**512),
+    // which requires an extremely negative baseCost.
+    const estimate = m < 2 ** -512 ? (delta - m) * 2 ** 500 : yac / (delta + m);
     // Defensive coding.
     // This never happens as long as the math above is correct and we do not remove the sanity checks for bnMult and
     // skill settings.

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -101,7 +101,7 @@ export class Skill {
   calculateMaxUpgradeCount(currentLevel: number, cost: PositiveNumber): number {
     // Check edge cases.
     // Sanity checks for bnMult and skill settings.
-    if (currentNodeMults.BladeburnerSkillCost <= 0 || this.baseCost <= 0 || this.costInc <= 0) {
+    if (currentNodeMults.BladeburnerSkillCost <= 0 || this.costInc <= 0) {
       throw new Error(
         `Invalid bnMult or skill settings. BladeburnerSkillCost: ${currentNodeMults.BladeburnerSkillCost}, baseCost: ${this.baseCost}, costInc: ${this.costInc}`,
       );
@@ -186,8 +186,15 @@ export class Skill {
      */
     const m = 2 ** -500 * (this.baseCost / this.costInc) + 2 ** -500 * currentLevel - 2 ** -501;
     const yac = (2 ** -499 * cost) / (currentNodeMults.BladeburnerSkillCost * this.costInc);
-    const delta = Math.sqrt(m * m + 2 ** -500 * yac);
-    const estimate = yac / (delta + m);
+    let estimate;
+    if (m === 0) {
+      // Divide-by-zero avoidance: If m is zero, it is possible for the normal calculation of estimate to divide-by-zero,
+      // so we use a simplified version without that problem.
+      estimate = Math.sqrt(yac) * 2 ** 250;
+    } else {
+      const delta = Math.sqrt(m * m + 2 ** -500 * yac);
+      estimate = yac / (delta + m);
+    }
     // Defensive coding.
     // This never happens as long as the math above is correct and we do not remove the sanity checks for bnMult and
     // skill settings.

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -193,24 +193,23 @@ export class Skill {
      */
     const finalLevel = Math.round(currentLevel + result);
     let x = finalLevel;
-    if (this.calculateCost(currentLevel, finalLevel - currentLevel as PositiveInteger) <= cost) {
+    if (this.calculateCost(currentLevel, (finalLevel - currentLevel) as PositiveInteger) <= cost) {
       // Search upwards. This loop *will* terminate because eventually calculateCost will return Infinity,
       // and from the edge-checks above we know cost < Infinity.
-      while (true) {
+      for (;;) {
         const prev = x;
         x = Math.max(x + 1, nextafter(x, Number.POSITIVE_INFINITY));
-        if (this.calculateCost(currentLevel, x - currentLevel as PositiveInteger) > cost) {
+        if (this.calculateCost(currentLevel, (x - currentLevel) as PositiveInteger) > cost) {
           return prev - currentLevel;
         }
       }
     } else {
-      let i = 0;
       // Search downwards. This loop *will* terminate because eventually x will be currentLevel.
-      while (true) {
+      for (;;) {
         // We need an explicit check because x can start at currentLevel.
         if (x <= currentLevel) return 0;
         x = Math.min(x - 1, nextafter(x, 0));
-        if (this.calculateCost(currentLevel, x - currentLevel as PositiveInteger) <= cost) {
+        if (this.calculateCost(currentLevel, (x - currentLevel) as PositiveInteger) <= cost) {
           return x - currentLevel;
         }
       }

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -103,7 +103,7 @@ export class Skill {
     if (Number.isNaN(currentLevel) || Number.isNaN(cost)) {
       return Number.NaN;
     }
-    if (cost < 1) {
+    if (cost < this.baseCost) {
       return 0;
     }
     if (!Number.isFinite(cost)) {
@@ -183,39 +183,38 @@ export class Skill {
     const delta = Math.sqrt(m * m + 2 ** -500 * yac);
     const result = yac / (delta + m);
     /**
-     * Now we have to find the actual answer. We search a window that includes the (rounded) result as well as the next
-     * higher and lower numbers. For reasons that I believe can be proven but am only handwaving here, the true result
-     * will lie in this window, so checking these three values will be sufficient.
+     * Now we have to find the actual answer. We use the perspective of "final level" rather than amount, because that
+     * has the property that at large values it rounds correctly - the available amounts that can be used aren't the
+     * whole range of integers anymore, but are only restricted to a smaller set of powers of 2. For small values, the
+     * final level will be an integer.
+     * We start with an initial guess, and then depending on if it was high or low, we search linearly until the guess
+     * changes result. The speed (but not correctness) relies on the fact that our initial guess will be very close -
+     * almost always within 1 (or 1 ulp for large values) of the correct answer.
      */
-    let r0, r1, r2;
-    const nextLevel = currentLevel + result;
-    // MAX_SAFE_INTEGER (+1) is the first point where intervals between numbers become 2, so not all integers are
-    // representable. Half this value is the first point where intervals between numbers become *1*, which is very
-    // important for rounding.
-    const HALF_SAFE = (Number.MAX_SAFE_INTEGER + 1) / 2;
-    if (nextLevel > HALF_SAFE) {
-      // Because the result is *strictly greater* than HALF_SAFE, we know that both the successor and predecessor
-      // will also be integers. So we use nextafter() to find these values to
-      // form our window. The simple addition will correctly round nextLevel, the middle of our range.
-      r1 = nextLevel - currentLevel;
-      r2 = nextafter(nextLevel, Number.POSITIVE_INFINITY) - currentLevel;
-      r0 = nextafter(nextLevel, 0) - currentLevel;
+    const finalLevel = Math.round(currentLevel + result);
+    let x = finalLevel;
+    if (this.calculateCost(currentLevel, finalLevel - currentLevel as PositiveInteger) <= cost) {
+      // Search upwards. This loop *will* terminate because eventually calculateCost will return Infinity,
+      // and from the edge-checks above we know cost < Infinity.
+      while (true) {
+        const prev = x;
+        x = Math.max(x + 1, nextafter(x, Number.POSITIVE_INFINITY));
+        if (this.calculateCost(currentLevel, x - currentLevel as PositiveInteger) > cost) {
+          return prev - currentLevel;
+        }
+      }
     } else {
-      // Since the (rounded) sum is <= HALF_SAFE, we know the rounded result alone is also <= HALF_SAFE.
-      // So we can operate directly on the rounded result, +-1.
-      r1 = Math.round(result);
-      r2 = r1 + 1;
-      r0 = r1 - 1;
+      let i = 0;
+      // Search downwards. This loop *will* terminate because eventually x will be currentLevel.
+      while (true) {
+        // We need an explicit check because x can start at currentLevel.
+        if (x <= currentLevel) return 0;
+        x = Math.min(x - 1, nextafter(x, 0));
+        if (this.calculateCost(currentLevel, x - currentLevel as PositiveInteger) <= cost) {
+          return x - currentLevel;
+        }
+      }
     }
-    const costOfResultPlus = this.calculateCost(currentLevel, r2 as PositiveInteger);
-    if (costOfResultPlus <= cost) {
-      return r2;
-    }
-    const costOfResult = this.calculateCost(currentLevel, r1 as PositiveInteger);
-    if (costOfResult <= cost) {
-      return r1;
-    }
-    return r0;
   }
 
   calculateMaxUpgradeCountNew(currentLevel: number, cost: PositiveNumber): number {

--- a/src/Bladeburner/Skill.ts
+++ b/src/Bladeburner/Skill.ts
@@ -109,7 +109,7 @@ export class Skill {
     if (Number.isNaN(currentLevel) || Number.isNaN(cost)) {
       return Number.NaN;
     }
-    if (cost < currentNodeMults.BladeburnerSkillCost * this.baseCost) {
+    if (cost <= 0) {
       return 0;
     }
     if (!Number.isFinite(cost)) {

--- a/src/utils/NextAfter.ts
+++ b/src/utils/NextAfter.ts
@@ -1,0 +1,40 @@
+// This is an implementation of the C/C++ function nextafter from the standard
+// math library. JS doesn't have an analogue to it. It returns the next value
+// after x in the direction of y. There are a number of interesting edge
+// cases, so this is more-or-less reimplemented straight from the C library.
+export function nextafter(x: number, y: number): number {
+  if (Number.isNaN(x)) {
+    return x;
+  }
+  if (Number.isNaN(y)) {
+    return y;
+  }
+  if (x === y) {
+    // Subtle -0 case here.
+    return y;
+  }
+  if (x === 0) {
+    // y can't be 0, from above
+    return y > 0 ? Number.MIN_VALUE : -Number.MIN_VALUE;
+  }
+  const f64 = Float64Array.of(x, y);
+  const u32 = new Uint32Array(f64.buffer);
+  // We can't underflow 0 or overflow here, because 0 is 0.0 (already checked
+  // for), and the max value is NaN (already checked for).
+  if (x < y === x > 0) {
+    if (u32[0] === -1 >>> 0) {
+      u32[0] = 0;
+      u32[1]++;
+    } else {
+      u32[0]++;
+    }
+  } else {
+    if (u32[0] === 0) {
+      u32[0] = -1 >>> 0;
+      u32[1]--;
+    } else {
+      u32[0]--;
+    }
+  }
+  return f64[0];
+}

--- a/src/utils/NextAfter.ts
+++ b/src/utils/NextAfter.ts
@@ -17,24 +17,24 @@ export function nextafter(x: number, y: number): number {
     // y can't be 0, from above
     return y > 0 ? Number.MIN_VALUE : -Number.MIN_VALUE;
   }
-  const f64 = Float64Array.of(x, y);
-  const u32 = new Uint32Array(f64.buffer);
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, x, true);
+  // We use Int32 for convenience of the test below. Because storage in
+  // TypedArrays is wrapping and we are only doing addition, signed/unsigned
+  // does not matter.
+  const u0 = view.getInt32(0, true);
   // We can't underflow 0 or overflow here, because 0 is 0.0 (already checked
   // for), and the max value is NaN (already checked for).
   if (x < y === x > 0) {
-    if (u32[0] === -1 >>> 0) {
-      u32[0] = 0;
-      u32[1]++;
-    } else {
-      u32[0]++;
+    view.setInt32(0, u0 + 1, true);
+    if (u0 === -1) {
+      view.setInt32(4, view.getInt32(4, true) + 1, true);
     }
   } else {
-    if (u32[0] === 0) {
-      u32[0] = -1 >>> 0;
-      u32[1]--;
-    } else {
-      u32[0]--;
+    view.setInt32(0, u0 - 1, true);
+    if (u0 === 0) {
+      view.setInt32(4, view.getInt32(4, true) - 1, true);
     }
   }
-  return f64[0];
+  return view.getFloat64(0, true);
 }

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -2,8 +2,6 @@ import { BladeburnerSkillName } from "@enums";
 import { Skills } from "../../../src/Bladeburner/data/Skills";
 import { nextafter } from "../../../src/utils/NextAfter";
 import type { PositiveNumber } from "../../../src/types";
-import { Skill } from "../../../src/Bladeburner/Skill";
-import { currentNodeMults } from "../../../src/BitNode/BitNodeMultipliers";
 
 const hyperdrive = Skills[BladeburnerSkillName.Hyperdrive];
 
@@ -12,51 +10,27 @@ describe("Bladeburner Skill", () => {
     it("should return 0 when currentLevel is too high for floating-point precision", () => {
       // At level 1e18, the smallest gap between numbers is 128. The cost of
       // 128 levels will be 128 * (1 + 2.5 * 127/2 + 2.5 * 1e18) = 128 * (2.5e18) = 3.2e20.
-      const result = hyperdrive.calculateMaxUpgradeCountNew(1e18, nextafter(3.2e20, 0) as PositiveNumber);
+      const result = hyperdrive.calculateMaxUpgradeCount(1e18, nextafter(3.2e20, 0) as PositiveNumber);
       expect(result).toBe(0);
     });
 
     it("should return correct count at high currentLevel", () => {
-      const currentLevel = 1e18;
-      const cost = nextafter(3.2e20, 1e99) as PositiveNumber;
-      const result = hyperdrive.calculateMaxUpgradeCountNew(currentLevel, cost);
-      expect(result).toBe(191);
-      expect(currentLevel + result).toBe(1.0000000000000001e18);
+      const result = hyperdrive.calculateMaxUpgradeCount(1e18, nextafter(3.2e20, 1e99) as PositiveNumber);
+      expect(result).toBe(128);
     });
 
     it("should return correct count at normal levels", () => {
       // At level 0 with cost 1, baseCost 1, costInc 2.5:
       // cost of 1 level = round(1 * 1 * (1 + 2.5 * (0 + 0/2))) = round(1) = 1
-      const result = hyperdrive.calculateMaxUpgradeCountNew(0, 1 as PositiveNumber);
+      const result = hyperdrive.calculateMaxUpgradeCount(0, 1 as PositiveNumber);
       expect(result).toBe(1);
     });
 
     it("should return 0 when cost is less than the price of one level", () => {
       // At level 10: cost of 1 level = round(1 * 1 * (1 + 2.5 * 10)) = 26
       const costOfOne = hyperdrive.calculateCost(10);
-      const result = hyperdrive.calculateMaxUpgradeCountNew(10, (costOfOne - 1) as PositiveNumber);
+      const result = hyperdrive.calculateMaxUpgradeCount(10, (costOfOne - 1) as PositiveNumber);
       expect(result).toBe(0);
-    });
-
-    it("edge cases", () => {
-      const skill = new Skill({
-        name: BladeburnerSkillName.Hyperdrive,
-        desc: "",
-        baseCost: 1,
-        costInc: 1,
-        mults: {},
-      });
-      currentNodeMults.BladeburnerSkillCost = 1;
-
-      // True result is smaller than r0.
-      // The binary search enters an infinite loop if the granularity floor check is removed.
-      expect(skill.calculateMaxUpgradeCountNew(2048, 2.049e32 as PositiveNumber)).toBe(20243517480910200);
-
-      // numericallyStableSeed is NaN.
-      expect(skill.calculateMaxUpgradeCountNew(1, 1e308 as PositiveNumber)).toBe(1.414213562373095e154);
-
-      // countMin calculation enters an infinite loop if the granularity floor check is removed.
-      expect(skill.calculateMaxUpgradeCountNew(1e35, 1 as PositiveNumber)).toBe(0);
     });
   });
 });

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -2,6 +2,8 @@ import { BladeburnerSkillName } from "@enums";
 import { Skills } from "../../../src/Bladeburner/data/Skills";
 import { nextafter } from "../../../src/utils/NextAfter";
 import type { PositiveNumber } from "../../../src/types";
+import { Skill } from "../../../src/Bladeburner/Skill";
+import { currentNodeMults } from "../../../src/BitNode/BitNodeMultipliers";
 
 const hyperdrive = Skills[BladeburnerSkillName.Hyperdrive];
 
@@ -10,27 +12,51 @@ describe("Bladeburner Skill", () => {
     it("should return 0 when currentLevel is too high for floating-point precision", () => {
       // At level 1e18, the smallest gap between numbers is 128. The cost of
       // 128 levels will be 128 * (1 + 2.5 * 127/2 + 2.5 * 1e18) = 128 * (2.5e18) = 3.2e20.
-      const result = hyperdrive.calculateMaxUpgradeCount(1e18, nextafter(3.2e20, 0) as PositiveNumber);
+      const result = hyperdrive.calculateMaxUpgradeCountNew(1e18, nextafter(3.2e20, 0) as PositiveNumber);
       expect(result).toBe(0);
     });
 
     it("should return correct count at high currentLevel", () => {
-      const result = hyperdrive.calculateMaxUpgradeCount(1e18, nextafter(3.2e20, 1e99) as PositiveNumber);
-      expect(result).toBe(128);
+      const currentLevel = 1e18;
+      const cost = nextafter(3.2e20, 1e99) as PositiveNumber;
+      const result = hyperdrive.calculateMaxUpgradeCountNew(currentLevel, cost);
+      expect(result).toBe(191);
+      expect(currentLevel + result).toBe(1.0000000000000001e18);
     });
 
     it("should return correct count at normal levels", () => {
       // At level 0 with cost 1, baseCost 1, costInc 2.5:
       // cost of 1 level = round(1 * 1 * (1 + 2.5 * (0 + 0/2))) = round(1) = 1
-      const result = hyperdrive.calculateMaxUpgradeCount(0, 1 as PositiveNumber);
+      const result = hyperdrive.calculateMaxUpgradeCountNew(0, 1 as PositiveNumber);
       expect(result).toBe(1);
     });
 
     it("should return 0 when cost is less than the price of one level", () => {
       // At level 10: cost of 1 level = round(1 * 1 * (1 + 2.5 * 10)) = 26
       const costOfOne = hyperdrive.calculateCost(10);
-      const result = hyperdrive.calculateMaxUpgradeCount(10, (costOfOne - 1) as PositiveNumber);
+      const result = hyperdrive.calculateMaxUpgradeCountNew(10, (costOfOne - 1) as PositiveNumber);
       expect(result).toBe(0);
+    });
+
+    it("edge cases", () => {
+      const skill = new Skill({
+        name: BladeburnerSkillName.Hyperdrive,
+        desc: "",
+        baseCost: 1,
+        costInc: 1,
+        mults: {},
+      });
+      currentNodeMults.BladeburnerSkillCost = 1;
+
+      // True result is smaller than r0.
+      // The binary search enters an infinite loop if the granularity floor check is removed.
+      expect(skill.calculateMaxUpgradeCountNew(2048, 2.049e32 as PositiveNumber)).toBe(20243517480910200);
+
+      // numericallyStableSeed is NaN.
+      expect(skill.calculateMaxUpgradeCountNew(1, 1e308 as PositiveNumber)).toBe(1.414213562373095e154);
+
+      // countMin calculation enters an infinite loop if the granularity floor check is removed.
+      expect(skill.calculateMaxUpgradeCountNew(1e35, 1 as PositiveNumber)).toBe(0);
     });
   });
 });

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -66,7 +66,7 @@ describe("Bladeburner Skill", () => {
     });
 
     it("Last possible upgrade", () => {
-      let level = 2 ** 537 * 1.6 - 2 ** 486;
+      const level = 2 ** 537 * 1.6 - 2 ** 486;
       let result = hyperdrive.calculateCost(level, (2 ** 485) as PositiveNumber);
       expect(result).toBe(Number.MAX_VALUE);
 
@@ -193,11 +193,15 @@ describe("Bladeburner Skill", () => {
         // process.stderr.write(`With parameters {level:${level}, cost:${cost}, amount:${amount}}\n`);
 
         // We have to advance to the *biggest* amount.
-        while (true) {
+        for (;;) {
           // The middle term seems spurious here. However, when amount and level are both large enough that the gap is
           // larger than 1, and amount >> level, and level is exactly halfway between two representable amounts, we can
           // get a situation where the last term returns amount again due to ties-to-even rounding.
-          const nextAmount = Math.max(amount + 1, nextafter(amount, Number.POSITIVE_INFINITY), nextafter(level + amount, Number.POSITIVE_INFINITY) - level);
+          const nextAmount = Math.max(
+            amount + 1,
+            nextafter(amount, Number.POSITIVE_INFINITY),
+            nextafter(level + amount, Number.POSITIVE_INFINITY) - level,
+          );
           if (hyperdrive.calculateCost(level, nextAmount as PositiveNumber) > cost) {
             break;
           }
@@ -211,7 +215,9 @@ describe("Bladeburner Skill", () => {
           expect(hyperdrive.calculateMaxUpgradeCount(level, cost as PositiveNumber)).toBe(amount);
           expect(hyperdrive.calculateMaxUpgradeCount(level, prevCost as PositiveNumber)).toBeLessThan(amount);
         } catch (e) {
-          throw new Error(`With parameters {level:${level}, cost:${cost}, prevCost:${prevCost}, amount:${amount}}`, {cause: e});
+          throw new Error(`With parameters {level:${level}, cost:${cost}, prevCost:${prevCost}, amount:${amount}}`, {
+            cause: e,
+          });
         }
         i++; // Not in the loop body so we can rejection-sample
       }

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -1,16 +1,22 @@
 import { BladeburnerSkillName } from "@enums";
 import { Skills } from "../../../src/Bladeburner/data/Skills";
+import { nextafter } from "../../../src/utils/NextAfter";
 import type { PositiveNumber } from "../../../src/types";
 
 const hyperdrive = Skills[BladeburnerSkillName.Hyperdrive];
 
 describe("Bladeburner Skill", () => {
   describe("calculateMaxUpgradeCount", () => {
-    it.skip("should return 0 when currentLevel is too high for floating-point precision", () => {
-      // At level 1e50, adding 1 is below float64 precision: 1e50 + 1 === 1e50
-      // So calculateCost returns 0 for any count, and no upgrade is possible
-      const result = hyperdrive.calculateMaxUpgradeCount(1e50, 1 as PositiveNumber);
+    it("should return 0 when currentLevel is too high for floating-point precision", () => {
+      // At level 1e18, the smallest gap between numbers is 128. The cost of
+      // 128 levels will be 128 * (1 + 2.5 * 127/2 + 2.5 * 1e18) = 128 * (2.5e18) = 3.2e20.
+      const result = hyperdrive.calculateMaxUpgradeCount(1e18, nextafter(3.2e20, 0) as PositiveNumber);
       expect(result).toBe(0);
+    });
+
+    it("should return correct count at high currentLevel", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(1e18, nextafter(3.2e20, 1e99) as PositiveNumber);
+      expect(result).toBe(128);
     });
 
     it("should return correct count at normal levels", () => {

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -1,12 +1,138 @@
 import { BladeburnerSkillName } from "@enums";
 import { Skills } from "../../../src/Bladeburner/data/Skills";
+import { Skill } from "../../../src/Bladeburner/Skill";
 import { nextafter } from "../../../src/utils/NextAfter";
 import type { PositiveNumber } from "../../../src/types";
 
 const hyperdrive = Skills[BladeburnerSkillName.Hyperdrive];
 
+// Given two Uint32s (presumably randomly generated), return a floating point
+// value for testing. The first part of the tuple is an integer, and the 2nd
+// is a multiplier of the form 2**x. The values are designed for use with
+// calculateCost: half the time the multiplier will be 1, and the multiplier
+// won't exceed 2**512 (since after this point all results will be Infinity).
+function getValue(uint1: number, uint2: number): [number, number] {
+  if (uint2 < 2 ** 31) {
+    // One-half chance of a simple integer. It will span [0, 2**53).
+    const high = (uint2 & 0x1fffff) * 2 ** 32;
+    return [uint1 + high, 1];
+  } else {
+    // Use the representation of a double to create an integer spanning
+    // [2**52, 2**53). The multiplier will be a minimum of 2.
+    // Exponent bits: 1023 + 52 = 1075 = 0x433
+    const high_bits = (uint2 & 0xfffff) | 0x4330_0000;
+    const utyped = Uint32Array.of(uint1, high_bits);
+    const ftyped = new Float64Array(utyped.buffer);
+    const r0 = ftyped[0];
+    utyped[0] = 0;
+    // Exponent bits: 1024 = 0x400 corresponds to 2**1
+    utyped[1] = (uint2 & 0x1ff0_0000) + 0x4000_0000;
+    return [r0, ftyped[0]];
+  }
+}
+
 describe("Bladeburner Skill", () => {
+  // calculateCost is only behind callsites that check its arguments, so we don't need to
+  // test for NaN. Add those tests if that changes.
+  describe("calculateCost", () => {
+    it("MAX_VALUE arg 1", () => {
+      const result = hyperdrive.calculateCost(Number.MAX_VALUE, 1 as PositiveNumber);
+      expect(result).toBe(0);
+    });
+
+    it("MAX_VALUE arg 2", () => {
+      const result = hyperdrive.calculateCost(0, Number.MAX_VALUE as PositiveNumber);
+      expect(result).toBe(Infinity);
+    });
+
+    it("MAX_VALUE arg both", () => {
+      const result = hyperdrive.calculateCost(Number.MAX_VALUE, Number.MAX_VALUE as PositiveNumber);
+      expect(result).toBe(Infinity);
+    });
+
+    it("Inf arg 1", () => {
+      const result = hyperdrive.calculateCost(Infinity, 1 as PositiveNumber);
+      expect(result).toBe(Infinity);
+    });
+
+    it("Inf arg 2", () => {
+      const result = hyperdrive.calculateCost(0, Infinity as PositiveNumber);
+      expect(result).toBe(Infinity);
+    });
+
+    it("Inf arg both", () => {
+      const result = hyperdrive.calculateCost(Infinity, Infinity as PositiveNumber);
+      expect(result).toBe(Infinity);
+    });
+
+    it("Last possible upgrade", () => {
+      let level = 2 ** 537 * 1.6 - 2 ** 486;
+      let result = hyperdrive.calculateCost(level, (2 ** 485) as PositiveNumber);
+      expect(result).toBe(Number.MAX_VALUE);
+
+      // Can't upgrade again
+      result = hyperdrive.calculateCost(level + 2 ** 485, (2 ** 485) as PositiveNumber);
+      expect(result).toBe(Infinity);
+
+      // Can't add a smaller increment
+      expect(level + 2 ** 484).toBe(level);
+    });
+  });
+
   describe("calculateMaxUpgradeCount", () => {
+    it("NaN arg 1", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(NaN, 1 as PositiveNumber);
+      expect(result).toBe(NaN);
+    });
+
+    it("NaN arg 2", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(0, NaN as PositiveNumber);
+      expect(result).toBe(NaN);
+    });
+
+    it("Inf arg 1", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(Infinity, 1 as PositiveNumber);
+      expect(result).toBe(0);
+    });
+
+    it("Inf arg 2", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(0, Infinity as PositiveNumber);
+      expect(result).toBe(Infinity);
+    });
+
+    it("Inf arg both", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(Infinity, Infinity as PositiveNumber);
+      expect(result).toBe(Infinity);
+    });
+
+    it("MAX_VALUE arg 1", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(Number.MAX_VALUE, 1 as PositiveNumber);
+      expect(result).toBe(0);
+    });
+
+    it("MAX_VALUE arg 2", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(0, Number.MAX_VALUE as PositiveNumber);
+      expect(result).toBe(nextafter(2 ** 512 / Math.sqrt(1.25), 0));
+    });
+
+    it("MAX_VALUE arg both", () => {
+      const result = hyperdrive.calculateMaxUpgradeCount(Number.MAX_VALUE, Number.MAX_VALUE as PositiveNumber);
+      expect(result).toBe(0);
+    });
+
+    it("Example that tests a rounding edge case", () => {
+      // See the comments on https://github.com/bitburner-official/bitburner-src/pull/2905 for more details
+      const testSkill = new Skill({
+        name: BladeburnerSkillName.Cloak,
+        desc: "test",
+        baseCost: 1,
+        costInc: 1,
+        mults: {},
+      });
+      const result = testSkill.calculateMaxUpgradeCount(2048, 2.049e32 as PositiveNumber);
+      expect(result).toBe(20243517480910200);
+    });
+
     it("should return 0 when currentLevel is too high for floating-point precision", () => {
       // At level 1e18, the smallest gap between numbers is 128. The cost of
       // 128 levels will be 128 * (1 + 2.5 * 127/2 + 2.5 * 1e18) = 128 * (2.5e18) = 3.2e20.
@@ -31,6 +157,36 @@ describe("Bladeburner Skill", () => {
       const costOfOne = hyperdrive.calculateCost(10);
       const result = hyperdrive.calculateMaxUpgradeCount(10, (costOfOne - 1) as PositiveNumber);
       expect(result).toBe(0);
+    });
+
+    it("test random values", () => {
+      // Basic tests of our helper
+      expect(getValue(0, 0)).toStrictEqual([0, 1]);
+      expect(getValue(1, 0)).toStrictEqual([1, 1]);
+      expect(getValue(0xffff_ffff, 0x7fff_ffff)).toStrictEqual([Number.MAX_SAFE_INTEGER, 1]);
+      expect(getValue(0, 0x8000_0000)).toStrictEqual([2 ** 52, 2]);
+
+      const typed = new Uint32Array(4);
+      // When the implementation was insufficient, 1000 iterations was enough to guarantee a failure.
+      for (let i = 0; i < 10000; ) {
+        // We don't need secure values, we just want a guaranteed number of random bits.
+        // (Math.random has no guarantees for how much randomness it provides.)
+        crypto.getRandomValues(typed);
+        const [v1, v1mul] = getValue(typed[0], typed[1]);
+        const [v2, v2mul] = getValue(typed[0], typed[1]);
+        const level = v1 * v1mul;
+        // This is also scaled by v1mul because otherwise amount would round to 0.
+        const amount = v2 * v2mul * v1mul;
+        const cost = hyperdrive.calculateCost(level, amount as PositiveNumber);
+        if (!Number.isFinite(cost)) continue;
+        const prevCost = Math.min(cost - 1, nextafter(cost, 0));
+        // Because the parameters to this test are random, it is possible for this test to be flaky on one of
+        // these next two lines. However, any failures here are *real*, and the test log should have enough
+        // info to reliably reproduce the issue (call it with the same params) and thus fix it.
+        expect(hyperdrive.calculateMaxUpgradeCount(level, cost as PositiveNumber)).toBe(amount);
+        expect(hyperdrive.calculateMaxUpgradeCount(level, prevCost as PositiveNumber)).toBeLessThan(amount);
+        i++; // Not in the loop body so we can rejection-sample
+      }
     });
   });
 });

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -7,11 +7,13 @@ import { currentNodeMults } from "../../../src/BitNode/BitNodeMultipliers";
 
 const hyperdrive = Skills[BladeburnerSkillName.Hyperdrive];
 
-// Given two Uint32s (presumably randomly generated), return a floating point
-// value for testing. The first part of the tuple is an integer, and the 2nd
-// is a multiplier of the form 2**x. The values are designed for use with
-// calculateCost: half the time the multiplier will be 1, and the multiplier
-// won't exceed 2**512 (since after this point all results will be Infinity).
+// Given two random Uint32 values, construct a test value represented as
+// (integer, multiplier), where the numeric value is integer * multiplier.
+// The multiplier is of the form 2**x, and the representation will be unique,
+// i.e. the same numeric value won't be formed with different multipliers.
+// The values are designed for use with calculateCost: half the time the
+// multiplier will be 1, and the multiplier won't exceed 2**512
+// (since after this point all results will be Infinity).
 function getValue(uint1: number, uint2: number): [number, number] {
   if (uint2 < 2 ** 31) {
     // One-half chance of a simple integer. It will span [0, 2**53).
@@ -67,6 +69,12 @@ describe("Bladeburner Skill", () => {
     });
 
     it("Last possible upgrade", () => {
+      // This tests the functioning of calculateCost at the point of the last possible skill upgrade that can be
+      // purchased. The specific value depends on skill.costInc, BN mults, etc., but in general it will be at
+      // approximately 2**(512 + 26), since this is where a minimal representable amount of ~ 2**(512 - 27) will result
+      // in a cost just shy of Infinity.
+      // The form of the specific value comes from 1.6 * 2.5 (costInc) = 4, and needing a slightly smaller value to
+      // avoid overflow to infinity.
       const level = 2 ** 537 * 1.6 - 2 ** 486;
       let result = hyperdrive.calculateCost(level, (2 ** 485) as PositiveInteger);
       expect(result).toBe(Number.MAX_VALUE);
@@ -75,7 +83,7 @@ describe("Bladeburner Skill", () => {
       result = hyperdrive.calculateCost(level + 2 ** 485, (2 ** 485) as PositiveInteger);
       expect(result).toBe(Infinity);
 
-      // Can't add a smaller increment
+      // Can't add a smaller increment - the gap is too large
       expect(level + 2 ** 484).toBe(level);
     });
   });
@@ -161,9 +169,15 @@ describe("Bladeburner Skill", () => {
       expect(result).toBe(20243517480910200);
     });
 
+    // At level 1e18, the smallest gap between numbers is 128. The cost of
+    // 128 levels will be 128 * (1 + 2.5 * 127/2 + 2.5 * 1e18) = 128 * (2.5e18) = 3.2e20.
+    // These next two tests check that we return the proper result around this particular edge-case.
+    // Note that the correct value on the high side is 128 and not 191: This is because we do not return the
+    // largest integer that can be successfully passed to calculateCost, but rather the largest "valid" upgrade count.
+    // Since upgrades are always rounded in calculateCost and similar functions to the nearest representable level,
+    // it is misleading to return a larger value that is not actually giving more levels. For more discussion, see
+    // https://github.com/bitburner-official/bitburner-src/pull/2905
     it("should return 0 when currentLevel is too high for floating-point precision", () => {
-      // At level 1e18, the smallest gap between numbers is 128. The cost of
-      // 128 levels will be 128 * (1 + 2.5 * 127/2 + 2.5 * 1e18) = 128 * (2.5e18) = 3.2e20.
       const result = hyperdrive.calculateMaxUpgradeCount(1e18, nextafter(3.2e20, 0) as PositiveNumber);
       expect(result).toBe(0);
     });

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -140,6 +140,42 @@ describe("Bladeburner Skill", () => {
       expect(() => testSkill.calculateMaxUpgradeCount(1, 1 as PositiveNumber)).toThrow();
     });
 
+    // This is not something we'd ever do, but it's also not *completely* invalid
+    it("negative baseCost", () => {
+      const testSkill = new Skill({
+        name: BladeburnerSkillName.Cloak,
+        desc: "test",
+        baseCost: -20,
+        costInc: 1,
+        mults: {},
+      });
+      expect(testSkill.calculateMaxUpgradeCount(0, 1 as PositiveNumber)).toBe(41);
+      expect(testSkill.calculateMaxUpgradeCount(10, 1 as PositiveNumber)).toBe(21);
+      expect(testSkill.calculateMaxUpgradeCount(18, 1 as PositiveNumber)).toBe(5);
+      expect(testSkill.calculateMaxUpgradeCount(19, 1 as PositiveNumber)).toBe(3);
+      expect(testSkill.calculateMaxUpgradeCount(20, 1 as PositiveNumber)).toBe(2);
+      expect(testSkill.calculateMaxUpgradeCount(21, 1 as PositiveNumber)).toBe(1);
+    });
+
+    // This uses numbers that are technically valid, but would never be encountered in the game.
+    // These precise numbers tickle an edge case that leads to divide-by-zero in a previous revision of the algorithm.
+    it("divide-by-zero edge-case", () => {
+      const testSkill = new Skill({
+        name: BladeburnerSkillName.Cloak,
+        desc: "test",
+        baseCost: 1,
+        costInc: 2,
+        mults: {},
+      });
+      try {
+        // This just needs to be big enough.
+        currentNodeMults.BladeburnerSkillCost = 1e100;
+        expect(testSkill.calculateMaxUpgradeCount(0, 1 as PositiveNumber)).toBe(0);
+      } finally {
+        currentNodeMults.BladeburnerSkillCost = 1;
+      }
+    });
+
     it("mult < 1", () => {
       const testSkill = new Skill({
         name: BladeburnerSkillName.Cloak,

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -2,7 +2,8 @@ import { BladeburnerSkillName } from "@enums";
 import { Skills } from "../../../src/Bladeburner/data/Skills";
 import { Skill } from "../../../src/Bladeburner/Skill";
 import { nextafter } from "../../../src/utils/NextAfter";
-import type { PositiveNumber } from "../../../src/types";
+import type { PositiveInteger, PositiveNumber } from "../../../src/types";
+import { currentNodeMults } from "../../../src/BitNode/BitNodeMultipliers";
 
 const hyperdrive = Skills[BladeburnerSkillName.Hyperdrive];
 
@@ -36,42 +37,42 @@ describe("Bladeburner Skill", () => {
   // test for NaN. Add those tests if that changes.
   describe("calculateCost", () => {
     it("MAX_VALUE arg 1", () => {
-      const result = hyperdrive.calculateCost(Number.MAX_VALUE, 1 as PositiveNumber);
+      const result = hyperdrive.calculateCost(Number.MAX_VALUE, 1 as PositiveInteger);
       expect(result).toBe(0);
     });
 
     it("MAX_VALUE arg 2", () => {
-      const result = hyperdrive.calculateCost(0, Number.MAX_VALUE as PositiveNumber);
+      const result = hyperdrive.calculateCost(0, Number.MAX_VALUE as PositiveInteger);
       expect(result).toBe(Infinity);
     });
 
     it("MAX_VALUE arg both", () => {
-      const result = hyperdrive.calculateCost(Number.MAX_VALUE, Number.MAX_VALUE as PositiveNumber);
+      const result = hyperdrive.calculateCost(Number.MAX_VALUE, Number.MAX_VALUE as PositiveInteger);
       expect(result).toBe(Infinity);
     });
 
     it("Inf arg 1", () => {
-      const result = hyperdrive.calculateCost(Infinity, 1 as PositiveNumber);
+      const result = hyperdrive.calculateCost(Infinity, 1 as PositiveInteger);
       expect(result).toBe(Infinity);
     });
 
     it("Inf arg 2", () => {
-      const result = hyperdrive.calculateCost(0, Infinity as PositiveNumber);
+      const result = hyperdrive.calculateCost(0, Infinity as PositiveInteger);
       expect(result).toBe(Infinity);
     });
 
     it("Inf arg both", () => {
-      const result = hyperdrive.calculateCost(Infinity, Infinity as PositiveNumber);
+      const result = hyperdrive.calculateCost(Infinity, Infinity as PositiveInteger);
       expect(result).toBe(Infinity);
     });
 
     it("Last possible upgrade", () => {
       const level = 2 ** 537 * 1.6 - 2 ** 486;
-      let result = hyperdrive.calculateCost(level, (2 ** 485) as PositiveNumber);
+      let result = hyperdrive.calculateCost(level, (2 ** 485) as PositiveInteger);
       expect(result).toBe(Number.MAX_VALUE);
 
       // Can't upgrade again
-      result = hyperdrive.calculateCost(level + 2 ** 485, (2 ** 485) as PositiveNumber);
+      result = hyperdrive.calculateCost(level + 2 ** 485, (2 ** 485) as PositiveInteger);
       expect(result).toBe(Infinity);
 
       // Can't add a smaller increment
@@ -118,6 +119,33 @@ describe("Bladeburner Skill", () => {
     it("MAX_VALUE arg both", () => {
       const result = hyperdrive.calculateMaxUpgradeCount(Number.MAX_VALUE, Number.MAX_VALUE as PositiveNumber);
       expect(result).toBe(0);
+    });
+
+    it("infinite loop in downward search", () => {
+      const testSkill = new Skill({
+        name: BladeburnerSkillName.Cloak,
+        desc: "test",
+        baseCost: 0,
+        costInc: 0,
+        mults: {},
+      });
+      expect(() => testSkill.calculateMaxUpgradeCount(1, 1 as PositiveNumber)).toThrow();
+    });
+
+    it("mult < 1", () => {
+      const testSkill = new Skill({
+        name: BladeburnerSkillName.Cloak,
+        desc: "test",
+        baseCost: 10,
+        costInc: 1,
+        mults: {},
+      });
+      currentNodeMults.BladeburnerSkillCost = 0.5;
+      try {
+        expect(testSkill.calculateMaxUpgradeCount(0, 6 as PositiveNumber)).toBe(1);
+      } finally {
+        currentNodeMults.BladeburnerSkillCost = 1;
+      }
     });
 
     it("Example that tests a rounding edge case", () => {
@@ -185,7 +213,7 @@ describe("Bladeburner Skill", () => {
         let amount = v2 * v2mul * v1mul;
         // amount might not be properly rounded due to collectively crossing a 2**x precision boundary.
         amount = level + amount - level;
-        const cost = hyperdrive.calculateCost(level, amount as PositiveNumber);
+        const cost = hyperdrive.calculateCost(level, amount as PositiveInteger);
         // Rejection-sample: Simply try again if these parameters are out-of-bounds. Most of them are in-bounds.
         if (!Number.isFinite(cost)) continue;
         // If this test ever hits an infinite loop, console.log'ing won't help because jest does stuff to it.
@@ -202,7 +230,7 @@ describe("Bladeburner Skill", () => {
             nextafter(amount, Number.POSITIVE_INFINITY),
             nextafter(level + amount, Number.POSITIVE_INFINITY) - level,
           );
-          if (hyperdrive.calculateCost(level, nextAmount as PositiveNumber) > cost) {
+          if (hyperdrive.calculateCost(level, nextAmount as PositiveInteger) > cost) {
             break;
           }
           amount = nextAmount;

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -159,6 +159,10 @@ describe("Bladeburner Skill", () => {
       expect(result).toBe(0);
     });
 
+    // This test chooses random values to generate a cost via calculateCost, and then tests that
+    // calculateMaxUpgradeCount matches it for the chosen parameters and finds a smaller value when given slightly less
+    // cost. Even for such a straightforward-sounding test, there are a lot of complexities involved in choosing correct
+    // values, due to floating-point issues.
     it("test random values", () => {
       // Basic tests of our helper
       expect(getValue(0, 0)).toStrictEqual([0, 1]);
@@ -167,24 +171,48 @@ describe("Bladeburner Skill", () => {
       expect(getValue(0, 0x8000_0000)).toStrictEqual([2 ** 52, 2]);
 
       const typed = new Uint32Array(4);
-      // When the implementation was insufficient, 1000 iterations was enough to guarantee a failure.
-      for (let i = 0; i < 10000; ) {
+      // When the implementation was insufficient or the test itself had problems,
+      // 1000 iterations was enough to practically guarantee a failure or infinite loop.
+      // 5000 runs very quickly, so we select that for safety.
+      for (let i = 0; i < 5000; ) {
         // We don't need secure values, we just want a guaranteed number of random bits.
         // (Math.random has no guarantees for how much randomness it provides.)
         crypto.getRandomValues(typed);
         const [v1, v1mul] = getValue(typed[0], typed[1]);
-        const [v2, v2mul] = getValue(typed[0], typed[1]);
+        const [v2, v2mul] = getValue(typed[2], typed[3]);
         const level = v1 * v1mul;
         // This is also scaled by v1mul because otherwise amount would round to 0.
-        const amount = v2 * v2mul * v1mul;
+        let amount = v2 * v2mul * v1mul;
+        // amount might not be properly rounded due to collectively crossing a 2**x precision boundary.
+        amount = level + amount - level;
         const cost = hyperdrive.calculateCost(level, amount as PositiveNumber);
+        // Rejection-sample: Simply try again if these parameters are out-of-bounds. Most of them are in-bounds.
         if (!Number.isFinite(cost)) continue;
+        // If this test ever hits an infinite loop, console.log'ing won't help because jest does stuff to it.
+        // In that case, uncomment this line to find the problematic parameters.
+        // process.stderr.write(`With parameters {level:${level}, cost:${cost}, amount:${amount}}\n`);
+
+        // We have to advance to the *biggest* amount.
+        while (true) {
+          // The middle term seems spurious here. However, when amount and level are both large enough that the gap is
+          // larger than 1, and amount >> level, and level is exactly halfway between two representable amounts, we can
+          // get a situation where the last term returns amount again due to ties-to-even rounding.
+          const nextAmount = Math.max(amount + 1, nextafter(amount, Number.POSITIVE_INFINITY), nextafter(level + amount, Number.POSITIVE_INFINITY) - level);
+          if (hyperdrive.calculateCost(level, nextAmount as PositiveNumber) > cost) {
+            break;
+          }
+          amount = nextAmount;
+        }
         const prevCost = Math.min(cost - 1, nextafter(cost, 0));
-        // Because the parameters to this test are random, it is possible for this test to be flaky on one of
+        // Because the parameters to this test are random, it is conceivable for this test to be flaky on one of
         // these next two lines. However, any failures here are *real*, and the test log should have enough
         // info to reliably reproduce the issue (call it with the same params) and thus fix it.
-        expect(hyperdrive.calculateMaxUpgradeCount(level, cost as PositiveNumber)).toBe(amount);
-        expect(hyperdrive.calculateMaxUpgradeCount(level, prevCost as PositiveNumber)).toBeLessThan(amount);
+        try {
+          expect(hyperdrive.calculateMaxUpgradeCount(level, cost as PositiveNumber)).toBe(amount);
+          expect(hyperdrive.calculateMaxUpgradeCount(level, prevCost as PositiveNumber)).toBeLessThan(amount);
+        } catch (e) {
+          throw new Error(`With parameters {level:${level}, cost:${cost}, prevCost:${prevCost}, amount:${amount}}`, {cause: e});
+        }
         i++; // Not in the loop body so we can rejection-sample
       }
     });

--- a/test/jest/Bladeburner/Skill.test.ts
+++ b/test/jest/Bladeburner/Skill.test.ts
@@ -176,6 +176,32 @@ describe("Bladeburner Skill", () => {
       }
     });
 
+    // This uses numbers that are technically valid, but would never be encountered in the game.
+    // These leads to divide-by-zero in a previous revision of the algorithm that fixed the previous test.
+    it("divide-by-zero edge-case 2", () => {
+      const testSkill = new Skill({
+        name: BladeburnerSkillName.Cloak,
+        desc: "test",
+        baseCost: 1,
+        costInc: 1e50,
+        mults: {},
+      });
+      expect(testSkill.calculateMaxUpgradeCount(0, 1 as PositiveNumber)).toBe(1);
+    });
+
+    // Rounding out the m ~= 0 edge-cases.
+    // This tests that the final estimate is close enough to quickly get to the correct answer.
+    it("divide-by-zero edge-case 3", () => {
+      const testSkill = new Skill({
+        name: BladeburnerSkillName.Cloak,
+        desc: "test",
+        baseCost: 1,
+        costInc: 2,
+        mults: {},
+      });
+      expect(testSkill.calculateMaxUpgradeCount(0, 1e20 as PositiveNumber)).toBe(1e10);
+    });
+
     it("mult < 1", () => {
       const testSkill = new Skill({
         name: BladeburnerSkillName.Cloak,
@@ -203,6 +229,12 @@ describe("Bladeburner Skill", () => {
       });
       const result = testSkill.calculateMaxUpgradeCount(2048, 2.049e32 as PositiveNumber);
       expect(result).toBe(20243517480910200);
+    });
+
+    it("Example that tests a rounding edge case 2", () => {
+      // This example was gleaned from the random tests. The estimate starts two steps below the correct value.
+      const result = hyperdrive.calculateMaxUpgradeCount(1501603967766474, 9.587200318209743e31 as PositiveNumber);
+      expect(result).toBe(8885517262472117 - 1501603967766474);
     });
 
     // At level 1e18, the smallest gap between numbers is 128. The cost of

--- a/test/jest/NextAfter.test.ts
+++ b/test/jest/NextAfter.test.ts
@@ -1,0 +1,41 @@
+import { nextafter } from "../../src/utils/NextAfter";
+
+function zero_pad(x: string) {
+  return "0".repeat(8 - x.length) + x;
+}
+
+// Because we are dealing with specific binary values, the data is specified
+// as hex strings.
+test.each([
+  ["0000000000000000", "0000000000000000", "0000000000000000"], // 0, 0 -> 0
+  ["8000000000000000", "0000000000000000", "0000000000000000"], // -0, 0 -> 0
+  ["0000000000000000", "8000000000000000", "8000000000000000"], // 0, -0 -> -0
+  ["8000000000000000", "8000000000000000", "8000000000000000"], // -0, -0 -> -0
+  ["fff0000000000001", "3ff0000000000000", "fff0000000000001"], // NaN, 1 -> NaN
+  ["4000000000000000", "7ff0000000000002", "7ff0000000000002"], // 2, NaN -> NaN
+  ["7ff0000000000003", "fff0000000000004", "7ff0000000000003"], // NaN, NaN -> NaN
+  ["7ff0000000000000", "7ff0000000000000", "7ff0000000000000"], // inf, inf -> inf
+  ["fff0000000000000", "fff0000000000000", "fff0000000000000"], // -inf, -inf -> -inf
+  ["fff0000000000000", "7ff0000000000000", "ffefffffffffffff"], // -inf, inf -> -Big
+  ["7ff0000000000000", "fff0000000000000", "7fefffffffffffff"], // inf, -inf -> Big
+  ["0000000000000000", "7ff0000000000000", "0000000000000001"], // 0, inf -> Small
+  ["8000000000000000", "7ff0000000000000", "0000000000000001"], // -0, inf -> Small
+  ["0000000000000000", "fff0000000000000", "8000000000000001"], // 0, -inf -> -Small
+  ["8000000000000000", "fff0000000000000", "8000000000000001"], // -0, -inf -> -Small
+  ["3fefffffffffffff", "3ff0000000000000", "3ff0000000000000"], // .999_, 1 -> 1
+  ["3fefffffffffffff", "bff0000000000000", "3feffffffffffffe"], // .999_, -1 -> .999__
+  ["bfefffffffffffff", "3ff0000000000000", "bfeffffffffffffe"], // -.999_, 1 -> -.999__
+  ["bfefffffffffffff", "bff0000000000000", "bff0000000000000"], // -.999_, -1 -> -1
+])("nextafter test(%s, %s)", (x, y, expected) => {
+  // Endianness: We write numbers big-endian, but they are stored little-endian.
+  const u32 = Uint32Array.of(
+    parseInt(x.slice(8), 16),
+    parseInt(x.slice(0, 8), 16),
+    parseInt(y.slice(8), 16),
+    parseInt(y.slice(0, 8), 16),
+  );
+  const f64 = new Float64Array(u32.buffer);
+  f64[0] = nextafter(f64[0], f64[1]);
+  const result = zero_pad(u32[1].toString(16)) + zero_pad(u32[0].toString(16));
+  expect(result).toBe(expected);
+});


### PR DESCRIPTION
This bug has been lingering a long time. A proper fix required the ability to find the next greater/smaller floating-point number. Fixes: #1693

I also changed the format on the big comment block away from LaTeX, for better readability. LaTeX is readable-enough for formulas that will be rendered, but comments don't get rendered.

The tests pass. I didn't do any manual testing.