### PR TITLE
UI: Allow access to grafting UI outside New Tokyo

### DIFF
--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -1,11 +1,12 @@
 import type { Augmentation } from "../../../Augmentation/Augmentation";
 
 import { Player } from "@player";
-import { AugmentationName } from "@enums";
+import { AugmentationName, CityName } from "@enums";
 
 import React, { useState } from "react";
 import { CheckBox, CheckBoxOutlineBlank, Construction, Search } from "@mui/icons-material";
 import { Box, Button, Container, List, ListItemButton, Paper, TextField, Typography } from "@mui/material";
+import Tooltip from "@mui/material/Tooltip";
 
 import { GraftingWork } from "../../../Work/GraftingWork";
 import { Augmentations } from "../../../Augmentation/Augmentations";
@@ -22,6 +23,8 @@ import { convertTimeMsToTimeElapsedString } from "../../../utils/StringHelperFun
 import { GraftableAugmentation } from "../GraftableAugmentation";
 import { calculateGraftingTimeWithBonus, getGraftingAvailableAugs } from "../GraftingHelpers";
 import { useCycleRerender } from "../../../ui/React/hooks";
+import type { Result } from "@nsdefs";
+import { dialogBoxCreate } from "../../../ui/React/DialogBox";
 
 export const GraftableAugmentations = (): Record<string, GraftableAugmentation> => {
   const gAugs: Record<string, GraftableAugmentation> = {};
@@ -33,11 +36,17 @@ export const GraftableAugmentations = (): Record<string, GraftableAugmentation> 
   return gAugs;
 };
 
-const canGraft = (aug: GraftableAugmentation): boolean => {
-  if (Player.money < aug.cost) {
-    return false;
+const canGraft = (aug: GraftableAugmentation): Result => {
+  if (Player.city !== CityName.NewTokyo) {
+    return { success: false, message: "You must be in New Tokyo to begin grafting an augmentation." };
   }
-  return hasAugmentationPrereqs(aug.augmentation);
+  if (Player.money < aug.cost) {
+    return { success: false, message: "You do not have enough money." };
+  }
+  if (!hasAugmentationPrereqs(aug.augmentation)) {
+    return { success: false, message: "You do not have the pre-requisites augmentations." };
+  }
+  return { success: true };
 };
 
 interface IProps {
@@ -92,6 +101,8 @@ export const GraftingRoot = (): React.ReactElement => {
     rerender();
   };
 
+  const checkResult = canGraft(graftableAugmentations[selectedAug]);
+
   return (
     <Container disableGutters maxWidth="lg" sx={{ mx: 0 }}>
       <Button onClick={() => Router.back()}>Back</Button>
@@ -141,7 +152,9 @@ export const GraftingRoot = (): React.ReactElement => {
                   <ListItemButton key={i + 1} onClick={() => setSelectedAug(k)} selected={selectedAug === k}>
                     <Typography
                       sx={{
-                        color: canGraft(graftableAugmentations[k]) ? Settings.theme.primary : Settings.theme.disabled,
+                        color: canGraft(graftableAugmentations[k]).success
+                          ? Settings.theme.primary
+                          : Settings.theme.disabled,
                       }}
                     >
                       {k}
@@ -154,21 +167,27 @@ export const GraftingRoot = (): React.ReactElement => {
               <Typography variant="h6" sx={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
                 <Construction sx={{ mr: 1 }} /> {selectedAug}
               </Typography>
-              <Button
-                onClick={() => setGraftOpen(true)}
-                sx={{ width: "100%" }}
-                disabled={!canGraft(graftableAugmentations[selectedAug])}
-              >
-                Graft Augmentation (
-                <Typography>
-                  <Money money={graftableAugmentations[selectedAug].cost} forPurchase={true} />
-                </Typography>
-                )
-              </Button>
+              <Tooltip title={checkResult.message}>
+                <span>
+                  <Button onClick={() => setGraftOpen(true)} sx={{ width: "100%" }} disabled={!checkResult.success}>
+                    Graft Augmentation (
+                    <Typography>
+                      <Money money={graftableAugmentations[selectedAug].cost} forPurchase={true} />
+                    </Typography>
+                    )
+                  </Button>
+                </span>
+              </Tooltip>
               <ConfirmationModal
                 open={graftOpen}
                 onClose={() => setGraftOpen(false)}
                 onConfirm={() => {
+                  const checkResult = canGraft(graftableAugmentations[selectedAug]);
+                  if (!checkResult.success) {
+                    setGraftOpen(false);
+                    dialogBoxCreate(checkResult.message);
+                    return;
+                  }
                   Player.startWork(
                     new GraftingWork({
                       augmentation: selectedAug,

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -50,7 +50,7 @@ import { CONSTANTS } from "../../Constants";
 import { iTutorialSteps, iTutorialNextStep, ITutorial } from "../../InteractiveTutorial";
 import { getAvailableCreatePrograms } from "../../Programs/ProgramHelpers";
 import { Settings } from "../../Settings/Settings";
-import { AugmentationName, CityName } from "@enums";
+import { AugmentationName } from "@enums";
 
 import { ProgramsSeen } from "../../Programs/ui/ProgramsRoot";
 import { InvitationsSeen } from "../../Faction/ui/FactionsRoot";
@@ -169,7 +169,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
     Player.exploits.length > 0;
 
   const canOpenSleeves = Player.sleeves.length > 0;
-  const canOpenGrafting = Player.canAccessGrafting() && Player.city === CityName.NewTokyo;
+  const canOpenGrafting = Player.canAccessGrafting();
 
   const canCorporation = !!Player.corporation;
   const canGang = !!Player.gang;


### PR DESCRIPTION
Previously, the grafting UI and the `ns.grafting.graftAugmentation` API could only be used when players were in New Tokyo. As discussed on Discord, it's fine to remove this requirement for the grafting UI, so players can now open that UI to check grafting information from anywhere.

Note that the location requirement is still enforced in the API.

I also added a tooltip to the grafting UI and fixed a race condition.

@d0sboots There are two things to consider.

First, when players work for VitaLife, the Jobs tab shows the "Enter the Secret Lab" button. This button implies that they are in New Tokyo (VitaLife is in that city), so it seems strange to show the button when players are not in New Tokyo. This isn't really an issue now that we've removed the location requirement. The Bladeburner UI works the same way (the NSA job always shows the "Enter Bladeburner Headquarters" button).

Second, when players are not in New Tokyo, we throw an error, but we return false when they do not satisfy other requirements. I think we should always return false to be consistent here. It's a minor breaking change, but I don't think it will be a problem.
