### PR TITLE
BUGFIX: AutoLink.exe makes it too easy to conect to darknet servers

### DIFF
--- a/src/Server/BaseServer.ts
+++ b/src/Server/BaseServer.ts
@@ -291,6 +291,10 @@ export abstract class BaseServer implements IServer {
     return this.writeToScriptFile(path, content);
   }
 
+  isHyperLinkAllowed(): boolean {
+    return true;
+  }
+
   // Serialize the current object to a JSON save state
   // Called by subclasses, not stringify.
   toJSONBase(ctorName: string, keys: readonly (keyof this)[]): IReviverValue {

--- a/src/Server/DarknetServer.ts
+++ b/src/Server/DarknetServer.ts
@@ -5,6 +5,7 @@ import { createRandomIp } from "../utils/IPAddress";
 import type { CacheFilePath } from "../Paths/CacheFilePath";
 import type { IPAddress } from "../Types/strings";
 import type { DarknetServerData } from "../DarkNet/utils/darknetServerUtils";
+import { SpecialServers } from "./data/SpecialServers";
 
 export interface DarknetServerConstructorParams {
   // Properties of BaseServer
@@ -82,6 +83,10 @@ export class DarknetServer extends BaseServer implements DarknetServerData {
     this.logTrafficInterval = params.logTrafficInterval;
     this.requiredCharismaSkill = params.requiredCharismaSkill;
     this.isStationary = params.isStationary;
+  }
+
+  isHyperLinkAllowed(): boolean {
+    return this.hostname === SpecialServers.DarkWeb || this.backdoorInstalled;
   }
 
   toJSON(): IReviverValue {

--- a/src/Terminal/Terminal.ts
+++ b/src/Terminal/Terminal.ts
@@ -285,6 +285,19 @@ export class Terminal {
     }
   }
 
+  onServerHyperLinkClick(hostname: string): void {
+    const server = GetServer(hostname);
+    if (server == null) {
+      this.error("Invalid server. Connection failed.");
+      return;
+    }
+    if (!server.isHyperLinkAllowed()) {
+      this.error("Tried to connect to a dnet server without backdoor or stasis link. Connection failed.");
+      return;
+    }
+    this.connectToServer(hostname);
+  }
+
   async executeCommands(commands: string): Promise<void> {
     // Handle Terminal History - multiple commands should be saved as one
     if (this.commandHistory[this.commandHistory.length - 1] != commands) {

--- a/src/Terminal/commands/scananalyze.ts
+++ b/src/Terminal/commands/scananalyze.ts
@@ -46,7 +46,7 @@ export function scananalyze(args: (string | number | boolean)[]): undefined {
 
 function executeScanAnalyzeCommand(depth: number, all: boolean): void {
   interface Node {
-    hostname: string;
+    server: BaseServer;
     children: Node[];
   }
 
@@ -54,7 +54,7 @@ function executeScanAnalyzeCommand(depth: number, all: boolean): void {
     (!all && s.purchasedByPlayer && s.hostname != "home") ||
     d > depth ||
     (!all && s instanceof HacknetServer) ||
-    (!all && s instanceof DarknetServer && s.hostname !== SpecialServers.DarkWeb);
+    ((!all || !s.hasAdminRights) && s instanceof DarknetServer && s.hostname !== SpecialServers.DarkWeb);
 
   const makeNode = (root: BaseServer = Player.getCurrentServer()) => {
     // Keep track of previously seen servers to prevent backtracking (since darknet can be cyclical)
@@ -62,7 +62,7 @@ function executeScanAnalyzeCommand(depth: number, all: boolean): void {
     const populateNode = (s: BaseServer, d = 1): Node => {
       seenServers.push(s.hostname);
       return {
-        hostname: s.hostname,
+        server: s,
         children: s.serversOnNetwork
           .filter((h) => !seenServers.includes(h))
           .map((s) => GetServer(s))
@@ -79,14 +79,13 @@ function executeScanAnalyzeCommand(depth: number, all: boolean): void {
   const printOutput = (node: Node, prefix = ["  "], last = true) => {
     const titlePrefix = prefix.slice(0, prefix.length - 1).join("") + (last ? "┗ " : "┣ ");
     const infoPrefix = prefix.join("") + (node.children.length > 0 ? "┃   " : "    ");
-    if (Player.hasProgram(CompletedProgramName.autoLink)) {
-      Terminal.append(new Link(titlePrefix, node.hostname));
+    const { server } = node;
+    if (server.isHyperLinkAllowed() && Player.hasProgram(CompletedProgramName.autoLink)) {
+      Terminal.append(new Link(titlePrefix, server.hostname));
     } else {
-      Terminal.print(titlePrefix + node.hostname + "\n");
+      Terminal.print(titlePrefix + server.hostname + "\n");
     }
 
-    const server = GetServer(node.hostname);
-    if (!server) return;
     const hasRoot = server.hasAdminRights ? "YES" : "NO";
     if (server instanceof Server) {
       Terminal.print(

--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -94,7 +94,7 @@ export function TerminalRoot(): React.ReactElement {
             {item instanceof Link && (
               <Typography component="div" classes={{ root: classes.preformatted }}>
                 {item.dashes}
-                <MuiLink onClick={() => Terminal.connectToServer(item.hostname)}>{item.hostname}</MuiLink>
+                <MuiLink onClick={() => Terminal.onServerHyperLinkClick(item.hostname)}>{item.hostname}</MuiLink>
               </Typography>
             )}
           </li>


### PR DESCRIPTION
* During the discussion of #2948 I have noticed two issues with how `scan-analyze` with the `-a` flag interacts with the dark net:
  1. `scan-analyze 10 -a` often shows more servers than can be seen on the "Dark net" page.
  2. If you have AutoLink.exe, `scan-analyze 10 -a` creates clickable links to all the dark net servers that it displays. The links continue to function even if the destination becomes airgapped.

## To reproduce the bug

1. Precondition: you do not have DarkscapeNavigator.exe.
2. Add money and buy DarkscapeNavigator.exe, AutoLink.exe and  DeepscanV2.exe.
3. Run `scan-analyze 10 -a` from the `home` server.
4. scan-analyze reveals all dnet servers that have a path to home, but dnet UI only reveals servers up to a certain depth (based on the deepest server you managed to get admin rights on).
5. One of the servers printed by scan-analyze becomes disconnected from its neighbors.
6. Click on a link to the disconnected server. It still works.

## Proposed solution
1. `scan-analyze -a` no longer recurses into dnet servers that you do not have admin rights on
2. AutoLink.exe only produces links to dnet servers if the destination is backdoored and/or has a stasis link
3. When the player clicks a link produced by AutoLink.exe, the destination is checked again because in dnet backdoors and stasis link can be removed