### PR TITLE
DNET: Harden logic around darkweb connections to home to prevent errors

### DIFF
--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -122,7 +122,7 @@ export const clearDarknet = () => {
   }
   const darkwebRoot = GetServer(SpecialServers.DarkWeb);
   if (darkwebRoot) {
-    darkwebRoot.serversOnNetwork = [Player.getHomeComputer().hostname];
+    darkwebRoot.serversOnNetwork = Player.hasTorRouter() ? [Player.getHomeComputer().hostname] : [];
   }
 
   for (const lab of getLabyrinthServerNames()) {

--- a/src/DevMenu/ui/DarknetDev.tsx
+++ b/src/DevMenu/ui/DarknetDev.tsx
@@ -173,6 +173,7 @@ export function DarknetDev(): React.ReactElement {
         </AccordionSummary>
         <AccordionDetails>
           <OptionSwitch
+            disabled={!hasDarknetAccess()}
             checked={DarknetState.showFullNetwork}
             onChange={(newValue) => toggleShowFullNetwork(newValue)}
             text="Show Full Network"

--- a/src/DevMenu/ui/DarknetDev.tsx
+++ b/src/DevMenu/ui/DarknetDev.tsx
@@ -54,6 +54,7 @@ import {
   ServerConfig,
   serverFactory,
 } from "../../DarkNet/controllers/ServerGenerator";
+import { hasDarknetAccess } from "../../DarkNet/utils/darknetAuthUtils";
 
 export function DarknetDev(): React.ReactElement {
   const [open, setOpen] = React.useState(false);
@@ -186,86 +187,90 @@ export function DarknetDev(): React.ReactElement {
               Get {CompletedProgramName.darkscape}
             </Button>
           </Tooltip>
-          <br />
-          <br />
-          <Tooltip title={<Typography>Create a new darkweb network.</Typography>}>
-            <Button
-              onClick={() => {
-                clearDarknet();
-                populateDarknet();
-                SnackbarEvents.emit("New dark network generated", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Generate New Dark Network
-            </Button>
-          </Tooltip>
-          <br />
-          <br />
-          <Tooltip title={<Typography>Reposition the majority of servers in the darknet.</Typography>}>
-            <Button
-              onClick={() => {
-                moveRandomDarknetServers(Math.floor(getAllDarknetServers().length / 2));
-                SnackbarEvents.emit("Darknet servers shuffled", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Shuffle Server Locations
-            </Button>
-          </Tooltip>
-          <br />
-          <br />
-          <Tooltip title={<Typography>Adds a new server of a specific variety.</Typography>}>
-            <Button onClick={() => setOpen(true)}>Add Darknet Servers...</Button>
-          </Tooltip>
-          <br />
-          <br />
-          <Tooltip title={<Typography>Root all standard darknet servers.</Typography>}>
-            <Button
-              onClick={() => {
-                getAllMovableDarknetServers().forEach((server) => {
-                  if (!isLabyrinthServer(server.hostname)) {
-                    handleSuccessfulAuth(server, 1, -1);
-                  }
-                });
-                SnackbarEvents.emit("Gained darknet server admin rights", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Gain admin access to all darknet servers
-            </Button>
-          </Tooltip>
-          <br />
-          <br />
-          <Tooltip title={<Typography>Root all darknet labyrinth servers.</Typography>}>
-            <Button
-              onClick={() => {
-                getAllDarknetServers().forEach((server) => {
-                  if (isLabyrinthServer(server.hostname)) {
-                    server.hasAdminRights = true;
-                  }
-                });
-                SnackbarEvents.emit("Gained lab admin rights", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Gain admin access to labyrinth server
-            </Button>
-          </Tooltip>
-          <br />
-          <br />
-          <Tooltip
-            title={
-              <Typography>
-                Start a violent "webstorm," which will wipe out much of the dark net and replace it.
-              </Typography>
-            }
-          >
-            <Button
-              onClick={() => {
-                void launchWebstorm();
-                Router.toPage(SimplePage.DarkNet);
-              }}
-            >
-              START WEBSTORM
-            </Button>
-          </Tooltip>
+          {hasDarknetAccess() && (
+            <>
+              <br />
+              <br />
+              <Tooltip title={<Typography>Create a new darkweb network.</Typography>}>
+                <Button
+                  onClick={() => {
+                    clearDarknet();
+                    populateDarknet();
+                    SnackbarEvents.emit("New dark network generated", ToastVariant.SUCCESS, 2000);
+                  }}
+                >
+                  Generate New Dark Network
+                </Button>
+              </Tooltip>
+              <br />
+              <br />
+              <Tooltip title={<Typography>Reposition the majority of servers in the darknet.</Typography>}>
+                <Button
+                  onClick={() => {
+                    moveRandomDarknetServers(Math.floor(getAllDarknetServers().length / 2));
+                    SnackbarEvents.emit("Darknet servers shuffled", ToastVariant.SUCCESS, 2000);
+                  }}
+                >
+                  Shuffle Server Locations
+                </Button>
+              </Tooltip>
+              <br />
+              <br />
+              <Tooltip title={<Typography>Adds a new server of a specific variety.</Typography>}>
+                <Button onClick={() => setOpen(true)}>Add Darknet Servers...</Button>
+              </Tooltip>
+              <br />
+              <br />
+              <Tooltip title={<Typography>Root all standard darknet servers.</Typography>}>
+                <Button
+                  onClick={() => {
+                    getAllMovableDarknetServers().forEach((server) => {
+                      if (!isLabyrinthServer(server.hostname)) {
+                        handleSuccessfulAuth(server, 1, -1);
+                      }
+                    });
+                    SnackbarEvents.emit("Gained darknet server admin rights", ToastVariant.SUCCESS, 2000);
+                  }}
+                >
+                  Gain admin access to all darknet servers
+                </Button>
+              </Tooltip>
+              <br />
+              <br />
+              <Tooltip title={<Typography>Root all darknet labyrinth servers.</Typography>}>
+                <Button
+                  onClick={() => {
+                    getAllDarknetServers().forEach((server) => {
+                      if (isLabyrinthServer(server.hostname)) {
+                        server.hasAdminRights = true;
+                      }
+                    });
+                    SnackbarEvents.emit("Gained lab admin rights", ToastVariant.SUCCESS, 2000);
+                  }}
+                >
+                  Gain admin access to labyrinth server
+                </Button>
+              </Tooltip>
+              <br />
+              <br />
+              <Tooltip
+                title={
+                  <Typography>
+                    Start a violent "webstorm," which will wipe out much of the dark net and replace it.
+                  </Typography>
+                }
+              >
+                <Button
+                  onClick={() => {
+                    void launchWebstorm();
+                    Router.toPage(SimplePage.DarkNet);
+                  }}
+                >
+                  START WEBSTORM
+                </Button>
+              </Tooltip>
+            </>
+          )}
         </AccordionDetails>
       </AutoExpandAccordion>
     </>

--- a/src/DevMenu/ui/DarknetDev.tsx
+++ b/src/DevMenu/ui/DarknetDev.tsx
@@ -190,70 +190,80 @@ export function DarknetDev(): React.ReactElement {
           <br />
           <br />
           <Tooltip title={<Typography>Create a new darkweb network.</Typography>}>
-            <Button
-              disabled={!hasDarknetAccess()}
-              onClick={() => {
-                clearDarknet();
-                populateDarknet();
-                SnackbarEvents.emit("New dark network generated", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Generate New Dark Network
-            </Button>
+            <span>
+              <Button
+                disabled={!hasDarknetAccess()}
+                onClick={() => {
+                  clearDarknet();
+                  populateDarknet();
+                  SnackbarEvents.emit("New dark network generated", ToastVariant.SUCCESS, 2000);
+                }}
+              >
+                Generate New Dark Network
+              </Button>
+            </span>
           </Tooltip>
           <br />
           <br />
           <Tooltip title={<Typography>Reposition the majority of servers in the darknet.</Typography>}>
-            <Button
-              disabled={!hasDarknetAccess()}
-              onClick={() => {
-                moveRandomDarknetServers(Math.floor(getAllDarknetServers().length / 2));
-                SnackbarEvents.emit("Darknet servers shuffled", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Shuffle Server Locations
-            </Button>
+            <span>
+              <Button
+                disabled={!hasDarknetAccess()}
+                onClick={() => {
+                  moveRandomDarknetServers(Math.floor(getAllDarknetServers().length / 2));
+                  SnackbarEvents.emit("Darknet servers shuffled", ToastVariant.SUCCESS, 2000);
+                }}
+              >
+                Shuffle Server Locations
+              </Button>
+            </span>
           </Tooltip>
           <br />
           <br />
           <Tooltip title={<Typography>Adds a new server of a specific variety.</Typography>}>
-            <Button disabled={!hasDarknetAccess()} onClick={() => setOpen(true)}>
-              Add Darknet Servers...
-            </Button>
+            <span>
+              <Button disabled={!hasDarknetAccess()} onClick={() => setOpen(true)}>
+                Add Darknet Servers...
+              </Button>
+            </span>
           </Tooltip>
           <br />
           <br />
           <Tooltip title={<Typography>Root all standard darknet servers.</Typography>}>
-            <Button
-              disabled={!hasDarknetAccess()}
-              onClick={() => {
-                getAllMovableDarknetServers().forEach((server) => {
-                  if (!isLabyrinthServer(server.hostname)) {
-                    handleSuccessfulAuth(server, 1, -1);
-                  }
-                });
-                SnackbarEvents.emit("Gained darknet server admin rights", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Gain admin access to all darknet servers
-            </Button>
+            <span>
+              <Button
+                disabled={!hasDarknetAccess()}
+                onClick={() => {
+                  getAllMovableDarknetServers().forEach((server) => {
+                    if (!isLabyrinthServer(server.hostname)) {
+                      handleSuccessfulAuth(server, 1, -1);
+                    }
+                  });
+                  SnackbarEvents.emit("Gained darknet server admin rights", ToastVariant.SUCCESS, 2000);
+                }}
+              >
+                Gain admin access to all darknet servers
+              </Button>
+            </span>
           </Tooltip>
           <br />
           <br />
           <Tooltip title={<Typography>Root all darknet labyrinth servers.</Typography>}>
-            <Button
-              disabled={!hasDarknetAccess()}
-              onClick={() => {
-                getAllDarknetServers().forEach((server) => {
-                  if (isLabyrinthServer(server.hostname)) {
-                    server.hasAdminRights = true;
-                  }
-                });
-                SnackbarEvents.emit("Gained lab admin rights", ToastVariant.SUCCESS, 2000);
-              }}
-            >
-              Gain admin access to labyrinth server
-            </Button>
+            <span>
+              <Button
+                disabled={!hasDarknetAccess()}
+                onClick={() => {
+                  getAllDarknetServers().forEach((server) => {
+                    if (isLabyrinthServer(server.hostname)) {
+                      server.hasAdminRights = true;
+                    }
+                  });
+                  SnackbarEvents.emit("Gained lab admin rights", ToastVariant.SUCCESS, 2000);
+                }}
+              >
+                Gain admin access to labyrinth server
+              </Button>
+            </span>
           </Tooltip>
           <br />
           <br />
@@ -264,15 +274,17 @@ export function DarknetDev(): React.ReactElement {
               </Typography>
             }
           >
-            <Button
-              disabled={!hasDarknetAccess()}
-              onClick={() => {
-                void launchWebstorm();
-                Router.toPage(SimplePage.DarkNet);
-              }}
-            >
-              START WEBSTORM
-            </Button>
+            <span>
+              <Button
+                disabled={!hasDarknetAccess()}
+                onClick={() => {
+                  void launchWebstorm();
+                  Router.toPage(SimplePage.DarkNet);
+                }}
+              >
+                START WEBSTORM
+              </Button>
+            </span>
           </Tooltip>
         </AccordionDetails>
       </AutoExpandAccordion>

--- a/src/DevMenu/ui/DarknetDev.tsx
+++ b/src/DevMenu/ui/DarknetDev.tsx
@@ -187,90 +187,93 @@ export function DarknetDev(): React.ReactElement {
               Get {CompletedProgramName.darkscape}
             </Button>
           </Tooltip>
-          {hasDarknetAccess() && (
-            <>
-              <br />
-              <br />
-              <Tooltip title={<Typography>Create a new darkweb network.</Typography>}>
-                <Button
-                  onClick={() => {
-                    clearDarknet();
-                    populateDarknet();
-                    SnackbarEvents.emit("New dark network generated", ToastVariant.SUCCESS, 2000);
-                  }}
-                >
-                  Generate New Dark Network
-                </Button>
-              </Tooltip>
-              <br />
-              <br />
-              <Tooltip title={<Typography>Reposition the majority of servers in the darknet.</Typography>}>
-                <Button
-                  onClick={() => {
-                    moveRandomDarknetServers(Math.floor(getAllDarknetServers().length / 2));
-                    SnackbarEvents.emit("Darknet servers shuffled", ToastVariant.SUCCESS, 2000);
-                  }}
-                >
-                  Shuffle Server Locations
-                </Button>
-              </Tooltip>
-              <br />
-              <br />
-              <Tooltip title={<Typography>Adds a new server of a specific variety.</Typography>}>
-                <Button onClick={() => setOpen(true)}>Add Darknet Servers...</Button>
-              </Tooltip>
-              <br />
-              <br />
-              <Tooltip title={<Typography>Root all standard darknet servers.</Typography>}>
-                <Button
-                  onClick={() => {
-                    getAllMovableDarknetServers().forEach((server) => {
-                      if (!isLabyrinthServer(server.hostname)) {
-                        handleSuccessfulAuth(server, 1, -1);
-                      }
-                    });
-                    SnackbarEvents.emit("Gained darknet server admin rights", ToastVariant.SUCCESS, 2000);
-                  }}
-                >
-                  Gain admin access to all darknet servers
-                </Button>
-              </Tooltip>
-              <br />
-              <br />
-              <Tooltip title={<Typography>Root all darknet labyrinth servers.</Typography>}>
-                <Button
-                  onClick={() => {
-                    getAllDarknetServers().forEach((server) => {
-                      if (isLabyrinthServer(server.hostname)) {
-                        server.hasAdminRights = true;
-                      }
-                    });
-                    SnackbarEvents.emit("Gained lab admin rights", ToastVariant.SUCCESS, 2000);
-                  }}
-                >
-                  Gain admin access to labyrinth server
-                </Button>
-              </Tooltip>
-              <br />
-              <br />
-              <Tooltip
-                title={
-                  <Typography>
-                    Start a violent "webstorm," which will wipe out much of the dark net and replace it.
-                  </Typography>
-                }
-              >
-                <Button
-                  onClick={() => {
-                    void launchWebstorm();
-                    Router.toPage(SimplePage.DarkNet);
-                  }}
-                >
-                  START WEBSTORM
-                </Button>
-              </Tooltip>
-            </>
-          )}
+          <br />
+          <br />
+          <Tooltip title={<Typography>Create a new darkweb network.</Typography>}>
+            <Button
+              disabled={!hasDarknetAccess()}
+              onClick={() => {
+                clearDarknet();
+                populateDarknet();
+                SnackbarEvents.emit("New dark network generated", ToastVariant.SUCCESS, 2000);
+              }}
+            >
+              Generate New Dark Network
+            </Button>
+          </Tooltip>
+          <br />
+          <br />
+          <Tooltip title={<Typography>Reposition the majority of servers in the darknet.</Typography>}>
+            <Button
+              disabled={!hasDarknetAccess()}
+              onClick={() => {
+                moveRandomDarknetServers(Math.floor(getAllDarknetServers().length / 2));
+                SnackbarEvents.emit("Darknet servers shuffled", ToastVariant.SUCCESS, 2000);
+              }}
+            >
+              Shuffle Server Locations
+            </Button>
+          </Tooltip>
+          <br />
+          <br />
+          <Tooltip title={<Typography>Adds a new server of a specific variety.</Typography>}>
+            <Button disabled={!hasDarknetAccess()} onClick={() => setOpen(true)}>
+              Add Darknet Servers...
+            </Button>
+          </Tooltip>
+          <br />
+          <br />
+          <Tooltip title={<Typography>Root all standard darknet servers.</Typography>}>
+            <Button
+              disabled={!hasDarknetAccess()}
+              onClick={() => {
+                getAllMovableDarknetServers().forEach((server) => {
+                  if (!isLabyrinthServer(server.hostname)) {
+                    handleSuccessfulAuth(server, 1, -1);
+                  }
+                });
+                SnackbarEvents.emit("Gained darknet server admin rights", ToastVariant.SUCCESS, 2000);
+              }}
+            >
+              Gain admin access to all darknet servers
+            </Button>
+          </Tooltip>
+          <br />
+          <br />
+          <Tooltip title={<Typography>Root all darknet labyrinth servers.</Typography>}>
+            <Button
+              disabled={!hasDarknetAccess()}
+              onClick={() => {
+                getAllDarknetServers().forEach((server) => {
+                  if (isLabyrinthServer(server.hostname)) {
+                    server.hasAdminRights = true;
+                  }
+                });
+                SnackbarEvents.emit("Gained lab admin rights", ToastVariant.SUCCESS, 2000);
+              }}
+            >
+              Gain admin access to labyrinth server
+            </Button>
+          </Tooltip>
+          <br />
+          <br />
+          <Tooltip
+            title={
+              <Typography>
+                Start a violent "webstorm," which will wipe out much of the dark net and replace it.
+              </Typography>
+            }
+          >
+            <Button
+              disabled={!hasDarknetAccess()}
+              onClick={() => {
+                void launchWebstorm();
+                Router.toPage(SimplePage.DarkNet);
+              }}
+            >
+              START WEBSTORM
+            </Button>
+          </Tooltip>
         </AccordionDetails>
       </AutoExpandAccordion>
     </>

--- a/test/jest/Darknet/Darknet.test.ts
+++ b/test/jest/Darknet/Darknet.test.ts
@@ -66,9 +66,12 @@ import { getAllDarknetServers } from "../../../src/DarkNet/utils/darknetNetworkU
 import { prestigeAugmentation } from "../../../src/Prestige";
 import { initStockMarket, StockMarket, SymbolToStockMap } from "../../../src/StockMarket/StockMarket";
 import { StockSymbol } from "@enums";
-import { GetAllServers } from "../../../src/Server/AllServers";
+import { disconnectServers, GetAllServers, GetServerOrThrow } from "../../../src/Server/AllServers";
 import { roundToTwo } from "../../../src/utils/helpers/roundToTwo";
 import { getRamBlock } from "../../../src/DarkNet/effects/ramblock";
+import { SpecialServers } from "../../../src/Server/data/SpecialServers";
+import { clearDarknet } from "../../../src/DarkNet/controllers/NetworkGenerator";
+import { getTorRouter } from "../../../src/Server/ServerHelpers";
 
 beforeAll(() => {
   initGameEnvironment();
@@ -985,5 +988,35 @@ describe("ramblock", () => {
     } finally {
       Math.random = saved;
     }
+  });
+});
+
+describe("clearDarknet", () => {
+  it("leaves home<->darkweb disconnected on both sides when the player has no TOR router", () => {
+    const home = Player.getHomeComputer();
+    const darkweb = GetServerOrThrow(SpecialServers.DarkWeb);
+
+    disconnectServers(home, darkweb);
+    expect(Player.hasTorRouter()).toBe(false);
+
+    clearDarknet();
+
+    expect(darkweb.serversOnNetwork.includes(home.hostname)).toBe(home.serversOnNetwork.includes(darkweb.hostname));
+    expect(home.serversOnNetwork).not.toContain(darkweb.hostname);
+    expect(darkweb.serversOnNetwork).not.toContain(home.hostname);
+  });
+
+  it("leaves home<->darkweb connected on both sides when the player has a TOR router", () => {
+    const home = Player.getHomeComputer();
+    const darkweb = GetServerOrThrow(SpecialServers.DarkWeb);
+
+    getTorRouter();
+    expect(Player.hasTorRouter()).toBe(true);
+
+    clearDarknet();
+
+    expect(darkweb.serversOnNetwork.includes(home.hostname)).toBe(home.serversOnNetwork.includes(darkweb.hostname));
+    expect(home.serversOnNetwork).toContain(darkweb.hostname);
+    expect(darkweb.serversOnNetwork).toContain(home.hostname);
   });
 });

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -321,7 +321,7 @@ describe("home", () => {
     await ns.singularity.installBackdoor();
     // Can exec from home
     expect(ns.exec(scriptPath, dnetServerHostname)).toBeGreaterThan(0);
-  });
+  }, 8000);
   test("getServerRequiredCharismaLevel", () => {
     const ns = getNS(SpecialServers.Home);
     const server = GetServerOrThrow(SpecialServers.Home);


### PR DESCRIPTION
In the past there have been ways to get invalid networks, where darknet is connected to home but not vice-versa. This can still be done, technically, in the latest dev branch by starting a new save and hitting "generate new darknet network" in the dev menu without having a tor router or the darkscape navigator.

This PR hardens the logic around clearing the darknet to avoid causing uni-directional links. It also hides the dev menu options that aren't meaningful if the game doesn't have darknet initialized yet.