### PR TITLE
CODEBASE: Remove optional filename parameter when generating contracts

### DIFF
--- a/src/CodingContract/ContractGenerator.ts
+++ b/src/CodingContract/ContractGenerator.ts
@@ -129,7 +129,6 @@ export const generateDummyContract = (problemType: CodingContractName, server: B
 interface IGenerateContractParams {
   problemType?: CodingContractName;
   server?: string;
-  filename?: ContractFilePath;
   reward?: ICodingContractReward;
   rewardScaling?: number;
 }
@@ -161,7 +160,7 @@ export function generateContract(params: IGenerateContractParams): ContractFileP
     return null;
   }
 
-  const filename = params.filename ? params.filename : getRandomFilename(server);
+  const filename = getRandomFilename(server);
   if (filename == null) {
     return null;
   }


### PR DESCRIPTION
#2399 prevents generating contracts with duplicate filenames. However, that prevention can be bypassed by using this optional parameter. There is currently nothing that uses it, and I don't think we'll actually need it. Let's remove it to prevent misuse.