### PR TITLE
UI: Automatically connect when clicking Remote API status icon

### DIFF
--- a/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
+++ b/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
@@ -10,6 +10,7 @@ import { Settings } from "../../Settings/Settings";
 import { Router } from "../../ui/GameRoot";
 import { Page } from "../../ui/Router";
 import { RemoteFileApiConnectionEvents } from "../../RemoteFileAPI/Remote";
+import { isValidConnectionHostname, isValidConnectionPort } from "src/Settings/SettingsUtils";
 
 export const RemoteFileApiConnectionStatus = ({ showIcon }: { showIcon: boolean }): React.ReactElement => {
   const [rfaConnectionStatus, setRfaConnectionStatus] = useState(getRemoteFileApiConnectionStatus());
@@ -43,8 +44,8 @@ export const RemoteFileApiConnectionStatus = ({ showIcon }: { showIcon: boolean 
           onClick={() => {
             if (
               !isRemoteFileApiConnectionLive() &&
-              Settings.RemoteFileApiAddress !== "" &&
-              Settings.RemoteFileApiPort > 0
+              isValidConnectionHostname(Settings.RemoteFileApiAddress) &&
+              isValidConnectionPort(Settings.RemoteFileApiPort)
             ) {
               newRemoteFileApiConnection();
             }

--- a/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
+++ b/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { Box, IconButton, Tooltip, Typography } from "@mui/material";
-import { getRemoteFileApiConnectionStatus } from "../../RemoteFileAPI/RemoteFileAPI";
+import {
+  getRemoteFileApiConnectionStatus,
+  isRemoteFileApiConnectionLive,
+  newRemoteFileApiConnection,
+} from "../../RemoteFileAPI/RemoteFileAPI";
 import OnlinePredictionIcon from "@mui/icons-material/OnlinePrediction";
 import { Settings } from "../../Settings/Settings";
 import { Router } from "../../ui/GameRoot";
@@ -34,7 +38,19 @@ export const RemoteFileApiConnectionStatus = ({ showIcon }: { showIcon: boolean 
   return (
     <Box style={{ display: "flex", flex: 1, justifyContent: "flex-start", alignItems: "center" }}>
       {showIcon ? (
-        <IconButton aria-label="Remote API status" onClick={() => Router.toPage(Page.Options, { tab: "Remote API" })}>
+        <IconButton
+          aria-label="Remote API status"
+          onClick={() => {
+            if (
+              !isRemoteFileApiConnectionLive() &&
+              Settings.RemoteFileApiAddress !== "" &&
+              Settings.RemoteFileApiPort > 0
+            ) {
+              newRemoteFileApiConnection();
+            }
+            Router.toPage(Page.Options, { tab: "Remote API" });
+          }}
+        >
           <Tooltip title={`Remote API: ${rfaConnectionStatus}`}>
             <OnlinePredictionIcon style={{ fontSize: "30px", color }} />
           </Tooltip>

--- a/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
+++ b/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
@@ -10,7 +10,7 @@ import { Settings } from "../../Settings/Settings";
 import { Router } from "../../ui/GameRoot";
 import { Page } from "../../ui/Router";
 import { RemoteFileApiConnectionEvents } from "../../RemoteFileAPI/Remote";
-import { isValidConnectionHostname, isValidConnectionPort } from "src/Settings/SettingsUtils";
+import { isValidConnectionHostname, isValidConnectionPort } from "../../Settings/SettingsUtils";
 
 export const RemoteFileApiConnectionStatus = ({ showIcon }: { showIcon: boolean }): React.ReactElement => {
   const [rfaConnectionStatus, setRfaConnectionStatus] = useState(getRemoteFileApiConnectionStatus());


### PR DESCRIPTION
This PR makes the remote API icon on the overview try a connect attempt when it is clicked. Regardless of the result, it still routes the player to the options tab.
I added this because it's bothering that to connect (when you already have the settings) you have to navigate to the options page, resetting the UI on whatever you were doing.