### PR TITLE
BUGFIX: getCompanyPositionInfo does not take BN-related mults into account when calculating salary

### DIFF
--- a/src/NetscriptFunctions/Singularity.ts
+++ b/src/NetscriptFunctions/Singularity.ts
@@ -38,7 +38,7 @@ import { FactionWork } from "../Work/FactionWork";
 import { CompanyWork } from "../Work/CompanyWork";
 import { canGetBonus } from "../ExportBonus";
 import { getSaveData, exportGame } from "../SaveObject";
-import { calculateCrimeWorkStats } from "../Work/Formulas";
+import { calculateCompanyWorkStats, calculateCrimeWorkStats } from "../Work/Formulas";
 import { Engine } from "../engine";
 import { getEnumHelper } from "../utils/EnumHelper";
 import { ScriptFilePath, resolveScriptFilePath } from "../Paths/ScriptFilePath";
@@ -680,7 +680,7 @@ export function NetscriptSingularity(): InternalAPI<ISingularity> {
         name: job.name,
         field: job.field,
         nextPosition: job.nextPosition,
-        salary: job.baseSalary * company.salaryMultiplier,
+        salary: calculateCompanyWorkStats(Player, company, job, company.favor).money,
         requiredReputation: calculateEffectiveRequiredReputation(companyName, job.requiredReputation),
         requiredSkills: job.requiredSkills(company.jobStatReqOffset),
       };


### PR DESCRIPTION
MRE:
- Load a clean save file.
- Set SF4 and SF5.
- Bitflume to BN11.
- Run test code.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  console.log(ns.formulas.work.companyGains(ns.getPlayer(), "Joe's Guns", "Employee", 0).money);
  console.log(ns.singularity.getCompanyPositionInfo("Joe's Guns", "Employee").salary);
}
```
Before:
```
11.011
22
```
After:
```
11.011
11.011
```

`getCompanyPositionInfo` should call `calculateCompanyWorkStats` instead of reimplementing the formula.