### PR TITLE
DOCS: Improve CONTRIBUTING and README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,21 +36,19 @@ already been reported as an [Issue](https://github.com/bitburner-official/bitbur
 - **Use a clear and descriptive title** for the Issue.
 - **State your browser, your browser's version, and your computer's OS.**
 - **Attach your save file**, if you think it would help solve the Issue.
-  Zip your save file first, then attach the zipped save file.
+  The game auto-zips the save, upload it as-is.
 - **Provide instructions on how to reproduce the bug** in as much detail
   as possible. If you cannot reliably reproduce the bug, then just try
   your best to explain what was happening when the bug occurred.
 - **Provide any scripts** that triggered the bug if the Issue is Netscript-related.
-- **Open your browser's Dev Console and report any error-related output**
+- **Open your browser's Dev Tools and report any error-related output**
   that may be printed there. The Dev Console can be opened on most modern
-  browsers by pressing F12.
+  browsers by pressing F12 or Ctrl+Shift+I.
 
 ## As a Developer
 
 Anyone is welcome to contribute to Bitburner code. However, please read
-the [license](./license.txt)
-and the [readme](./README.md)
-before doing so.
+the [LICENSE](./license.txt) and the [README](./README.md) before doing so.
 
 To contribute to Bitburner code, you will need to have
 [NodeJS](https://nodejs.org) installed. When installing NodeJS, a utility
@@ -103,7 +101,7 @@ Desktop, or command line.
 ```sh
 # This clones the game's code repository. The output you get might vary.
 $ git clone https://github.com/bitburner-official/bitburner-src.git
-Cloning into 'bitburner'...
+Cloning into 'bitburner-src'...
 remote: Enumerating objects: 57072, done.
 remote: Counting objects: 100% (404/404), done.
 remote: Compressing objects: 100% (205/205), done.
@@ -138,18 +136,38 @@ $ git fetch upstream
 $ git branch
 * dev
 $ git branch -r
-upstream/BN14
+origin/HEAD -> origin/dev
+origin/dev
 upstream/HEAD -> upstream/dev
 upstream/dev
-upstream/folders
-upstream/master
+...
 ```
 
 ## Development Workflow Best Practices
 
 - Work in a new branch forked from the `dev` branch to isolate your new code.
-  - Keep code-changes on a branch as small as possible. This makes it easier for code review. Each branch should be its own independent feature.
-  - Regularly rebase your branch against `dev` to make sure you have the latest updates pulled.
+
+```sh
+$ git checkout dev # or with modern syntax, git switch dev
+Switched to branch 'dev'
+Your branch is up to date with 'upstream/dev'
+# create another branch based on dev called 'new-stuff-to-add'
+# your changes will be stored in this branch, which later you will PR to upstream/dev
+$ git checkout -b new-stuff-to-add
+# ... (do some changes in the code)
+$ git add . # store my changes and prep them to go
+$ git commit -m "Commit Messsage" # this will store your changes into a "commit", which is
+$ git push origin new-stuff-to-add # upload changes to GitHub
+```
+
+- Keep code-changes on a branch as small as possible. This makes it easier for code review. Each branch should be its own independent feature.
+- Regularly rebase your branch against `dev` to make sure you have the latest updates pulled.
+
+```sh
+$ git checkout new-stuff-to-add
+Switched 'to branch new-stuff-to-add'
+$ git rebase upstream dev # git merge upstream dev works as well
+```
 
 ## Running locally
 
@@ -157,7 +175,7 @@ Install
 
 - NodeJS (maybe via `nvm`). When installing NodeJS, you also get a tool called `npm`. You can update `npm` to the latest version by running `npm install -g npm@latest`.
 - Github Desktop (Windows only)
-- Visual Studio Code (optional)
+- Visual Studio Code (optional but recommended)
 
 Inside the root of the repository run:
 
@@ -169,8 +187,10 @@ Saving a file will reload the game automatically.
 
 ### How to build the electron app
 
-Tested on Node 24.13.0 (LTS) on Windows.
-These steps only work in a Bash-like environment, like MinGW for Windows.
+Tested on:
+
+- Node 24.13.0 (LTS) on Windows.
+- These steps only work in a Bash-like environment, like MinGW for Windows.
 
 ```sh
 # Install the main game dependencies & build the app in debug mode.
@@ -192,13 +212,13 @@ the following rules:
 - Work in a branch forked from `dev` to isolate the new code.
 - Ensure you have the latest from the [game's main
   repository](../../tree/dev).
-- Rebase your branch if necessary.
-- Run the game locally to test out your changes.
+- Rebase or merge your branch if necessary.
+- Run the game locally to test out your changes (`npm run start:dev`).
 - When submitting the pull request, make sure that the base fork is
   _bitburner-official/bitburner-src_ and the base is _dev_.
 - If your changes affect the game's UI, attach some screenshots or GIFs showing
   the changes to the UI.
-- If your changes affect Netscript, provide some
+- If your changes affect the Netscript API, provide some
   scripts that can be used to test the Netscript changes.
 - Ensure you have run `npm run lint` to make sure your changes conform to the
   rules enforced across the code base. The command will fail if any of the
@@ -274,3 +294,15 @@ See [PR #8671](https://github.com/npm/cli/pull/8671) and [Issue #8690](https://g
 ### Unrelated failed Jest tests
 
 Some Jest tests fail to run in Node versions older than v24. On those versions, these tests show a small difference between the expected value ("Snapshot") and the actual value ("Received"). You need to use Node v24+ to run these tests.
+
+## TL;DR
+
+- Fork the repo ([How to setup your fork properly](#how-to-setup-your-fork-properly)).
+- Make your changes.
+- Run `npm run format` (prettier), `npm run lint` (linter) and `npm run test` (jest). If you made any changes to
+  `NetscriptDefinitions.d.ts`, run `npm run doc` (API documenter) as well.
+- Test your changes manually before submitting anything!! ([running locally](#running-locally)).
+- Commit your changes ([Development Workflow](#development-workflow-best-practices)).
+- Go to GitHub and create a PR following [these guidelines](#submitting-a-pull-request).
+- Follow maintainers' feedback and adjust any changes you made to their suggestions. If you have
+  any questions or doubts, check [this links](#in-general).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ Your branch is up to date with 'upstream/dev'
 $ git checkout -b new-stuff-to-add
 # ... (do some changes in the code)
 $ git add . # store my changes and prep them to go
-$ git commit -m "Commit Messsage" # this will store your changes into a "commit", which is
+$ git commit -m "Commit Messsage" # this will store your changes into a commit
 $ git push origin new-stuff-to-add # upload changes to GitHub
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,14 @@ already been reported as an [Issue](https://github.com/bitburner-official/bitbur
 - **Use a clear and descriptive title** for the Issue.
 - **State your browser, your browser's version, and your computer's OS.**
 - **Attach your save file**, if you think it would help solve the Issue.
-  The game auto-zips the save, upload it as-is.
+  Upload your save file as is. Do NOT compress or decompress it.
 - **Provide instructions on how to reproduce the bug** in as much detail
   as possible. If you cannot reliably reproduce the bug, then just try
   your best to explain what was happening when the bug occurred.
 - **Provide any scripts** that triggered the bug if the Issue is Netscript-related.
-- **Open your browser's Dev Tools and report any error-related output**
-  that may be printed there. The Dev Console can be opened on most modern
-  browsers by pressing F12 or Ctrl+Shift+I.
+- **Open the Console tab in your browser's Dev Tools and report any error-related output**
+  that may be printed there. The Dev Tools can be opened on most modern
+  browsers by pressing F12 or Ctrl+Shift+I (Cmd + Option + I on macOS machines).
 
 ## As a Developer
 
@@ -136,37 +136,30 @@ $ git fetch upstream
 $ git branch
 * dev
 $ git branch -r
-origin/HEAD -> origin/dev
-origin/dev
 upstream/HEAD -> upstream/dev
 upstream/dev
-...
 ```
 
 ## Development Workflow Best Practices
 
-- Work in a new branch forked from the `dev` branch to isolate your new code.
+- Work in a new branch based on the `dev` branch to isolate your changes.
 
 ```sh
-$ git checkout dev # or with modern syntax, git switch dev
-Switched to branch 'dev'
-Your branch is up to date with 'upstream/dev'
-# create another branch based on dev called 'new-stuff-to-add'
-# your changes will be stored in this branch, which later you will PR to upstream/dev
-$ git checkout -b new-stuff-to-add
-# ... (do some changes in the code)
-$ git add . # store my changes and prep them to go
-$ git commit -m "Commit Messsage" # this will store your changes into a commit
-$ git push origin new-stuff-to-add # upload changes to GitHub
+$ git checkout dev
+$ git checkout -b new-stuff-to-add # Create a new branch for your changes.
+# ... (Make your changes)
+$ git add . # Stage your changes.
+$ git commit -m "Commit Message" # Commit your staged changes.
+$ git push origin new-stuff-to-add # Push your branch to GitHub.
 ```
 
-- Keep code-changes on a branch as small as possible. This makes it easier for code review. Each branch should be its own independent feature.
-- Regularly rebase your branch against `dev` to make sure you have the latest updates pulled.
+- Keep code changes on a branch as small as possible. This makes it easier for code review. Each branch should be its own independent feature.
+- Regularly rebase your branch onto `upstream/dev` to keep it up to date.
 
 ```sh
+$ git fetch upstream
 $ git checkout new-stuff-to-add
-Switched 'to branch new-stuff-to-add'
-$ git rebase upstream dev # git merge upstream dev works as well
+$ git rebase upstream/dev
 ```
 
 ## Running locally
@@ -175,7 +168,7 @@ Install
 
 - NodeJS (maybe via `nvm`). When installing NodeJS, you also get a tool called `npm`. You can update `npm` to the latest version by running `npm install -g npm@latest`.
 - Github Desktop (Windows only)
-- Visual Studio Code (optional but recommended)
+- Visual Studio Code (optional)
 
 Inside the root of the repository run:
 
@@ -187,9 +180,7 @@ Saving a file will reload the game automatically.
 
 ### How to build the electron app
 
-Tested on:
-
-- Node 24.13.0 (LTS) on Windows.
+Tested on Node 24.13.0 (LTS) on Windows.
 
 These steps only work in a Bash-like environment, like MinGW for Windows.
 
@@ -219,7 +210,7 @@ the following rules:
   _bitburner-official/bitburner-src_ and the base is _dev_.
 - If your changes affect the game's UI, attach some screenshots or GIFs showing
   the changes to the UI.
-- If your changes affect the Netscript API, provide some
+- If your changes affect the Netscript APIs, provide some
   scripts that can be used to test the Netscript changes.
 - Ensure you have run `npm run lint` to make sure your changes conform to the
   rules enforced across the code base. The command will fail if any of the
@@ -288,9 +279,9 @@ After running `npm install`, if you do not change anything in `package.json` and
 
 ### Lots of `peer: true` lines added in `package-lock.json`
 
-npm version 11.6.2 has a bug that causes this. If you can, switch to the `24.18.0` version which is the LTS as of this writing and re-run `npm install`.
+npm version 11.6.2 has a bug that causes this. You need to update npm and rerun `npm install`.
 
-See [PR #8671](https://github.com/npm/cli/pull/8671) and [Issue #8690](https://github.com/npm/cli/issues/8690) for details.
+See https://github.com/npm/cli/pull/8671 and https://github.com/npm/cli/issues/8690 for details.
 
 ### Unrelated failed Jest tests
 
@@ -300,10 +291,8 @@ Some Jest tests fail to run in Node versions older than v24. On those versions, 
 
 - Fork the repo ([How to setup your fork properly](#how-to-setup-your-fork-properly)).
 - Make your changes.
-- Run `npm run format` (prettier), `npm run lint` (linter) and `npm run test` (jest). If you made any changes to
-  `NetscriptDefinitions.d.ts`, run `npm run doc` (API documenter) as well.
-- Test your changes manually before submitting anything!! ([running locally](#running-locally)).
+- Test your changes manually before submitting anything ([Running locally](#running-locally)).
+- Run `npm run format`, `npm run lint`, and `npm run test`. If you make any changes to
+  `NetscriptDefinitions.d.ts` or in-game documentation pages, run `npm run doc`.
 - Commit your changes ([Development Workflow](#development-workflow-best-practices)).
-- Go to GitHub and create a PR following [these guidelines](#submitting-a-pull-request).
-- Follow maintainers' feedback and adjust any changes you made to their suggestions. If you have
-  any questions or doubts, check [this links](#in-general).
+- Go to GitHub and create a PR [Submitting a Pull Request](#submitting-a-pull-request).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,8 @@ Saving a file will reload the game automatically.
 Tested on:
 
 - Node 24.13.0 (LTS) on Windows.
-- These steps only work in a Bash-like environment, like MinGW for Windows.
+
+These steps only work in a Bash-like environment, like MinGW for Windows.
 
 ```sh
 # Install the main game dependencies & build the app in debug mode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,12 +61,12 @@ called `npm` is installed as well.
 Not all code contributions will be accepted. The safest way to ensure
 that you don't waste time working on something that gets rejected is to
 run your idea(s)/plan(s) past the developers first.
-You can contact him through Discord.
+You can contact them through Discord.
 
 Otherwise, here are some general guidelines for determining what types of
 changes are okay to contribute:
 
-##### Contributions that Will Most Likely Be Accepted
+##### Contributions that will most likely be accepted
 
 - Bug fixes
 - Quality-of-life changes
@@ -76,14 +76,14 @@ changes are okay to contribute:
   - Adding a new Terminal command
 - Code refactors that conform to good/standard practices
 
-##### Contributions that will not be Accepted without prior approval
+##### Contributions that will not be accepted without prior approval
 
 - Changes that directly affect the game's balance
 - New gameplay mechanics
 
 ---
 
-## How to setup fork properly
+## How to setup your fork properly
 
 Clone and fork the game's repository by using one of these methods: web browser, GitHub
 Desktop, or command line.
@@ -213,23 +213,7 @@ the following rules:
 - The title of your Pull Request will need to be formatted like
   `MISC: Reticulated the splines`, where the first word must be capitalised
   and relate to the kind of change being implemented. Possible examples
-  are UI, BUGFIX, SERVERS, NETSCRIPT... You get the idea.
-
-## Troubleshooting common issues
-
-### Unrelated changes in `package-lock.json`
-
-After running `npm install`, if you do not change anything in `package.json` and `package-lock.json` is still changed, you need to update `npm` to the latest version. After that, discard the changes in `package-lock.json`, delete the `node_modules` folder, and run `npm install` again.
-
-### Lots of `peer: true` lines added in `package-lock.json`
-
-npm version 11.6.2 has a bug that causes this. Unfortunately, this is the current LTS (stable) release as of this writing. Use a newer or older npm version, and re-run `npm install`.
-
-See https://github.com/npm/cli/pull/8671 and https://github.com/npm/cli/issues/8690 for details.
-
-### Unrelated failed Jest tests
-
-Some Jest tests fail to run in Node versions older than v24. On those versions, these tests show a small difference between the expected value ("Snapshot") and the actual value ("Received"). You need to use Node v24+ to run these tests.
+  are UI, BUGFIX, SERVERS, API... You get the idea.
 
 ## As a Documenter
 
@@ -274,3 +258,19 @@ Avoid:
 
 - Failure conditions. It's very frustrating to lose several days' worth of progress.
 - Making existing mechanics harder. This makes it hard to port the content to other BNs.
+
+## Troubleshooting common issues
+
+### Unrelated changes in `package-lock.json`
+
+After running `npm install`, if you do not change anything in `package.json` and `package-lock.json` is still changed, you need to update `npm` to the latest version. After that, discard the changes in `package-lock.json`, delete the `node_modules` folder, and run `npm install` again.
+
+### Lots of `peer: true` lines added in `package-lock.json`
+
+npm version 11.6.2 has a bug that causes this. If you can, switch to the `24.18.0` version which is the LTS as of this writing and re-run `npm install`.
+
+See [PR #8671](https://github.com/npm/cli/pull/8671) and [Issue #8690](https://github.com/npm/cli/issues/8690) for details.
+
+### Unrelated failed Jest tests
+
+Some Jest tests fail to run in Node versions older than v24. On those versions, these tests show a small difference between the expected value ("Snapshot") and the actual value ("Received"). You need to use Node v24+ to run these tests.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ that revolves around hacking and cyberpunk themes.
 The game can be played at https://bitburner-official.github.io/ (release build), https://bitburner-official.github.io/bitburner-src/ (development build), or installed through [Steam](https://store.steampowered.com/app/1812820/Bitburner/).
 The location of the release build may change in the near future.
 
-See the [frequently asked questions](/src/Documentation/doc/en/help/faq.md) for more information. To discuss the game or get help, join the [official Discord server](https://discord.gg/TFc3hKD).
+See the [frequently asked questions](./src/Documentation/doc/en/help/faq.md) for more information. To discuss the game or get help, join the [official Discord server](https://discord.gg/TFc3hKD).
 
 # Documentation
 
@@ -19,7 +19,7 @@ There are 2 types of documentation:
 - NS API documentation: It's generated from the [TypeScript definitions](./src/ScriptEditor/NetscriptDefinitions.d.ts). You can read it at [API Documentation](./markdown/bitburner.md).
 
 Anyone is welcome to contribute to the documentation by editing the [source
-files](/src/Documentation/doc/en) and then making a pull request with your contributions.
+files](./src/Documentation/doc/en) and then making a pull request with your contributions.
 For further guidance, please refer to the "As A Documenter" section of
 [CONTRIBUTING](./CONTRIBUTING.md#as-a-documenter).
 
@@ -31,11 +31,11 @@ please refer to the [CONTRIBUTING](./CONTRIBUTING.md) document.
 
 You will retain all ownership of the Copyright of any contributions you make,
 and will have the same rights to use or license your contributions. By
-submitting a pull request you agree to grant me perpetual, worldwide,
+submitting a pull request you agree to grant the project owner(s) perpetual, worldwide,
 non-exclusive, transferable, royalty-free, and irrevocable rights to use,
 publish, and distribute your contributions to the project. A formal
 Contributor's License Agreement will be drawn up in the future.
 
 If you would like to make significant contributions to the project as a
-collaborator, please reach out in #suggestions or #development on Discord to
+collaborator, please reach out in [#suggestions](https://discord.com/channels/415207508303544321/415213435974975508) or [#development](https://discord.com/channels/415207508303544321/459097632896188436) on Discord to
 help coordinate the effort.


### PR DESCRIPTION
I added some more instructions to the CONTRIBUTING document so it's easier for first-time contributors to read it and understand it.
I have also fixed some relative paths (`/src` to `./src`), clarified a few things, updated the npm LTS version and added links for the discord channels. I also added a TL;DR section with quick instructions to get started as fast as possible (and still check the whole document, but only when needed, one step at a time)