### PR TITLE
DNET: Check darknet API access for all dnet methods

### DIFF
--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -500,7 +500,6 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
     },
     isDarknetServer: (ctx) => (_host) => {
       const targetHost = helpers.string(ctx, "host", _host ?? ctx.workerScript.hostname);
-      expectDarknetAccess(ctx);
       const server = GetServer(targetHost);
       if (!server) {
         return false;

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -315,6 +315,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
       (ctx: NetscriptContext) =>
       (_returnByIp): string[] => {
         const returnByIP = helpers.boolean(ctx, "returnByIP", _returnByIp ?? false);
+        expectDarknetAccess(ctx);
         const server = ctx.workerScript.getServer();
         const out = [];
         for (const neighbor of server.serversOnNetwork) {
@@ -366,6 +367,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
           .then(() => setStasisLink(ctx, server, shouldLink));
       },
     getStasisLinkLimit: (ctx: NetscriptContext) => (): number => {
+      expectDarknetAccess(ctx);
       const limit = getStasisLinkLimit();
       logger(ctx)(`Stasis link limit: ${limit}`);
       return limit;
@@ -374,6 +376,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
       (ctx: NetscriptContext) =>
       (_returnByIP): string[] => {
         const returnByIp = helpers.boolean(ctx, "returnByIP", _returnByIP ?? false);
+        expectDarknetAccess(ctx);
         const servers = getStasisLinkServers();
         const serverNames = servers.map((s) => (returnByIp ? s.ip : s.hostname));
         logger(ctx)(`Stasis linked servers: ${serverNames}`);
@@ -497,6 +500,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
     },
     isDarknetServer: (ctx) => (_host) => {
       const targetHost = helpers.string(ctx, "host", _host ?? ctx.workerScript.hostname);
+      expectDarknetAccess(ctx);
       const server = GetServer(targetHost);
       if (!server) {
         return false;


### PR DESCRIPTION
This PR adds a check to ensure that players have the DarknetNavigator.exe to the remaining dnet namespace methods that did not yet have such a check.

Closes #2908