### PR TITLE
UI: Disable docs home button if already on home

### DIFF
--- a/src/Documentation/ui/DocumentationRoot.tsx
+++ b/src/Documentation/ui/DocumentationRoot.tsx
@@ -85,7 +85,9 @@ export function DocumentationRoot({ docPage }: { docPage?: string }): React.Reac
         <Button onClick={() => history.pop()} disabled={history.pages.length === 0}>
           Back
         </Button>
-        <Button onClick={() => history.home()}>Home</Button>
+        <Button onClick={() => history.home()} disabled={history.pages.length === 0}>
+          Home
+        </Button>
         <DocumentationAutocomplete
           sx={{ marginLeft: "10px" }}
           onChange={(path, external) => {


### PR DESCRIPTION
#2850 disabled the "back" button if history was empty (i.e the page was home). This also disables the "home" for the same reason. Tested manually.