### PR TITLE
UI: Move instability info to top left of darknet UI

### DIFF
--- a/src/DarkNet/ui/NetworkDisplayWrapper.tsx
+++ b/src/DarkNet/ui/NetworkDisplayWrapper.tsx
@@ -18,7 +18,7 @@ import { drawOnCanvas, getPixelPosition } from "./networkCanvas";
 import { dnetStyles, DWServerLogStyles } from "./dnetStyles";
 import { getLabyrinthDetails, isLabyrinthServer } from "../effects/labyrinth";
 import { DarknetServer } from "../../Server/DarknetServer";
-import { getAllDarknetServers, getAllMovableDarknetServers } from "../utils/darknetNetworkUtils";
+import { getAllDarknetServers, getBackdooredDarknetServers } from "../utils/darknetNetworkUtils";
 import { ServerDetailsModal } from "./ServerDetailsModal";
 import { AutoCompleteSearchBox } from "../../ui/AutoCompleteSearchBox";
 import { getDarknetServerOrThrow } from "../utils/darknetServerUtils";
@@ -226,36 +226,34 @@ export function NetworkDisplayWrapper(): React.ReactElement {
         ""
       )}
       {DarknetState.mutationLock ? (
-        <Typography variant={"h6"} className={classes.gold}>
+        <Typography variant={"h5"} className={classes.gold}>
           [WEBSTORM WARNING]
         </Typography>
       ) : (
-        <Box className={`${classes.inlineFlexBox}`}>
-          <Typography variant={"h5"} sx={{ fontWeight: "bold" }}>
-            Dark Net
-          </Typography>
+        <Typography variant={"h5"} sx={{ fontWeight: "bold", display: "flex", alignItems: "center" }}>
+          Dark Net
           {instability > 0 && (
             <Tooltip
               title={
                 <>
-                  If too many darknet servers are backdoored or frozen, it will increase the chance that authentication{" "}
+                  If too many darknet servers are backdoored (without stasis links) or frozen, it will increase the
+                  chance that authentication attempts return a 408 Request Timeout error even if the password is
+                  correct.
                   <br />
-                  attempts will return a 408 Request Timeout error (even if the password is correct). <br />
                   Most servers will eventually restart or go offline, which removes backdoors over time.
                   <br />
-                  Current backdoored servers: {getAllMovableDarknetServers().filter((s) => s.backdoorInstalled).length}
+                  Current backdoored servers: {getBackdooredDarknetServers().length}
                   <br />
                   Current frozen servers: {getAllDarknetServers().filter((s) => !s.maxRam).length}
                 </>
               }
             >
-              <Typography variant={"subtitle1"} sx={{ fontStyle: "italic" }}>
-                {" "}
-                Instability: {instabilityText}
+              <Typography component="span" sx={{ fontStyle: "italic", marginLeft: "10px" }}>
+                (Instability: {instabilityText})
               </Typography>
             </Tooltip>
           )}
-        </Box>
+        </Typography>
       )}
 
       <div

--- a/src/DarkNet/utils/darknetNetworkUtils.ts
+++ b/src/DarkNet/utils/darknetNetworkUtils.ts
@@ -87,7 +87,7 @@ export const getAllAdjacentNeighbors = (x: number, y: number): DarknetServer[] =
 export const getIslands = () => getAllMovableDarknetServers().filter((s) => !s.serversOnNetwork.length);
 
 export const getBackdooredDarknetServers = (): DarknetServer[] =>
-  getAllMovableDarknetServers().filter((s) => !s.hasStasisLink && s.backdoorInstalled);
+  getAllMovableDarknetServers().filter((s) => s.backdoorInstalled);
 
 export const getNearbyNonEmptyPasswordServer = (server: DarknetServer, disconnected = false) => {
   return getAllAdjacentNeighbors(server.depth, server.leftOffset).find(


### PR DESCRIPTION
The instability info is currently positioned in the top right of the darknet UI, which is hidden by the overview window. If players don't move the overview window, they may never see this feature.

Other minor changes:
- Use h5 for "WEBSTORM WARNING".
- Remove an unnecessary check in `getBackdooredDarknetServers`. `getAllMovableDarknetServers` already checks `hasStasisLink`.

Before:

<img width="1134" height="466" alt="before" src="https://github.com/user-attachments/assets/a9bfe70d-082e-4f0b-b9dd-1644019ba3a9" />

After:

<img width="1134" height="482" alt="after" src="https://github.com/user-attachments/assets/a486efbc-a1cb-4b1f-83b0-7546129174de" />
