### PR TITLE
UI: Do not show Entropy virus notice when grafting Congruity Implant

### DIFF
--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -201,16 +201,14 @@ export const GraftingRoot = (): React.ReactElement => {
                   <Typography component="div" paddingBottom="1rem">
                     Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b>{" "}
                     be returned.
-                    {!Player.hasAugmentation(AugmentationName.CongruityImplant) && (
-                      <>
-                        <br />
-                        <br />
-                        {selectedAug !== AugmentationName.CongruityImplant &&
-                          "Additionally, grafting an augmentation will increase the potency of the Entropy virus."}
-                        {selectedAug === AugmentationName.CongruityImplant &&
-                          "This augmentation will remove the Entropy virus effect."}
-                      </>
-                    )}
+                    {!Player.hasAugmentation(AugmentationName.CongruityImplant) &&
+                      selectedAug !== AugmentationName.CongruityImplant && (
+                        <>
+                          <br />
+                          <br />
+                          Additionally, grafting an augmentation will increase the potency of the Entropy virus.
+                        </>
+                      )}
                   </Typography>
                 }
               />

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -205,7 +205,10 @@ export const GraftingRoot = (): React.ReactElement => {
                       <>
                         <br />
                         <br />
-                        Additionally, grafting an augmentation will increase the potency of the Entropy virus.
+                        {selectedAug !== AugmentationName.CongruityImplant &&
+                          "Additionally, grafting an augmentation will increase the potency of the Entropy virus."}
+                        {selectedAug === AugmentationName.CongruityImplant &&
+                          "This augmentation will remove the Entropy virus effect."}
                       </>
                     )}
                   </Typography>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -201,13 +201,14 @@ export const GraftingRoot = (): React.ReactElement => {
                   <Typography component="div" paddingBottom="1rem">
                     Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b>{" "}
                     be returned.
-                    {selectedAug !== AugmentationName.CongruityImplant && (
-                      <>
-                        <br />
-                        <br />
-                        Additionally, grafting an augmentation will increase the potency of the Entropy virus.
-                      </>
-                    )}
+                    {!Player.hasAugmentation(AugmentationName.CongruityImplant) &&
+                      selectedAug !== AugmentationName.CongruityImplant && (
+                        <>
+                          <br />
+                          <br />
+                          Additionally, grafting an augmentation will increase the potency of the Entropy virus.
+                        </>
+                      )}
                   </Typography>
                 }
               />

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -201,14 +201,13 @@ export const GraftingRoot = (): React.ReactElement => {
                   <Typography component="div" paddingBottom="1rem">
                     Cancelling grafting will <b>not</b> save grafting progress, and the money you spend will <b>not</b>{" "}
                     be returned.
-                    {!Player.hasAugmentation(AugmentationName.CongruityImplant) &&
-                      selectedAug !== AugmentationName.CongruityImplant && (
-                        <>
-                          <br />
-                          <br />
-                          Additionally, grafting an augmentation will increase the potency of the Entropy virus.
-                        </>
-                      )}
+                    {selectedAug !== AugmentationName.CongruityImplant && (
+                      <>
+                        <br />
+                        <br />
+                        Additionally, grafting an augmentation will increase the potency of the Entropy virus.
+                      </>
+                    )}
                   </Typography>
                 }
               />


### PR DESCRIPTION
First off, sorry for the typo in the commit :)
This PR modifies the grafting popup when the augmentation is the Congruity Implant it the text "grafting an augmentation will increase the potency of the entropy virus" changes to "This augmentation will remove the Entropy virus effect".