### PR TITLE
UI: Wrap long strings in contract description onto multiple lines

### DIFF
--- a/src/CodingContract/contracts/AlgorithmicStockTrader.ts
+++ b/src/CodingContract/contracts/AlgorithmicStockTrader.ts
@@ -14,7 +14,7 @@ export const algorithmicStockTrader: Pick<
       return [
         "You are given the following array of stock prices (which are numbers)",
         "where the i-th element represents the stock price on day i:\n\n",
-        `${data}\n\n`,
+        `[${data}]\n\n`,
         "Determine the maximum possible profit you can earn using at most",
         "one transaction (i.e. you can only buy and sell the stock once). If no profit can be made",
         "then the answer should be 0. Note",
@@ -53,7 +53,7 @@ export const algorithmicStockTrader: Pick<
       return [
         "You are given the following array of stock prices (which are numbers)",
         "where the i-th element represents the stock price on day i:\n\n",
-        `${data}\n\n`,
+        `[${data}]\n\n`,
         "Determine the maximum possible profit you can earn using as many",
         "transactions as you'd like. A transaction is defined as buying",
         "and then selling one share of the stock. Note that you cannot",
@@ -92,7 +92,7 @@ export const algorithmicStockTrader: Pick<
       return [
         "You are given the following array of stock prices (which are numbers)",
         "where the i-th element represents the stock price on day i:\n\n",
-        `${data}\n\n`,
+        `[${data}]\n\n`,
         "Determine the maximum possible profit you can earn using at most",
         "two transactions. A transaction is defined as buying",
         "and then selling one share of the stock. Note that you cannot",

--- a/src/ui/React/CodingContractModal.tsx
+++ b/src/ui/React/CodingContractModal.tsx
@@ -70,7 +70,7 @@ export function CodingContractModal(): React.ReactElement {
   const description = [];
   for (const [i, value] of contractType.desc(eventData.codingContract.getData()).split("\n").entries()) {
     description.push(
-      <span key={i} style={{ whiteSpace: "pre-wrap" }}>
+      <span key={i} style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>
         {value} <br />
       </span>,
     );


### PR DESCRIPTION
Closes #2938.

Before:

<img width="1098" height="332" alt="before" src="https://github.com/user-attachments/assets/696c9eb0-fbce-404e-a4c0-61d362dd3939" />

After:

<img width="1096" height="346" alt="after" src="https://github.com/user-attachments/assets/345def40-0a22-4cab-adab-9f5edced0358" />

I also added `[]` to the descriptions of 3 contracts for consistency.

Our way of constructing the description adds unnecessary whitespace, but it's unrelated to #2938, so I'll address it in a separate PR.