### PR TITLE
UI: Improve accessibility of wire cutter minigame

### DIFF
--- a/src/Infiltration/model/WireCuttingModel.ts
+++ b/src/Infiltration/model/WireCuttingModel.ts
@@ -18,13 +18,13 @@ const difficultySettings = {
   Brutal: { timer: 4000, wiresmin: 9, wiresmax: 9, rules: 4 },
 };
 
-const colors = ["red", "#FFC107", "blue", "white"] as const;
+const colors = ["#D55E00", "#F0E442", "#0072B2", "#FFFFFF"] as const;
 
 const colorNames = {
-  red: "RED",
-  "#FFC107": "YELLOW",
-  blue: "BLUE",
-  white: "WHITE",
+  "#D55E00": "RED",
+  "#F0E442": "YELLOW",
+  "#0072B2": "BLUE",
+  "#FFFFFF": "WHITE",
 } as const;
 
 interface Wire {

--- a/src/Infiltration/model/WireCuttingModel.ts
+++ b/src/Infiltration/model/WireCuttingModel.ts
@@ -18,10 +18,13 @@ const difficultySettings = {
   Brutal: { timer: 4000, wiresmin: 9, wiresmax: 9, rules: 4 },
 };
 
+// These colors, except white, come from the Okabe-Ito palette. White is used because it provides high contrast on a
+// black background.
+// Reference: https://jfly.uni-koeln.de/color/
 const colors = ["#D55E00", "#F0E442", "#0072B2", "#FFFFFF"] as const;
 
 const colorNames = {
-  "#D55E00": "RED",
+  "#D55E00": "RED", // Okabe-Ito Vermilion
   "#F0E442": "YELLOW",
   "#0072B2": "BLUE",
   "#FFFFFF": "WHITE",

--- a/src/Infiltration/model/WireCuttingModel.tsx
+++ b/src/Infiltration/model/WireCuttingModel.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { InfiltrationStage, KeyboardLikeEvent } from "../InfiltrationStage";
 import type { Infiltration } from "../Infiltration";
 import { interpolate } from "./Difficulty";
@@ -36,14 +37,14 @@ interface Wire {
 }
 
 interface Question {
-  toString: () => string;
+  render: () => React.ReactNode;
   shouldCut: (wire: Wire, index: number) => boolean;
 }
 
 function randomPositionQuestion(wires: Wire[]): Question {
   const index = Math.floor(Math.random() * wires.length);
   return {
-    toString: (): string => {
+    render: () => {
       return `Cut wire number ${index + 1}.`;
     },
     shouldCut: (_wire: Wire, i: number): boolean => {
@@ -56,8 +57,12 @@ function randomColorQuestion(wires: Wire[]): Question {
   const index = Math.floor(Math.random() * wires.length);
   const cutColor = wires[index].colors[0];
   return {
-    toString: (): string => {
-      return `Cut all wires colored ${colorNames[cutColor]}.`;
+    render: () => {
+      return (
+        <>
+          Cut all wires colored <span style={{ color: cutColor }}>{colorNames[cutColor]}</span>.
+        </>
+      );
     },
     shouldCut: (wire: Wire): boolean => {
       return wire.colors.includes(cutColor);

--- a/src/Infiltration/ui/WireCuttingGame.tsx
+++ b/src/Infiltration/ui/WireCuttingGame.tsx
@@ -4,7 +4,6 @@ import type { WireCuttingModel } from "../model/WireCuttingModel";
 import { Box, Paper, Typography } from "@mui/material";
 import { AugmentationName } from "@enums";
 import { Player } from "@player";
-import { Settings } from "../../Settings/Settings";
 
 interface IProps {
   state: Infiltration;
@@ -13,6 +12,7 @@ interface IProps {
 
 export function WireCuttingGame({ stage }: IProps): React.ReactElement {
   const hasAugment = Player.hasAugmentation(AugmentationName.KnowledgeOfApollo, true);
+  const wrongWireColor = "#CC79A7";
   return (
     <>
       <Paper sx={{ display: "grid", justifyItems: "center", pb: 1 }}>
@@ -28,11 +28,13 @@ export function WireCuttingGame({ stage }: IProps): React.ReactElement {
             gridTemplateColumns: `repeat(${stage.wires.length}, 1fr)`,
             columnGap: 3,
             justifyItems: "center",
+            background: "black",
+            padding: "10px 20px",
           }}
         >
           {Array.from({ length: stage.wires.length }, (_, i) => {
             const isCorrectWire = stage.cutWires[i] || stage.wiresToCut.has(i);
-            const color = hasAugment && !isCorrectWire ? Settings.theme.disabled : Settings.theme.primary;
+            const color = hasAugment && !isCorrectWire ? wrongWireColor : "#009E73";
             return (
               <Typography key={i} style={{ color: color }}>
                 {i + 1}
@@ -46,8 +48,7 @@ export function WireCuttingGame({ stage }: IProps): React.ReactElement {
                   return <Typography key={j}></Typography>;
                 }
                 const isCorrectWire = stage.cutWires[j] || stage.wiresToCut.has(j);
-                const wireColor =
-                  hasAugment && !isCorrectWire ? Settings.theme.disabled : wire.colors[i % wire.colors.length];
+                const wireColor = hasAugment && !isCorrectWire ? wrongWireColor : wire.colors[i % wire.colors.length];
                 return (
                   <Typography key={j} style={{ color: wireColor }}>
                     |{wire.wireType[i % wire.wireType.length]}|

--- a/src/Infiltration/ui/WireCuttingGame.tsx
+++ b/src/Infiltration/ui/WireCuttingGame.tsx
@@ -12,6 +12,7 @@ interface IProps {
 
 export function WireCuttingGame({ stage }: IProps): React.ReactElement {
   const hasAugment = Player.hasAugmentation(AugmentationName.KnowledgeOfApollo, true);
+  // Okabe-Ito "Reddish Purple"
   const wrongWireColor = "#CC79A7";
   return (
     <>
@@ -34,7 +35,7 @@ export function WireCuttingGame({ stage }: IProps): React.ReactElement {
         >
           {Array.from({ length: stage.wires.length }, (_, i) => {
             const isCorrectWire = stage.cutWires[i] || stage.wiresToCut.has(i);
-            const color = hasAugment && !isCorrectWire ? wrongWireColor : "#009E73";
+            const color = hasAugment && !isCorrectWire ? wrongWireColor : "#009E73"; // Okabe-Ito "Bluish Green"
             return (
               <Typography key={i} style={{ color: color }}>
                 {i + 1}

--- a/src/Infiltration/ui/WireCuttingGame.tsx
+++ b/src/Infiltration/ui/WireCuttingGame.tsx
@@ -16,12 +16,19 @@ export function WireCuttingGame({ stage }: IProps): React.ReactElement {
   const wrongWireColor = "#CC79A7";
   return (
     <>
-      <Paper sx={{ display: "grid", justifyItems: "center", pb: 1 }}>
-        <Typography variant="h4" sx={{ width: "75%", textAlign: "center" }}>
+      <Paper sx={{ display: "grid", justifyItems: "center", pb: 1, background: "black" }}>
+        <Typography variant="h4" sx={{ width: "75%", textAlign: "center", color: "white" }}>
           Cut the wires with the following properties! (keyboard 1 to 9)
         </Typography>
         {stage.questions.map((question, i) => (
-          <Typography key={i}>{question.toString()}</Typography>
+          <Typography
+            key={i}
+            sx={{
+              color: "white",
+            }}
+          >
+            {question.render()}
+          </Typography>
         ))}
         <Box
           sx={{
@@ -29,7 +36,6 @@ export function WireCuttingGame({ stage }: IProps): React.ReactElement {
             gridTemplateColumns: `repeat(${stage.wires.length}, 1fr)`,
             columnGap: 3,
             justifyItems: "center",
-            background: "black",
             padding: "10px 20px",
           }}
         >


### PR DESCRIPTION
#2950 addressed the remaining issues with the light theme, except for the wire cutter minigame. A while ago, a player reported having trouble distinguishing red and yellow wires. They suggested adding the ability to change the wire colors. I considered adding more theme colors and using them for the wires. However, I now think we should change the color palette instead.

Allowing players to change the colors is a nice idea, but it seems like the XY problem. What players actually want is to distinguish the wire colors more easily. Adding new theme colors and telling players to adjust them on their own is unnecessary. Instead, I think we should choose a good palette that helps colorblind players while also solving the issue with the light theme.

This PR uses colors from the Okabe-Ito color palette (https://jfly.uni-koeln.de/color/), which is well known for addressing this kind of issue. It also forces a black background to improve contrast and ensure that unusual theme backgrounds do not introduce new color related issues.

Default theme:
Before:
<img width="940" height="534" alt="before-default-theme" src="https://github.com/user-attachments/assets/1cfc3933-a7fe-442d-953f-e46fe6396188" />

After:
<img width="938" height="552" alt="after-default-theme" src="https://github.com/user-attachments/assets/feb23fa0-75a5-482c-aef7-27444fe9e711" />

Iron Man theme:
Before:
<img width="940" height="534" alt="before-red" src="https://github.com/user-attachments/assets/060b71dd-a743-4df6-8ddc-e7aeade743c9" />

After:
<img width="940" height="545" alt="after-red" src="https://github.com/user-attachments/assets/c6a8b950-e30c-41be-b07d-a3b814ab0c07" />

Light theme:
Before:
<img width="942" height="529" alt="before-light" src="https://github.com/user-attachments/assets/25fe2144-2982-48fa-bf62-7028c93568a5" />

After:
<img width="943" height="540" alt="after-light" src="https://github.com/user-attachments/assets/7ef108f9-d985-49e4-8228-8d4c68ce0ecf" />

Have the `SoA - Knowledge of Apollo` augmentation:
<img width="939" height="547" alt="Capture" src="https://github.com/user-attachments/assets/d2c8b913-b781-4adf-ba76-a7aa4cd149dc" />
