### PR TITLE
UI: Add reminder for backing up save data

### DIFF
--- a/src/GameOptions/ui/SystemPage.tsx
+++ b/src/GameOptions/ui/SystemPage.tsx
@@ -147,6 +147,19 @@ export const SystemPage = (): React.ReactElement => {
         tooltip={<>If this is set, there will be no warning triggered when auto-save is disabled (at 0).</>}
       />
       <OptionSwitch
+        checked={Settings.DisableSaveDataBackupReminder}
+        onChange={(newValue) => {
+          Settings.DisableSaveDataBackupReminder = newValue;
+        }}
+        promptOptions={{
+          // Only require confirmation if the player is disabling the reminder.
+          shouldShowPrompt: (switchNewValue) => switchNewValue,
+          text: "Are you sure you want to disable the reminder?",
+        }}
+        text="Disable save data backup reminder"
+        tooltip={<>If enabled, we will not remind you to back up your save data.</>}
+      />
+      <OptionSwitch
         checked={Settings.SaveGameOnFileSave}
         onChange={(newValue) => (Settings.SaveGameOnFileSave = newValue)}
         text="Save game on file save"

--- a/src/GameOptions/ui/SystemPage.tsx
+++ b/src/GameOptions/ui/SystemPage.tsx
@@ -147,17 +147,17 @@ export const SystemPage = (): React.ReactElement => {
         tooltip={<>If this is set, there will be no warning triggered when auto-save is disabled (at 0).</>}
       />
       <OptionSwitch
-        checked={Settings.DisableSaveDataBackupReminder}
+        checked={Settings.EnableSaveDataBackupReminder}
         onChange={(newValue) => {
-          Settings.DisableSaveDataBackupReminder = newValue;
+          Settings.EnableSaveDataBackupReminder = newValue;
         }}
         promptOptions={{
           // Only require confirmation if the player is disabling the reminder.
-          shouldShowPrompt: (switchNewValue) => switchNewValue,
+          shouldShowPrompt: (switchNewValue) => !switchNewValue,
           text: "Are you sure you want to disable the reminder?",
         }}
-        text="Disable save data backup reminder"
-        tooltip={<>If enabled, we will not remind you to back up your save data.</>}
+        text="Enable save data backup reminder"
+        tooltip={<>If disabled, we will not remind you to back up your save data.</>}
       />
       <OptionSwitch
         checked={Settings.SaveGameOnFileSave}

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -69,6 +69,8 @@ export const Settings = {
   SuppressSavedGameToast: false,
   /** Whether to hide the toast warning when the autosave is disabled. */
   SuppressAutosaveDisabledWarnings: false,
+  /** Whether to disable the save data backup reminder. */
+  DisableSaveDataBackupReminder: false,
   /** Whether to GiB instead of GB. */
   UseIEC60027_2: false,
   /** Whether to display intermediary time unit when their value is null */
@@ -77,7 +79,7 @@ export const Settings = {
   ExcludeRunningScriptsFromSave: false,
   /**  Whether the game's sidebar is opened. */
   IsSidebarOpened: true,
-  /** Tail rendering intervall in ms */
+  /** Tail rendering interval in ms */
   TailRenderInterval: 1000,
   /** Theme colors. */
   theme: { ...defaultTheme },

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -69,8 +69,8 @@ export const Settings = {
   SuppressSavedGameToast: false,
   /** Whether to hide the toast warning when the autosave is disabled. */
   SuppressAutosaveDisabledWarnings: false,
-  /** Whether to disable the save data backup reminder. */
-  DisableSaveDataBackupReminder: false,
+  /** Whether to enable the save data backup reminder. */
+  EnableSaveDataBackupReminder: true,
   /** Whether to GiB instead of GB. */
   UseIEC60027_2: false,
   /** Whether to display intermediary time unit when their value is null */

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -57,6 +57,7 @@ import { processDarknet } from "./DarkNet/controllers/NetworkMovement";
 import { hasDarknetAccess } from "./DarkNet/utils/darknetAuthUtils";
 import { initForeignServers } from "./Server/ServerHelpers";
 import { apr1 } from "./Terminal/commands/apr1";
+import { LastExportBonus } from "./ExportBonus";
 
 declare global {
   // This property is only available in the dev build
@@ -143,18 +144,13 @@ const Engine = {
    */
   Counters: {
     autoSaveCounter: 300,
-    updateSkillLevelsCounter: 10,
-    updateDisplays: 3,
-    updateDisplaysLong: 15,
-    updateActiveScriptsDisplay: 5,
-    createProgramNotifications: 10,
-    augmentationsNotifications: 10,
     checkFactionInvitations: 10,
     passiveFactionGrowth: 5,
     messages: 150,
-    mechanicProcess: 5, // Process Bladeburner
+    bladeburnerProcess: 5,
     contractGeneration: 3000, // Generate Coding Contracts
     achievementsCounter: 5, // Check if we have new achievements
+    exportSaveData: 18000,
   },
 
   decrementAllCounters: function (numCycles = 1) {
@@ -194,7 +190,7 @@ const Engine = {
         Engine.Counters.messages = 150;
       }
     }
-    if (Engine.Counters.mechanicProcess <= 0) {
+    if (Engine.Counters.bladeburnerProcess <= 0) {
       if (Player.bladeburner) {
         try {
           Player.bladeburner.process();
@@ -202,7 +198,7 @@ const Engine = {
           exceptionAlert(e, true);
         }
       }
-      Engine.Counters.mechanicProcess = 5;
+      Engine.Counters.bladeburnerProcess = 5;
     }
 
     if (Engine.Counters.contractGeneration <= 0) {
@@ -213,6 +209,13 @@ const Engine = {
     if (Engine.Counters.achievementsCounter <= 0) {
       calculateAchievements();
       Engine.Counters.achievementsCounter = 5;
+    }
+
+    if (Engine.Counters.exportSaveData <= 0) {
+      if (LastExportBonus < Date.now() - 86400000 && !Settings.DisableSaveDataBackupReminder) {
+        SnackbarEvents.emit("You have not backed up your save data for over 24 hours!", ToastVariant.WARNING, 30000);
+      }
+      Engine.Counters.exportSaveData = 18000;
     }
 
     // This **MUST** remain the last block in the function!

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -212,7 +212,7 @@ const Engine = {
     }
 
     if (Engine.Counters.exportSaveData <= 0) {
-      if (LastExportBonus < Date.now() - 86400000 && !Settings.DisableSaveDataBackupReminder) {
+      if (LastExportBonus < Date.now() - 86400000 && Settings.EnableSaveDataBackupReminder) {
         SnackbarEvents.emit("You have not backed up your save data for over 24 hours!", ToastVariant.WARNING, 30000);
       }
       Engine.Counters.exportSaveData = 18000;

--- a/src/ui/React/OptionSwitch.tsx
+++ b/src/ui/React/OptionSwitch.tsx
@@ -1,5 +1,6 @@
 import { FormControlLabel, Switch, Tooltip, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
+import { PromptEvent } from "./PromptManager";
 
 type OptionSwitchProps = {
   checked: boolean;
@@ -8,6 +9,10 @@ type OptionSwitchProps = {
   text: React.ReactNode;
   tooltip: React.ReactNode;
   wrapperStyles?: React.CSSProperties;
+  promptOptions?: {
+    shouldShowPrompt: (switchNewValue: boolean) => boolean;
+    text: string;
+  };
 };
 
 export function OptionSwitch({
@@ -17,13 +22,26 @@ export function OptionSwitch({
   text,
   tooltip,
   wrapperStyles,
+  promptOptions,
 }: OptionSwitchProps): React.ReactElement {
   const [value, setValue] = useState(checked);
 
   function handleSwitchChange(event: React.ChangeEvent<HTMLInputElement>): void {
     const newValue = event.target.checked;
-    setValue(newValue);
-    onChange(newValue);
+    if (promptOptions?.shouldShowPrompt(newValue)) {
+      PromptEvent.emit({
+        txt: promptOptions.text,
+        resolve: (value) => {
+          if (value === true) {
+            setValue(newValue);
+            onChange(newValue);
+          }
+        },
+      });
+    } else {
+      setValue(newValue);
+      onChange(newValue);
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
We sometimes receive reports about corrupted save data. In some cases, players reported that it happens after events such as power cut or browser crashes. In other cases, they do not remember whether anything unusual happened. Anyway, these reports show us:
- Generally, browsers try to ensure data durability, but it may fail. Sometimes, browsers may prioritize other things such as performance over durability (https://developer.chrome.com/blog/indexeddb-durability-mode-now-defaults-to-relaxed).
- Many players underestimate the importance of data backup.

Currently, we give players a small benefit when they export save data every day, but this is not very effective at encouraging them to back up their data. I also don't want to grant more in-game rewards. Instead of trying to encourage players by increasing the rewards, which I think is a bad idea, we should remind them if they have not backed up their data for a long time. If they still don't do that even after we remind them, that's on them.

This PR adds a reminder that shows a warning toast if players have not backed up their data for over 24 hours. The toast appears every hour and lasts 30 seconds. This should be noticeable without being too intrusive. There is a setting to disable the reminder. Disabling it requires confirmation.

I also removed unused counters and renamed the `mechanicProcess` counter to `bladeburnerProcess`.

<img width="973" height="329" alt="1" src="https://github.com/user-attachments/assets/a3927901-70ab-4c28-b658-4e289ed8e94b" />

<img width="402" height="118" alt="2" src="https://github.com/user-attachments/assets/0126b951-3ff8-485c-b357-d020be1b7966" />
