### PR TITLE
CORPORATION: Remove passive popularity decay

### DIFF
--- a/src/Corporation/Division.ts
+++ b/src/Corporation/Division.ts
@@ -193,10 +193,6 @@ export class Division {
       this.processMaterialMarket();
       this.processProductMarket(marketCycles);
 
-      // Process loss of popularity
-      this.popularity -= marketCycles * 0.0001;
-      this.popularity = Math.max(0, this.popularity);
-
       return;
     }
 

--- a/src/Documentation/doc/en/advanced/corporation/wilson-analytics-advert.md
+++ b/src/Documentation/doc/en/advanced/corporation/wilson-analytics-advert.md
@@ -8,8 +8,6 @@ Awareness and popularity are capped at `Number.MAX_VALUE` (~1.7976931348623157E+
 
 Raw values of those stats are crucial, but their ratio is also important. We want to have high ratio of popularity/awareness, check this [section](./optimal-selling-price-market-ta2.md) for formulas.
 
-Popularity decreases by 0.0001 per cycle.
-
 ## Wilson Analytics
 
 Wilson is a multiplier that is applied on Advert's benefits when we buy Advert, so it's not retroactive. Therefore, we need to buy it as soon as possible. However, there are cases that Wilson is too expensive and it does not bring much benefits. Round 1 and 2 are those cases.


### PR DESCRIPTION
This is one of many pointless mechanics in Corp.

Each market cycle (10 seconds), popularity decreases by 0.0001. This means that even if you buy only 1 advert level (which grants 1.005 popularity), it takes about 27.9 hours (1.005 / 0.0001 * 10 / 3600) for the popularity to decrease to 0.

This decay rate serves no purpose except to give players an excuse to buy one level of DreamSense, which I also removed.