### PR TITLE
UI: Accounting for ellipsis length when shortening hostnames

### DIFF
--- a/src/ui/ActiveScripts/ServerAccordion.tsx
+++ b/src/ui/ActiveScripts/ServerAccordion.tsx
@@ -22,9 +22,10 @@ export function ServerAccordion({ server, scripts, startOpen }: ServerAccordionP
   // Accordion's header text
   const longestHostnameLength = 26;
   // Use spread operator to get accurate length on servers with UTF-16 names
-  const paddedName = [...server.hostname].length > longestHostnameLength
-      ? [...server.hostname].slice(0, longestHostnameLength - 3).join('') + "..."
-      : [...`${server.hostname}${" ".repeat(longestHostnameLength)}`].slice(0, longestHostnameLength).join('');
+  const hostnameChars = [...server.hostname];
+  const paddedName = hostnameChars.length > longestHostnameLength
+      ? hostnameChars.slice(0, longestHostnameLength - 3).join('') + "..."
+      : server.hostname + " ".repeat(longestHostnameLength - hostnameChars.length);
   const barOptions = {
     progress: server.ramUsed / server.maxRam,
     totalTicks: 30,

--- a/src/ui/ActiveScripts/ServerAccordion.tsx
+++ b/src/ui/ActiveScripts/ServerAccordion.tsx
@@ -21,16 +21,10 @@ export function ServerAccordion({ server, scripts, startOpen }: ServerAccordionP
 
   // Accordion's header text
   const longestHostnameLength = 26;
-  const truncatedHostname =
-    server.hostname.length > longestHostnameLength - 2
-      ? server.hostname.slice(0, longestHostnameLength - 3) + "..."
-      : server.hostname;
-  const paddedName = `${truncatedHostname}${" ".repeat(longestHostnameLength)}`.slice(
-    0,
-    Math.max(truncatedHostname.length, longestHostnameLength),
-const paddedName = server.hostname.length > longestHostnameLength
-      ? server.hostname.slice(0, longestHostnameLength - 3) + "..."
-      : `${server.hostname}${" ".repeat(longestHostnameLength)}`.slice(0, longestHostnameLength);
+  // Use spread operator to get accurate length on servers with UTF-16 names
+  const paddedName = [...server.hostname].length > longestHostnameLength
+      ? [...server.hostname].slice(0, longestHostnameLength - 3).join('') + "..."
+      : [...`${server.hostname}${" ".repeat(longestHostnameLength)}`].slice(0, longestHostnameLength).join('');
   const barOptions = {
     progress: server.ramUsed / server.maxRam,
     totalTicks: 30,

--- a/src/ui/ActiveScripts/ServerAccordion.tsx
+++ b/src/ui/ActiveScripts/ServerAccordion.tsx
@@ -23,8 +23,9 @@ export function ServerAccordion({ server, scripts, startOpen }: ServerAccordionP
   const longestHostnameLength = 26;
   // Use spread operator to get accurate length on servers with UTF-16 names
   const hostnameChars = [...server.hostname];
-  const paddedName = hostnameChars.length > longestHostnameLength
-      ? hostnameChars.slice(0, longestHostnameLength - 3).join('') + "..."
+  const paddedName =
+    hostnameChars.length > longestHostnameLength
+      ? hostnameChars.slice(0, longestHostnameLength - 3).join("") + "..."
       : server.hostname + " ".repeat(longestHostnameLength - hostnameChars.length);
   const barOptions = {
     progress: server.ramUsed / server.maxRam,

--- a/src/ui/ActiveScripts/ServerAccordion.tsx
+++ b/src/ui/ActiveScripts/ServerAccordion.tsx
@@ -28,7 +28,9 @@ export function ServerAccordion({ server, scripts, startOpen }: ServerAccordionP
   const paddedName = `${truncatedHostname}${" ".repeat(longestHostnameLength)}`.slice(
     0,
     Math.max(truncatedHostname.length, longestHostnameLength),
-  );
+const paddedName = server.hostname.length > longestHostnameLength
+      ? server.hostname.slice(0, longestHostnameLength - 3) + "..."
+      : `${server.hostname}${" ".repeat(longestHostnameLength)}`.slice(0, longestHostnameLength);
   const barOptions = {
     progress: server.ramUsed / server.maxRam,
     totalTicks: 30,

--- a/src/ui/ActiveScripts/ServerAccordion.tsx
+++ b/src/ui/ActiveScripts/ServerAccordion.tsx
@@ -23,7 +23,7 @@ export function ServerAccordion({ server, scripts, startOpen }: ServerAccordionP
   const longestHostnameLength = 26;
   const truncatedHostname =
     server.hostname.length > longestHostnameLength - 2
-      ? server.hostname.slice(0, longestHostnameLength) + "..."
+      ? server.hostname.slice(0, longestHostnameLength - 3) + "..."
       : server.hostname;
   const paddedName = `${truncatedHostname}${" ".repeat(longestHostnameLength)}`.slice(
     0,


### PR DESCRIPTION
# Accounting for ellipsis length when shorting hostnames in the Active Scripts panel

The `truncatedHostname` in the Active Scripts panel are 3 characters too long, causing the corresponding RAM meter to be misaligned

<img width="547" height="287" alt="before" src="https://github.com/user-attachments/assets/5ff4fa04-47b0-49b4-9356-e786321f0a7e" />

# Bug fix

Subtracting 3 from the length to account for the length of the ellipsis fixes this

<img width="529" height="326" alt="after" src="https://github.com/user-attachments/assets/fadb9f8e-8f8e-47ea-a327-90a24a55001e" />

Code tested locally using the same save in which I observed the bug