### PR TITLE
UI: Replace hardcoded white text with theme color

### DIFF
--- a/src/DarkNet/ui/dnetStyles.ts
+++ b/src/DarkNet/ui/dnetStyles.ts
@@ -14,7 +14,7 @@ export const MAP_BORDER_WIDTH = 300;
 export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" })((theme: Theme, __, __classes) => ({
   DWServer: {
     "&:hover": {
-      backgroundColor: Settings.theme.well + " !important",
+      backgroundColor: theme.colors.well + " !important",
     },
   },
   NetWrapper: {
@@ -22,7 +22,7 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
     height: "calc(100vh - 80px)",
     overflow: "scroll",
     position: "relative",
-    border: "solid 1px " + Settings.theme.secondary,
+    border: "solid 1px " + theme.colors.secondary,
   },
   button: {
     color: theme.colors.white,
@@ -105,10 +105,10 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
     borderColor: theme.colors.success,
   },
   green: {
-    borderColor: Settings.theme.primary,
+    borderColor: theme.colors.primary,
   },
   grey: {
-    borderColor: Settings.theme.secondary,
+    borderColor: theme.colors.secondary,
   },
   goldBorder: {
     borderColor: theme.colors.money,
@@ -116,7 +116,7 @@ export const dnetStyles = makeStyles<unknown, dwColors>({ uniqId: "dnetStyles" }
   serverDetailsText: {
     marginLeft: "-2em",
     textIndent: "2em",
-    color: Settings.theme.secondary,
+    color: theme.colors.secondary,
   },
 }));
 

--- a/src/ErrorHandling/RecentErrorsPage.tsx
+++ b/src/ErrorHandling/RecentErrorsPage.tsx
@@ -101,7 +101,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   errorText: {
     margin: "4px",
-    color: "white",
+    color: theme.colors.primary,
     textOverflow: "ellipsis",
     whiteSpace: "pre-wrap",
     lineClamp: "6",

--- a/src/Infiltration/ui/Intro.tsx
+++ b/src/Infiltration/ui/Intro.tsx
@@ -40,7 +40,7 @@ function coloredArrow(difficulty: number): JSX.Element {
   const cappedDifficulty = Math.min(difficulty, MaxDifficultyForInfiltration);
   if (cappedDifficulty === 0) {
     return (
-      <span style={{ color: "white" }}>
+      <span style={{ color: Settings.theme.success }}>
         {">"}
         {" ".repeat(51)}
       </span>

--- a/src/Themes/ui/Theme.tsx
+++ b/src/Themes/ui/Theme.tsx
@@ -25,6 +25,9 @@ declare module "@mui/material/styles" {
       black: React.CSSProperties["color"];
       maplocation: React.CSSProperties["color"];
       disabled: React.CSSProperties["color"];
+      primary: React.CSSProperties["color"];
+      secondary: React.CSSProperties["color"];
+      well: React.CSSProperties["color"];
     };
   }
   interface ThemeOptions {
@@ -46,6 +49,9 @@ declare module "@mui/material/styles" {
       black: React.CSSProperties["color"];
       maplocation: React.CSSProperties["color"];
       disabled: React.CSSProperties["color"];
+      primary: React.CSSProperties["color"];
+      secondary: React.CSSProperties["color"];
+      well: React.CSSProperties["color"];
     };
   }
 }
@@ -73,6 +79,9 @@ export function refreshTheme(): void {
       black: Settings.theme.black,
       maplocation: Settings.theme.maplocation,
       disabled: Settings.theme.disabled,
+      primary: Settings.theme.primary,
+      secondary: Settings.theme.secondary,
+      well: Settings.theme.well,
     },
     palette: {
       primary: {


### PR DESCRIPTION
#2944 did not resolve all issues reported in #2851. This PR fixes the remaining issues.

Consideration:

1. In the "Recent Errors" tab, we use white for error logs, but I think it's unnecessary, so I use the primary theme color, which is the default color for all text.

2. Wrong comment
https://github.com/bitburner-official/bitburner-src/blob/a340453a9b0c5c0254f3ee2a472324329f4b0ee9/src/DarkNet/ui/dnetStyles.ts#L123-L130

This comment is wrong. You can test it easily by changing any component to this MRE and then inspecting the Elements tab in the dev console:
```ts
import * as React from "react";
import { makeStyles } from "tss-react/mui";

function Foo() {
  const styles = makeStyles()({
    root: {
      color: "#123456",
    },
  })();
  return <div className={styles.classes.root}>{Math.random()}</div>;
}

export function MilestonesRoot(): JSX.Element {
  const content = [];
  for (let i = 0; i < 1000; ++i) {
    content.push(<Foo />);
  }
  return <>{content}</>;
}
```
That comment is only correct if we call `makeStyles` with dynamic code like this:
```ts
  const styles = makeStyles()({
    root: {
      color: "#123456",
    },
    [`${Math.random()}`]: {
      color: "#654321",
    },
  })();
```
However, that's not the case here.

I'm not sure whether there was actually any performance improvement when fico made this change, but even if there was, the real reason is not what this comment claims. I'm too lazy to investigate it now, and it's not related to this PR, so I won't touch it now.

3. IPvGO UI

It currently looks like this:

<img width="909" height="833" alt="Capture" src="https://github.com/user-attachments/assets/0c7bec62-a794-4c72-b4f1-0c3d92a3c47b" />

It's obviously an issue, but I think the "Traditional Go look" feature is good enough for mitigating it. This is the only theme that excessively uses the white color everywhere. I can force a black background on the non-traditional board, but I don't think it's necessary.

5. Wirecutter minigame

This minigame has the same issue, but I'll handle it in a separate PR. A player reported an issue related to that minigame. The gist is that the colors in this minigame are hard for color-blind players to distinguish.

Closes #2851.