### PR TITLE
JEST: Allow setting hostname when creating mocked NS context

### DIFF
--- a/test/jest/Netscript/Darknet.test.ts
+++ b/test/jest/Netscript/Darknet.test.ts
@@ -320,7 +320,7 @@ describe("home", () => {
     await ns.singularity.installBackdoor();
     // Can exec from home
     expect(ns.exec(scriptPath, dnetServerHostname)).toBeGreaterThan(0);
-  }, 8000);
+  }, 8000); // TODO: Check why this test is flaky.
   test("getServerRequiredCharismaLevel", () => {
     const ns = getNS(SpecialServers.Home);
     const server = GetServerOrThrow(SpecialServers.Home);
@@ -713,14 +713,12 @@ describe("darkweb targets home", () => {
 describe("expectRunningOnDarknetServer", () => {
   test("throws when called on non-darknet server", () => {
     const logger = jest.fn();
-    const ctx = getMockedNetscriptContext(logger);
-    ctx.workerScript.hostname = SpecialServers.Home;
+    const ctx = getMockedNetscriptContext(logger, SpecialServers.Home);
     expect(() => expectRunningOnDarknetServer(ctx)).toThrow("This API can only be used on a darknet server");
   });
   test("does not throw when called on darknet server", () => {
     const logger = jest.fn();
-    const ctx = getMockedNetscriptContext(logger);
-    ctx.workerScript.hostname = SpecialServers.DarkWeb;
+    const ctx = getMockedNetscriptContext(logger, SpecialServers.DarkWeb);
     expect(() => expectRunningOnDarknetServer(ctx)).not.toThrow();
   });
 });

--- a/test/jest/Utilities.ts
+++ b/test/jest/Utilities.ts
@@ -117,13 +117,16 @@ export function getNS(hostname: string = SpecialServers.Home): NSFull {
 
 export function getMockedNetscriptContext(
   workerScriptLogFunction: (func: string, txt: () => string) => void = () => {},
+  hostname?: string,
 ): NetscriptContext {
   return {
     function: "",
     functionPath: "",
     workerScript: {
+      hostname,
       log: workerScriptLogFunction,
       scriptRef: {
+        server: hostname,
         dependencies: [],
       },
     } as unknown as WorkerScript,


### PR DESCRIPTION
After #2890, `workerScript.hostname` is a getter, so we can no longer set it via `ctx.workerScript.hostname`. This still works in Jest tests because they use a mocked context instead of a real `WorkerScript` instance. Instead of suppressing lint errors, we should create a proper context.

I also added a TODO comment. Fico works around the flaky test by increasing the timeout, but we should investigate why it happens in the first place.