### PR TITLE
MISC: Fix WHRNG description wrong

### DIFF
--- a/src/Casino/RNG.ts
+++ b/src/Casino/RNG.ts
@@ -42,9 +42,8 @@ export class WHRNG implements RNG {
   s2 = 0;
   s3 = 0;
 
-  constructor(totalPlaytime: number) {
-    // This one is seeded by the players total play time.
-    const v: number = (totalPlaytime / 1000) % 30000;
+  constructor(randomizer: number) {
+    const v: number = (randomizer / 1000) % 30000;
     this.s1 = v;
     this.s2 = v;
     this.s3 = v;

--- a/src/Casino/SlotMachine.tsx
+++ b/src/Casino/SlotMachine.tsx
@@ -138,6 +138,7 @@ const initialBet = 1000;
 const maxBet = 1e6;
 
 export function SlotMachine(): React.ReactElement {
+  // This one is seeded by the player's total play time.
   const [rng] = useState(new WHRNG(Player.totalPlaytime));
   const [index, setIndex] = useState<number[]>([0, 0, 0, 0, 0]);
   const [locks, setLocks] = useState<number[]>([0, 0, 0, 0, 0]);


### PR DESCRIPTION
Before:
```ts
export class WHRNG implements RNG {
  s1 = 0;
  s2 = 0;
  s3 = 0;

  constructor(totalPlaytime: number) {
    // This one is seeded by the players total play time.
    const v: number = (totalPlaytime / 1000) % 30000;
    this.s1 = v;
    this.s2 = v;
    this.s3 = v;
  }
  ```
  The comment is wrong. The most cases use `Date.now().getTime()`, not the player's total playtime. I moved the comment to `SlotMachine.tsx` which does use the player's total playtime. I also renamed the param to `randomizer`, though I think it could be better renamed to `seed`.