### PR TITLE
BUGFIX: Follow up to #2818

### DIFF
--- a/markdown/bitburner.darknet.freezeserver.md
+++ b/markdown/bitburner.darknet.freezeserver.md
@@ -44,7 +44,7 @@ string
 
 </td><td>
 
-the server to freeze
+Hostname/IP of the target server.
 
 
 </td></tr>

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -1,4 +1,4 @@
-import { connectServers, DeleteServer, disconnectServers, GetServer } from "../../Server/AllServers";
+import { connectServers, DeleteServer, disconnectServers, GetServer, GetServerOrThrow } from "../../Server/AllServers";
 import {
   DarknetEvents,
   DarknetState,
@@ -269,22 +269,22 @@ const disconnectRandomServer = (): void => {
 };
 
 /**
- * By default, this function disconnects the specified server from its neighbors, unless the neighbor is darkweb. Use
- * the second parameter to ignore the exception. We added this exception to improve the stability of the servers
- * directly connected to darkweb.
+ * By default, this function disconnects the specified server from its neighbors, unless the neighbor is darkweb or a
+ * labyrinth server. Use the second parameter to ignore the exception.
+ * We added this exception to improve the stability of the servers directly connected to darkweb or labyrinth servers.
  */
-export const disconnectServer = (server: DarknetServer, disconnectFromDarkweb = false): void => {
+export const disconnectServer = (server: DarknetServer, force = false): void => {
   if (server.hostname === SpecialServers.DarkWeb) {
     exceptionAlert(new Error("Something is trying to disconnect darkweb"), true);
     return;
   }
-  if (isImmutable(server)) {
+  if (isImmutable(server) && !force) {
     return;
   }
   for (const neighbor of server.serversOnNetwork) {
-    const connectedServer = GetServer(neighbor);
+    const connectedServer = GetServerOrThrow(neighbor);
     const isOkToDisconnect =
-      (disconnectFromDarkweb || connectedServer?.hostname !== SpecialServers.DarkWeb) && !isLabyrinthServer(neighbor);
+      force || (connectedServer.hostname !== SpecialServers.DarkWeb && !isLabyrinthServer(neighbor));
     if (connectedServer && isOkToDisconnect) {
       disconnectServers(server, connectedServer);
     }
@@ -399,6 +399,13 @@ export const validateDarknetNetwork = (): void => {
 };
 
 export const freezeServer = (server: DarknetServer): void => {
+  killServerScripts(server, "Server was frozen.");
   server.maxRam = 0;
+  server.blockedRam = 0;
+  // When blockedRam is non-zero, server.ramUsed is equal to blockedRam. When scripts are running, server.ramUsed is
+  // equal to totalRAMCost + blockedRam. After all scripts are killed, server.ramUsed resets to blockedRam.
+  // When a server is frozen, its maxRam is 0, so blockedRam should naturally also be 0. Therefore, we need to manually
+  // set ramUsed to 0.
+  server.updateRamUsed(0);
   server.isStationary = true;
 };

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -231,7 +231,6 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
           success: false,
           code: serverCheck.code,
           message: serverCheck.message,
-          logs: [],
         };
       }
       freezeServer(serverCheck.server);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4577,7 +4577,7 @@ export interface Darknet {
    * @remarks
    * RAM cost: 2 GB
    *
-   * @param host the server to freeze
+   * @param host - Hostname/IP of the target server.
    */
   freezeServer(host: string): DarknetResult;
 


### PR DESCRIPTION
While reviewing #2818, I found a non-critical bug and some other minor issues. However, now I find a critical bug that activates the recovery screen. I still have not finished my testing, but let's fix what I have found first.

MRE 1:
- Load a clean save file.
- Bitfume to BN15.
- Wait until a network mutation hits server `foo` next to the lab server or use webstorm: `Error: Found invalid neighbor dnet server. hostname: th3_l4byr1nth. neighbor: terminal%blad3&53cur17y. serversOnNetwork: sun_megasystems,terminal%blad3&53cur17y,echo_services,emet1🅱️,qu4ntum%bl4de`

This happens because of the `!isLabyrinthServer(neighbor)` check at https://github.com/bitburner-official/bitburner-src/blob/dabd96512c6820f419ce19a776e1c6b348fa7715/src/DarkNet/controllers/NetworkMovement.ts#L287
When `foo` is deleted by `deleteDarknetServer`, `neighbor` is a lab server, so the connection between `foo` and the lab server is not cleaned up.

MRE 2:
- Load a clean save file.
- Bitfume to BN15.
- Freeze server `foo` next to darkweb.
- Launch webstorm: `Found invalid neighbor dnet server. hostname: darkweb. neighbor: shadows_of_anarchy. serversOnNetwork: home,light;flame%org,shadows_of_anarchy,neon.zenith::blade`

This happens because of https://github.com/bitburner-official/bitburner-src/blob/dabd96512c6820f419ce19a776e1c6b348fa7715/src/DarkNet/controllers/NetworkMovement.ts#L281
When `foo` is deleted by `deleteDarknetServer`, `isImmutable(foo)` is true, so `disconnectServer` returns early, and the connection between `foo` and darkweb is not cleaned up.

MRE 3:
- Apply the patch in `disconnectServer` to avoid unnecessary warning popups about broken connections.
- Load a clean save file.
- Bitfume to BN15.
- Freeze server `foo` next to darkweb.
- Run a script on `foo`.
- From darkweb, freeze `foo`.
- Run `free` on `foo`.
```
[hacker:c0rp /]> free
Total:      0.00GB
Used:       1.60GB
Available: -1.60GB
```
When freezing servers, we need to kill all running scripts and reset all RAM-related fields, not just `maxRam`.

Other changes:
- Minor doc change.
- Remove `logs: []`. I'm fairly sure fico copied this code from `heartbleed`.