### PR TITLE
REFACTOR: Change Aug impl for greater sanity

### DIFF
--- a/src/Augmentation/Augmentation.ts
+++ b/src/Augmentation/Augmentation.ts
@@ -1,8 +1,8 @@
 // Class definition for a single Augmentation object
-import { Player } from "@player";
-import { AugmentationName, CompletedProgramName, FactionName } from "@enums";
+import type { AugmentationName, CompletedProgramName, FactionName } from "@enums";
+import type { Multipliers } from "@nsdefs";
 import { formatPercent } from "../ui/formatNumber";
-import { Multipliers, defaultMultipliers } from "../PersonObjects/Multipliers";
+import { defaultMultipliers } from "../PersonObjects/Multipliers";
 import { getRecordKeys } from "../Types/Record";
 
 export interface AugmentationCosts {
@@ -232,20 +232,5 @@ export class Augmentation {
     if (params.stats === undefined)
       this.stats = generateStatsDescription(this.mults, params.programs, params.startingMoney);
     else this.stats = params.stats;
-  }
-
-  /** Get the current level of an augmentation before buying. Currently only relevant for NFG. */
-  getLevel(): number {
-    // Only NFG currently has levels, all others will be level 0 before purchase
-    if (this.name !== AugmentationName.NeuroFluxGovernor) return 0;
-    // Owned NFG has the level baked in
-    const ownedNFGLevel = Player.augmentations.find((aug) => aug.name === this.name)?.level ?? 0;
-    // Queued NFG is queued multiple times for each level purchased
-    const queuedNFGLevel = Player.queuedAugmentations.filter((aug) => aug.name === this.name).length;
-    return ownedNFGLevel + queuedNFGLevel;
-  }
-  /** Get the next level of an augmentation to buy. Currently only relevant for NFG. */
-  getNextLevel(): number {
-    return this.getLevel() + 1;
   }
 }

--- a/src/Augmentation/AugmentationHelpers.ts
+++ b/src/Augmentation/AugmentationHelpers.ts
@@ -5,6 +5,7 @@ import { AugmentationName } from "@enums";
 
 import { CONSTANTS } from "../Constants";
 import { Player } from "@player";
+import type { Multipliers } from "@nsdefs";
 import { prestigeAugmentation } from "../Prestige";
 
 import { dialogBoxCreate } from "../ui/React/DialogBox";
@@ -36,33 +37,55 @@ export function getGenericAugmentationPriceMultiplier(): number {
   return Math.pow(getBaseAugmentationPriceMultiplier(), queuedNonSoAAugmentationList.length);
 }
 
-export function applyAugmentation(aug: PlayerOwnedAugmentation, reapply = false): void {
-  const staticAugmentation = Augmentations[aug.name];
+// When effectOnly == true, the augmentation is not actually added to the
+// Player, only its effect is added to their mults.
+export function applyAugmentation(aug: PlayerOwnedAugmentation, effectOnly = false): void {
+  let previousLevel = 0;
+  if (!effectOnly) {
+    // Update current level, or add a new Aug if it didn't exist
+    for (const pAug of Player.augmentations) {
+      if (pAug.name === aug.name) {
+        previousLevel = pAug.level;
+        pAug.level = aug.level;
+        break;
+      }
+    }
+    if (!previousLevel) {
+      const ownedAug = new PlayerOwnedAugmentation(aug.name);
+      ownedAug.level = aug.level;
+      Player.augmentations.push(ownedAug);
+    }
+  }
 
   // Apply multipliers
-  Player.mults = mergeMultipliers(Player.mults, staticAugmentation.mults);
+  updateMultipliers(Player.mults, aug, previousLevel);
 
   // Special logic for Congruity Implant
-  if (aug.name === AugmentationName.CongruityImplant && !reapply) {
+  if (aug.name === AugmentationName.CongruityImplant && !effectOnly) {
     Player.entropy = 0;
+    // This ends up recursively calling this function, but with
+    // effectOnly=true, so it doesn't loop. However, it does mean it's
+    // important that everything is in the proper state by this point.
     Player.applyEntropy(Player.entropy);
   }
 
   // Recalculate skill levels after applying multipliers.
   Player.updateSkillLevels();
+}
 
-  // Special logic for NeuroFlux Governor
-  const ownedNfg = Player.augmentations.find((pAug) => pAug.name === AugmentationName.NeuroFluxGovernor);
-  if (aug.name === AugmentationName.NeuroFluxGovernor && !reapply && ownedNfg) {
-    ownedNfg.level = aug.level;
-    return;
+// Update the multipliers in "mults" from previousLevel to aug.level. This should be used in most cases
+// instead of mergeMultipliers, since it handles special cases like NFG uniformly. (It works for both
+// queued and installed augs.)
+export function updateMultipliers(mults: Multipliers, aug: PlayerOwnedAugmentation, previousLevel: number): void {
+  const staticAugmentation = Augmentations[aug.name];
+  if (aug.level <= previousLevel) {
+    throw new Error(`Trying to downlevel/relevel aug {aug.name} from {previousLevel} to {aug.level}!`);
   }
-
-  // Push onto Player's Augmentation list
-  if (!reapply) {
-    const ownedAug = new PlayerOwnedAugmentation(aug.name);
-
-    Player.augmentations.push(ownedAug);
+  if (aug.name !== AugmentationName.NeuroFluxGovernor && (aug.level !== 1 || previousLevel !== 0)) {
+    throw new Error(`Unexpected levels for {aug.name}: Leveling {previousLevel} to {aug.level}!`);
+  }
+  for (let i = previousLevel; i < aug.level; ++i) {
+    mergeMultipliers(mults, staticAugmentation.mults);
   }
 }
 
@@ -124,6 +147,25 @@ export interface AugmentationCosts {
   repCost: number;
 }
 
+/** Get the current level (installed + queued) of an augmentation before buying. */
+export function getAugLevel(aug: Augmentation): number {
+  let level = 0;
+  for (const pAug of Player.augmentations) {
+    if (pAug.name === aug.name) {
+      // There shouldn't be duplicates here, but use the last if there are.
+      level = pAug.level;
+    }
+  }
+  for (const pAug of Player.queuedAugmentations) {
+    if (pAug.name === aug.name) {
+      // There *definitely* can be duplicates here, and we want the last (most powerful) one.
+      // Note that queued levels will always be higher than installed levels, if they exist.
+      level = pAug.level;
+    }
+  }
+  return level;
+}
+
 export function getAugCost(aug: Augmentation): AugmentationCosts {
   let moneyCost = aug.baseCost;
   let repCost = aug.baseRepRequirement;
@@ -131,7 +173,7 @@ export function getAugCost(aug: Augmentation): AugmentationCosts {
   switch (aug.name) {
     // Special cost for NFG
     case AugmentationName.NeuroFluxGovernor: {
-      const multiplier = Math.pow(CONSTANTS.NeuroFluxGovernorLevelMult, aug.getLevel());
+      const multiplier = Math.pow(CONSTANTS.NeuroFluxGovernorLevelMult, getAugLevel(aug));
       repCost = aug.baseRepRequirement * multiplier * currentNodeMults.AugmentationRepCost;
       moneyCost = aug.baseCost * multiplier * currentNodeMults.AugmentationMoneyCost;
       moneyCost *= getGenericAugmentationPriceMultiplier();

--- a/src/Augmentation/ui/PlayerMultipliers.tsx
+++ b/src/Augmentation/ui/PlayerMultipliers.tsx
@@ -1,19 +1,27 @@
+import type { Multipliers } from "@nsdefs";
+import type { AugmentationName } from "@enums";
 import { DoubleArrow } from "@mui/icons-material";
 import { List, ListItem, ListItemText, Paper, Typography } from "@mui/material";
 import * as React from "react";
-import { Multipliers, defaultMultipliers, mergeMultipliers } from "../../PersonObjects/Multipliers";
+import { defaultMultipliers } from "../../PersonObjects/Multipliers";
 import { currentNodeMults } from "../../BitNode/BitNodeMultipliers";
 import { Player } from "@player";
 import { Settings } from "../../Settings/Settings";
 import { formatPercent } from "../../ui/formatNumber";
-import { Augmentations } from "../Augmentations";
+import { updateMultipliers } from "../AugmentationHelpers";
 import { canAccessBitNodeFeature } from "../../BitNode/BitNodeUtils";
 
 function calculateAugmentedStats(): Multipliers {
-  let augP: Multipliers = defaultMultipliers();
+  const augP: Multipliers = defaultMultipliers();
+  // Given the specifics of how we enqueue augs, we could do this another way.
+  // But using a map is straightforward and future-proof.
+  const levels = new Map<AugmentationName, number>();
+  for (const aug of Player.augmentations) {
+    levels.set(aug.name, aug.level);
+  }
   for (const aug of Player.queuedAugmentations) {
-    const augObj = Augmentations[aug.name];
-    augP = mergeMultipliers(augP, augObj.mults);
+    updateMultipliers(augP, aug, levels.get(aug.name) ?? 0);
+    levels.set(aug.name, aug.level);
   }
   return augP;
 }

--- a/src/Augmentation/ui/PurchasableAugmentations.tsx
+++ b/src/Augmentation/ui/PurchasableAugmentations.tsx
@@ -13,7 +13,7 @@ import { Augmentation } from "../Augmentation";
 import { AugmentationName, FactionName } from "@enums";
 import { Augmentations } from "../Augmentations";
 import { PurchaseAugmentationModal } from "./PurchaseAugmentationModal";
-import { getAugCost } from "../AugmentationHelpers";
+import { getAugCost, getAugLevel } from "../AugmentationHelpers";
 import { useRerender } from "../../ui/React/hooks";
 import { Requirement } from "../../ui/Components/Requirement";
 
@@ -160,7 +160,7 @@ export function PurchasableAugmentation(props: IPurchasableAugProps): React.Reac
 
   const aug = Augmentations[props.augName];
   if (!aug) return <></>;
-  const augLevel = aug.getLevel();
+  const augLevel = getAugLevel(aug);
   const augCosts = getAugCost(aug);
   const cost = props.parent.sleeveAugs ? aug.baseCost : augCosts.moneyCost;
   const repCost = augCosts.repCost;

--- a/src/CotMG/StaneksGift.ts
+++ b/src/CotMG/StaneksGift.ts
@@ -1,4 +1,5 @@
 import { Player } from "@player";
+import type { Multipliers } from "@nsdefs";
 import { AugmentationName, FactionName } from "@enums";
 import { Fragment } from "./Fragment";
 import { ActiveFragment } from "./ActiveFragment";
@@ -10,7 +11,7 @@ import { StaneksGiftEvents } from "./StaneksGiftEvents";
 import { Generic_fromJSON, Generic_toJSON, IReviverValue, constructorsForReviver } from "../utils/JSONReviver";
 import { StanekConstants } from "./data/Constants";
 import { currentNodeMults } from "../BitNode/BitNodeMultipliers";
-import { defaultMultipliers, mergeMultipliers, Multipliers, scaleMultipliers } from "../PersonObjects/Multipliers";
+import { defaultMultipliers, mergeMultipliers, scaleMultipliers } from "../PersonObjects/Multipliers";
 import { Augmentations } from "../Augmentation/Augmentations";
 import { getKeyList } from "../utils/helpers/getKeyList";
 
@@ -205,13 +206,13 @@ export class StaneksGift extends BaseGift {
 
   updateMults(): void {
     const mults = this.calculateMults();
-    Player.mults = mergeMultipliers(Player.mults, mults);
+    mergeMultipliers(Player.mults, mults);
     Player.updateSkillLevels();
     const zoeAmt = Player.sleeves.reduce((n, sleeve) => n + (sleeve.hasAugmentation(AugmentationName.ZOE) ? 1 : 0), 0);
     if (zoeAmt === 0) return;
     // Less powerful for each copy.
     const scaling = 3 / (zoeAmt + 2);
-    const sleeveMults = scaleMultipliers(mults, scaling);
+    scaleMultipliers(mults, scaling);
     for (const sleeve of Player.sleeves) {
       if (!sleeve.hasAugmentation(AugmentationName.ZOE)) continue;
       sleeve.resetMultipliers();
@@ -221,7 +222,7 @@ export class StaneksGift extends BaseGift {
         sleeve.applyAugmentation(aug);
       }
       //applying stanek multiplier
-      sleeve.mults = mergeMultipliers(sleeve.mults, sleeveMults);
+      mergeMultipliers(sleeve.mults, mults);
       sleeve.updateSkillLevels();
     }
   }

--- a/src/Go/effects/effect.ts
+++ b/src/Go/effects/effect.ts
@@ -1,10 +1,11 @@
 import { Player } from "@player";
+import type { Multipliers } from "@nsdefs";
 
 import { GoOpponent } from "@enums";
 import { Go } from "../Go";
 import { currentNodeMults } from "../../BitNode/BitNodeMultipliers";
 import { opponentDetails } from "../Constants";
-import { defaultMultipliers, mergeMultipliers, Multipliers } from "../../PersonObjects/Multipliers";
+import { defaultMultipliers, mergeMultipliers } from "../../PersonObjects/Multipliers";
 import { formatPercent } from "../../ui/formatNumber";
 import { getOpponentStats } from "../boardAnalysis/scoring";
 import { getRecordEntries, getRecordValues } from "../../Types/Record";
@@ -58,7 +59,7 @@ export function getBonusText(opponent: GoOpponent) {
  */
 export function updateGoMults(): void {
   const mults = calculateMults();
-  Player.mults = mergeMultipliers(Player.mults, mults);
+  mergeMultipliers(Player.mults, mults);
   Player.updateSkillLevels();
 }
 

--- a/src/PersonObjects/Grafting/EntropyAccumulation.ts
+++ b/src/PersonObjects/Grafting/EntropyAccumulation.ts
@@ -1,7 +1,7 @@
 import { CONSTANTS } from "../../Constants";
 
 import { Player } from "@player";
-import { Multipliers } from "../Multipliers";
+import type { Multipliers } from "@nsdefs";
 
 export const calculateEntropy = (stacks = 1): Multipliers => {
   const nerf = CONSTANTS.EntropyEffect ** stacks;

--- a/src/PersonObjects/Multipliers.ts
+++ b/src/PersonObjects/Multipliers.ts
@@ -1,36 +1,4 @@
-export interface Multipliers {
-  hacking_chance: number;
-  hacking_speed: number;
-  hacking_money: number;
-  hacking_grow: number;
-  hacking: number;
-  hacking_exp: number;
-  strength: number;
-  strength_exp: number;
-  defense: number;
-  defense_exp: number;
-  dexterity: number;
-  dexterity_exp: number;
-  agility: number;
-  agility_exp: number;
-  charisma: number;
-  charisma_exp: number;
-  hacknet_node_money: number;
-  hacknet_node_purchase_cost: number;
-  hacknet_node_ram_cost: number;
-  hacknet_node_core_cost: number;
-  hacknet_node_level_cost: number;
-  company_rep: number;
-  faction_rep: number;
-  work_money: number;
-  crime_success: number;
-  crime_money: number;
-  dnet_money: number;
-  bladeburner_max_stamina: number;
-  bladeburner_stamina_gain: number;
-  bladeburner_analysis: number;
-  bladeburner_success_chance: number;
-}
+import type { Multipliers } from "@nsdefs";
 
 export const defaultMultipliers = (): Multipliers => {
   return {
@@ -68,74 +36,29 @@ export const defaultMultipliers = (): Multipliers => {
   };
 };
 
-export const mergeMultipliers = (m0: Multipliers, m1: Multipliers): Multipliers => {
-  return {
-    hacking_chance: m0.hacking_chance * m1.hacking_chance,
-    hacking_speed: m0.hacking_speed * m1.hacking_speed,
-    hacking_money: m0.hacking_money * m1.hacking_money,
-    hacking_grow: m0.hacking_grow * m1.hacking_grow,
-    hacking: m0.hacking * m1.hacking,
-    hacking_exp: m0.hacking_exp * m1.hacking_exp,
-    strength: m0.strength * m1.strength,
-    strength_exp: m0.strength_exp * m1.strength_exp,
-    defense: m0.defense * m1.defense,
-    defense_exp: m0.defense_exp * m1.defense_exp,
-    dexterity: m0.dexterity * m1.dexterity,
-    dexterity_exp: m0.dexterity_exp * m1.dexterity_exp,
-    agility: m0.agility * m1.agility,
-    agility_exp: m0.agility_exp * m1.agility_exp,
-    charisma: m0.charisma * m1.charisma,
-    charisma_exp: m0.charisma_exp * m1.charisma_exp,
-    hacknet_node_money: m0.hacknet_node_money * m1.hacknet_node_money,
-    hacknet_node_purchase_cost: m0.hacknet_node_purchase_cost * m1.hacknet_node_purchase_cost,
-    hacknet_node_ram_cost: m0.hacknet_node_ram_cost * m1.hacknet_node_ram_cost,
-    hacknet_node_core_cost: m0.hacknet_node_core_cost * m1.hacknet_node_core_cost,
-    hacknet_node_level_cost: m0.hacknet_node_level_cost * m1.hacknet_node_level_cost,
-    company_rep: m0.company_rep * m1.company_rep,
-    faction_rep: m0.faction_rep * m1.faction_rep,
-    work_money: m0.work_money * m1.work_money,
-    crime_success: m0.crime_success * m1.crime_success,
-    crime_money: m0.crime_money * m1.crime_money,
-    dnet_money: m0.dnet_money * m1.dnet_money,
-    bladeburner_max_stamina: m0.bladeburner_max_stamina * m1.bladeburner_max_stamina,
-    bladeburner_stamina_gain: m0.bladeburner_stamina_gain * m1.bladeburner_stamina_gain,
-    bladeburner_analysis: m0.bladeburner_analysis * m1.bladeburner_analysis,
-    bladeburner_success_chance: m0.bladeburner_success_chance * m1.bladeburner_success_chance,
-  };
+const allMultiplierKeys = Object.keys(defaultMultipliers()) as (keyof Multipliers)[];
+
+export const mergeMultipliers = (result: Multipliers, m1: Multipliers): void => {
+  for (const key of allMultiplierKeys) {
+    result[key] *= m1[key];
+  }
 };
 
-export const scaleMultipliers = (m0: Multipliers, v: number): Multipliers => {
-  return {
-    hacking_chance: (m0.hacking_chance - 1) * v + 1,
-    hacking_speed: (m0.hacking_speed - 1) * v + 1,
-    hacking_money: (m0.hacking_money - 1) * v + 1,
-    hacking_grow: (m0.hacking_grow - 1) * v + 1,
-    hacking: (m0.hacking - 1) * v + 1,
-    hacking_exp: (m0.hacking_exp - 1) * v + 1,
-    strength: (m0.strength - 1) * v + 1,
-    strength_exp: (m0.strength_exp - 1) * v + 1,
-    defense: (m0.defense - 1) * v + 1,
-    defense_exp: (m0.defense_exp - 1) * v + 1,
-    dexterity: (m0.dexterity - 1) * v + 1,
-    dexterity_exp: (m0.dexterity_exp - 1) * v + 1,
-    agility: (m0.agility - 1) * v + 1,
-    agility_exp: (m0.agility_exp - 1) * v + 1,
-    charisma: (m0.charisma - 1) * v + 1,
-    charisma_exp: (m0.charisma_exp - 1) * v + 1,
-    hacknet_node_money: (m0.hacknet_node_money - 1) * v + 1,
-    hacknet_node_purchase_cost: (m0.hacknet_node_purchase_cost - 1) * v + 1,
-    hacknet_node_ram_cost: (m0.hacknet_node_ram_cost - 1) * v + 1,
-    hacknet_node_core_cost: (m0.hacknet_node_core_cost - 1) * v + 1,
-    hacknet_node_level_cost: (m0.hacknet_node_level_cost - 1) * v + 1,
-    company_rep: (m0.company_rep - 1) * v + 1,
-    faction_rep: (m0.faction_rep - 1) * v + 1,
-    work_money: (m0.work_money - 1) * v + 1,
-    crime_success: (m0.crime_success - 1) * v + 1,
-    crime_money: (m0.crime_money - 1) * v + 1,
-    dnet_money: (m0.dnet_money - 1) * v + 1,
-    bladeburner_max_stamina: (m0.bladeburner_max_stamina - 1) * v + 1,
-    bladeburner_stamina_gain: (m0.bladeburner_stamina_gain - 1) * v + 1,
-    bladeburner_analysis: (m0.bladeburner_analysis - 1) * v + 1,
-    bladeburner_success_chance: (m0.bladeburner_success_chance - 1) * v + 1,
-  };
+export const scaleMultipliers = (result: Multipliers, v: number): void => {
+  for (const key of allMultiplierKeys) {
+    const effect = result[key];
+    // For buffs that apply positively, this is a linear scaling. For
+    // instance, scaling a 2x mult (+100%) by 1.5 gives 2.5x (+150%).
+    //
+    // However, inverse mults apply in a reciprocal fashion, so we have to
+    // take that into effect here. For instance, scaling a 0.5x mult (/2) by
+    // 1.5 gives a 0.4x mult (/2.5). This has the same effect on stats, but a
+    // more complicated formula. We assume any mult that is less than 1 is
+    // applying this way.
+    if (effect >= 1) {
+      result[key] = (effect - 1) * v + 1;
+    } else {
+      result[key] = 1 / ((1 / effect - 1) * v + 1);
+    }
+  }
 };

--- a/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
+++ b/src/PersonObjects/Player/PlayerObjectGeneralMethods.ts
@@ -13,7 +13,7 @@ import {
 import type { PlayerObject } from "./PlayerObject";
 import type { ProgramFilePath } from "../../Paths/ProgramFilePath";
 
-import { applyAugmentation } from "../../Augmentation/AugmentationHelpers";
+import { applyAugmentation, getAugLevel } from "../../Augmentation/AugmentationHelpers";
 import { PlayerOwnedAugmentation } from "../../Augmentation/PlayerOwnedAugmentation";
 import { currentNodeMults } from "../../BitNode/BitNodeMultipliers";
 import { CodingContractRewardType, ICodingContractReward } from "../../CodingContract/Contract";
@@ -415,14 +415,6 @@ export function reapplyAllAugmentations(this: PlayerObject, resetMultipliers = t
   }
 
   for (const playerAug of this.augmentations) {
-    const augName = playerAug.name;
-
-    if (augName == AugmentationName.NeuroFluxGovernor) {
-      for (let i = 0; i < playerAug.level; ++i) {
-        applyAugmentation(playerAug, true);
-      }
-      continue;
-    }
     applyAugmentation(playerAug, true);
   }
 
@@ -471,29 +463,16 @@ export function setBitNodeNumber(this: PlayerObject, n: number): void {
 }
 
 export function queueAugmentation(this: PlayerObject, name: AugmentationName): void {
-  if (name !== AugmentationName.NeuroFluxGovernor) {
-    for (const aug of this.queuedAugmentations) {
-      if (name === aug.name) {
-        AlertEvents.emit(`Tried to queue ${name} twice. This is a bug. Please contact developers.`);
-        return;
-      }
-    }
-
-    for (const aug of this.augmentations) {
-      if (aug.name === name) {
-        AlertEvents.emit(
-          `Tried to queue ${name}, but this augmentation was installed. This is a bug. Please contact developers.`,
-        );
-        return;
-      }
-    }
+  const currentLevel = getAugLevel(Augmentations[name]);
+  if (name !== AugmentationName.NeuroFluxGovernor && currentLevel !== 0) {
+    AlertEvents.emit(
+      `Tried to queue ${name}, but it was already installed or queued. This is a bug. Please contact developers.`,
+    );
+    return;
   }
 
   const queuedAugmentation = new PlayerOwnedAugmentation(name);
-  if (name === AugmentationName.NeuroFluxGovernor) {
-    const augmentation = Augmentations[name];
-    queuedAugmentation.level = augmentation.getNextLevel();
-  }
+  queuedAugmentation.level = currentLevel + 1;
   this.queuedAugmentations.push(queuedAugmentation);
 }
 

--- a/src/PersonObjects/Sleeve/Sleeve.ts
+++ b/src/PersonObjects/Sleeve/Sleeve.ts
@@ -7,7 +7,7 @@
  * Sleeves are unlocked in BitNode-10.
  */
 
-import type { Result, SleevePerson } from "@nsdefs";
+import type { Result, SleevePerson, Multipliers } from "@nsdefs";
 import type { Augmentation } from "../../Augmentation/Augmentation";
 import type { SleeveWork } from "./Work/Work";
 
@@ -45,7 +45,7 @@ import { SleeveBladeburnerWork } from "./Work/SleeveBladeburnerWork";
 import { SleeveCrimeWork } from "./Work/SleeveCrimeWork";
 import { calculateIntelligenceBonus } from "../formulas/intelligence";
 import { getEnumHelper } from "../../utils/EnumHelper";
-import { Multipliers, mergeMultipliers } from "../Multipliers";
+import { mergeMultipliers } from "../Multipliers";
 import { getFactionAugmentationsFiltered } from "../../Faction/FactionHelpers";
 import { Augmentations } from "../../Augmentation/Augmentations";
 import { getAugCost } from "../../Augmentation/AugmentationHelpers";
@@ -84,7 +84,7 @@ export class Sleeve extends Person implements SleevePerson {
 
   /** Updates this object's multipliers for the given augmentation */
   applyAugmentation(aug: Augmentation): void {
-    this.mults = mergeMultipliers(this.mults, aug.mults);
+    mergeMultipliers(this.mults, aug.mults);
   }
 
   findPurchasableAugs(): Augmentation[] {

--- a/src/Work/WorkStats.ts
+++ b/src/Work/WorkStats.ts
@@ -2,7 +2,7 @@ import type { MoneySource } from "../utils/MoneySourceTracker";
 
 import { Person } from "../PersonObjects/Person";
 import { Player } from "@player";
-import { Multipliers } from "../PersonObjects/Multipliers";
+import type { Multipliers } from "@nsdefs";
 
 export interface WorkStats {
   money: number;


### PR DESCRIPTION
The augmentation code was a bit of a mess, with NFG tacked on as a special-case all over the place. This reworks that in preparation for the "socks" PR, so that it doesn't need to add a pile more special-cases.

The weirdness where augs are unique when installed, but can have duplicates in the queued list is now handled in a uniform way. I thought about changing that, but we'd need to keep supporting duplicates in the queued list ~forever anyway, because of old saves. But now there's a *lot* more comments for the weird sections.

This also cleans up the way multipliers are calculated, as augs are the primary user of that code.

# Testing

I tested augs manually using the dev menu. I should check if we have automated tests, but got lazy and wanted to get this out there.

@ficocelliguy you can see the plan now. Also you can poke me if I forget about this again.