### PR TITLE
API: Make ns.dnet.promoteStock require TIX API access

### DIFF
--- a/markdown/bitburner.darknet.md
+++ b/markdown/bitburner.darknet.md
@@ -302,6 +302,8 @@ Note that there is no guarantee about the order of servers in the returned list.
 
 Spends some time spreading propaganda about a stock to increase its volatility. This does not actually change the stock's forecasts, but a savvy investor can take advantage of the chaos. The effect scales with charisma and the number of threads used, but degrades over time if left alone.
 
+This function requires TIX API access. You can use [purchaseTixApi](./bitburner.stock.purchasetixapi.md) to purchase it.
+
 
 </td></tr>
 <tr><td>

--- a/markdown/bitburner.darknet.promotestock.md
+++ b/markdown/bitburner.darknet.promotestock.md
@@ -6,6 +6,8 @@
 
 Spends some time spreading propaganda about a stock to increase its volatility. This does not actually change the stock's forecasts, but a savvy investor can take advantage of the chaos. The effect scales with charisma and the number of threads used, but degrades over time if left alone.
 
+This function requires TIX API access. You can use [purchaseTixApi](./bitburner.stock.purchasetixapi.md) to purchase it.
+
 **Signature:**
 
 ```typescript

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -606,6 +606,9 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
     promoteStock:
       (ctx: NetscriptContext) =>
       (_symbol): Promise<DarknetResult> => {
+        if (!Player.hasTixApiAccess) {
+          throw helpers.errorMessage(ctx, `You don't have TIX API Access! Cannot use ${ctx.function}()`);
+        }
         const symbol = helpers.string(ctx, "symbol", _symbol);
         const stock = getStockFromSymbol(ctx, symbol);
         expectRunningOnDarknetServer(ctx);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4800,8 +4800,11 @@ export interface Darknet {
   getDepth(host?: string): number;
 
   /**
-   * Spends some time spreading propaganda about a stock to increase its volatility. This does not actually change the stock's forecasts, but
-   * a savvy investor can take advantage of the chaos. The effect scales with charisma and the number of threads used, but degrades over time if left alone.
+   * Spends some time spreading propaganda about a stock to increase its volatility. This does not actually change the
+   * stock's forecasts, but a savvy investor can take advantage of the chaos. The effect scales with charisma and the
+   * number of threads used, but degrades over time if left alone.
+   *
+   * This function requires TIX API access. You can use {@link Stock.purchaseTixApi | purchaseTixApi} to purchase it.
    *
    * @remarks
    * RAM cost: 2 GB


### PR DESCRIPTION
This API can only be used after the stock market is initialized; otherwise, players will see the `Invalid stock symbol` error. This means players need to purchase stock market access (WSE/TIX) or wait until they have a dnet cache containing stock shares. The latter depends on a debatable behavior of dnet cache, so we should gate this API behind market access to avoid showing a confusing error message. WSE is only for UI access, so I chose to require TIX.