### PR TITLE
UI: Always print result to terminal when manually solving contract succeeds

### DIFF
--- a/src/Terminal/commands/run.ts
+++ b/src/Terminal/commands/run.ts
@@ -53,14 +53,12 @@ export function run(args: (string | number | boolean)[], server: BaseServer): un
 
       switch (promptResult.result) {
         case CodingContractResult.Success:
-          if (contract.reward !== null) {
-            const reward = Player.gainCodingContractReward(
-              contract.reward,
-              contract.getDifficulty(),
-              contract.rewardScaling,
-            );
-            Terminal.print(`Contract SUCCESS - ${reward}`);
-          }
+          const reward = Player.gainCodingContractReward(
+            contract.reward,
+            contract.getDifficulty(),
+            contract.rewardScaling,
+          );
+          Terminal.print(`Contract SUCCESS - ${reward}`);
           server.removeContract(contract);
           break;
         case CodingContractResult.InvalidFormat:

--- a/src/Terminal/commands/run.ts
+++ b/src/Terminal/commands/run.ts
@@ -52,7 +52,7 @@ export function run(args: (string | number | boolean)[], server: BaseServer): un
       }
 
       switch (promptResult.result) {
-        case CodingContractResult.Success:
+        case CodingContractResult.Success: {
           const reward = Player.gainCodingContractReward(
             contract.reward,
             contract.getDifficulty(),
@@ -61,6 +61,7 @@ export function run(args: (string | number | boolean)[], server: BaseServer): un
           Terminal.print(`Contract SUCCESS - ${reward}`);
           server.removeContract(contract);
           break;
+        }
         case CodingContractResult.InvalidFormat:
           Terminal.error(
             `Contract FAILED - ${


### PR DESCRIPTION
This commit/pull request removes the requirement for the Terminal confirmation for Coding Contracts solved manually to be only for normally-generated/natural Coding Contracts. Now, when successfully solving a Dummy Coding Contract manually, instead of the .cct file being removed with no confirmation that the user has actually correctly solved it, it now says:
```
Contract SUCCESS - No reward for this contract
```