### PR TITLE
CLI: make scan-analyze less powerful

### DIFF
--- a/src/Terminal/OutputTypes.tsx
+++ b/src/Terminal/OutputTypes.tsx
@@ -26,11 +26,13 @@ export class RawOutput {
 }
 
 export class Link {
-  hostname: string;
   dashes: string;
-  constructor(dashes: string, hostname: string) {
+  path: string[];
+  text: string;
+  constructor(dashes: string, path: string[], text: string) {
     if (Settings.TimestampsFormat) dashes = "[" + formatTime(Settings.TimestampsFormat) + "] " + dashes;
-    this.hostname = hostname;
     this.dashes = dashes;
+    this.path = path;
+    this.text = text;
   }
 }

--- a/src/Terminal/commands/scananalyze.ts
+++ b/src/Terminal/commands/scananalyze.ts
@@ -2,7 +2,6 @@ import { Player } from "@player";
 import { CompletedProgramName } from "@enums";
 import { Terminal } from "../../Terminal";
 import type { BaseServer } from "../../Server/BaseServer";
-import { HacknetServer } from "../../Hacknet/HacknetServer";
 import { Server } from "../../Server/Server";
 import { DarknetServer } from "../../Server/DarknetServer";
 import { GetServer } from "../../Server/AllServers";
@@ -47,31 +46,41 @@ export function scananalyze(args: (string | number | boolean)[]): undefined {
 function executeScanAnalyzeCommand(depth: number, all: boolean): void {
   interface Node {
     hostname: string;
+    path: string[];
     children: Node[];
   }
 
-  const ignoreServer = (s: BaseServer, d: number): boolean =>
-    (!all && s.purchasedByPlayer && s.hostname != "home") ||
-    d > depth ||
-    (!all && s instanceof HacknetServer) ||
-    (!all && s instanceof DarknetServer && s.hostname !== SpecialServers.DarkWeb);
+  const showServer = (s: BaseServer, d: number): boolean => {
+    if (d > depth) {
+      return false;
+    }
+    if (s.purchasedByPlayer && s.hostname !== SpecialServers.Home) {
+      // cloud servers, hacknet servers
+      return all;
+    }
+    if (s instanceof DarknetServer && s.hostname !== SpecialServers.DarkWeb) {
+      return all && s.hasAdminRights;
+    }
+    return true;
+  };
 
   const makeNode = (root: BaseServer = Player.getCurrentServer()) => {
     // Keep track of previously seen servers to prevent backtracking (since darknet can be cyclical)
     const seenServers = [root.hostname];
-    const populateNode = (s: BaseServer, d = 1): Node => {
+    const populateNode = (s: BaseServer = root, path: string[] = [root.hostname], d = 1): Node => {
       seenServers.push(s.hostname);
       return {
         hostname: s.hostname,
+        path,
         children: s.serversOnNetwork
           .filter((h) => !seenServers.includes(h))
           .map((s) => GetServer(s))
-          .filter((v): v is BaseServer => !!v)
-          .filter((v) => !ignoreServer(v, d))
-          .map((h) => populateNode(h, d + 1)),
+          .filter((v) => v != null)
+          .filter((v) => showServer(v, d))
+          .map((h) => populateNode(h, [...path, s.hostname], d + 1)),
       };
     };
-    return populateNode(root);
+    return populateNode();
   };
 
   const root = makeNode();
@@ -80,7 +89,7 @@ function executeScanAnalyzeCommand(depth: number, all: boolean): void {
     const titlePrefix = prefix.slice(0, prefix.length - 1).join("") + (last ? "┗ " : "┣ ");
     const infoPrefix = prefix.join("") + (node.children.length > 0 ? "┃   " : "    ");
     if (Player.hasProgram(CompletedProgramName.autoLink)) {
-      Terminal.append(new Link(titlePrefix, node.hostname));
+      Terminal.append(new Link(titlePrefix, node.path, node.hostname));
     } else {
       Terminal.print(titlePrefix + node.hostname + "\n");
     }

--- a/src/Terminal/commands/scananalyze.ts
+++ b/src/Terminal/commands/scananalyze.ts
@@ -77,7 +77,7 @@ function executeScanAnalyzeCommand(depth: number, all: boolean): void {
           .map((s) => GetServer(s))
           .filter((v) => v != null)
           .filter((v) => showServer(v, d))
-          .map((h) => populateNode(h, [...path, s.hostname], d + 1)),
+          .map((h) => populateNode(h, [...path, h.hostname], d + 1)),
       };
     };
     return populateNode();

--- a/src/Terminal/ui/ConnectLink.tsx
+++ b/src/Terminal/ui/ConnectLink.tsx
@@ -19,17 +19,20 @@ export function ConnectLink({ path, text }: IConnectLinkProps): React.ReactEleme
     }
     Terminal.connectToServer(result.destination);
   }, [path]);
-  const first = path[0];
-  const last = path.at(-1);
   let tooltip: string;
-  if (last == null) {
-    tooltip = "";
-  } else if (path.length === 1) {
-    tooltip = `connect ${first}`;
-  } else if (path.length === 2) {
-    tooltip = `connect ${first}; connect ${last}`;
-  } else {
-    tooltip = `connect ${first}; ...; connect ${last}`;
+  switch (path.length) {
+    case 0:
+      tooltip = "";
+      break;
+    case 1:
+      tooltip = `connect ${path[0]}`;
+      break;
+    case 2:
+      tooltip = `connect ${path[0]}; connect ${path[1]}`;
+      break;
+    default:
+      tooltip = `connect ${path[0]}; ...; connect ${path.at(-1)}`;
+      break;
   }
   return (
     <Tooltip title={tooltip}>

--- a/src/Terminal/ui/ConnectLink.tsx
+++ b/src/Terminal/ui/ConnectLink.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
-import { Link as MuiLink } from "@mui/material";
+import Link from "@mui/material/Link";
+import Tooltip from "@mui/material/Tooltip";
 import { Terminal } from "../../Terminal";
 import { Player } from "@player";
 import { validateConnections } from "../../Server/ServerHelpers";
@@ -18,5 +19,21 @@ export function ConnectLink({ path, text }: IConnectLinkProps): React.ReactEleme
     }
     Terminal.connectToServer(result.destination);
   }, [path]);
-  return <MuiLink onClick={onClick}>{text}</MuiLink>;
+  const first = path[0];
+  const last = path.at(-1);
+  let tooltip: string;
+  if (last == null) {
+    tooltip = "";
+  } else if (path.length === 1) {
+    tooltip = `connect ${first}`;
+  } else if (path.length === 2) {
+    tooltip = `connect ${first}; connect ${last}`;
+  } else {
+    tooltip = `connect ${first}; ...; connect ${last}`;
+  }
+  return (
+    <Tooltip title={tooltip}>
+      <Link onClick={onClick}>{text}</Link>
+    </Tooltip>
+  );
 }

--- a/src/Terminal/ui/TerminalRoot.tsx
+++ b/src/Terminal/ui/TerminalRoot.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Link as MuiLink, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { Theme } from "@mui/material/styles";
 import { makeStyles } from "tss-react/mui";
 import _ from "lodash";
@@ -14,6 +14,7 @@ import { CodingContractModal } from "../../ui/React/CodingContractModal";
 import { ANSIITypography } from "../../ui/React/ANSIITypography";
 import { useRerender } from "../../ui/React/hooks";
 import { TerminalActionTimer } from "./TerminalActionTimer";
+import { ConnectLink } from "./ConnectLink";
 
 const useStyles = makeStyles()((theme: Theme) => ({
   container: {
@@ -94,7 +95,7 @@ export function TerminalRoot(): React.ReactElement {
             {item instanceof Link && (
               <Typography component="div" classes={{ root: classes.preformatted }}>
                 {item.dashes}
-                <MuiLink onClick={() => Terminal.connectToServer(item.hostname)}>{item.hostname}</MuiLink>
+                <ConnectLink path={item.path} text={item.text} />
               </Typography>
             )}
           </li>


### PR DESCRIPTION
Marking this pull request as a draft because it depends on #2948, which hasn't been merged yet.

* d0sboots pointed out that there are issues with how `scan-analyze` with the `-a` flag interacts with the dark net.
 https://github.com/bitburner-official/bitburner-src/pull/2948#issuecomment-4898943573
* In my opinion there are two issues:
  1. `scan-analyze 10 -a` often shows more servers than can be seen on the "Dark net" page.
  2. If you have AutoLink.exe, `scan-analyze 10 -a` creates clickable links to all the dark net servers that it displays. The links continue to function even if the destination becomes airgapped.
* d0sboots suggested that links created by `scan-analyze` should work the same as links created by `ns.ui.createConnectLink()` https://github.com/bitburner-official/bitburner-src/pull/2948#issuecomment-4938841268

## Proposed solution
### more servers than UI
Now scan-analyze -a reveals less information than the UI because it no longer recurses into dnet servers that you do not have admin rights on.

### AutoLink.exe
* Every link created by scan-analyze now contains a sequence of `connect` commands that it tries it execute when it is clicked.
* Example:
  * You have AutoLink.exe
  * You are connected to home
  * You execute scan-analyze
  * scan-analyze produces a link to n00dles
  * Clicking on the link is equivalent to typing `connect home; connect n00dles`, except that the sequence of connect commands is atomic: it will either successfully connect to the destination or it will not move you at all.
* Note that the sequence of connect commands always starts with the server you were connected to when you executed scan-analyze

This has several consequences:
1. Links to dnet servers stop working when server movement makes the path invalid.
2. Links to normal servers do not always work. Example:
   * Step 1: You have AutoLink.exe
   * Step 2: You are connected to n00dles
   * Step 3: n00dles is not backdoored
   * Step 4: You execute scan-analyze
   * Step 5: scan-analyze produces a links that contain commands that start with `connect n00dles`
   * Step 6: You connect to a server that is not adjacent to n00dles
   * Step 7: If you now click on any of the links produced in step 5, it will tell you that it is unable to connect to n00dles