### PR TITLE
ELECTRON: Add command line parameter to disable Steam integration

### DIFF
--- a/electron/steamworksUtils.js
+++ b/electron/steamworksUtils.js
@@ -54,17 +54,13 @@ function verifyLibraryFiles() {
   return { success: true };
 }
 
-/** Steam integration can be disabled entirely with the --no-steam command-line flag. When disabled, we never load
- * steamworks.js or connect to the Steam client, and we don't set global.steamworksError, so the "Could not connect
- * to Steam" dialog is skipped. Steam Cloud and achievements are already no-ops when steamworksClient is undefined. */
-const steamworksDisabled = process.argv.includes("--no-steam");
-
+/** Steam integration is optional. Players can disable it by passing the --no-steam flag. */
 let steamworks;
 try {
-  if (!steamworksDisabled) {
+  if (!process.argv.includes("--no-steam")) {
     steamworks = require("@catloversg/steamworks.js");
   } else {
-    log.info("Steam integration disabled by --no-steam flag");
+    log.info("Steam integration was disabled by --no-steam flag");
   }
 } catch (error) {
   log.error(error);

--- a/electron/steamworksUtils.js
+++ b/electron/steamworksUtils.js
@@ -54,9 +54,18 @@ function verifyLibraryFiles() {
   return { success: true };
 }
 
+/** Steam integration can be disabled entirely with the --no-steam command-line flag. When disabled, we never load
+ * steamworks.js or connect to the Steam client, and we don't set global.steamworksError, so the "Could not connect
+ * to Steam" dialog is skipped. Steam Cloud and achievements are already no-ops when steamworksClient is undefined. */
+const steamworksDisabled = process.argv.includes("--no-steam");
+
 let steamworks;
 try {
-  steamworks = require("@catloversg/steamworks.js");
+  if (!steamworksDisabled) {
+    steamworks = require("@catloversg/steamworks.js");
+  } else {
+    log.info("Steam integration disabled by --no-steam flag");
+  }
 } catch (error) {
   log.error(error);
   log.info(


### PR DESCRIPTION
Adding Command Line Parameter to Disable Steam Integration
CATEGORY: MISC

This PR enables the '--no-steam' command line parameter. If set, it will not initialize Steamworks.

Steam integration is optional. However, force loading Steamworks can cause issues for some players. In some cases these issues manifest as an error dialog saying Steam is not installed. In other cases, users may find Steam does not allow them to run both BitBurner and Steam games at the same time. While neither of these issues are fatal, they can be annoying to users who do hit them. 

This settings is off by default. If the command line parameter isn't set, it will run the game like normal with steam integration.