### PR TITLE
DOCS: fix incorrect information in the ns.formulas.getHeartbleedTime() documentation

### DIFF
--- a/markdown/bitburner.darknetformulas.getheartbleedtime.md
+++ b/markdown/bitburner.darknetformulas.getheartbleedtime.md
@@ -58,7 +58,7 @@ number
 
 </td><td>
 
-_(Optional)_ The number of threads to use for the authentication. Optional, defaults to 1
+_(Optional)_ The number of threads to use for log scraping. Optional, defaults to 1
 
 
 </td></tr>

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6601,7 +6601,7 @@ interface DarknetFormulas {
   /**
    * Gets the time it will take to scrape logs from a server.
    * @param serverDetails - The server to check heartbleed log scraping time on.
-   * @param threads - The number of threads to use for the authentication. Optional, defaults to 1
+   * @param threads - The number of threads to use for log scraping. Optional, defaults to 1
    * @param player - The player object. Optional, defaults to the current player status
    */
   getHeartbleedTime(serverDetails: DarknetServerDetails, threads?: number, player?: Person): number;


### PR DESCRIPTION
Looks like this was a copy-paste error