### PR TITLE
DOCS: Update `temporary` description in runOptions to reflect the script won't appear in `recently killed` tab

### DIFF
--- a/markdown/bitburner.runoptions.md
+++ b/markdown/bitburner.runoptions.md
@@ -93,7 +93,7 @@ boolean
 
 </td><td>
 
-_(Optional)_ Whether this script is excluded from saves, defaults to false
+_(Optional)_ Whether this script is excluded from saves and the "Recently Killed" tab in Active Scripts, defaults to false
 
 
 </td></tr>

--- a/markdown/bitburner.runoptions.temporary.md
+++ b/markdown/bitburner.runoptions.temporary.md
@@ -4,7 +4,7 @@
 
 ## RunOptions.temporary property
 
-Whether this script is excluded from saves, defaults to false
+Whether this script is excluded from saves and the "Recently Killed" tab in Active Scripts, defaults to false
 
 **Signature:**
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -314,7 +314,7 @@ interface RunningScript {
 interface RunOptions {
   /** Number of threads that the script will run with, defaults to 1 */
   threads?: number;
-  /** Whether this script is excluded from saves, defaults to false */
+  /** Whether this script is excluded from saves and the "Recently Killed" tab in Active Scripts, defaults to false */
   temporary?: boolean;
   /**
    * The RAM allocation to launch each thread of the script with.


### PR DESCRIPTION
Per title, closes #2737
