### PR TITLE
RFA: Tighten message definitions, update documentation, and add new community tools

### DIFF
--- a/src/Documentation/doc/en/programming/remote_api.md
+++ b/src/Documentation/doc/en/programming/remote_api.md
@@ -9,7 +9,8 @@ You only need to do 2 things:
 
 ## Community tools
 
-All these tools support synchronizing scripts to Bitburner and transpiling TypeScript/JSX to JavaScript. Note that Bitburner has native support for TypeScript/JSX.
+All these tools support synchronizing scripts to Bitburner. Some tools support transpiling TypeScript/JSX to JavaScript.
+Note that Bitburner has native support for TypeScript/JSX.
 
 Links:
 
@@ -17,9 +18,10 @@ Links:
 - [viteburner](https://github.com/Tanimodori/viteburner): Daemon tools of bitburner using vite for script transform, file syncing, RAM monitoring and more!
 - [bb-external-editor](https://github.com/shyguy1412/bb-external-editor): This tool uses esbuild to transpile and bundle your scripts. It supports JS, TS and React as well as importing from any browser-compatible npm library out of the box.
 - [BitburnerGoFilesync](https://github.com/CTNOriginals/BitburnerGoFilesync): A standalone binary cli tool that doesn't require any setup or third party libraries. It is designed to be very minimal and easy to use out of the box.
+- [VS Code Extension: Bitburner File Sync Plugin](https://github.com/ficocelliguy/bitburner-file-sync-plugin): A VS Code extension that syncs your local script files to Bitburner.
 
 `typescript-template` and `BitburnerGoFilesync` both have a small set of options and features, their simplicity is by design.  
-`viteburner` and `bb-external-editor` have more fancy features and may offer more control for specific use cases.
+`viteburner`, `bb-external-editor`, and `VS Code Extension: Bitburner File Sync Plugin` have more fancy features and may offer more control for specific use cases.
 
 ## Troubleshooting tips
 
@@ -35,9 +37,9 @@ Links:
 
 ## API specification
 
-All APIs use an input/output format similar to the JSON RPC 2.0 protocol.
+All APIs use a request/response format similar to the JSON RPC 2.0 protocol.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -46,20 +48,27 @@ Input:
             "params": any
         }
 
-Output:
+Success Response:
 
         {
             "jsonrpc": "2.0",
             "id": number,
-            "result": any,
-            "error": any
+            "result": any
+        }
+
+Error Response:
+
+        {
+            "jsonrpc": "2.0",
+            "id": number,
+            "error": string
         }
 
 ### pushFile
 
 Create or update a file.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -72,7 +81,7 @@ Input:
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -84,7 +93,7 @@ Output:
 
 Read a file and its content.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -96,7 +105,7 @@ Input:
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -108,7 +117,7 @@ Output:
 
 Read metadata of a file.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -120,7 +129,7 @@ Input:
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -137,7 +146,7 @@ Output:
 
 Delete a file.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -149,7 +158,7 @@ Input:
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -161,7 +170,7 @@ Output:
 
 List all file names on a server.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -172,7 +181,7 @@ Input:
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -184,7 +193,7 @@ Output:
 
 Get the content of all files on a server.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -195,7 +204,7 @@ Input:
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -208,7 +217,7 @@ Output:
 
 ### getAllFileMetadata
 
-Input:
+Request:
 
 Get the content of all files on a server.
 
@@ -221,7 +230,7 @@ Get the content of all files on a server.
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -238,7 +247,7 @@ Output:
 
 Calculate the in-game ram cost of a script.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -250,7 +259,7 @@ Input:
             }
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -262,7 +271,7 @@ Output:
 
 Get the definition file of NS APIs.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -270,7 +279,7 @@ Input:
             "method": "getDefinitionFile"
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -282,7 +291,7 @@ Output:
 
 Get save data.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -290,7 +299,7 @@ Input:
             "method": "getSaveFile"
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",
@@ -306,7 +315,7 @@ Output:
 
 Get all servers.
 
-Input:
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -314,7 +323,7 @@ Input:
             "method": "getAllServers"
         }
 
-Output:
+Response:
 
         {
             "jsonrpc": "2.0",

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -1,22 +1,43 @@
 import type { SaveData } from "../types";
 import type { BaseServer } from "../Server/BaseServer";
 
-export class RFAMessage {
-  jsonrpc = "2.0"; // Transmits version of JSON-RPC. Compliance maybe allows some funky interaction with external tools?
-  public method?: string; // Is defined when it's a request/notification, otherwise undefined
-  public result?: ResultType; // Is defined when it's a response, otherwise undefined
-  public params?: FileDescription; // Optional parameters to method
-  public error?: string; // Only defined on error
-  public id?: number; // ID to keep track of request -> response interaction, undefined with notifications, defined with request/response
+abstract class RFAMessage {
+  jsonrpc = "2.0";
+  public id: number; // ID to keep track of request -> response interaction
 
-  constructor(
-    obj: { method?: string; result?: ResultType; params?: FileDescription; error?: string; id?: number } = {},
-  ) {
+  constructor(id: number) {
+    this.id = id;
+  }
+}
+
+export class RFARequest extends RFAMessage {
+  public method: string;
+  public params: FileDescription;
+
+  constructor(obj: { id: number; method: string; params: FileDescription }) {
+    super(obj.id);
     this.method = obj.method;
-    this.result = obj.result;
     this.params = obj.params;
+  }
+}
+
+export abstract class RFAResponse extends RFAMessage {}
+
+export class RFASuccessResponse extends RFAResponse {
+  public result: ResultType;
+
+  constructor(obj: { id: number; result: ResultType }) {
+    super(obj.id);
+    this.result = obj.result;
+  }
+}
+
+export class RFAErrorResponse extends RFAResponse {
+  public error: string;
+
+  constructor(obj: { id: number; error: string }) {
+    super(obj.id);
     this.error = obj.error;
-    this.id = obj.id;
   }
 }
 

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -3,13 +3,16 @@ import { hasTextExtension } from "../Paths/TextFilePath";
 import { hasScriptExtension } from "../Paths/ScriptFilePath";
 import { GetServer, GetAllServers } from "../Server/AllServers";
 import {
-  RFAMessage,
   isFileServer,
   isFileLocation,
   isFileData,
   type FileData,
   type FileLocation,
   type FileServer,
+  RFAErrorResponse,
+  type RFARequest,
+  type RFAResponse,
+  RFASuccessResponse,
 } from "./MessageDefinitions";
 
 import libSource from "../ScriptEditor/NetscriptDefinitions.d.ts?raw";
@@ -19,14 +22,14 @@ import type { BaseServer } from "../Server/BaseServer";
 import type { ContentFilePath } from "../Paths/ContentFile";
 
 type SuccessResult<T> = { success: true; params: T };
-type FailureResult = { success: false; errorResponse: RFAMessage };
+type FailureResult = { success: false; errorResponse: RFAErrorResponse };
 export type ValidationResult<T> = SuccessResult<T> | FailureResult;
 
-function getErrorResponse(errorMsg: string, { id }: RFAMessage): RFAMessage {
-  return new RFAMessage({ error: errorMsg, id });
+function getErrorResponse(errorMsg: string, { id }: RFARequest): RFAErrorResponse {
+  return new RFAErrorResponse({ error: errorMsg, id });
 }
 
-function validateParams<T>(validationFunction: (p: unknown) => p is T, request: RFAMessage): ValidationResult<T> {
+function validateParams<T>(validationFunction: (p: unknown) => p is T, request: RFARequest): ValidationResult<T> {
   if (!request.params) {
     return { success: false, errorResponse: getErrorResponse("Missing params", request) };
   }
@@ -41,7 +44,7 @@ function validateParams<T>(validationFunction: (p: unknown) => p is T, request: 
 
 function validateFilePathAndServerParams<T extends FileData | FileLocation>(
   validationFunction: (p: unknown) => p is T,
-  request: RFAMessage,
+  request: RFARequest,
 ): { success: true; data: { filePath: ContentFilePath; server: BaseServer; params: T } } | FailureResult {
   const validationResult = validateParams(validationFunction, request);
   if (!validationResult.success) {
@@ -69,7 +72,7 @@ function validateFilePathAndServerParams<T extends FileData | FileLocation>(
 }
 
 function validateServerParams(
-  request: RFAMessage,
+  request: RFARequest,
 ): { success: true; data: { server: BaseServer; params: FileServer } } | FailureResult {
   const validationResult = validateParams(isFileServer, request);
   if (!validationResult.success) {
@@ -85,8 +88,8 @@ function validateServerParams(
   return { success: true, data: { server, params: fileServer } };
 }
 
-export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessage | Promise<RFAMessage>> = {
-  pushFile: function (msg: RFAMessage): RFAMessage {
+export const RFARequestHandler: Record<string, (message: RFARequest) => RFAResponse | Promise<RFAResponse>> = {
+  pushFile: function (msg: RFARequest): RFAResponse {
     const validationResult = validateFilePathAndServerParams(isFileData, msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -94,10 +97,10 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
     const validationData = validationResult.data;
 
     validationData.server.writeToContentFile(validationData.filePath, validationData.params.content);
-    return new RFAMessage({ result: "OK", id: msg.id });
+    return new RFASuccessResponse({ result: "OK", id: msg.id });
   },
 
-  getFile: function (msg: RFAMessage): RFAMessage {
+  getFile: function (msg: RFARequest): RFAResponse {
     const validationResult = validateFilePathAndServerParams(isFileLocation, msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -109,10 +112,10 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
       return getErrorResponse(`File does not exist. Filename: ${validationData.params.filename}`, msg);
     }
 
-    return new RFAMessage({ result: file.content, id: msg.id });
+    return new RFASuccessResponse({ result: file.content, id: msg.id });
   },
 
-  getFileMetadata: function (msg: RFAMessage): RFAMessage {
+  getFileMetadata: function (msg: RFARequest): RFAResponse {
     const validationResult = validateFilePathAndServerParams(isFileLocation, msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -124,7 +127,7 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
       return getErrorResponse(`File does not exist. Filename: ${validationData.params.filename}`, msg);
     }
 
-    return new RFAMessage({
+    return new RFASuccessResponse({
       result: {
         filename: file.filename,
         ...file.metadata.plain(),
@@ -133,7 +136,7 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
     });
   },
 
-  deleteFile: function (msg: RFAMessage): RFAMessage {
+  deleteFile: function (msg: RFARequest): RFAResponse {
     const validationResult = validateFilePathAndServerParams(isFileLocation, msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -145,10 +148,10 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
       return getErrorResponse(resultOfRemovingFile.msg ?? "Failed", msg);
     }
 
-    return new RFAMessage({ result: "OK", id: msg.id });
+    return new RFASuccessResponse({ result: "OK", id: msg.id });
   },
 
-  getFileNames: function (msg: RFAMessage): RFAMessage {
+  getFileNames: function (msg: RFARequest): RFAResponse {
     const validationResult = validateServerParams(msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -157,10 +160,10 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
 
     const fileNameList = [...validationData.server.textFiles.keys(), ...validationData.server.scripts.keys()];
 
-    return new RFAMessage({ result: fileNameList, id: msg.id });
+    return new RFASuccessResponse({ result: fileNameList, id: msg.id });
   },
 
-  getAllFiles: function (msg: RFAMessage): RFAMessage {
+  getAllFiles: function (msg: RFARequest): RFAResponse {
     const validationResult = validateServerParams(msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -171,10 +174,10 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
       filename,
       content: file.content,
     }));
-    return new RFAMessage({ result: fileList, id: msg.id });
+    return new RFASuccessResponse({ result: fileList, id: msg.id });
   },
 
-  getAllFileMetadata: function (msg: RFAMessage): RFAMessage {
+  getAllFileMetadata: function (msg: RFARequest): RFAResponse {
     const validationResult = validateServerParams(msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -185,10 +188,10 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
       filename: filename,
       ...file.metadata.plain(),
     }));
-    return new RFAMessage({ result: fileList, id: msg.id });
+    return new RFASuccessResponse({ result: fileList, id: msg.id });
   },
 
-  calculateRam: function (msg: RFAMessage): RFAMessage {
+  calculateRam: function (msg: RFARequest): RFAResponse {
     const validationResult = validateFilePathAndServerParams(isFileLocation, msg);
     if (!validationResult.success) {
       return validationResult.errorResponse;
@@ -213,18 +216,18 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
       );
     }
 
-    return new RFAMessage({ result: ramUsage, id: msg.id });
+    return new RFASuccessResponse({ result: ramUsage, id: msg.id });
   },
 
-  getDefinitionFile: function (msg: RFAMessage): RFAMessage {
-    return new RFAMessage({ result: libSource, id: msg.id });
+  getDefinitionFile: function (msg: RFARequest): RFAResponse {
+    return new RFASuccessResponse({ result: libSource, id: msg.id });
   },
 
-  getSaveFile: async function (msg: RFAMessage): Promise<RFAMessage> {
+  getSaveFile: async function (msg: RFARequest): Promise<RFAResponse> {
     const saveData = await getSaveData();
 
     if (typeof saveData === "string") {
-      return new RFAMessage({
+      return new RFASuccessResponse({
         result: {
           identifier: Player.identifier,
           binary: false,
@@ -241,7 +244,7 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
       converted += String.fromCharCode(saveData[i]);
     }
 
-    return new RFAMessage({
+    return new RFASuccessResponse({
       result: {
         identifier: Player.identifier,
         binary: true,
@@ -251,13 +254,13 @@ export const RFARequestHandler: Record<string, (message: RFAMessage) => RFAMessa
     });
   },
 
-  getAllServers: function (msg: RFAMessage): RFAMessage {
+  getAllServers: function (msg: RFARequest): RFAResponse {
     const servers = GetAllServers().map(({ hostname, hasAdminRights, purchasedByPlayer }) => ({
       hostname,
       hasAdminRights,
       purchasedByPlayer,
     }));
 
-    return new RFAMessage({ result: servers, id: msg.id });
+    return new RFASuccessResponse({ result: servers, id: msg.id });
   },
 };

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -1,4 +1,4 @@
-import { RFAMessage } from "./MessageDefinitions";
+import { type RFARequest, RFAErrorResponse } from "./MessageDefinitions";
 import { RFARequestHandler } from "./MessageHandlers";
 import { SnackbarEvents } from "../ui/React/Snackbar";
 import { ToastVariant } from "@enums";
@@ -117,16 +117,14 @@ function handleMessageEvent(this: WebSocket, e: MessageEvent): void {
    * Validating e.data and the result of JSON.parse() is too troublesome, so we typecast them here. If the data is
    * invalid, it means the RFA "client" (the tool that the player is using) is buggy, but that's not our problem.
    */
-  const msg = JSON.parse(e.data as string) as RFAMessage;
+  const msg = JSON.parse(e.data as string) as RFARequest;
 
   if (!msg.method || !RFARequestHandler[msg.method]) {
-    const response = new RFAMessage({ error: "Unknown message received", id: msg.id });
+    const response = new RFAErrorResponse({ error: "Unknown message received", id: msg.id });
     this.send(JSON.stringify(response));
     return;
   }
   const response = RFARequestHandler[msg.method](msg);
-  if (!response) return;
-
   if (response instanceof Promise) {
     void response.then((data) => this.send(JSON.stringify(data)));
     return;


### PR DESCRIPTION
Our internal `RFAMessage` class currently defines all fields as optional (except `jsonrpc`) to accommodate different message types (requests, success responses, and error responses). However, we can define separate classes for each message type to ensure we don't accidentally construct invalid messages, such as passing an error string to a success response.

I also documented the new VS Code extension.

Tested manually with my RFA client.