### PR TITLE
CCT: Adding Info to Largest Rectangle in a Matrix

### DIFF
--- a/src/CodingContract/contracts/LargestRectangle.ts
+++ b/src/CodingContract/contracts/LargestRectangle.ts
@@ -16,7 +16,8 @@ export const largestRectangle: Pick<CodingContractTypes, CodingContractName.Larg
 ${gridString}
 ]
 
-Your task is to find the two corners of the largest rectangle ([[r1,c1],[r2,c2]]) that does not contain any 1s.
+Your task is to find the two corners of the largest rectangle ([[r1,c1],[r2,c2]]) that does not contain any 1s, these 
+corners being the top-left and bottom right corners respectively, in [row,column] order.
 
 Example 1:
 Data:


### PR DESCRIPTION
This commit slightly modifies the description given for the Coding Contract "Largest Rectangle in a Matrix", by adding more information about the corners. Since the problem statement confused even me, I believe this change would clear things up a bit, by telling that the corners to be given in the answer are the top-left and bottom-right corner respectively, in [row,column] order.