### PR TITLE
DOCUMENTATION: Mark host parameter of `ns.ls` as optional

### DIFF
--- a/markdown/bitburner.ns.ls.md
+++ b/markdown/bitburner.ns.ls.md
@@ -9,7 +9,7 @@ List files on a server.
 **Signature:**
 
 ```typescript
-ls(host: string, substring?: string): string[];
+ls(host?: string, substring?: string): string[];
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-Hostname/IP of the target server.
+_(Optional)_ Hostname/IP of the target server. Defaults to current server if not provided.
 
 
 </td></tr>

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -827,7 +827,7 @@ export const ns: InternalAPI<NSFull> = {
     }
     return noFailures;
   },
-  ls: (ctx) => (_host, _substring) => {
+  ls: (ctx) => (_host = ctx.workerScript.hostname, _substring) => {
     const [server] = helpers.getServer(ctx, _host);
     const substring = helpers.string(ctx, "substring", _substring ?? "");
     if (!server) {

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -827,25 +827,27 @@ export const ns: InternalAPI<NSFull> = {
     }
     return noFailures;
   },
-  ls: (ctx) => (_host = ctx.workerScript.hostname, _substring) => {
-    const [server] = helpers.getServer(ctx, _host);
-    const substring = helpers.string(ctx, "substring", _substring ?? "");
-    if (!server) {
-      return [];
-    }
+  ls:
+    (ctx) =>
+    (_host = ctx.workerScript.hostname, _substring) => {
+      const [server] = helpers.getServer(ctx, _host);
+      const substring = helpers.string(ctx, "substring", _substring ?? "");
+      if (!server) {
+        return [];
+      }
 
-    const allFilenames = [
-      ...server.contracts.map((contract) => contract.fn),
-      ...(server instanceof DarknetServer ? server.caches : []),
-      ...server.messages,
-      ...server.programs,
-      ...server.scripts.keys(),
-      ...server.textFiles.keys(),
-    ];
+      const allFilenames = [
+        ...server.contracts.map((contract) => contract.fn),
+        ...(server instanceof DarknetServer ? server.caches : []),
+        ...server.messages,
+        ...server.programs,
+        ...server.scripts.keys(),
+        ...server.textFiles.keys(),
+      ];
 
-    if (!substring) return allFilenames.sort();
-    return allFilenames.filter((filename) => ("/" + filename).includes(substring)).sort();
-  },
+      if (!substring) return allFilenames.sort();
+      return allFilenames.filter((filename) => ("/" + filename).includes(substring)).sort();
+    },
   getRecentScripts: () => (): RecentScript[] => {
     return recentScripts.map((rs) => ({
       timeOfDeath: rs.timeOfDeath,

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -827,27 +827,25 @@ export const ns: InternalAPI<NSFull> = {
     }
     return noFailures;
   },
-  ls:
-    (ctx) =>
-    (_host = ctx.workerScript.hostname, _substring) => {
-      const [server] = helpers.getServer(ctx, _host);
-      const substring = helpers.string(ctx, "substring", _substring ?? "");
-      if (!server) {
-        return [];
-      }
+  ls: (ctx) => (_host, _substring) => {
+    const [server] = helpers.getServer(ctx, _host);
+    const substring = helpers.string(ctx, "substring", _substring ?? "");
+    if (!server) {
+      return [];
+    }
 
-      const allFilenames = [
-        ...server.contracts.map((contract) => contract.fn),
-        ...(server instanceof DarknetServer ? server.caches : []),
-        ...server.messages,
-        ...server.programs,
-        ...server.scripts.keys(),
-        ...server.textFiles.keys(),
-      ];
+    const allFilenames = [
+      ...server.contracts.map((contract) => contract.fn),
+      ...(server instanceof DarknetServer ? server.caches : []),
+      ...server.messages,
+      ...server.programs,
+      ...server.scripts.keys(),
+      ...server.textFiles.keys(),
+    ];
 
-      if (!substring) return allFilenames.sort();
-      return allFilenames.filter((filename) => ("/" + filename).includes(substring)).sort();
-    },
+    if (!substring) return allFilenames.sort();
+    return allFilenames.filter((filename) => ("/" + filename).includes(substring)).sort();
+  },
   getRecentScripts: () => (): RecentScript[] => {
     return recentScripts.map((rs) => ({
       timeOfDeath: rs.timeOfDeath,

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -8175,11 +8175,11 @@ export interface NS {
    * Returns an array with the filenames of all files on the specified server
    * (as strings). The returned array is sorted in alphabetic order.
    *
-   * @param host - Hostname/IP of the target server.
+   * @param host - Hostname/IP of the target server. Defaults to current server if not provided.
    * @param substring - A substring to search for in the filename.
    * @returns Array with the filenames of all files on the specified server.
    */
-  ls(host: string, substring?: string): string[];
+  ls(host?: string, substring?: string): string[];
 
   /**
    * List running scripts on a server.


### PR DESCRIPTION
This PR makes `ns.ls()` default to current host if the `host` param is undefined. Tested manually