### PR TITLE
DNET: remove TRP from darknet in BN12

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -951,6 +951,7 @@ export function getBitNodeMultipliers(n: number, lvl: number): BitNodeMultiplier
         ScriptHackMoney: dec,
         CodingContractMoney: dec,
         DarknetMoneyMultiplier: dec,
+        DarknetLabyrinthRewardsTheRedPill: 0,
 
         ClassGymExpGain: dec,
         CompanyWorkExpGain: dec,


### PR DESCRIPTION
From player feedback, it was discovered that having the red pill accessible from darknet in BN12 collapsed the challenge and strategy of the node such that the puzzle did not change at different levels. This PR removes TRP from darknet in BN12, the same as BN8.