### PR TITLE
API: Disallow transferring Symbol via port APIs

### DIFF
--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -8,8 +8,8 @@ const emptyPortData = "NULL PORT DATA";
 /** The object property is for typechecking and is not present at runtime */
 export type PortNumber = PositiveInteger & { __PortNumber: true };
 
-function isObjectLike(value: unknown): value is object {
-  return (typeof value === "object" && value !== null) || typeof value === "function";
+function needsChecking(value: unknown): boolean {
+  return (typeof value === "object" && value !== null) || typeof value === "function" || typeof value === "symbol";
 }
 
 /** Gets the numbered port, initializing it if it doesn't already exist.
@@ -28,7 +28,7 @@ export class Port {
   promise: Promise<void> | null = null;
   add(data: unknown) {
     let value = data;
-    if (isObjectLike(data)) {
+    if (needsChecking(data)) {
       try {
         value = structuredClone(data);
       } catch (ex) {
@@ -54,7 +54,6 @@ export class PortHandle implements NetscriptPort {
 
   write(value: unknown): unknown {
     const port = getPort(this.n);
-    // Primitives don't need to be cloned.
     port.add(value);
     if (port.data.length > Settings.MaxPortCapacity) return port.data.shift();
     return null;
@@ -63,7 +62,6 @@ export class PortHandle implements NetscriptPort {
   tryWrite(value: unknown): boolean {
     const port = getPort(this.n);
     if (port.data.length >= Settings.MaxPortCapacity) return false;
-    // Primitives don't need to be cloned.
     port.add(value);
     return true;
   }
@@ -80,7 +78,7 @@ export class PortHandle implements NetscriptPort {
     const port = NetscriptPorts.get(this.n);
     if (!port || !port.data.length) return emptyPortData;
     // Needed to avoid exposing internal objects.
-    return isObjectLike(port.data[0]) ? structuredClone(port.data[0]) : port.data[0];
+    return needsChecking(port.data[0]) ? structuredClone(port.data[0]) : port.data[0];
   }
 
   nextWrite(): Promise<void> {

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -13,7 +13,7 @@ function isObjectLike(value: unknown): value is object {
 }
 
 function isSymbol(value: unknown): value is symbol {
-  return typeof value === 'symbol';
+  return typeof value === "symbol";
 }
 
 /** Gets the numbered port, initializing it if it doesn't already exist.

--- a/src/NetscriptPort.ts
+++ b/src/NetscriptPort.ts
@@ -8,8 +8,12 @@ const emptyPortData = "NULL PORT DATA";
 /** The object property is for typechecking and is not present at runtime */
 export type PortNumber = PositiveInteger & { __PortNumber: true };
 
-function needsChecking(value: unknown): boolean {
-  return (typeof value === "object" && value !== null) || typeof value === "function" || typeof value === "symbol";
+function isObjectLike(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+function isSymbol(value: unknown): value is symbol {
+  return typeof value === 'symbol';
 }
 
 /** Gets the numbered port, initializing it if it doesn't already exist.
@@ -28,7 +32,7 @@ export class Port {
   promise: Promise<void> | null = null;
   add(data: unknown) {
     let value = data;
-    if (needsChecking(data)) {
+    if (isObjectLike(data) || isSymbol(data)) {
       try {
         value = structuredClone(data);
       } catch (ex) {
@@ -78,7 +82,7 @@ export class PortHandle implements NetscriptPort {
     const port = NetscriptPorts.get(this.n);
     if (!port || !port.data.length) return emptyPortData;
     // Needed to avoid exposing internal objects.
-    return needsChecking(port.data[0]) ? structuredClone(port.data[0]) : port.data[0];
+    return isObjectLike(port.data[0]) ? structuredClone(port.data[0]) : port.data[0];
   }
 
   nextWrite(): Promise<void> {


### PR DESCRIPTION
## Motivation
As the current logic stands, Symbols are not handled consistently by `Port.add`, and therefore the invariant of allowing only serializable data (as described in the documentation and in the error message of `Port.add`) is conditionally violated.

Examples (accurate as of v3.0.1):
```typescript
// Passing an object with a Symbol key
const obj = { [Symbol.for('test')]: "foo" };
ns.writePort(5555, obj);
const out = ns.readPort(5555);

// Symbol keys are stripped out, as expected.  Prints "{}"
ns.tprint(out)
```
```typescript
// Passing an object with a Symbol value
const obj = { test: Symbol.for('test') };
ns.writePort(5555, obj);
const out = ns.readPort(5555);

// Error is thrown on `ns.writePort` as expected.  Print is never reached.
ns.tprint(out)
```
```typescript
// Passing a bare symbol
const symbol = Symbol.for('test');
ns.writePort(5555, symbol);
const out = ns.readPort(5555);

// No errors are thrown.  Unexpectedly prints "Symbol(test)"
ns.tprint(out);
```
This PR tightens up the invariant by ensuring bare Symbols are rejected like their object value counterparts.

## Scope
There were several approaches to handling this, but I took the simplest route.  I renamed the helper function from `isObjectLike` to `needsChecking`, and expanded its functionality to include bare Symbols.  With that change, the existing logic already routes them through `structuredClone`, and from there to the existing catch block, enforcing the invariant.

Bare `bigints`, `numbers`, `booleans`, or `strings` still bypass the cloning step, since they are already in their serialized form (per `structuredClone`'s behavior).

This also required changing the `PortHandle.peek` implementation to use the renamed helper, but otherwise doesn't impact its output.


## Considerations
- This is a potential breaking change for any players that may be pushing bare Symbols through ports; however, I find the likelihood of this being a common or even *uncommon* practice very low, as Symbols are rather niche as stand-alone values in player code. Still worth noting.
- No documentation updates are needed, since this only enforces existing documentation.
- There are other ways to handle this invariant, such as explicitly handling Symbols, or inverting the filter into an allow list of types that don't need serialization, as examples.  I simply took the option that required the least refactoring.  If the maintainers would prefer a different approach, I will re-write to the preferred method.

Tested on latest version of 3.0.2dev
