### PR TITLE
UI: Make coding contract successful attempts print to terminal

### DIFF
--- a/src/Terminal/commands/run.ts
+++ b/src/Terminal/commands/run.ts
@@ -53,14 +53,11 @@ export function run(args: (string | number | boolean)[], server: BaseServer): un
 
       switch (promptResult.result) {
         case CodingContractResult.Success:
-          if (contract.reward !== null) {
-            const reward = Player.gainCodingContractReward(
-              contract.reward,
-              contract.getDifficulty(),
-              contract.rewardScaling,
-            );
-            Terminal.print(`Contract SUCCESS - ${reward}`);
-          }
+          const reward =
+            contract.reward !== null
+              ? Player.gainCodingContractReward(contract.reward, contract.getDifficulty(), contract.rewardScaling)
+              : null;
+          Terminal.print(`Contract SUCCESS - ${reward ?? "No reward"}`);
           server.removeContract(contract);
           break;
         case CodingContractResult.InvalidFormat:

--- a/src/Terminal/commands/run.ts
+++ b/src/Terminal/commands/run.ts
@@ -52,7 +52,7 @@ export function run(args: (string | number | boolean)[], server: BaseServer): un
       }
 
       switch (promptResult.result) {
-        case CodingContractResult.Success:
+        case CodingContractResult.Success: {
           const reward =
             contract.reward !== null
               ? Player.gainCodingContractReward(contract.reward, contract.getDifficulty(), contract.rewardScaling)
@@ -60,6 +60,7 @@ export function run(args: (string | number | boolean)[], server: BaseServer): un
           Terminal.print(`Contract SUCCESS - ${reward ?? "No reward"}`);
           server.removeContract(contract);
           break;
+        }
         case CodingContractResult.InvalidFormat:
           Terminal.error(
             `Contract FAILED - ${


### PR DESCRIPTION
MRE: Create a dummy coding contract. Solve it manually via the UI.
There is no message indicating the success, although if you fail it there is an error that indicates failure.

I have modified the printing logic via ternary operators (cleanest), but I can do it as an if-else block if you wish me to. Tested manually.