### PR TITLE
DNET: Remove hard-coded styles

### DIFF
--- a/src/DarkNet/ui/LabyrinthSummary.tsx
+++ b/src/DarkNet/ui/LabyrinthSummary.tsx
@@ -13,6 +13,7 @@ import { useCycleRerender } from "../../ui/React/hooks";
 import { findRunningScriptByPid } from "../../Script/ScriptHelpers";
 import { GetServerOrThrow } from "../../Server/AllServers";
 import { assertPasswordResponse, isPasswordResponse } from "../models/DarknetServerOptions";
+import { Settings } from "../../Settings/Settings";
 
 export type LabyrinthSummaryProps = {
   isAuthenticating: boolean;
@@ -168,7 +169,7 @@ export const LabyrinthSummary = ({ isAuthenticating }: LabyrinthSummaryProps): R
             Logs scraped via <pre style={{ display: "inline" }}>heartbleed</pre>:
           </Typography>
           <Card style={{ padding: "8px", minHeight: "270px", marginBottom: "8px" }}>
-            <div style={{ color: "white" }}>
+            <div style={{ color: Settings.theme.maplocation }}>
               <pre style={{ whiteSpace: "pre-wrap", margin: 0 }}>{getLogs()}</pre>
             </div>
           </Card>
@@ -177,7 +178,7 @@ export const LabyrinthSummary = ({ isAuthenticating }: LabyrinthSummaryProps): R
             ns.dnet.labreport:
           </Typography>
           <Card style={{ padding: "8px" }}>
-            <div style={{ color: "white" }}>
+            <div style={{ color: Settings.theme.maplocation }}>
               <pre style={{ whiteSpace: "pre-wrap", margin: 0, fontSize: "10.5px" }}>{getLocationStatusString()}</pre>
             </div>
           </Card>

--- a/src/DarkNet/ui/PasswordPrompt.tsx
+++ b/src/DarkNet/ui/PasswordPrompt.tsx
@@ -12,6 +12,7 @@ import { sleep } from "../../utils/Utility";
 import { getSharedChars } from "../utils/darknetAuthUtils";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { formatObjectWithColoredKeys } from "./uiUtilities";
+import { Settings } from "../../Settings/Settings";
 
 export type PasswordPromptProps = {
   server: DarknetServer;
@@ -134,7 +135,7 @@ export const PasswordPrompt = ({ server, onClose }: PasswordPromptProps): React.
         <div style={{ width: "50%" }}>
           <Container disableGutters>
             {isLabServer ? (
-              <div style={{ color: "white" }}>
+              <div style={{ color: Settings.theme.maplocation }}>
                 <pre style={{ whiteSpace: "pre-wrap", margin: 0 }}>
                   <span className={classes.serverDetailsText}>Hint:</span> {server.staticPasswordHint}
                   <br />
@@ -145,7 +146,7 @@ export const PasswordPrompt = ({ server, onClose }: PasswordPromptProps): React.
                 </pre>
               </div>
             ) : (
-              <div style={{ color: "white" }}>
+              <div style={{ color: Settings.theme.maplocation }}>
                 <pre style={{ whiteSpace: "pre-wrap", margin: 0 }}>
                   <span className={classes.serverDetailsText}>Hint:</span> {server.staticPasswordHint}
                   <br />
@@ -168,7 +169,7 @@ export const PasswordPrompt = ({ server, onClose }: PasswordPromptProps): React.
           <br />
           {!isLabServer && (
             <Card style={{ padding: "8px", minHeight: "60px", marginBottom: "8px" }}>
-              <div style={{ color: "white" }}>
+              <div style={{ color: Settings.theme.maplocation }}>
                 {typeof authFeedback !== "string" ? (
                   authFeedback
                 ) : (

--- a/src/DarkNet/ui/ServerDetailsModal.tsx
+++ b/src/DarkNet/ui/ServerDetailsModal.tsx
@@ -11,6 +11,7 @@ import { copyToClipboard, formatObjectWithColoredKeys, formatToMaxDigits } from 
 import { useCycleRerender } from "../../ui/React/hooks";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { logBoxBaseZIndex } from "../../ui/React/Constants";
+import { Settings } from "../../Settings/Settings";
 
 export type DWPasswordPromptModalProps = {
   open: boolean;
@@ -104,7 +105,7 @@ export const ServerDetailsModal = ({
           {!isLabServer && (
             <>
               <Card style={{ height: "250px", overflowY: "scroll" }}>
-                <div style={{ color: "white", paddingLeft: "10px" }}>{logContent}</div>
+                <div style={{ color: Settings.theme.maplocation, paddingLeft: "10px" }}>{logContent}</div>
               </Card>
             </>
           )}

--- a/src/DarkNet/ui/ServerStatusBox.tsx
+++ b/src/DarkNet/ui/ServerStatusBox.tsx
@@ -8,6 +8,7 @@ import { ServerSummary } from "./ServerSummary";
 
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { DWServerStyles, ServerName } from "./dnetStyles";
+import { Settings } from "../../Settings/Settings";
 
 export type DWServerProps = {
   server: DarknetServer;
@@ -35,10 +36,16 @@ export function ServerStatusBox({ server, enableAuth, classes }: DWServerProps):
     const position = getPixelPosition(server);
     const hasRunningScripts = !!server.runningScriptMap.size;
     return {
-      ...DWServerStyles,
+      ...DWServerStyles(),
       top: `${position.top}px`,
       left: `${position.left}px`,
-      borderColor: server.hasStasisLink ? "gold" : hasRunningScripts ? "green" : !server.maxRam ? "#6495ED" : "grey",
+      borderColor: !server.maxRam
+        ? Settings.theme.info
+        : server.hasStasisLink
+        ? Settings.theme.money
+        : hasRunningScripts
+        ? Settings.theme.primary
+        : Settings.theme.secondary,
     };
   };
 

--- a/src/DarkNet/ui/ServerSummary.tsx
+++ b/src/DarkNet/ui/ServerSummary.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { SvgIcon, Tooltip, Typography } from "@mui/material";
-import { Bolt, Code, Description, DoorBackSharp, Inventory2, LockPerson, Terminal } from "@mui/icons-material";
+import { AcUnit, Bolt, Code, Description, DoorBackSharp, Inventory2, LockPerson, Terminal } from "@mui/icons-material";
 import { formatNumber } from "../../ui/formatNumber";
 import { CompletedProgramName, ComplexPage } from "@enums";
 import { formatToMaxDigits } from "./uiUtilities";
@@ -8,6 +8,7 @@ import { formatToMaxDigits } from "./uiUtilities";
 import type { DarknetServer } from "../../Server/DarknetServer";
 import { DarknetConstants } from "../Constants";
 import { Router } from "../../ui/GameRoot";
+import { Settings } from "../../Settings/Settings";
 
 export type ServerSummaryProps = {
   server: DarknetServer;
@@ -25,7 +26,7 @@ export function ServerSummary({
   showDetails = false,
 }: ServerSummaryProps): React.ReactElement {
   if (!server.hasAdminRights && enableAuth) {
-    return <Typography color="secondary">[ auth required ]</Typography>;
+    return <Typography color={Settings.theme.int}>[ auth required ]</Typography>;
   }
   if (!server.hasAdminRights && !enableAuth) {
     return <Typography color="secondary">(no connection)</Typography>;
@@ -109,10 +110,21 @@ export function ServerSummary({
       </Tooltip>,
     );
   }
-  if (server.hasStasisLink) {
+  if (!server.maxRam) {
     components.push(
       <Tooltip
-        key="backdoor"
+        key="frozen"
+        title={<>Server has been frozen. It will not move, but has no max ram and does not give charisma xp.</>}
+      >
+        <Typography>
+          <SvgIcon component={AcUnit} className={`${classes.blue} ${classes.serverStatusIcon}`} />
+        </Typography>
+      </Tooltip>,
+    );
+  } else if (server.hasStasisLink) {
+    components.push(
+      <Tooltip
+        key="stasisLinked"
         title={
           <>
             Stasis link installed. This allows connecting to the server remotely, as well as ns.exec from any distance.

--- a/src/DarkNet/ui/dnetStyles.ts
+++ b/src/DarkNet/ui/dnetStyles.ts
@@ -1,5 +1,6 @@
 import { Theme } from "@mui/material/styles";
 import { makeStyles } from "tss-react/mui";
+import { Settings } from "../../Settings/Settings";
 
 export const dwColors = ["hack", "hp", "money", "int", "cha", "rep", "success"] as const;
 export type dwColors = (typeof dwColors)[number];
@@ -13,7 +14,7 @@ export const MAP_BORDER_WIDTH = 300;
 export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" })((theme: Theme, __, __classes) => ({
   DWServer: {
     "&:hover": {
-      backgroundColor: "#333 !important",
+      backgroundColor: Settings.theme.well + " !important",
     },
   },
   NetWrapper: {
@@ -21,7 +22,7 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
     height: "calc(100vh - 80px)",
     overflow: "scroll",
     position: "relative",
-    border: "solid 1px slategray",
+    border: "solid 1px " + Settings.theme.secondary,
   },
   button: {
     color: theme.colors.white,
@@ -68,6 +69,9 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
   gold: {
     color: theme.colors.money,
   },
+  blue: {
+    color: theme.colors.int,
+  },
   red: {
     color: theme.colors.hp,
   },
@@ -101,18 +105,18 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
     borderColor: theme.colors.success,
   },
   green: {
-    borderColor: "green",
+    borderColor: Settings.theme.primary,
   },
   grey: {
-    borderColor: "grey",
+    borderColor: Settings.theme.secondary,
   },
   goldBorder: {
-    borderColor: "gold",
+    borderColor: theme.colors.money,
   },
   serverDetailsText: {
     marginLeft: "-2em",
     textIndent: "2em",
-    color: "grey",
+    color: Settings.theme.secondary,
   },
 }));
 
@@ -124,7 +128,7 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
    This is done instead of adding hundreds of <style> tags into the DOM, which in some cases took multiple seconds
    waiting for insertBefore calls and reflowing the page when loading the darknet UI view.
  */
-export const DWServerStyles = {
+export const DWServerStyles = () => ({
   width: `${DW_SERVER_WIDTH}px`,
   height: `${DW_SERVER_HEIGHT}px`,
   borderWidth: "1px",
@@ -133,7 +137,7 @@ export const DWServerStyles = {
   borderRadius: "4px",
   zIndex: 10,
   cursor: "auto",
-  backgroundColor: "#000",
+  backgroundColor: Settings.theme.backgroundprimary,
 
   display: "inline-flex",
   alignItems: "center",
@@ -148,8 +152,8 @@ export const DWServerStyles = {
   lineHeight: 1.75,
   transition:
     "background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
-  color: "#0c0",
-};
+  color: Settings.theme.primary,
+});
 export const DWServerLogStyles = { fontFamily: 'JetBrainsMono, "Courier New", monospace', fontSize: "12px" };
 
 export const ServerName = {

--- a/src/DarkNet/ui/uiUtilities.tsx
+++ b/src/DarkNet/ui/uiUtilities.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { SnackbarEvents } from "../../ui/React/Snackbar";
 import { ToastVariant } from "@enums";
 import { DWServerLogStyles } from "./dnetStyles";
+import { Settings } from "../../Settings/Settings";
 
 export const formatToMaxDigits = (value: number, maxDigits: number): string => {
   if (value === 0) return "0";
@@ -29,7 +30,7 @@ export const formatObjectWithColoredKeys = (obj: Record<string, unknown>, filter
       {Object.entries(filteredObject).map(([key, value]) => {
         return (
           <React.Fragment key={key}>
-            <span style={{ color: "grey" }}>{key}: </span>
+            <span style={{ color: Settings.theme.secondary }}>{key}: </span>
             {/* React does not render null, undefined, and boolean values */}
             {typeof value !== "boolean" ? value : String(value)}
             <br />


### PR DESCRIPTION
This PR removes the hard-coded styles in the Darknet component and uses theme-based colors instead.

This allows the flashbang theme to still have the text be readable, and standardizes the look and feel to better match the rest of the UI for other themes.

It also adds an icon and border color for frozen servers, and improves the coloring of servers that have a connection but need authentication still.

Closes #2851 

<img width="960" height="618" alt="image" src="https://github.com/user-attachments/assets/f639d66d-5847-486a-a09f-472ab74de078" />

<img width="957" height="486" alt="image" src="https://github.com/user-attachments/assets/f7292373-8a11-42b6-b8dd-5696aa112d99" />

<img width="964" height="623" alt="image" src="https://github.com/user-attachments/assets/3aa9a296-e431-4a90-9370-bcd1bb592a84" />
