### PR TITLE
REFACTOR: Refactor corporation code and remove unused properties

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -411,7 +411,7 @@ export class Division {
     const markupMultiplier = calculateMarkupMultiplier(sCost, marketPrice, markupLimit);
 
     // Calculate how much of the material sells (per second)
-    const maxSellPerCycle =
+    const maxSellPerSecond =
       qualityAndEffectiveRatingFactor *
       marketFactor *
       markupMultiplier *
@@ -419,13 +419,8 @@ export class Division {
       corporation.getSalesMult() *
       advertisingFactor *
       this.getSalesMultiplier();
-    if (isMaterial) {
-      item.maxSellPerCycle = maxSellPerCycle;
-    } else {
-      item.maxSellAmount = maxSellPerCycle;
-    }
 
-    sellAmt = Math.min(maxSellPerCycle, sellAmt);
+    sellAmt = Math.min(maxSellPerSecond, sellAmt);
     sellAmt = sellAmt * corpConstants.secondsPerMarketCycle * marketCycles;
     sellAmt = Math.min(stored, sellAmt);
     const setActualSellAmount = (value: number) => {

--- a/src/Corporation/Material.ts
+++ b/src/Corporation/Material.ts
@@ -67,9 +67,6 @@ export class Material {
   marketTa2 = false;
   uiMarketPrice = 0;
 
-  // Determines the maximum amount of this material that can be sold in one market cycle
-  maxSellPerCycle = 0;
-
   constructor(params?: IConstructorParams) {
     this.name = params?.name ?? materialNames[0];
     this.demand = MaterialInfo[this.name].demandBase;
@@ -138,9 +135,6 @@ export class Material {
     const material = Generic_fromJSON(Material, value.data);
     if (!Number.isFinite(material.quality)) {
       material.quality = 1;
-    }
-    if (!Number.isFinite(material.maxSellPerCycle)) {
-      material.maxSellPerCycle = 0;
     }
     /**
      * averagePrice has not been calculated properly, so if it is an invalid value (Number.isFinite returns false) or 0

--- a/src/Corporation/Product.ts
+++ b/src/Corporation/Product.ts
@@ -94,9 +94,6 @@ export class Product {
   marketTa2 = false;
   uiMarketPrice = createEnumKeyedRecord(CityName, () => 0);
 
-  /** Effective number that "MAX" represents in a sell amount */
-  maxSellAmount = 0;
-
   constructor(params: IConstructorParams | null = null) {
     if (!params) return;
     this.name = params.name;


### PR DESCRIPTION
Cleanup: removed `Material.maxSellPerCycle`:
Based on the output of `git grep maxSellPerCycle`, this field appears to be unused
   
Cleanup: removed `Product.maxSellAmount`:
Based on the output of `git grep maxSellAmount`, this field appears to be unused

Fix incorrect variable name: renamed `maxSellPerCycle` to `maxSellPerSecond`:
The variable was called `maxSellPerCycle`, but a couple lines lower we multiply by `corpConstants.secondsPerMarketCycle` as if `maxSellPerCycle` is actually per second and needs to be converted to per cycle

## npm run test
```
Test Suites: 56 passed, 56 total
Tests:       4 skipped, 4508 passed, 4512 total
Snapshots:   141 passed, 141 total
Time:        52.775 s, estimated 100 s
Ran all test suites.
```