### PR TITLE
BUGFIX: Stock market does not reset after prestige in edge cases

### DIFF
--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -166,6 +166,8 @@ export function prestigeAugmentation(): void {
   // Reset Stock market
   if (canAccessStockMarket()) {
     initStockMarket();
+  } else {
+    deleteStockMarket();
   }
 
   // Red Pill

--- a/src/StockMarket/StockMarket.ts
+++ b/src/StockMarket/StockMarket.ts
@@ -178,6 +178,10 @@ export function isStockMarketInitialized(): boolean {
  */
 export function deleteStockMarket(): void {
   StockMarket = getDefaultEmptyStockMarket();
+  for (const key of Object.keys(SymbolToStockMap)) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete SymbolToStockMap[key];
+  }
 }
 
 export function initStockMarket(): void {

--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -6,7 +6,6 @@ import { addCacheToServer } from "../../../src/DarkNet/effects/cacheFiles";
 import { getDarkscapeNavigator } from "../../../src/DarkNet/effects/effects";
 import { connectServers, GetServerOrThrow } from "../../../src/Server/AllServers";
 import { SpecialServers } from "../../../src/Server/data/SpecialServers";
-import { initStockMarket } from "../../../src/StockMarket/StockMarket";
 import {
   fixDoImportIssue,
   getMockedNetscriptContext,
@@ -45,7 +44,6 @@ fixDoImportIssue();
 
 beforeAll(() => {
   initGameEnvironment();
-  initStockMarket();
 });
 beforeEach(() => {
   DarknetState.offlineServers = new Set();
@@ -238,6 +236,7 @@ describe("home", () => {
   });
   test("promoteStock", async () => {
     const ns = getNsOnHome();
+    expect(ns.stock.purchaseTixApi()).toBe(true);
     await expect(async () => {
       await ns.dnet.promoteStock("ECP");
     }).rejects.toContain("This API can only be used on a darknet server");
@@ -402,6 +401,7 @@ describe("Normal NPC server", () => {
   });
   test("promoteStock", async () => {
     const ns = getNS(SpecialServers.CyberSecServer);
+    expect(ns.stock.purchaseTixApi()).toBe(true);
     await expect(async () => {
       await ns.dnet.promoteStock("ECP");
     }).rejects.toContain("This API can only be used on a darknet server");
@@ -492,6 +492,7 @@ describe("Private server", () => {
   });
   test("promoteStock", async () => {
     const ns = getNS("test-server-1");
+    expect(ns.stock.purchaseTixApi()).toBe(true);
     await expect(async () => {
       await ns.dnet.promoteStock("ECP");
     }).rejects.toContain("This API can only be used on a darknet server");
@@ -582,6 +583,7 @@ describe("Hashnet server", () => {
   });
   test("promoteStock", async () => {
     const ns = getNS("hacknet-server-0");
+    expect(ns.stock.purchaseTixApi()).toBe(true);
     await expect(async () => {
       await ns.dnet.promoteStock("ECP");
     }).rejects.toContain("This API can only be used on a darknet server");
@@ -820,6 +822,7 @@ describe("darkweb", () => {
   });
   test("promoteStock", async () => {
     const ns = getNsOnDarkWeb();
+    expect(ns.stock.purchaseTixApi()).toBe(true);
     const result = await ns.dnet.promoteStock("ECP");
     expect(result.success).toStrictEqual(true);
     expect(result.code).toStrictEqual(ResponseCodeEnum.Success);
@@ -1017,6 +1020,7 @@ describe("Non-darkweb darknet server", () => {
   });
   test("promoteStock", async () => {
     const ns = getNsOnNonDarkwebDarknetServer();
+    expect(ns.stock.purchaseTixApi()).toBe(true);
     const result = await ns.dnet.promoteStock("ECP");
     expect(result.success).toStrictEqual(true);
     expect(result.code).toStrictEqual(ResponseCodeEnum.Success);

--- a/test/jest/Netscript/StockMarket.test.ts
+++ b/test/jest/Netscript/StockMarket.test.ts
@@ -1,11 +1,18 @@
 import { Player } from "@player";
 import { getMockedNetscriptContext, getNS, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
-import { deleteStockMarket, getDefaultEmptyStockMarket, StockMarket } from "../../../src/StockMarket/StockMarket";
+import {
+  deleteStockMarket,
+  getDefaultEmptyStockMarket,
+  StockMarket,
+  SymbolToStockMap,
+} from "../../../src/StockMarket/StockMarket";
 import { Stock } from "../../../src/StockMarket/Stock";
 import { buyStock } from "../../../src/StockMarket/BuyingAndSelling";
+import { getStockReward } from "../../../src/DarkNet/effects/cacheFiles";
 
 function expectUninitializedStockMarket(): void {
   expect(StockMarket).toStrictEqual(getDefaultEmptyStockMarket());
+  expect(Object.keys(SymbolToStockMap).length).toBe(0);
 }
 
 function expectInitializedStockMarket(): void {
@@ -14,6 +21,7 @@ function expectInitializedStockMarket(): void {
   expect(symbols.includes("ECP")).toStrictEqual(true);
   expect(StockMarket["ECorp"] instanceof Stock).toStrictEqual(true);
   expect(StockMarket.lastUpdate).toBeGreaterThan(0);
+  expect(Object.keys(SymbolToStockMap).length).toBeGreaterThan(0);
 }
 
 function buyShareOfECP(): void {
@@ -110,6 +118,18 @@ describe("Prestige", () => {
     ns.singularity.softReset();
     expect(StockMarket["ECorp"].playerShares).toStrictEqual(0);
   });
+  test("soft reset after getting shares from dnet caches", () => {
+    const ns = getNS();
+    expectUninitializedStockMarket();
+    const reward = getStockReward(0);
+    if (!reward.stockSymbol) {
+      throw new Error(`Invalid cache reward: ${JSON.stringify(reward)}`);
+    }
+    expectInitializedStockMarket();
+    expect(SymbolToStockMap[reward.stockSymbol].playerShares).toBeGreaterThan(0);
+    ns.singularity.softReset();
+    expectUninitializedStockMarket();
+  });
   test("b1tflum3", () => {
     const ns = getNS();
     ns.stock.purchaseTixApi();
@@ -129,5 +149,17 @@ describe("Prestige", () => {
     ns.singularity.b1tflum3(1);
     expectInitializedStockMarket();
     expect(StockMarket["ECorp"].playerShares).toStrictEqual(0);
+  });
+  test("b1tflum3 after getting shares from dnet caches", () => {
+    const ns = getNS();
+    expectUninitializedStockMarket();
+    const reward = getStockReward(0);
+    if (!reward.stockSymbol) {
+      throw new Error(`Invalid cache reward: ${JSON.stringify(reward)}`);
+    }
+    expectInitializedStockMarket();
+    expect(SymbolToStockMap[reward.stockSymbol].playerShares).toBeGreaterThan(0);
+    ns.singularity.b1tflum3(1);
+    expectUninitializedStockMarket();
   });
 });


### PR DESCRIPTION
MRE:
- Load a clean save file.
- Add money and buy `DarkscapeNavigator.exe`.
- Run `getStockReward(0)` to get the stock share reward.
- Open the cache.
- `StockMarket[foo].playerShares` is greater than 0.
- Soft reset.
- `StockMarket[foo].playerShares` is still greater than 0.

There are two issues:
- In `deleteStockMarket`, after resetting `StockMarket`, we did not reset `SymbolToStockMap`.
- On prestige, if players don't have access to the stock market, we need to reset the market. We did that on BN prestige, but not on augmentation prestige.