### PR TITLE
DOCUMENTATION: Clarify that port handle methods remain usable after the ns instance is dead

### DIFF
--- a/markdown/bitburner.md
+++ b/markdown/bitburner.md
@@ -1013,7 +1013,7 @@ Player must have at least this much money.
 
 Object representing a port. A port is a serialized queue.
 
-All methods in this interface can be used even after the ns instance is dead.
+All methods in this interface can be used while the ns instance is "busy" (they avoid the concurrency check), or even when it is dead.
 
 
 </td></tr>

--- a/markdown/bitburner.md
+++ b/markdown/bitburner.md
@@ -1013,6 +1013,8 @@ Player must have at least this much money.
 
 Object representing a port. A port is a serialized queue.
 
+All methods in this interface can be used even after the ns instance is dead.
+
 
 </td></tr>
 <tr><td>

--- a/markdown/bitburner.netscriptport.md
+++ b/markdown/bitburner.netscriptport.md
@@ -6,6 +6,8 @@
 
 Object representing a port. A port is a serialized queue.
 
+All methods in this interface can be used even after the ns instance is dead.
+
 **Signature:**
 
 ```typescript

--- a/markdown/bitburner.netscriptport.md
+++ b/markdown/bitburner.netscriptport.md
@@ -6,7 +6,7 @@
 
 Object representing a port. A port is a serialized queue.
 
-All methods in this interface can be used even after the ns instance is dead.
+All methods in this interface can be used while the ns instance is "busy" (they avoid the concurrency check), or even when it is dead.
 
 **Signature:**
 

--- a/markdown/bitburner.ns.getporthandle.md
+++ b/markdown/bitburner.ns.getporthandle.md
@@ -58,7 +58,7 @@ RAM cost: 0 GB
 
 Get a handle to a Netscript Port.
 
-All methods of the port handle can be used even after the ns instance is dead.
+All methods of the port handle can be used while the ns instance is "busy" (they avoid the concurrency check), or even when it is dead.
 
 Ports are shared across all hosts and contents are reset on game restart.
 

--- a/markdown/bitburner.ns.getporthandle.md
+++ b/markdown/bitburner.ns.getporthandle.md
@@ -56,5 +56,9 @@ Port number. Must be a positive integer.
 
 RAM cost: 0 GB
 
-Get a handle to a Netscript Port. Ports are shared across all hosts and contents are reset on game restart.
+Get a handle to a Netscript Port.
+
+All methods of the port handle can be used even after the ns instance is dead.
+
+Ports are shared across all hosts and contents are reset on game restart.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1173,8 +1173,12 @@ export type SleeveTask =
   | SleeveSupportTask
   | SleeveSynchroTask;
 
-/** Object representing a port. A port is a serialized queue.
- * @public */
+/**
+ * Object representing a port. A port is a serialized queue.
+ *
+ * All methods in this interface can be used even after the ns instance is dead.
+ * @public
+ */
 export interface NetscriptPort {
   /** Write data to a port.
    * @remarks
@@ -8683,6 +8687,9 @@ export interface NS {
    * RAM cost: 0 GB
    *
    * Get a handle to a Netscript Port.
+   *
+   * All methods of the port handle can be used even after the ns instance is dead.
+   *
    * Ports are shared across all hosts and contents are reset on game restart.
    *
    * @param portNumber - Port number. Must be a positive integer.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -1176,7 +1176,8 @@ export type SleeveTask =
 /**
  * Object representing a port. A port is a serialized queue.
  *
- * All methods in this interface can be used even after the ns instance is dead.
+ * All methods in this interface can be used while the ns instance is "busy" (they avoid the concurrency check), or even
+ * when it is dead.
  * @public
  */
 export interface NetscriptPort {
@@ -8688,7 +8689,8 @@ export interface NS {
    *
    * Get a handle to a Netscript Port.
    *
-   * All methods of the port handle can be used even after the ns instance is dead.
+   * All methods of the port handle can be used while the ns instance is "busy" (they avoid the concurrency check), or
+   * even when it is dead.
    *
    * Ports are shared across all hosts and contents are reset on game restart.
    *


### PR DESCRIPTION
This behavior is not documented currently. Before I finish the port documentation and the technical deep dive into how "dead" scripts work in Bitburner, let's add a small clarification to the port API documentation.