### PR TITLE
CLEANUP: Removed horizontal mirroring for IPvGo

### DIFF
--- a/src/Go/boardAnalysis/patternMatching.ts
+++ b/src/Go/boardAnalysis/patternMatching.ts
@@ -172,8 +172,7 @@ function expandAllThreeByThreePatterns() {
     ...threeByThreePatterns.map(rotate90Degrees).map(rotate90Degrees),
     ...threeByThreePatterns.map(rotate90Degrees).map(rotate90Degrees).map(rotate90Degrees),
   ];
-  const mirroredPatterns = [...rotatedPatterns, ...rotatedPatterns.map(verticalMirror)];
-  return [...mirroredPatterns, ...mirroredPatterns.map(horizontalMirror)];
+  return [...rotatedPatterns, ...rotatedPatterns.map(verticalMirror)];
 }
 
 function rotate90Degrees(pattern: string[]) {
@@ -186,12 +185,4 @@ function rotate90Degrees(pattern: string[]) {
 
 function verticalMirror(pattern: string[]) {
   return [pattern[2], pattern[1], pattern[0]];
-}
-
-function horizontalMirror(pattern: string[]) {
-  return [
-    pattern[0].split("").reverse().join(),
-    pattern[1].split("").reverse().join(),
-    pattern[2].split("").reverse().join(),
-  ];
 }


### PR DESCRIPTION
We do not need to mirror the results twice, through a horizontal and vertical mirror.

A square has exactly 8 unique symmetric orientations (known as the D4 dihedral group). You can generate all 8 possible states using only one reflection and rotations.  In essence, we are creating double the number of patterns to search through.  I have removed the more elaborate horizontal mirror as it is not needed.