### PR TITLE
DOCS: Enhance bladeburner docs and use in-game flavor for bladeburner ops

### DIFF
--- a/src/Bladeburner/data/BlackOperations.ts
+++ b/src/Bladeburner/data/BlackOperations.ts
@@ -349,7 +349,7 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
         `${BladeburnerBlackOpName.OperationK}, we've discovered that a small group of MK-VI Synthoids were able to make off with ` +
         "the schematics and design of the technology before the operation. It is almost a certainty that these Synthoids " +
         "are some of the rogue MK-VI ones from the Synthoid Uprising.\n\n" +
-        `The goal of ${BladeburnerBlackOpName.OperationDeckard} is to hunt down these Synthoids and retire them. I don't need to ` +
+        `The goal of ${BladeburnerBlackOpName.OperationDeckard} is to hunt down these Synthoids and retire them. We don't need to ` +
         "tell you how critical this mission is.",
     }),
     [BladeburnerBlackOpName.OperationTyrell]: new BlackOperation({
@@ -452,8 +452,8 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       },
       isStealth: true,
       desc:
-        "China's Solaris Space Systems is secretly launching the first manned spacecraft in over a decade using " +
-        "Synthoids. We believe China is trying to establish the first off-world colonies.\n\n" +
+        `${CityName.Chongqing}'s Solaris Space Systems is secretly launching the first manned spacecraft in over a decade using ` +
+        `Synthoids. We believe ${CityName.Chongqing} is trying to establish the first off-world colonies.\n\n` +
         "The mission is to prevent this launch without instigating an international conflict. When you accept this " +
         "mission, you will be officially disavowed by the NSA and the national government until after you successfully " +
         "return. In the event of failure, all of the operation's team members must not let themselves be captured alive.",

--- a/src/Bladeburner/data/BlackOperations.ts
+++ b/src/Bladeburner/data/BlackOperations.ts
@@ -1,6 +1,6 @@
 import { assertLoadingType } from "../../utils/TypeAssertion";
 import { BlackOperation } from "../Actions/BlackOperation";
-import { BladeburnerBlackOpName, CityName, FactionName } from "@enums";
+import { BladeburnerBlackOpName, CityName, FactionName, LocationName } from "@enums";
 
 export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOperation> {
   return {
@@ -67,9 +67,9 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       desc:
         "AeroCorp is one of the world's largest defense contractors. Its leader, Steve Watataki, is thought to be " +
         "a supporter of Synthoid rights. He must be removed.\n\n" +
-        `The goal of ${BladeburnerBlackOpName.OperationZero} is to covertly infiltrate AeroCorp and uncover any incriminating ` +
-        "evidence or information against Watataki that will cause him to be removed from his position at AeroCorp. " +
-        "Incriminating evidence can be fabricated as a last resort. Be warned that AeroCorp has some of the most advanced " +
+        `The goal of ${BladeburnerBlackOpName.OperationZero} is to covertly infiltrate ${LocationName.AevumAeroCorp} and uncover any incriminating ` +
+        `evidence or information against Watataki that will cause him to be removed from his position at ${LocationName.AevumAeroCorp}. ` +
+        `Incriminating evidence can be fabricated as a last resort. Be warned that ${LocationName.AevumAeroCorp} has some of the most advanced ` +
         "security measures in the world.",
     }),
     [BladeburnerBlackOpName.OperationX]: new BlackOperation({
@@ -136,9 +136,9 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       },
       isKill: true,
       desc:
-        "Several months ago, Titan Laboratories' Bioengineering department was infiltrated by Synthoids. As far as we " +
-        "know, Titan Laboratories' management has no knowledge about this. We don't know what the Synthoids are up to, " +
-        "but the research that they could be conducting using Titan Laboratories' vast resources is potentially very " +
+        `Several months ago,${LocationName.AevumNetLinkTechnologies}' Bioengineering department was infiltrated by Synthoids. As far as we ` +
+        `know, ${LocationName.AevumNetLinkTechnologies}' management has no knowledge about this. We don't know what the Synthoids are up to, ` +
+        `but the research that they could be conducting using ${LocationName.AevumNetLinkTechnologies}' vast resources is potentially very ` +
         "dangerous.\n\n" +
         `Your goal is to enter and destroy the Bioengineering department's facility in ${CityName.Aevum}. The task is not ` +
         "just to retire the Synthoids there, but also to destroy any information or research at the facility that is " +
@@ -241,7 +241,7 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       desc:
         "The CIA has just encountered a new security threat. A new criminal group, led by a shadowy operative who calls " +
         "himself Juggernaut, has been smuggling drugs and weapons (including suspected bioweapons) into " +
-        `${CityName.Sector12}. We also have reason to believe they tried to break into one of Universal Energy's ` +
+        `${CityName.Sector12}. We also have reason to believe they tried to break into one of ${LocationName.Sector12UniversalEnergy}'s ` +
         "facilities in order to cause a city-wide blackout. The CIA suspects that Juggernaut is a heavily augmented " +
         "Synthoid and has thus enlisted our help.\n\n" +
         "Your mission is to eradicate Juggernaut and his followers.",
@@ -308,9 +308,9 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       },
       isKill: true,
       desc:
-        "CODE RED SITUATION. Our intelligence tells us that VitaLife has discovered a new android cloning technology. " +
+        `CODE RED SITUATION. Our intelligence tells us that ${LocationName.NewTokyoVitaLife} has discovered a new android cloning technology. ` +
         "This technology is supposedly capable of cloning Synthoids, not only physically but also their advanced AI " +
-        "modules. We do not believe that VitaLife is trying to use this technology illegally or maliciously, but if any " +
+        `modules. We do not believe that ${LocationName.NewTokyoVitaLife} is trying to use this technology illegally or maliciously, but if any ` +
         "Synthoids were able to infiltrate the corporation and take advantage of this technology, then the results would " +
         "be catastrophic.\n\n" +
         "We do not have the power or jurisdiction to shut this down through legal or political means, so we must resort " +
@@ -452,7 +452,7 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       },
       isStealth: true,
       desc:
-        `${CityName.Chongqing}'s Solaris Space Systems is secretly launching the first manned spacecraft in over a decade using ` +
+        `${CityName.Chongqing}'s ${LocationName.ChongqingSolarisSpaceSystems} is secretly launching the first manned spacecraft in over a decade using ` +
         `Synthoids. We believe ${CityName.Chongqing} is trying to establish the first off-world colonies.\n\n` +
         "The mission is to prevent this launch without instigating an international conflict. When you accept this " +
         "mission, you will be officially disavowed by the NSA and the national government until after you successfully " +

--- a/src/Bladeburner/data/BlackOperations.ts
+++ b/src/Bladeburner/data/BlackOperations.ts
@@ -172,8 +172,8 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       },
       isKill: true,
       desc:
-        "One of our undercover agents, Agent Carter, has informed us of a massive weapons deal going down in Dubai " +
-        "between rogue Russian militants and a radical Synthoid community. These weapons are next-gen plasma and energy " +
+        `One of our undercover agents, Agent Carter, has informed us of a massive weapons deal going down in ${CityName.Volhaven} ` +
+        "between rogue local militants and a radical Synthoid community. These weapons are next-gen plasma and energy " +
         "weapons. It is critical for the safety of humanity that this deal does not happen.\n\n" +
         "Your task is to intercept the deal. Leave no survivors.",
     }),
@@ -205,7 +205,7 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
       },
       isKill: true,
       desc:
-        "Our analysts have discovered that the popular Red Rabbit brothel in Amsterdam is run and 'staffed' by MK-VI " +
+        `Our analysts have discovered that the popular Red Rabbit brothel in ${CityName.Chongqing} is run and 'staffed' by MK-VI ` +
         "Synthoids. Intelligence suggests that the profit from this brothel is used to fund a large black market arms " +
         "trafficking operation.\n\n" +
         "The goal of this operation is to take out the leaders that are running the Red Rabbit brothel. Try to limit the " +
@@ -277,7 +277,7 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
         `The ${FactionName.Tetrads} criminal organization is suspected of reverse-engineering the MK-VI Synthoid design. ` +
         "We believe they altered and possibly improved the design and began manufacturing their own Synthoid models in " +
         "order to bolster their criminal activities.\n\n" +
-        `Your task is to infiltrate and destroy the ${FactionName.Tetrads}' base of operations in Los Angeles. ` +
+        `Your task is to infiltrate and destroy the ${FactionName.Tetrads}' base of operations in ${CityName.NewTokyo}. ` +
         "Intelligence tells us that their base houses one of their Synthoid manufacturing units.",
     }),
     [BladeburnerBlackOpName.OperationK]: new BlackOperation({
@@ -490,7 +490,7 @@ export function createBlackOperations(): Record<BladeburnerBlackOpName, BlackOpe
         "using human brains as core processors. This supercomputer is rumored to be able to store vast amounts of data " +
         "and perform computations unmatched by any other supercomputer on the planet. But more importantly, the use of " +
         "organic human brains means that the supercomputer may be able to reason abstractly and become self-aware.\n\n" +
-        "I do not need to remind you why sentient-level AIs pose a serious threat to all of mankind.\n\n" +
+        "We do not need to remind you why sentient-level AIs pose a serious threat to all of mankind.\n\n" +
         `The research for this project is being conducted at one of ${FactionName.FulcrumSecretTechnologies} secret ` +
         `facilities in ${CityName.Aevum}, codenamed 'Alpha Ranch'. Infiltrate the compound, delete and destroy the work, ` +
         "and then find and kill the project lead.",

--- a/src/Documentation/doc/en/advanced/bladeburners.md
+++ b/src/Documentation/doc/en/advanced/bladeburners.md
@@ -10,6 +10,34 @@ Designed to improve a human agent's capabilities beyond their natural limits, Bl
 
 Bladeburners also offer unique [Augmentations](../basic/augmentations.md) and a [Faction](factions.md) invite to agents who "put in the work" to gain a small amount of rank. While Bladeburner rank and skill points persist after any augmentation installs, faction reputation will be reset. Bladeburner faction reputation can only be gained through Bladeburner actions.
 
+## Team members
+You can recruit team members via the "Recruitment" action in the General tab. [Sleeves](../advanced/sleeves.md) can also do this action.
+The more team members you have, the more difficult it will be to complete the task successfully. Team members increase your success chance in Operations and
+BlackOps, but they will also die no matter if you fail or succeed in the task.
+
 ## Distribution
+
 ### General
-Here you will find all you need to start earning money, reputation and rank. 
+Here you will find basic activities that can improve your stats and gain you rank. From here, you can recruit members, train, recover HP and take
+some minor contracts to gain rank. You should train your stats first before attempting any of the other activities.
+
+## Contracts
+Contracts are a basic way to increase your rank and gain money. Contracts will level up as you succeed and make you loose HP if you fail them.
+The higher the level, the more rank, experience and money you will gain, but the difficulty will also increase. [Sleeves](../advanced/sleeves.md) can also take
+contracts.
+
+## Operations
+Operations are harder and more punishing than contracts, but are also more rewarding. Failing an Operation will have the same effects but on a higher scale as failing a contract, but it will also reduce your rank. Similarly, succeeding an Operation will earn you more rank and more experience than Contracts. Operations do not earn money.
+For Operations you may use a team. See the team section above for more detailed information.
+
+## Black Operations
+Black Operations (BlackOps) are special, one-time covert operations. Each BlackOp must be unlocked successively by completing the one before it.
+Failing a BlackOp will incur heavy HP and rank losses.
+**You must complete all BlackOps in order to destroy the World Daemon.**
+
+## Skills
+Here you can purchase upgrades for bladeburner actions. You will gain one skill point every 3 ranks, and those can be spent on different skills.
+Skills can improve your chances of success, the rewards, reduce the necessary time to complete tasks... Each individual skill can be leveled up
+infinitely, except the "Overclock" skill which can only be upgraded to level 90. However, each skill will become more expensive as you level them up.
+The effects of each upgrade on a skill is additive, however the effects of different skills with each other is multiplicative.
+It is recommended that you create a script to automate the process of spending skill points, as you're gonna earn them fast and in large quantities.

--- a/src/Documentation/doc/en/advanced/bladeburners.md
+++ b/src/Documentation/doc/en/advanced/bladeburners.md
@@ -4,7 +4,7 @@ Bladeburner divisions were created internationally in the mid-21st century. Task
 
 ## Bladeburner Skills:
 
-Designed to improve a human agent's capabilities beyond their natural limits, Bladeburner skills add a persistent bonus while in the [BitNode](bitnodes.md) where they were purchased. Bladeburner skills are purchased with Bladeburner skill points, not money. There is no limit on the skills level, except for the "Overclock" which can only reach level 90. Each individual skill will become more expensive as you level it up. Each skill level is additive, however different skills' effects are multiplicative.
+Designed to improve a human agent's capabilities beyond their natural limits, Bladeburner skills add a persistent bonus while in the [BitNode](bitnodes.md) where they were purchased. Bladeburner skills are purchased with Bladeburner skill points, not money. There is no limit on the skills level, except for "Overclock" which can only reach level 90. Each individual skill will become more expensive as you level it up. Each skill level is additive, however different skills' effects are multiplicative.
 
 ## Faction and Rank:
 

--- a/src/Documentation/doc/en/advanced/bladeburners.md
+++ b/src/Documentation/doc/en/advanced/bladeburners.md
@@ -4,16 +4,16 @@ Bladeburner divisions were created internationally in the mid-21st century. Task
 
 ## Bladeburner Skills:
 
-Designed to improve a human agent's capabilities beyond their natural limits, Bladeburner skills add a persistent bonus while in the [BitNode](bitnodes.md) where they were purchased. Bladeburner skills are purchased with Bladeburner skill points, not money.
+Designed to improve a human agent's capabilities beyond their natural limits, Bladeburner skills add a persistent bonus while in the [BitNode](bitnodes.md) where they were purchased. Bladeburner skills are purchased with Bladeburner skill points, not money. There is no limit on the skills level, except for the "Overclock" which can only reach level 90. Each individual skill will become more expensive as you level it up. Each skill level is additive, however different skills' effects are multiplicative.
 
 ## Faction and Rank:
 
 Bladeburners also offer unique [Augmentations](../basic/augmentations.md) and a [Faction](factions.md) invite to agents who "put in the work" to gain a small amount of rank. While Bladeburner rank and skill points persist after any augmentation installs, faction reputation will be reset. Bladeburner faction reputation can only be gained through Bladeburner actions.
 
 ## Team members
-You can recruit team members via the "Recruitment" action in the General tab. [Sleeves](../advanced/sleeves.md) can also do this action.
-The more team members you have, the more difficult it will be to complete the task successfully. Team members increase your success chance in Operations and
-BlackOps, but they will also die no matter if you fail or succeed in the task.
+You can recruit team members via the "Recruitment" action in the General tab. [Sleeves](../advanced/sleeves.md) can also perform this action.
+The more team members you have, the more easy it will be to complete the task successfully. Team members increase your success chance in Operations and
+BlackOps, but they will also die no matter if you fail or succeed in the task. Note that, the more team members you have, the more difficult it is to recruit them.
 
 ## Distribution
 
@@ -21,23 +21,20 @@ BlackOps, but they will also die no matter if you fail or succeed in the task.
 Here you will find basic activities that can improve your stats and gain you rank. From here, you can recruit members, train, recover HP and take
 some minor contracts to gain rank. You should train your stats first before attempting any of the other activities.
 
-## Contracts
+### Contracts
 Contracts are a basic way to increase your rank and gain money. Contracts will level up as you succeed and make you loose HP if you fail them.
 The higher the level, the more rank, experience and money you will gain, but the difficulty will also increase. [Sleeves](../advanced/sleeves.md) can also take
 contracts.
 
-## Operations
+### Operations
 Operations are harder and more punishing than contracts, but are also more rewarding. Failing an Operation will have the same effects but on a higher scale as failing a contract, but it will also reduce your rank. Similarly, succeeding an Operation will earn you more rank and more experience than Contracts. Operations do not earn money.
 For Operations you may use a team. See the team section above for more detailed information.
 
-## Black Operations
+### Black Operations
 Black Operations (BlackOps) are special, one-time covert operations. Each BlackOp must be unlocked successively by completing the one before it.
 Failing a BlackOp will incur heavy HP and rank losses.
-**You must complete all BlackOps in order to destroy the World Daemon.**
 
-## Skills
-Here you can purchase upgrades for bladeburner actions. You will gain one skill point every 3 ranks, and those can be spent on different skills.
-Skills can improve your chances of success, the rewards, reduce the necessary time to complete tasks... Each individual skill can be leveled up
-infinitely, except the "Overclock" skill which can only be upgraded to level 90. However, each skill will become more expensive as you level them up.
-The effects of each upgrade on a skill is additive, however the effects of different skills with each other is multiplicative.
-It is recommended that you create a script to automate the process of spending skill points, as you're gonna earn them fast and in large quantities.
+**You must complete all the BlackOps in order to destroy the World Daemon.**
+
+## Sleeves and Bladeburner
+[Sleeves](../advanced/sleeves.md) can perform various bladeburner actions. They are able to do all the "General" tab actions, Infiltrate Synthoids (generate more contracts and operations), support the main sleeve (bonus to your bladeburner work) and take on contracts (as if it were you).

--- a/src/Documentation/doc/en/advanced/bladeburners.md
+++ b/src/Documentation/doc/en/advanced/bladeburners.md
@@ -13,7 +13,7 @@ Bladeburners also offer unique [Augmentations](../basic/augmentations.md) and a 
 ## Team members
 
 You can recruit team members via the "Recruitment" action in the General tab. [Sleeves](../advanced/sleeves.md) can also perform this action.
-The more team members you have, the more easy it will be to complete the task successfully. Team members increase your success chance in Operations and
+The more team members you have, the easier it will be to complete the task successfully. Team members increase your success chance in Operations and
 BlackOps, but they will also die no matter if you fail or succeed in the task. Note that, the more team members you have, the more difficult it is to recruit them.
 
 ## Distribution

--- a/src/Documentation/doc/en/advanced/bladeburners.md
+++ b/src/Documentation/doc/en/advanced/bladeburners.md
@@ -9,3 +9,7 @@ Designed to improve a human agent's capabilities beyond their natural limits, Bl
 ## Faction and Rank:
 
 Bladeburners also offer unique [Augmentations](../basic/augmentations.md) and a [Faction](factions.md) invite to agents who "put in the work" to gain a small amount of rank. While Bladeburner rank and skill points persist after any augmentation installs, faction reputation will be reset. Bladeburner faction reputation can only be gained through Bladeburner actions.
+
+## Distribution
+### General
+Here you will find all you need to start earning money, reputation and rank. 

--- a/src/Documentation/doc/en/advanced/bladeburners.md
+++ b/src/Documentation/doc/en/advanced/bladeburners.md
@@ -25,7 +25,7 @@ some minor contracts to gain rank. You should train your stats first before atte
 
 ### Contracts
 
-Contracts are a basic way to increase your rank and gain money. Contracts will level up as you succeed and make you loose HP if you fail them.
+Contracts are a basic way to increase your rank and gain money. Contracts will level up as you succeed and make you lose HP if you fail them.
 The higher the level, the more rank, experience and money you will gain, but the difficulty will also increase. [Sleeves](../advanced/sleeves.md) can also take
 contracts.
 

--- a/src/Documentation/doc/en/advanced/bladeburners.md
+++ b/src/Documentation/doc/en/advanced/bladeburners.md
@@ -11,6 +11,7 @@ Designed to improve a human agent's capabilities beyond their natural limits, Bl
 Bladeburners also offer unique [Augmentations](../basic/augmentations.md) and a [Faction](factions.md) invite to agents who "put in the work" to gain a small amount of rank. While Bladeburner rank and skill points persist after any augmentation installs, faction reputation will be reset. Bladeburner faction reputation can only be gained through Bladeburner actions.
 
 ## Team members
+
 You can recruit team members via the "Recruitment" action in the General tab. [Sleeves](../advanced/sleeves.md) can also perform this action.
 The more team members you have, the more easy it will be to complete the task successfully. Team members increase your success chance in Operations and
 BlackOps, but they will also die no matter if you fail or succeed in the task. Note that, the more team members you have, the more difficult it is to recruit them.
@@ -18,23 +19,28 @@ BlackOps, but they will also die no matter if you fail or succeed in the task. N
 ## Distribution
 
 ### General
+
 Here you will find basic activities that can improve your stats and gain you rank. From here, you can recruit members, train, recover HP and take
 some minor contracts to gain rank. You should train your stats first before attempting any of the other activities.
 
 ### Contracts
+
 Contracts are a basic way to increase your rank and gain money. Contracts will level up as you succeed and make you loose HP if you fail them.
 The higher the level, the more rank, experience and money you will gain, but the difficulty will also increase. [Sleeves](../advanced/sleeves.md) can also take
 contracts.
 
 ### Operations
+
 Operations are harder and more punishing than contracts, but are also more rewarding. Failing an Operation will have the same effects but on a higher scale as failing a contract, but it will also reduce your rank. Similarly, succeeding an Operation will earn you more rank and more experience than Contracts. Operations do not earn money.
 For Operations you may use a team. See the team section above for more detailed information.
 
 ### Black Operations
+
 Black Operations (BlackOps) are special, one-time covert operations. Each BlackOp must be unlocked successively by completing the one before it.
 Failing a BlackOp will incur heavy HP and rank losses.
 
 **You must complete all the BlackOps in order to destroy the World Daemon.**
 
 ## Sleeves and Bladeburner
+
 [Sleeves](../advanced/sleeves.md) can perform various bladeburner actions. They are able to do all the "General" tab actions, Infiltrate Synthoids (generate more contracts and operations), support the main sleeve (bonus to your bladeburner work) and take on contracts (as if it were you).


### PR DESCRIPTION
This PR aims to expand Bladeburner documentation by documenting all the main page tabs (General, Contracts, Ops, BlackOps), tean members and sleeve integration within bladeburner.  Most of the text is very similar to the one on the Bladeburner page, but I think it should be on the docs as well.

I would like to add a few more titles, but I'd like your approval before doing so:
- Formulas (add the formulas on each section, e.g. team members' success chance increase)
- Expand the "sleeves and bladeburner" section describing more the "Infiltrate synthoids", "support main sleeve" and "take on contracts" actions
- Basic gameplay sequence (train -> contracts -> ops -> blackops when chance is ~X%...) AND/OR a simple bladeburner script
- Document bladeburner console

I have also updated the `BlackOperations.ts`'s blackops description field to use `LocationName` for in-game locations and replaced non-game countries (e.g China, russia...) to use in-game cities