### PR TITLE
DOCS: remove incorrect information from ns.mv() documentation

### DIFF
--- a/markdown/bitburner.ns.mv.md
+++ b/markdown/bitburner.ns.mv.md
@@ -90,7 +90,7 @@ RAM cost: 0 GB
 
 Move the source file to the specified destination on the target server.
 
-This command only works for scripts (.js, .jsx, .ts, .tsx) and text files (.txt, .json, .css). It cannot, however, be used to convert from script to text file, or vice versa.
+This command only works for scripts (.js, .jsx, .ts, .tsx) and text files (.txt, .json, .css).
 
 This function can also be used to rename files.
 

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -9204,8 +9204,7 @@ export interface NS {
    *
    * Move the source file to the specified destination on the target server.
    *
-   * This command only works for scripts (.js, .jsx, .ts, .tsx) and text files (.txt, .json, .css). It cannot, however, be
-   * used to convert from script to text file, or vice versa.
+   * This command only works for scripts (.js, .jsx, .ts, .tsx) and text files (.txt, .json, .css).
    *
    * This function can also be used to rename files.
    *

--- a/test/jest/Netscript/Files.test.ts
+++ b/test/jest/Netscript/Files.test.ts
@@ -1,0 +1,23 @@
+import { getNS, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
+
+beforeAll(() => {
+  initGameEnvironment();
+});
+
+beforeEach(() => {
+  setupBasicTestingEnvironment();
+});
+
+test("mv can convert .js <--> .txt", () => {
+  const ns = getNS();
+  const wasJS = "// this file was .js";
+  const wasTXT = "// this file was .txt";
+  ns.write("foo.js", wasJS);
+  ns.write("bar.txt", wasTXT);
+
+  ns.mv("home", "foo.js", "foo.txt");
+  ns.mv("home", "bar.txt", "bar.js");
+
+  expect(ns.read("foo.txt")).toBe(wasJS);
+  expect(ns.read("bar.js")).toBe(wasTXT);
+});


### PR DESCRIPTION
The docs used to incorrectly claim that `ns.mv()` can't convert between text files and scripts