### PR TITLE
INFO: Missing information in the Coding Contract type "Largest Rectangle in a Matrix"

### DIFF
--- a/src/CodingContract/contracts/LargestRectangle.ts
+++ b/src/CodingContract/contracts/LargestRectangle.ts
@@ -16,7 +16,8 @@ export const largestRectangle: Pick<CodingContractTypes, CodingContractName.Larg
 ${gridString}
 ]
 
-Your task is to find the two corners of the largest rectangle ([[r1,c1],[r2,c2]]) that does not contain any 1s.
+Your task is to find the two corners of the largest rectangle ([[r1,c1],[r2,c2]]) that does not contain any 1s, these 
+corners being the top-left and bottom-right corners respectively, in [row,column] order.
 
 Example 1:
 Data:


### PR DESCRIPTION
This change adds a bit more information to the coding contract aforementioned. It never states that the corners to be submitted have to be the top-left and bottom-right ones in order (which confused me a bit at first). And so this change corrects that for added clarity.
