### PR TITLE
UI: Fix description case for MONEY_1Q achievement

### DIFF
--- a/src/Achievements/AchievementData.json
+++ b/src/Achievements/AchievementData.json
@@ -144,7 +144,7 @@
     "MONEY_1Q": {
       "ID": "MONEY_1Q",
       "Name": "Here comes the money!",
-      "Description": "Have $1Q on your home computer."
+      "Description": "Have $1Q (not $1q) on your home computer."
     },
     "MONEY_M1B": {
       "ID": "MONEY_M1B",


### PR DESCRIPTION
To reduce the number of questions about not getting the achievement