### PR TITLE
CODEBASE: Update parameter name and comment in WHRNG constructor

### DIFF
--- a/src/Casino/RNG.ts
+++ b/src/Casino/RNG.ts
@@ -42,9 +42,9 @@ export class WHRNG implements RNG {
   s2 = 0;
   s3 = 0;
 
-  constructor(totalPlaytime: number) {
-    // This one is seeded by the players total play time.
-    const v: number = (totalPlaytime / 1000) % 30000;
+  constructor(seed: number) {
+    // Trying to cheat? This one is seeded by the players total play time. Allegedly.
+    const v: number = (seed / 1000) % 30000;
     this.s1 = v;
     this.s2 = v;
     this.s3 = v;


### PR DESCRIPTION
The current comment is technically incorrect, but I want to keep it for the reason I explained in #3000. I think the new comment strikes a good balance. For contributors, the parameter name is now correct (`seed` instead of `totalPlaytime`), and the "Trying to cheat?" bait clearly signals that the comment is not intended for them. For players trying to cheat the casino, it still serves as a lesson.