### PR TITLE
DOCUMENTATION: Clarify ns.singularity.softReset and soft reset button tooltip

### DIFF
--- a/markdown/bitburner.singularity.softreset.md
+++ b/markdown/bitburner.singularity.softreset.md
@@ -56,5 +56,5 @@ void
 
 RAM cost: 5 GB \* 16/4/1
 
-This function performs the same reset as when you install Augmentations, but it can be performed even when you don't have Augmentations queued. If you do have Augmentations queued, it will install them.
+Performs the same reset as when you install Augmentations. This can be used even when no Augmentations are queued. Installs any queued Augmentations.
 

--- a/markdown/bitburner.singularity.softreset.md
+++ b/markdown/bitburner.singularity.softreset.md
@@ -56,5 +56,5 @@ void
 
 RAM cost: 5 GB \* 16/4/1
 
-This function will perform a reset even if you don’t have any augmentation installed.
+This function performs the same reset as when you install augmentations, but it can be performed even when you don’t have augmentations queued. If you do have augmentaions queued, it will install them.
 

--- a/markdown/bitburner.singularity.softreset.md
+++ b/markdown/bitburner.singularity.softreset.md
@@ -42,7 +42,7 @@ string
 
 </td><td>
 
-_(Optional)_ This is a script that will automatically be run after Augmentations are installed (after the reset). This script will be run with no arguments and 1 thread. It must be located on your home computer.
+_(Optional)_ This is a script that will automatically be run after the reset. This script will be run with no arguments and 1 thread. It must be located on your home computer.
 
 
 </td></tr>
@@ -56,5 +56,5 @@ void
 
 RAM cost: 5 GB \* 16/4/1
 
-This function performs the same reset as when you install augmentations, but it can be performed even when you don’t have augmentations queued. If you do have augmentaions queued, it will install them.
+This function performs the same reset as when you install Augmentations, but it can be performed even when you don't have Augmentations queued. If you do have Augmentations queued, it will install them.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2775,7 +2775,7 @@ export interface Singularity {
    *
    * This function performs the same reset as when you install Augmentations, but it can be performed even when you don't have Augmentations queued. If you do have Augmentations queued, it will install them.
    *
-   * @param cbScript - This is a script that will automatically be run after Augmentations are installed (after the reset). This script will be run with no arguments and 1 thread. It must be located on your home computer.
+   * @param cbScript - This is a script that will automatically be run after the reset. This script will be run with no arguments and 1 thread. It must be located on your home computer.
    */
   softReset(cbScript?: string): void;
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2773,7 +2773,7 @@ export interface Singularity {
    * RAM cost: 5 GB * 16/4/1
    *
    *
-   * This function will perform a reset even if you don’t have any augmentation installed.
+   * This function performs the same reset as when you install Augmentations, but it can be performed even when you don't have Augmentations queued. If you do have Augmentations queued, it will install them.
    *
    * @param cbScript - This is a script that will automatically be run after Augmentations are installed (after the reset). This script will be run with no arguments and 1 thread. It must be located on your home computer.
    */

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -2773,9 +2773,9 @@ export interface Singularity {
    * RAM cost: 5 GB * 16/4/1
    *
    *
-   * This function performs the same reset as when you install Augmentations, but it can be performed even when you don't have Augmentations queued. If you do have Augmentations queued, it will install them.
+   * Performs the same reset as when you install Augmentations. This can be used even when no Augmentations are queued. Installs any queued Augmentations.
    *
-   * @param cbScript - This is a script that will automatically be run after the reset. This script will be run with no arguments and 1 thread. It must be located on your home computer.
+   * @param cbScript - This is a script that will automatically be run after the reset. This script will be run with no arguments and 1 thread. It must be located on your home computer.
    */
   softReset(cbScript?: string): void;
 

--- a/src/ui/React/SoftResetButton.tsx
+++ b/src/ui/React/SoftResetButton.tsx
@@ -41,7 +41,7 @@ Are you sure?
 
   return (
     <>
-      <Tooltip title="Perform a soft reset - the same reset as when you install Augmentations, but it can be performed even when you don't have Augmentations queued. If you do have Augmentations queued, it will install them.">
+      <Tooltip title="Perform the same reset as when you install Augmentations. This can be used even when no Augmentations are queued. Installs any queued Augmentations.">
         <Button startIcon={<RestartAltIcon />} color={color} onClick={handleButtonClick}>
           Soft Reset
         </Button>

--- a/src/ui/React/SoftResetButton.tsx
+++ b/src/ui/React/SoftResetButton.tsx
@@ -41,7 +41,7 @@ Are you sure?
 
   return (
     <>
-      <Tooltip title="Perform a Soft Reset - similar to installing Augmentations, even if you have none.">
+      <Tooltip title="Perform a soft reset - the same reset as when you install Augmentations, but it can be performed even when you don't have Augmentations queued. If you do have Augmentations queued, it will install them.">
         <Button startIcon={<RestartAltIcon />} color={color} onClick={handleButtonClick}>
           Soft Reset
         </Button>


### PR DESCRIPTION
Thanks Hallowed for the idea 💫

I've corrected and expanded the documentation and UI tooltip text for soft resets. The new version:

- corrects 'any augmentations installed' to 'augmentations queued'
- gives some extra context so it's clear what a 'reset' actually involves