### PR TITLE
UI: Remove duplicate border from tail box

### DIFF
--- a/src/ui/React/LogBoxManager.tsx
+++ b/src/ui/React/LogBoxManager.tsx
@@ -170,6 +170,7 @@ const useStyles = makeStyles()({
     flexDirection: "column-reverse",
     whiteSpace: "pre-wrap",
     wordWrap: "break-word",
+    borderWidth: "0 1px 1px 1px",
   },
   titleButton: {
     borderWidth: "0 0 0 1px",
@@ -336,16 +337,12 @@ function LogWindow({ hidden, script, onClose }: LogWindowProps): React.ReactElem
           zIndex: 1400,
           minWidth: `${minWindowSize[0]}px`,
           minHeight: `${minWindowSize[1]}px`,
-          ...(propsRef.current.minimized
-            ? {
-                border: "none",
-                margin: 0,
-                maxHeight: 0,
-                padding: 0,
-              }
-            : {
-                border: `1px solid ${Settings.theme.welllight}`,
-              }),
+          ...(propsRef.current.minimized && {
+            border: "none",
+            margin: 0,
+            maxHeight: 0,
+            padding: 0,
+          }),
         }}
         ref={container}
       >


### PR DESCRIPTION
This PR makes the tail log box borders consistently 1px in both expanded and minimized state, this also solves a minor issue I noticed where the bottom left corner would be jagged due to stacked borders not aligning properly.

BEFORE
<img width="299" height="125" alt="image" src="https://github.com/user-attachments/assets/237d5e0d-9313-47cf-8bbe-f52214e6255a" />
<img width="300" height="126" alt="image" src="https://github.com/user-attachments/assets/83b6be63-31ef-4acb-9a11-0fc51801886a" />
AFTER
<img width="297" height="123" alt="1783430958947071022" src="https://github.com/user-attachments/assets/a163144a-43e2-4c12-8fb8-d4c2acec4118" />
<img width="298" height="124" alt="1783430962945160119" src="https://github.com/user-attachments/assets/586e534f-9a7c-4a11-ac07-c29e82a1ebf5" />
