### PR TITLE
DOCS: Clarify ns.corporation.limitMaterialProduction()

### DIFF
--- a/markdown/bitburner.warehouseapi.limitmaterialproduction.md
+++ b/markdown/bitburner.warehouseapi.limitmaterialproduction.md
@@ -104,9 +104,13 @@ void
 
 RAM cost: 20 GB
 
-This limit applies only to output; it does not affect input consumption.
+This limit does not reduce input consumption.
 
-For example, in Agriculture, assume the division's raw production is 1000. You need to consume 500 Water and 200 Chemicals to produce 1000 Plants and 1000 Food. If you set the limits for Plants and Food to 200 and 100 respectively, you will still consume 500 Water and 200 Chemicals, but only produce 200 Plants and 100 Food.
+For example, in Agriculture, assume the division's raw production is 1000 and assume the division is bottlenecked by raw production (as opposed to lack of input materials or warehouse space). You need to consume 500 Water and 200 Chemicals to produce 1000 Plants and 1000 Food. If you set the limits for Plants and Food to 200 and 100 respectively, you will still consume 500 Water and 200 Chemicals, but only produce 200 Plants and 100 Food.
+
+The limit does not make production more space-efficient.
+
+For example, If you set the limit for Plants to 0, the formula effectively becomes 0.5 Water + 0.2 Chemicals ⟹ 1 Food, but it still requires empty warehouse space as if it were 0.5 Water + 0.2 Chemicals ⟹ 1 Plants + 1 Food.
 
 With industries that produce both materials and products, the material production limits do not affect product production.
 

--- a/markdown/bitburner.warehouseapi.limitmaterialproduction.md
+++ b/markdown/bitburner.warehouseapi.limitmaterialproduction.md
@@ -104,13 +104,17 @@ void
 
 RAM cost: 20 GB
 
-This limit does not reduce input consumption.
+This limit applies only to output. It does not reduce input consumption. The excess output is discarded after being produced.
 
-For example, in Agriculture, assume the division's raw production is 1000 and assume the division is bottlenecked by raw production (as opposed to lack of input materials or warehouse space). You need to consume 500 Water and 200 Chemicals to produce 1000 Plants and 1000 Food. If you set the limits for Plants and Food to 200 and 100 respectively, you will still consume 500 Water and 200 Chemicals, but only produce 200 Plants and 100 Food.
+For example: Assume the division's raw production is 1000 and the warehouse has enough input materials. In Agriculture, for each unit of raw production, you need 0.045 units of free space (check corporation documentation for further explanation). Therefore, with RawProduction = 1000, you need 45 units of free space to avoid being bottlenecked by insufficient free space.
 
-The limit does not make production more space-efficient.
+Case 1: Enough free space (Free space = 45). You need to consume 500 Water and 200 Chemicals to produce 1000 Plants and 1000 Food.
 
-For example, If you set the limit for Plants to 0, the formula effectively becomes 0.5 Water + 0.2 Chemicals ⟹ 1 Food, but it still requires empty warehouse space as if it were 0.5 Water + 0.2 Chemicals ⟹ 1 Plants + 1 Food.
+If you set the limits for Plants and Food to 200 and 100 respectively, you will still consume 500 Water and 200 Chemicals, but only produce 200 Plants and 100 Food (the excess 800 Plants and 900 Food are discarded after being produced). The free space after production is 67 (800 Plants and 900 Food are discarded).
+
+Case 2: Insufficient free space (Free space = 22.5). The available free space is only 50% of the required free space. Therefore, RawProduction is scaled down to 500.
+
+You need to consume 250 Water and 100 Chemicals to produce 500 Plants and 500 Food. If you set the Food limit to 0, you will still consume 250 Water and 100 Chemicals, but only produce 500 Plants (the excess 500 Food are discarded after being produced). The free space after production is 15 (500 Food are discarded).
 
 With industries that produce both materials and products, the material production limits do not affect product production.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -10302,11 +10302,19 @@ export interface WarehouseAPI {
    * @remarks
    * RAM cost: 20 GB
    *
-   * This limit applies only to output; it does not affect input consumption.
+   * This limit does not reduce input consumption.
    *
-   * For example, in Agriculture, assume the division's raw production is 1000. You need to consume 500 Water and 200
-   * Chemicals to produce 1000 Plants and 1000 Food. If you set the limits for Plants and Food to 200 and 100
-   * respectively, you will still consume 500 Water and 200 Chemicals, but only produce 200 Plants and 100 Food.
+   * For example, in Agriculture, assume the division's raw production is 1000 and assume the division
+   * is bottlenecked by raw production (as opposed to lack of input materials or warehouse space).
+   * You need to consume 500 Water and 200 Chemicals to produce 1000 Plants and 1000 Food. If you set
+   * the limits for Plants and Food to 200 and 100 respectively, you will still consume 500 Water
+   * and 200 Chemicals, but only produce 200 Plants and 100 Food.
+   *
+   * The limit does not make production more space-efficient.
+   *
+   * For example, If you set the limit for Plants to 0, the formula effectively becomes
+   * 0.5 Water + 0.2 Chemicals ⟹ 1 Food, but it still requires empty warehouse space as
+   * if it were 0.5 Water + 0.2 Chemicals ⟹ 1 Plants + 1 Food.
    *
    * With industries that produce both materials and products, the material production limits do not affect product
    * production.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -10302,19 +10302,27 @@ export interface WarehouseAPI {
    * @remarks
    * RAM cost: 20 GB
    *
-   * This limit does not reduce input consumption.
+   * This limit applies only to output. It does not reduce input consumption. The excess output is discarded after being
+   * produced.
    *
-   * For example, in Agriculture, assume the division's raw production is 1000 and assume the division
-   * is bottlenecked by raw production (as opposed to lack of input materials or warehouse space).
-   * You need to consume 500 Water and 200 Chemicals to produce 1000 Plants and 1000 Food. If you set
-   * the limits for Plants and Food to 200 and 100 respectively, you will still consume 500 Water
-   * and 200 Chemicals, but only produce 200 Plants and 100 Food.
+   * For example: Assume the division's raw production is 1000 and the warehouse has enough input materials. In
+   * Agriculture, for each unit of raw production, you need 0.045 units of free space (check corporation documentation
+   * for further explanation). Therefore, with RawProduction = 1000, you need 45 units of free space to avoid being
+   * bottlenecked by insufficient free space.
    *
-   * The limit does not make production more space-efficient.
+   * Case 1: Enough free space (Free space = 45). You need to consume 500 Water and 200 Chemicals to produce 1000
+   * Plants and 1000 Food.
    *
-   * For example, If you set the limit for Plants to 0, the formula effectively becomes
-   * 0.5 Water + 0.2 Chemicals ⟹ 1 Food, but it still requires empty warehouse space as
-   * if it were 0.5 Water + 0.2 Chemicals ⟹ 1 Plants + 1 Food.
+   * If you set the limits for Plants and Food to 200 and 100 respectively, you will still consume 500 Water and 200
+   * Chemicals, but only produce 200 Plants and 100 Food (the excess 800 Plants and 900 Food are discarded after being
+   * produced). The free space after production is 67 (800 Plants and 900 Food are discarded).
+   *
+   * Case 2: Insufficient free space (Free space = 22.5). The available free space is only 50% of the required free
+   * space. Therefore, RawProduction is scaled down to 500.
+   *
+   * You need to consume 250 Water and 100 Chemicals to produce 500 Plants and 500 Food. If you set the Food limit to 0,
+   * you will still consume 250 Water and 100 Chemicals, but only produce 500 Plants (the excess 500 Food are discarded
+   * after being produced). The free space after production is 15 (500 Food are discarded).
    *
    * With industries that produce both materials and products, the material production limits do not affect product
    * production.


### PR DESCRIPTION
In some industries (e.g. Agriculture) output materials take up more space than input materials. I thought that recent changes to how material production limits work unintentionally create a new optimal strategy: discarding some of the plants you produce to be able to produce more food than your warehouse space would otherwise allow (or discarding food to have more space for plants, depending on which of the two is more useful to you). It turns out, I was wrong: materials that are discarded by a production limit still require empty warehouse space.

I have updated the docs to clarify this.