### PR TITLE
BUGFIX: Stock symbol map is not initialized after loading in edge cases

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -24,7 +24,12 @@ import { saveGame, loadGame } from "./SaveObject";
 import { GetAllServers } from "./Server/AllServers";
 import { Settings } from "./Settings/Settings";
 import { FormatsNeedToChange } from "./ui/formatNumber";
-import { canAccessStockMarket, initSymbolToStockMap, processStockPrices } from "./StockMarket/StockMarket";
+import {
+  canAccessStockMarket,
+  initSymbolToStockMap,
+  isStockMarketInitialized,
+  processStockPrices,
+} from "./StockMarket/StockMarket";
 
 import { Money } from "./ui/React/Money";
 import { Hashes } from "./ui/React/Hashes";
@@ -240,7 +245,7 @@ const Engine = {
     if (saveData !== undefined && (await loadGame(saveData))) {
       FormatsNeedToChange.emit();
       initBitNodeMultipliers();
-      if (canAccessStockMarket()) {
+      if (isStockMarketInitialized()) {
         initSymbolToStockMap();
       }
 


### PR DESCRIPTION
MRE:
- Load a clean save file.
- Add money and buy `DarkscapeNavigator.exe`.
- Run `getStockReward(0)` to get the stock share reward.
- Check: `StockMarket.lastUpdate` is 0. `SymbolToStockMap` is empty.
- Open the cache.
- Check: `StockMarket.lastUpdate` is NOT 0. `SymbolToStockMap` is NOT empty.
- Reload the game.
- Check: `StockMarket.lastUpdate` is NOT 0. However, `SymbolToStockMap` is empty.
- Put a breakpoint in `purchaseTixApiAccess` in `src/StockMarket/ui/InfoAndPurchases.tsx`.
- Buy TIX API access via the UI. `isStockMarketInitialized()` is true, so `initStockMarket` is not called.
- `ns.stock.getPrice("ECP")`

The symbol map is initialized by `initSymbolToStockMap`, which is called at the end of `initStockMarket`. This means the map is always initialized if the market is initialized. When loading save data, we call `initSymbolToStockMap` if players have access to the stock market. Previously, this was fine because the market was only initialized after players gained access to it. However, with dnet caches, the market can now be initialized before that.

Regarding the behavior of dnet caches, I think it's fine to *not* grant stock shares if players don't have access to the market. However, I'm neutral on that change. It's up to @d0sboots and @ficocelliguy.

There is another bug in the prestige code, but that one is not related to this bug, so I'll fix it later.