### PR TITLE
UI: Add clarifying message when running port openers on home

### DIFF
--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -94,7 +94,7 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SSH Port (22) is already open!");
         return;
       }
-      if (server.hostname === "home" || server.purchasedByPlayer) {
+      if (server.purchasedByPlayer) {
         Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
@@ -122,7 +122,7 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("FTP Port (21) is already open!");
         return;
       }
-      if (server.hostname === "home" || server.purchasedByPlayer) {
+      if (server.purchasedByPlayer) {
         Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
@@ -150,7 +150,7 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SMTP Port (25) is already open!");
         return;
       }
-      if (server.hostname === "home" || server.purchasedByPlayer) {
+      if (server.purchasedByPlayer) {
         Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
@@ -178,7 +178,7 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("HTTP Port (80) is already open!");
         return;
       }
-      if (server.hostname === "home" || server.purchasedByPlayer) {
+      if (server.purchasedByPlayer) {
         Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
@@ -206,7 +206,7 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SQL Port (1433) is already open!");
         return;
       }
-      if (server.hostname === "home" || server.purchasedByPlayer) {
+      if (server.purchasedByPlayer) {
         Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 

--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -94,8 +94,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SSH Port (22) is already open!");
         return;
       }
-      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
-        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
+      if (server.hostname === "home" || server.purchasedByPlayer) {
+        Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.sshPortOpen = true;
@@ -122,8 +122,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("FTP Port (21) is already open!");
         return;
       }
-      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
-        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
+      if (server.hostname === "home" || server.purchasedByPlayer) {
+        Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.ftpPortOpen = true;
@@ -150,8 +150,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SMTP Port (25) is already open!");
         return;
       }
-      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
-        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
+      if (server.hostname === "home" || server.purchasedByPlayer) {
+        Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.smtpPortOpen = true;
@@ -178,8 +178,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("HTTP Port (80) is already open!");
         return;
       }
-      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
-        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
+      if (server.hostname === "home" || server.purchasedByPlayer) {
+        Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.httpPortOpen = true;
@@ -206,8 +206,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SQL Port (1433) is already open!");
         return;
       }
-      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
-        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
+      if (server.hostname === "home" || server.purchasedByPlayer) {
+        Terminal.print("Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.sqlPortOpen = true;

--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -94,9 +94,12 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SSH Port (22) is already open!");
         return;
       }
+      if (server.hostname === "home") {
+        Terminal.print("WARN: Opening ports has no effect on home");
+      }
 
       server.sshPortOpen = true;
-      Terminal.print("Opened SSH Port(22)!");
+      Terminal.print("Opened SSH Port (22)!");
       server.openPortCount++;
     },
   }),
@@ -118,6 +121,9 @@ export const Programs: Record<CompletedProgramName, Program> = {
       if (server.ftpPortOpen) {
         Terminal.print("FTP Port (21) is already open!");
         return;
+      }
+      if (server.hostname === "home") {
+        Terminal.print("WARN: Opening ports has no effect on home");
       }
 
       server.ftpPortOpen = true;
@@ -144,6 +150,9 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SMTP Port (25) is already open!");
         return;
       }
+      if (server.hostname === "home") {
+        Terminal.print("WARN: Opening ports has no effect on home");
+      }
 
       server.smtpPortOpen = true;
       Terminal.print("Opened SMTP Port (25)!");
@@ -169,6 +178,9 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("HTTP Port (80) is already open!");
         return;
       }
+      if (server.hostname === "home") {
+        Terminal.print("WARN: Opening ports has no effect on home");
+      }
 
       server.httpPortOpen = true;
       Terminal.print("Opened HTTP Port (80)!");
@@ -193,6 +205,9 @@ export const Programs: Record<CompletedProgramName, Program> = {
       if (server.sqlPortOpen) {
         Terminal.print("SQL Port (1433) is already open!");
         return;
+      }
+      if (server.hostname === "home") {
+        Terminal.print("WARN: Opening ports has no effect on home");
       }
 
       server.sqlPortOpen = true;

--- a/src/Programs/Programs.ts
+++ b/src/Programs/Programs.ts
@@ -94,8 +94,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SSH Port (22) is already open!");
         return;
       }
-      if (server.hostname === "home") {
-        Terminal.print("WARN: Opening ports has no effect on home");
+      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
+        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.sshPortOpen = true;
@@ -122,8 +122,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("FTP Port (21) is already open!");
         return;
       }
-      if (server.hostname === "home") {
-        Terminal.print("WARN: Opening ports has no effect on home");
+      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
+        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.ftpPortOpen = true;
@@ -150,8 +150,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SMTP Port (25) is already open!");
         return;
       }
-      if (server.hostname === "home") {
-        Terminal.print("WARN: Opening ports has no effect on home");
+      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
+        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.smtpPortOpen = true;
@@ -178,8 +178,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("HTTP Port (80) is already open!");
         return;
       }
-      if (server.hostname === "home") {
-        Terminal.print("WARN: Opening ports has no effect on home");
+      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
+        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.httpPortOpen = true;
@@ -206,8 +206,8 @@ export const Programs: Record<CompletedProgramName, Program> = {
         Terminal.print("SQL Port (1433) is already open!");
         return;
       }
-      if (server.hostname === "home") {
-        Terminal.print("WARN: Opening ports has no effect on home");
+      if (server.hostname === "home" || Player.purchasedServers.includes(server.hostname)) {
+        Terminal.print("INFO: Opening ports on your own machines has no negative consequences in the game.");
       }
 
       server.sqlPortOpen = true;


### PR DESCRIPTION
Context in #2943 
I added a message, suggestion from catlover in https://github.com/bitburner-official/bitburner-src/issues/2943#issuecomment-4861979179 .
Note that the message does not return and is after the "port opened" check, therefore only appears when _opening_ the port. I can tweak the message as you see.