### PR TITLE
IPVGO: Add the inital board state to ns.go.getMoveHistory() on new game

### DIFF
--- a/src/Go/effects/netscriptGoImplementation.ts
+++ b/src/Go/effects/netscriptGoImplementation.ts
@@ -320,7 +320,11 @@ export function getGameState() {
 }
 
 export function getMoveHistory(): SimpleBoard[] {
-  return Go.currentGame.previousBoards.map((boardString) => simpleBoardFromBoardString(boardString));
+  if (Go.currentGame.previousBoards.length > 0) {
+    return Go.currentGame.previousBoards.map((boardString) => simpleBoardFromBoardString(boardString));
+  } else {
+    return [simpleBoardFromBoard(Go.currentGame.board)];
+  }
 }
 
 /**


### PR DESCRIPTION
Add the initial board state to previousBoards (which feeds `ns.go.getMoveHistory()` ) on resetBoardState to improve the discoverability of entirely removing `ns.go.getGameState()` from the player's script to save on RAM.

It is possible already using the return value of `ns.go.resetBoardState()` to get the dead nodes of the new board, but it took me making this PR to realize this ¯\\_(ツ)_/¯

Documentation: 
getmovehistory.md does not mention that it currently returns an empty array on new game state, and this PR will prevent it, so no change needed.

