### PR TITLE
UI: Change how server summary displays dnet-specific information

### DIFF
--- a/src/DarkNet/ui/ServerSummary.tsx
+++ b/src/DarkNet/ui/ServerSummary.tsx
@@ -184,7 +184,7 @@ export function ServerSummary({
       ? components
       : [
           ...components.slice(0, 3),
-          <Tooltip key="others" title={components.slice(3)}>
+          <Tooltip key="others" placement="right" title={<div style={{ display: "flex" }}>{components.slice(3)}</div>}>
             <Typography>
               <SvgIcon component={Add} className={classes.serverStatusIcon} />
             </Typography>

--- a/src/DarkNet/ui/ServerSummary.tsx
+++ b/src/DarkNet/ui/ServerSummary.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import { SvgIcon, Tooltip, Typography } from "@mui/material";
-import { AcUnit, Bolt, Code, Description, DoorBackSharp, Inventory2, LockPerson, Terminal } from "@mui/icons-material";
+import {
+  AcUnit,
+  Add,
+  Bolt,
+  Code,
+  Description,
+  DoorBackSharp,
+  Inventory2,
+  LockPerson,
+  Terminal,
+} from "@mui/icons-material";
 import { formatNumber } from "../../ui/formatNumber";
 import { CompletedProgramName, ComplexPage } from "@enums";
 import { formatToMaxDigits } from "./uiUtilities";
@@ -66,7 +76,6 @@ export function ServerSummary({
     server.caches.length > 3 ? ` +${server.caches.length - 3}` : ""
   }`;
   const hasStormSeed = server.programs.includes(CompletedProgramName.stormSeed);
-  const hasBackdoor = server.backdoorInstalled && !server.hasStasisLink;
   const ramBlockedDetails = formatToMaxDigits(server.blockedRam, 2) + "GB";
   const ramBlocked = showDetails ? ramBlockedDetails : formatNumber(server.blockedRam, 0);
 
@@ -101,7 +110,22 @@ export function ServerSummary({
       </Tooltip>,
     );
   }
-  if (hasBackdoor) {
+  if (server.hasStasisLink) {
+    components.push(
+      <Tooltip
+        key="stasisLinked"
+        title={
+          <>
+            Stasis link installed. This allows connecting to the server remotely, as well as ns.exec from any distance.
+          </>
+        }
+      >
+        <Typography>
+          <SvgIcon component={DoorBackSharp} className={`${classes.gold} ${classes.serverStatusIcon}`} />
+        </Typography>
+      </Tooltip>,
+    );
+  } else if (server.backdoorInstalled) {
     components.push(
       <Tooltip key="backdoor" title={<>Backdoor installed. Warning: this increases darknet instability.</>}>
         <Typography>
@@ -118,21 +142,6 @@ export function ServerSummary({
       >
         <Typography>
           <SvgIcon component={AcUnit} className={`${classes.blue} ${classes.serverStatusIcon}`} />
-        </Typography>
-      </Tooltip>,
-    );
-  } else if (server.hasStasisLink) {
-    components.push(
-      <Tooltip
-        key="stasisLinked"
-        title={
-          <>
-            Stasis link installed. This allows connecting to the server remotely, as well as ns.exec from any distance.
-          </>
-        }
-      >
-        <Typography>
-          <SvgIcon component={DoorBackSharp} className={`${classes.gold} ${classes.serverStatusIcon}`} />
         </Typography>
       </Tooltip>,
     );
@@ -170,8 +179,17 @@ export function ServerSummary({
       </Tooltip>,
     );
   }
-  const maxIcons = showDetails ? components.length : 3;
-  const componentsToShow = components.slice(0, maxIcons);
+  const componentsToShow =
+    showDetails || components.length <= 4
+      ? components
+      : [
+          ...components.slice(0, 3),
+          <Tooltip key="others" title={components.slice(3)}>
+            <Typography>
+              <SvgIcon component={Add} className={classes.serverStatusIcon} />
+            </Typography>
+          </Tooltip>,
+        ];
 
   return (
     <div style={{ display: "inline-flex", flexDirection: "row", width: "100%", justifyContent: "space-between" }}>


### PR DESCRIPTION
The server summary currently displays at most three pieces of dnet-specific information. This can easily lead to unnecessary debates about which pieces should be prioritized. The box has enough space for four pieces, so we should display four instead of three. If there are more, the fourth item will be an icon that shows all remaining pieces on hover.

I also fixed an issue introduced in #2944. The current code assumes that a frozen server cannot have a stasis link, but that's not true. Players can set the stasis link on a server, then freeze it. That's a stupid thing to do, but it can happen.

Before:

<img width="1090" height="537" alt="before" src="https://github.com/user-attachments/assets/5b4b39c2-1af2-4023-a95a-17b3eae65206" />

After:

<img width="1083" height="597" alt="after" src="https://github.com/user-attachments/assets/0a05614d-e0ca-434f-a93d-1bba9f86d264" />