### PR TITLE
BUGFIX: Corporation modals use duplicate React keys

### DIFF
--- a/src/Corporation/ui/MaterialElem.tsx
+++ b/src/Corporation/ui/MaterialElem.tsx
@@ -132,7 +132,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
             </Button>
           </Tooltip>
           <PurchaseMaterialModal
-            key={`${division.name}-${city}`}
+            key={`PurchaseMaterialModal-${division.name}-${city}-${mat.name}`}
             mat={mat}
             warehouse={warehouse}
             open={purchaseMaterialOpen}
@@ -145,7 +145,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
               <Button onClick={() => setExportOpen(true)}>Export</Button>
 
               <ExportModal
-                key={`${division.name}-${city}`}
+                key={`ExportModal-${division.name}-${city}-${mat.name}`}
                 mat={mat}
                 open={exportOpen}
                 onClose={() => setExportOpen(false)}
@@ -160,7 +160,7 @@ export function MaterialElem(props: IMaterialProps): React.ReactElement {
             {sellButtonText}
           </Button>
           <SellMaterialModal
-            key={`${division.name}-${city}`}
+            key={`SellMaterialModal-${division.name}-${city}-${mat.name}`}
             mat={mat}
             div={division}
             open={sellMaterialOpen}

--- a/src/Corporation/ui/ProductElem.tsx
+++ b/src/Corporation/ui/ProductElem.tsx
@@ -168,7 +168,7 @@ export function ProductElem(props: IProductProps): React.ReactElement {
         <>
           <Button onClick={() => setSellOpen(true)}>{sellButtonText}</Button>
           <SellProductModal
-            key={`${division.name}-${city}`}
+            key={`SellProductModal-${division.name}-${city}-${product.name}`}
             product={product}
             div={division}
             city={city}


### PR DESCRIPTION
MRE: Create a corp, expand into an industry, then check the console tab.
```
Warning: Encountered two children with the same key, `foo-Sector-12`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```
This is a regression bug caused by #2972.