### PR TITLE
DOCUMENTATION: Rename DividendTax to TributeModifier in docs

### DIFF
--- a/src/Documentation/doc/en/advanced/corporation/unlocks-upgrade-research.md
+++ b/src/Documentation/doc/en/advanced/corporation/unlocks-upgrade-research.md
@@ -8,8 +8,8 @@
 | Smart Supply              | 25e9      | Enable "Smart Supply" feature. Only buy it if you don't implement your custom [Smart Supply](./smart-supply.md) script.                                    |
 | Market Research - Demand  | 5e9       | Grant access to [Demand](./demand-competition.md) data. You need it to implement a custom [Market-TA2](./optimal-selling-price-market-ta2.md) script.      |
 | Market Data - Competition | 5e9       | Grant access to [Competition](./demand-competition.md) data. You need it to implement a custom [Market-TA2](./optimal-selling-price-market-ta2.md) script. |
-| Shady Accounting          | 500e12    | Reduce [TributeModifier](./financial-statement.md) by 0.05                                                                                                     |
-| Government Partnership    | 2e15      | Reduce [TributeModifier](./financial-statement.md) by 0.1                                                                                                      |
+| Shady Accounting          | 500e12    | Reduce [TributeModifier](./financial-statement.md) by 0.05                                                                                                 |
+| Government Partnership    | 2e15      | Reduce [TributeModifier](./financial-statement.md) by 0.1                                                                                                  |
 
 &nbsp;
 

--- a/src/Documentation/doc/en/advanced/corporation/unlocks-upgrade-research.md
+++ b/src/Documentation/doc/en/advanced/corporation/unlocks-upgrade-research.md
@@ -8,8 +8,8 @@
 | Smart Supply              | 25e9      | Enable "Smart Supply" feature. Only buy it if you don't implement your custom [Smart Supply](./smart-supply.md) script.                                    |
 | Market Research - Demand  | 5e9       | Grant access to [Demand](./demand-competition.md) data. You need it to implement a custom [Market-TA2](./optimal-selling-price-market-ta2.md) script.      |
 | Market Data - Competition | 5e9       | Grant access to [Competition](./demand-competition.md) data. You need it to implement a custom [Market-TA2](./optimal-selling-price-market-ta2.md) script. |
-| Shady Accounting          | 500e12    | Reduce [DividendTax](./financial-statement.md) by 0.05                                                                                                     |
-| Government Partnership    | 2e15      | Reduce [DividendTax](./financial-statement.md) by 0.1                                                                                                      |
+| Shady Accounting          | 500e12    | Reduce [TributeModifier](./financial-statement.md) by 0.05                                                                                                     |
+| Government Partnership    | 2e15      | Reduce [TributeModifier](./financial-statement.md) by 0.1                                                                                                      |
 
 &nbsp;
 


### PR DESCRIPTION
* Follow-up for #2237
I found and fixed one place, where our documentation was still referring to TributeModifier as DividendTax