### PR TITLE
DNET: populate server logs with noise upon heartbleed

### DIFF
--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -50,6 +50,7 @@ import { type DarknetServerData, getDarknetServerOrThrow } from "../DarkNet/util
 import { shuffle } from "lodash";
 import { getSharedChars } from "../DarkNet/utils/darknetAuthUtils";
 import { freezeServer } from "../DarkNet/controllers/NetworkMovement";
+import { populateServerLogsWithNoise } from "../DarkNet/models/packetSniffing";
 
 type CompleteHeartbleedOptions = {
   peek: boolean;
@@ -284,6 +285,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
           };
         }
         const serverState = getServerState(server.hostname);
+        populateServerLogsWithNoise(server);
 
         logger(ctx)(`Extracted log data from ${server.hostname}... (Gained ${formatNumber(xpGained, 1)} cha xp)`);
 


### PR DESCRIPTION
Closes #3024 

Currently, server logs only get their random garbage log entries that they are due when you look at the server in the UI or when you authenticate via the API. This PR also updates the logs with any missing noise entries upon heartbleed, to make the noise more consistent based on the server's noise internal stats, and to make it more intuitive to players how the noise works.
