### PR TITLE
BUGFIX: Darknet server connections are drawn incorrectly

### DIFF
--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -43,6 +43,10 @@ export function NetworkDisplayWrapper(): React.ReactElement {
   const { classes } = dnetStyles({});
   const instability = getTimeoutChance();
   const instabilityText = instability > 0.01 ? `${(instability * 100).toFixed(1)}%` : "< 1%";
+  const darkWebRoot = getDarknetServerOrThrow(SpecialServers.DarkWeb);
+  const labDetails = getLabyrinthDetails();
+  const labyrinth = labDetails.lab;
+  const labDepth = labDetails.depth;
 
   const scrollTo = useCallback(
     (top: number, left: number) => {
@@ -70,10 +74,9 @@ export function NetworkDisplayWrapper(): React.ReactElement {
       startingDepth,
     );
     setNetDisplayDepth(deepestServerDepth + visibilityMargin);
-
     rerender();
-    drawOnCanvas(canvas.current, netDisplayDepth);
-  }, [rerender, netDisplayDepth]);
+    drawOnCanvas(canvas.current, deepestServerDepth + visibilityMargin, labDepth);
+  }, [rerender, labDepth]);
 
   useEffect(() => {
     const clearSubscription = DarknetEvents.subscribe(() => updateDisplay());
@@ -90,11 +93,6 @@ export function NetworkDisplayWrapper(): React.ReactElement {
     !!server &&
     (server.hasAdminRights ||
       server.serversOnNetwork.some((neighbor) => getDarknetServerOrThrow(neighbor).hasAdminRights));
-
-  const darkWebRoot = getDarknetServerOrThrow(SpecialServers.DarkWeb);
-  const labDetails = getLabyrinthDetails();
-  const labyrinth = labDetails.lab;
-  const depth = labDetails.depth;
 
   const handleDragStart: PointerEventHandler<HTMLDivElement> = (pointerEvent) => {
     const target = pointerEvent.target as HTMLDivElement;
@@ -208,7 +206,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
       .filter((s) => s.depth < netDisplayDepth && !isLabyrinthServer(s.hostname))
       .map((s) => s.hostname);
 
-    if (labyrinth && netDisplayDepth > depth) {
+    if (labyrinth && netDisplayDepth > labDepth) {
       return [...servers, labyrinth.hostname];
     }
 
@@ -289,7 +287,7 @@ export function NetworkDisplayWrapper(): React.ReactElement {
             ),
           )}
 
-          {!!labyrinth && netDisplayDepth > depth && (
+          {labyrinth && netDisplayDepth > labDepth && (
             <ServerStatusBox server={labyrinth} enableAuth={allowAuth(labyrinth)} classes={classes} />
           )}
         </div>

--- a/src/DarkNet/ui/networkCanvas.ts
+++ b/src/DarkNet/ui/networkCanvas.ts
@@ -12,7 +12,7 @@ import { NET_WIDTH } from "../Enums";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { getDarknetServerOrThrow } from "../utils/darknetServerUtils";
 
-export const drawOnCanvas = (canvas: HTMLCanvasElement, netDisplayDepth: number) => {
+export const drawOnCanvas = (canvas: HTMLCanvasElement, netDisplayDepth: number, labDepth: number) => {
   const ctx = canvas?.getContext("2d");
   if (!ctx || !canvas) {
     console.error("Could not get canvas context");
@@ -23,17 +23,20 @@ export const drawOnCanvas = (canvas: HTMLCanvasElement, netDisplayDepth: number)
   for (const server of DarknetState.Network.flat()) {
     if (
       !server ||
+      // Servers in DarknetState.Network are not labyrinth servers, so it's fine to check server.depth.
       server.depth >= netDisplayDepth ||
       (!server.hasAdminRights && !server.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights))
     ) {
       continue;
     }
 
-    // draw a line between each server and its connected servers
+    // Draw a line between each server and its connected servers
     for (const connectedServerName of server.serversOnNetwork) {
       const connectedServer = getDarknetServerOrThrow(connectedServerName);
+      // With labyrinth servers, server.depth is always -1, so we need to check labDepth.
+      const connectedServerDepth = isLabyrinthServer(connectedServerName) ? labDepth : connectedServer.depth;
       if (
-        connectedServer.depth >= netDisplayDepth ||
+        connectedServerDepth >= netDisplayDepth ||
         (!connectedServer.hasAdminRights &&
           !connectedServer.serversOnNetwork.find((s) => getDarknetServerOrThrow(s).hasAdminRights))
       ) {


### PR DESCRIPTION
This PR fixes 2 issues.

MRE 1: Load `bug-1.gz` and open the dnet tab.

When drawing the connections, we compare the server depth to `netDisplayDepth`, but with the lab server, `server.depth` is always -1, so we need to check `labDepth` instead.

MRE 2:
- Apply the patch in `networkCanvas.ts`, but revert the patch in `NetworkDisplayWrapper.tsx`:
  - `drawOnCanvas(canvas.current, netDisplayDepth, labDepth)`
  - `}, [rerender, netDisplayDepth, labDepth]);`
- Load `bug-2.gz`.
- Open the dnet tab. Make sure you can see both `d0s_slippers` and the lab server.
- Run `GetServer("d0s_slippers").hasAdminRights=false;DarknetEvents.emit()` to simulate a network mutation that resets `d0s_slippers`.
- Do NOT touch the UI. Notice the wrong connections.
- Touch the UI. Notice how the wrong connections disappear.

https://github.com/user-attachments/assets/2ab9222d-407a-4497-ae33-34f6d2d00f80

I'm not sure how to summarize this issue and the fix. You would need to add tons of `console.log` to `updateDisplay` and the following `useEffect` block to see why it happens.

Test save files:
[bug-1.gz](https://github.com/user-attachments/files/29412581/bug-1.gz)
[bug-2.gz](https://github.com/user-attachments/files/29412578/bug-2.gz)

Closes #2920.