### PR TITLE
BUGFIX: Intelligence slows down darknet authentication

### DIFF
--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -78,15 +78,16 @@ export const calculateAuthenticationTime = (
   const underleveledFactor = applyUnderleveledFactor ? 1.5 + (chaRequired + 50) / (person.skills.charisma + 50) : 1;
   const hasBootsFactor = Player.hasAugmentation(AugmentationName.TheBoots) ? 0.8 : 1;
   const hasSf15_2Factor = Player.activeSourceFileLvl(15) > 2 ? 0.8 : 1;
+  const intelligenceFactor = 1 / calculateIntelligenceBonus(person.skills.intelligence, 0.25);
 
   const time =
-    baseTime * skillFactor * backdoorFactor * underleveledFactor * hasBootsFactor * hasSf15_2Factor * threadsFactor;
+    baseTime * skillFactor * backdoorFactor * underleveledFactor * hasBootsFactor * hasSf15_2Factor * threadsFactor * intelligenceFactor;
 
   // Add extra time for timing attack server, per correct character
   const sharedChars = darknetServerData.modelId === ModelIds.TimingAttack ? correctCharsInPassword : 0;
   const sharedCharsExtraTime = sharedChars * 50 * threadsFactor;
 
-  return time * calculateIntelligenceBonus(person.skills.intelligence, 0.25) + sharedCharsExtraTime;
+  return time + sharedCharsExtraTime;
 };
 
 export const getBackdoorAuthTimeDebuff = () => {

--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -81,7 +81,14 @@ export const calculateAuthenticationTime = (
   const intelligenceFactor = 1 / calculateIntelligenceBonus(person.skills.intelligence, 0.25);
 
   const time =
-    baseTime * skillFactor * backdoorFactor * underleveledFactor * hasBootsFactor * hasSf15_2Factor * threadsFactor * intelligenceFactor;
+    baseTime *
+    skillFactor *
+    backdoorFactor *
+    underleveledFactor *
+    hasBootsFactor *
+    hasSf15_2Factor *
+    threadsFactor *
+    intelligenceFactor;
 
   // Add extra time for timing attack server, per correct character
   const sharedChars = darknetServerData.modelId === ModelIds.TimingAttack ? correctCharsInPassword : 0;


### PR DESCRIPTION
Currently, a higher level of intelligence increases the time it takes to run (i.e. slows down) functions based on `calculateAuthenticationTime`, namely:

- `ns.dnet.authenticate`
- `ns.dnet.heartbleed`
- `ns.dnet.labreport`
- `ns.dnet.labradar`

This fix causes intelligence to reduce authentication time instead, speeding up the above functions.

Test script (`authTimeFormulas.js`):
```javascript
/** @param {NS} ns */
export async function main(ns) {
  const server = ns.dnet.getServerDetails("darkweb")
  ns.tprint(ns.formulas.dnet.getAuthenticateTime(server))
}
``` 

Before:
<img width="639" height="128" alt="dnet_low_int_formulas" src="https://github.com/user-attachments/assets/6b9d422f-9082-4071-9778-b35854de58bf" />
<img width="628" height="133" alt="dnet_high_int_formulas" src="https://github.com/user-attachments/assets/18e9dd4a-ee16-4a7b-99b8-5882cecacdb2" />

After:
<img width="635" height="134" alt="dnet_low_int_formulas_postpatch" src="https://github.com/user-attachments/assets/0aee1adf-90a4-4b36-810c-a0b9dae410f5" />
<img width="646" height="154" alt="dnet_high_int_formulas_postpatch" src="https://github.com/user-attachments/assets/81d751f9-cbe4-47d1-9bcf-c8e10fbe2477" />

Saves for testing:
[bitburnerSave_1783924203_BN1x1_DNET_LOW_INT.json.gz](https://github.com/user-attachments/files/29955621/bitburnerSave_1783924203_BN1x1_DNET_LOW_INT.json.gz)
[bitburnerSave_1783924163_BN1x1_DNET_HIGH_INT.json.gz](https://github.com/user-attachments/files/29955636/bitburnerSave_1783924163_BN1x1_DNET_HIGH_INT.json.gz)
