### PR TITLE
UI: add price history charts to Stock Market

### DIFF
--- a/src/GameOptions/ui/InterfacePage.tsx
+++ b/src/GameOptions/ui/InterfacePage.tsx
@@ -1,16 +1,34 @@
 import React, { useState } from "react";
-import { TextField, Tooltip, Typography } from "@mui/material";
+import { Box, MenuItem, Select, SelectChangeEvent, TextField, Tooltip, Typography } from "@mui/material";
 import { Settings } from "../../Settings/Settings";
+import { StockChartTypeSetting } from "../../Settings/SettingEnums";
+import { clearStockPriceHistories } from "../../StockMarket/PriceHistory";
 import { OptionSwitch } from "../../ui/React/OptionSwitch";
 import { GameOptionsPage } from "./GameOptionsPage";
+import { OptionsSlider } from "./OptionsSlider";
 import { formatTime } from "../../utils/helpers/formatTime";
 
 export const InterfacePage = (): React.ReactElement => {
   const [timestampFormat, setTimestampFormat] = useState(Settings.TimestampsFormat);
+  const [stockChartType, setStockChartType] = useState(Settings.StockChartType);
+  const [stockHistoryDisabled, setStockHistoryDisabled] = useState(Settings.DisableStockPriceHistory);
 
   function handleTimestampFormatChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setTimestampFormat(event.target.value);
     Settings.TimestampsFormat = event.target.value;
+  }
+
+  function handleStockChartTypeChange(event: SelectChangeEvent): void {
+    const chartType = event.target.value as StockChartTypeSetting;
+    setStockChartType(chartType);
+    Settings.StockChartType = chartType;
+  }
+
+  function handleStockHistoryDisabledChange(newValue: boolean): void {
+    setStockHistoryDisabled(newValue);
+    Settings.DisableStockPriceHistory = newValue;
+    // Disabling is a promise that nothing is retained, not just that nothing new is recorded.
+    if (newValue) clearStockPriceHistories();
   }
   return (
     <GameOptionsPage title="Interface">
@@ -75,6 +93,54 @@ export const InterfacePage = (): React.ReactElement => {
         Example timestamp: {timestampFormat !== "" ? formatTime(timestampFormat) : "no timestamp"}
       </Typography>
       <br />
+      <Typography variant="h6">Stock Market price charts</Typography>
+      <OptionSwitch
+        checked={stockHistoryDisabled}
+        onChange={handleStockHistoryDisabledChange}
+        text="Disable price history"
+        tooltip={<>If this is set, price history charts are disabled and the current price history is erased.</>}
+      />
+      {!stockHistoryDisabled && (
+        <Box sx={{ pl: 2 }}>
+          <Select
+            startAdornment={<Typography>Chart&nbsp;type:&nbsp;</Typography>}
+            value={stockChartType}
+            onChange={handleStockChartTypeChange}
+            sx={{ my: 1 }}
+          >
+            <MenuItem value={StockChartTypeSetting.Line}>Line</MenuItem>
+            <MenuItem value={StockChartTypeSetting.Candlestick}>Candlestick</MenuItem>
+          </Select>
+          <OptionsSlider
+            label="Price history duration (minutes)"
+            initialValue={Settings.StockChartHistoryMinutes}
+            callback={(_event, newValue) => (Settings.StockChartHistoryMinutes = newValue as number)}
+            step={1}
+            min={1}
+            max={60}
+            tooltip={<>How much price history the charts keep, per stock. Default: 15</>}
+          />
+          {stockChartType === StockChartTypeSetting.Candlestick && (
+            <OptionsSlider
+              label="Market ticks per candle"
+              initialValue={Settings.StockChartTicksPerCandle}
+              callback={(_event, newValue) => (Settings.StockChartTicksPerCandle = newValue as number)}
+              step={1}
+              min={2}
+              max={15}
+              tooltip={<>How many market updates each candlestick aggregates. Default: 5</>}
+            />
+          )}
+          <OptionSwitch
+            checked={Settings.ShowStockChartInCollapsedRows}
+            onChange={(newValue) => (Settings.ShowStockChartInCollapsedRows = newValue)}
+            text="Show a small price chart in collapsed ticker rows"
+            tooltip={
+              <>If this is set, a small recent-trend chart is shown in collapsed rows on the Stock Market page.</>
+            }
+          />
+        </Box>
+      )}
     </GameOptionsPage>
   );
 };

--- a/src/Settings/SettingEnums.ts
+++ b/src/Settings/SettingEnums.ts
@@ -13,3 +13,10 @@ export enum OwnedAugmentationsOrderSetting {
   Alphabetically,
   AcquirementTime,
 }
+
+// String enum
+/** Allowed values for the 'StockChartType' setting */
+export enum StockChartTypeSetting {
+  Line = "Line",
+  Candlestick = "Candlestick",
+}

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -3,7 +3,11 @@ import { defaultMonacoTheme } from "../ScriptEditor/ui/themes";
 import { defaultStyles } from "../Themes/Styles";
 import { defaultTheme } from "../Themes/Themes";
 import type { PlayerDefinedKeyBindingsType } from "../utils/KeyBindingUtils";
-import { OwnedAugmentationsOrderSetting, PurchaseAugmentationsOrderSetting } from "./SettingEnums";
+import {
+  OwnedAugmentationsOrderSetting,
+  PurchaseAugmentationsOrderSetting,
+  StockChartTypeSetting,
+} from "./SettingEnums";
 
 /** The current options the player has customized to their play style. */
 export const Settings = {
@@ -144,4 +148,17 @@ export const Settings = {
   KeyBindings: {} as PlayerDefinedKeyBindingsType,
   /** Whether to sync Steam achievements */
   SyncSteamAchievements: true,
+  /**
+   * Whether to record stock price history at all. When set, recording stops, whatever was recorded
+   * is discarded (the options UI wipes on toggle), and the Stock Market page shows no charts.
+   */
+  DisableStockPriceHistory: false,
+  /** Which marks the expanded stock ticker's price chart is drawn with. */
+  StockChartType: StockChartTypeSetting.Line,
+  /** How far back the stock price charts reach, in minutes. The history itself is in-memory only. */
+  StockChartHistoryMinutes: 15,
+  /** Market ticks aggregated into each candle of the candlestick chart. */
+  StockChartTicksPerCandle: 5,
+  /** Whether collapsed stock ticker rows show a small price trend chart beside the header. */
+  ShowStockChartInCollapsedRows: true,
 };

--- a/src/StockMarket/PriceHistory.ts
+++ b/src/StockMarket/PriceHistory.ts
@@ -1,0 +1,78 @@
+/**
+ * Recent price history for each stock, kept in memory only.
+ *
+ * Deliberately not part of the save file. `Stock.toJSON` calls `Generic_toJSON` with no key list,
+ * so every own property of a Stock is serialized - putting history on the class would silently add
+ * it to every save. Keeping it in a module-level map instead means recording begins when a market
+ * is created or loaded and the series is discarded when the page goes away.
+ *
+ * Points are raw per-tick prices rather than pre-aggregated bars, since bars (open/high/low/close,
+ * for a candlestick view) can be derived from ticks but not the other way around.
+ */
+import { StockMarketConstants } from "./data/Constants";
+import { Settings } from "../Settings/Settings";
+
+/** How far back a stock's history reaches before its oldest points start being dropped. */
+export function getPriceHistoryDurationMs(): number {
+  return Settings.StockChartHistoryMinutes * 60 * 1000;
+}
+
+/**
+ * Points retained per stock. A function, not a const: the duration is a live setting. Market
+ * updates are wall-clock gated to no faster than `msPerStockUpdateMin`, so in practice a full
+ * buffer covers somewhat more than the nominal duration, never less. The floor of 2 keeps a
+ * nonsense setting (hand-edited save) from erasing the charts outright.
+ */
+export function getMaxPriceHistoryLength(): number {
+  return Math.max(2, Math.round(getPriceHistoryDurationMs() / StockMarketConstants.msPerStockUpdate));
+}
+
+const emptyHistory: readonly number[] = [];
+
+/**
+ * Symbol -> prices, oldest first. Entries are replaced rather than mutated so consumers can use
+ * reference equality to skip work: the Stock Market UI re-renders every game cycle (5Hz) but prices
+ * only move once per market update.
+ */
+const priceHistories = new Map<string, readonly number[]>();
+
+/**
+ * Symbol -> how many points have been dropped off the front of its history. Gives every retained
+ * point a stable absolute index (`offset + i`), which is what lets a candlestick view keep its
+ * bucket boundaries fixed in time: bucketing by array position would shift every candle's window
+ * each time the full buffer sheds a tick, morphing the whole chart once per update.
+ */
+const droppedCounts = new Map<string, number>();
+
+export function recordStockPrice(symbol: string, price: number): void {
+  // Guarded here rather than at the call sites so every recording path honors the setting,
+  // including the reset paths' re-anchoring. The options UI wipes existing history on toggle.
+  if (Settings.DisableStockPriceHistory) return;
+  const previous = priceHistories.get(symbol) ?? emptyHistory;
+  // Steady state drops at most one point, but lowering the duration setting mid-session can leave
+  // a history arbitrarily far over the new bound. Excess points are trimmed here, lazily, on each
+  // stock's next tick - until then a chart shows the longer series compressed into its width
+  // (sparklineGeometry widens to fit when data outgrows capacity), which resolves within seconds.
+  const dropCount = Math.max(0, previous.length - (getMaxPriceHistoryLength() - 1));
+  const trimmed = dropCount === 0 ? previous : previous.slice(dropCount);
+  if (dropCount > 0) droppedCounts.set(symbol, (droppedCounts.get(symbol) ?? 0) + dropCount);
+  priceHistories.set(symbol, [...trimmed, price]);
+}
+
+/** Prices for `symbol`, oldest first. Empty until the first price has been recorded. */
+export function getStockPriceHistory(symbol: string): readonly number[] {
+  return priceHistories.get(symbol) ?? emptyHistory;
+}
+
+/**
+ * Absolute index of the first retained point of `symbol`'s history - the number of points recorded
+ * and since dropped. See {@link droppedCounts} for why a consumer would want this.
+ */
+export function getStockPriceHistoryOffset(symbol: string): number {
+  return droppedCounts.get(symbol) ?? 0;
+}
+
+export function clearStockPriceHistories(): void {
+  priceHistories.clear();
+  droppedCounts.clear();
+}

--- a/src/StockMarket/Stock.ts
+++ b/src/StockMarket/Stock.ts
@@ -188,11 +188,13 @@ export class Stock {
       this.otlkMag += changeAmt;
     }
 
-    this.otlkMag = Math.min(this.otlkMag, 50);
     if (this.otlkMag < 0) {
       this.otlkMag *= -1;
       this.b = !this.b;
     }
+    // Clamp after the sign flip: a swing below -50 would otherwise flip into a magnitude the clamp
+    // never saw, and everything sized against the forecast column assumes otlkMag <= 50.
+    this.otlkMag = Math.min(this.otlkMag, 50);
   }
 
   /**

--- a/src/StockMarket/StockMarket.ts
+++ b/src/StockMarket/StockMarket.ts
@@ -19,6 +19,7 @@ import { getRandomIntInclusive } from "../utils/helpers/getRandomIntInclusive";
 import { JsonSchemaValidator } from "../JsonSchema/JsonSchemaValidator";
 import { Player } from "../Player";
 import { scaleDarknetVolatilityIncreases, getDarknetVolatilityMult } from "../DarkNet/effects/effects";
+import { clearStockPriceHistories, recordStockPrice } from "./PriceHistory";
 
 export function getDefaultEmptyStockMarket(): IStockMarket {
   return {
@@ -162,6 +163,21 @@ export function loadStockMarket(saveString: string): void {
   }
   // Typecasting here is fine because we validated the loaded data.
   StockMarket = stockMarketData as IStockMarket;
+  resetStockPriceHistories();
+}
+
+/**
+ * Discard any recorded price history and re-anchor each stock's series on its current price.
+ * History is per-session (see PriceHistory.ts), so it has to start over whenever the set of stocks
+ * is replaced - on load, on init, and on prestige.
+ */
+function resetStockPriceHistories(): void {
+  clearStockPriceHistories();
+  for (const name of Object.keys(StockMarket)) {
+    const stock = StockMarket[name];
+    if (!(stock instanceof Stock)) continue;
+    recordStockPrice(stock.symbol, stock.price);
+  }
 }
 
 export function canAccessStockMarket(): boolean {
@@ -182,6 +198,7 @@ export function deleteStockMarket(): void {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete SymbolToStockMap[key];
   }
+  clearStockPriceHistories();
 }
 
 export function initStockMarket(): void {
@@ -207,6 +224,7 @@ export function initStockMarket(): void {
   StockMarket.lastUpdate = Date.now();
   StockMarket.ticksUntilCycle = getRandomIntInclusive(1, StockMarketConstants.TicksPerCycle);
   initSymbolToStockMap();
+  resetStockPriceHistories();
 }
 
 export function initSymbolToStockMap(): void {
@@ -303,6 +321,8 @@ export function processStockPrices(numCycles = 1): void {
       processOrders(stock, OrderType.StopBuy, PositionType.Short, processOrderRefs);
       processOrders(stock, OrderType.StopSell, PositionType.Long, processOrderRefs);
     }
+
+    recordStockPrice(stock.symbol, stock.price);
 
     let otlkMagChange = stock.otlkMag * av;
     if (stock.otlkMag < 5) {

--- a/src/StockMarket/ui/InfoAndPurchases.tsx
+++ b/src/StockMarket/ui/InfoAndPurchases.tsx
@@ -271,6 +271,11 @@ export function InfoAndPurchases(props: IProps): React.ReactElement {
           <br />
           <br />A stock's price forecast can change over time. This is also affected by volatility. The more volatile a
           stock is, the more its price forecast will change.
+          <br />
+          <br />
+          Each stock is also charted behind its ticker, showing how its price has moved. Expand a ticker for the full
+          history and hover it to read a price off the chart. This history is only kept while the game is running: it is
+          not saved, so it starts over each time the game is loaded.
         </Typography>
       </StaticModal>
     </>

--- a/src/StockMarket/ui/StockPriceChart.tsx
+++ b/src/StockMarket/ui/StockPriceChart.tsx
@@ -1,0 +1,365 @@
+/**
+ * Price history charts for a stock ticker.
+ *
+ * The two views are laid out differently on purpose. A collapsed row is dense, so its chart sits
+ * *beside* the text in whatever space is left over and disappears when there is none. An expanded
+ * panel is mostly empty, so its chart is drawn *behind* the content, costing no vertical space; what
+ * keeps that line off the text is the fade, since the panel's text is left-aligned and a line that
+ * ramps in from the left is faintest exactly where the text is.
+ *
+ * Both go through this module, so the marks a stock is drawn with (a line or candlesticks, per the
+ * `StockChartType` setting) can change in one place.
+ */
+import React, { useEffect, useMemo, useState } from "react";
+
+import Box from "@mui/material/Box";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
+import { Stock } from "../Stock";
+import { getStockPriceHistory, getStockPriceHistoryOffset, getMaxPriceHistoryLength } from "../PriceHistory";
+import { StockMarketConstants } from "../data/Constants";
+
+import { Settings } from "../../Settings/Settings";
+import { StockChartTypeSetting } from "../../Settings/SettingEnums";
+import { Sparkline, sparklineGeometry } from "../../ui/React/Sparkline";
+import { Candlesticks } from "../../ui/React/Candlesticks";
+import { forecastLength, maxForecastLength } from "./StockTickerHeaderText";
+import { useElementWidth } from "../../ui/React/hooks";
+import { formatMoney } from "../../ui/formatNumber";
+
+/** Whether both views draw candlesticks (per the `StockChartType` setting). */
+function candleChartSelected(): boolean {
+  return Settings.StockChartType === StockChartTypeSetting.Candlestick;
+}
+/**
+ * Widest the candle chart's box gets, in px, anchored to the panel's right edge. The chart
+ * stretches to its container, and where a stretched line is still a line, stretched candles become
+ * huge slabs that walk left behind the panel's text. Capping the box keeps each candle at a
+ * readable width and, on wide windows, keeps the whole chart out from behind the text. Candle view
+ * only - the line keeps filling the panel.
+ */
+const maxCandleChartWidth = 800;
+/**
+ * Left-over panel width, in px, at which the candle chart is clear of the panel's text (the text
+ * block is ~460px wide). Past that the fade is dropped: it exists to keep marks from fighting the
+ * text, and when nothing is behind the text it only dims data.
+ */
+const candleTextClearance = 480;
+
+/**
+ * Span a collapsed row's chart covers. Shorter than the full buffer because a row is only tall
+ * enough for a trend - the whole history at that height is mush.
+ */
+const collapsedPointCount = 60;
+
+const rowChartHeight = "22px";
+/**
+ * A row's chart takes the space the header text leaves, up to this much of the row. Kept to a
+ * narrow sliver: a row's line is a glance at the recent trend, and the wider it gets the more it
+ * competes with the header text for the eye.
+ */
+const maxRowChartWidth = "12.5%";
+/** Below this, the leftover space is too cramped for a line to say anything, so none is drawn. */
+const minRowChartWidth = 60;
+/** Nearly half the line: at this width the ramp is what keeps the older end from reading as clutter. */
+const rowFadeIn = 0.48;
+/**
+ * Least space between the end of the header text and the start of the line, in characters of that
+ * text. Padding rather than a margin on purpose: `useElementWidth` measures `contentRect`, which
+ * excludes padding, so the gap never counts as room to draw in.
+ */
+const rowChartGapChars = 2;
+
+/** How strongly the panel's line reads against the text drawn over it. */
+const expandedOpacity = 0.55;
+const expandedFadeIn = 0.4;
+/**
+ * Share of the fade ramp excluded from the hover-readout zone, in both views. Left of this point
+ * the marks are mostly faded — a readout there describes data the eye can barely see, and in the
+ * expanded panel that stretch is exactly where the foreground text sits, so hovering the text kept
+ * popping a readout. The zone also never starts before the series itself does: while the buffer is
+ * filling, the empty left of the fixed time axis reads out nothing.
+ *
+ * Raise this toward 1 to trim more of the fade, lower it toward 0 to trim less
+ */
+const fadeHoverTrim = 0.5;
+/**
+ * Extra air, in label lines, between the bottom of the panel's chart and the label beneath it. The
+ * line is allowed behind the panel's text, where the fade keeps it faint, but not through the label
+ * - that one is short, sits at the far end of the line where the fade has already gone, and reads
+ * as struck through when the line crosses it.
+ */
+const labelClearanceGap = 0.25;
+/**
+ * Below this panel width, the corner label is given its own line instead of being tucked into the
+ * bottom-right, where it would collide with the last line of the panel's text. An approximation:
+ * the real threshold depends on how long that line's formatted numbers happen to be.
+ */
+const narrowPanelWidth = 560;
+/** Gap between the widths at which the label switches layouts. See the effect that uses it. */
+const narrowPanelHysteresis = 40;
+
+/**
+ * The line takes its color from the stock's forecast - the same signal the header reports as
+ * `Price Forecast: ++`, computed the same way.
+ *
+ * Coloring by the window's own start-to-end direction was unstable: on a nearly flat series the
+ * color flipped as soon as the first point aged out of the buffer, which is what made rows change
+ * color for no visible reason.
+ */
+function forecastColor(stock: Stock): string {
+  const bullish = stock.otlkMag < 0 ? !stock.b : stock.b;
+  return bullish ? Settings.theme.success : Settings.theme.error;
+}
+
+/**
+ * Elapsed time as `11m 54s`. Local rather than `convertTimeMsToTimeElapsedString`, which spells its
+ * units out in full - too long for a readout that sits in a corner of the panel. That helper is
+ * shared with other game systems, so it is not ours to shorten.
+ *
+ * Only minutes and seconds, because the history buffer is capped well under an hour.
+ */
+function formatElapsedShort(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes === 0 ? `${seconds}s` : `${minutes}m ${seconds}s`;
+}
+
+interface IProps {
+  stock: Stock;
+}
+
+/**
+ * Recent price history beside a collapsed ticker row. A glance: no labels, no cursor - just a
+ * tooltip summarizing the window (its span and its low/high) for anyone who pauses on it.
+ *
+ * Sizing is left to flexbox - the box takes what the header text does not, up to its cap, and an
+ * auto left margin keeps it against the right edge when the cap leaves slack. Measuring only
+ * decides whether the room it ended up with is worth drawing in.
+ */
+export function StockPriceRowChart({ stock, hidden }: IProps & { hidden?: boolean }): React.ReactElement {
+  const [ref, width] = useElementWidth<HTMLDivElement>();
+  const history = getStockPriceHistory(stock.symbol);
+  // Pad by however many characters of forecast this row happens to be short of the longest one, so
+  // every row's chart is measured against the same amount of room and the list shows its lines all
+  // together or not at all. Without this the decision is made per row against a leftover that
+  // differs by the width of a `+`, which lands some rows either side of the cutoff at the window
+  // widths where it bites. `ch` because the header is monospace, so a character is a fixed width.
+  const gap = `${rowChartGapChars + maxForecastLength - forecastLength(stock)}ch`;
+  // Slicing allocates, and the chart components compare `data` by reference to skip the ticker's
+  // 5Hz re-render, so the window has to be as stable as the history it comes from.
+  const window = useMemo(() => history.slice(-collapsedPointCount), [history]);
+  const summary = useMemo(() => {
+    if (window.length < 2 || !window.every((value) => Number.isFinite(value))) return "";
+    const min = window.reduce((acc, value) => Math.min(acc, value), Infinity);
+    const max = window.reduce((acc, value) => Math.max(acc, value), -Infinity);
+    const span = formatElapsedShort((window.length - 1) * StockMarketConstants.msPerStockUpdate);
+    return `Last ${span} - Low ${formatMoney(min)} - High ${formatMoney(max)}`;
+  }, [window]);
+  const hasRoom = width !== null && width >= minRowChartWidth;
+  const showChart = hasRoom && !hidden && Settings.ShowStockChartInCollapsedRows;
+  // The absolute index of window[0]: what the buffer has dropped, plus what the slice skipped.
+  const offset = getStockPriceHistoryOffset(stock.symbol) + Math.max(0, history.length - window.length);
+  // Share of the chart's width the tooltip responds over, anchored right: the drawn series minus
+  // the mostly-faded start of its ramp (see fadeHoverTrim). The empty left of a still-filling axis
+  // and the faded edge both stay inert.
+  const hoverWidth = useMemo(() => {
+    if (window.length < 2) return 0;
+    const { xOf, viewWidth } = sparklineGeometry(window, collapsedPointCount);
+    const seriesStart = xOf(0) / viewWidth;
+    const hoverStart = seriesStart + fadeHoverTrim * rowFadeIn * (1 - seriesStart);
+    return `${((1 - hoverStart) * 100).toFixed(1)}%`;
+  }, [window]);
+
+  // The box is kept even when nothing is drawn in it, so expanding a ticker does not shift the row
+  // it was expanded from.
+  return (
+    <Box
+      ref={ref}
+      sx={{
+        // Relies on content-box sizing (the project has no CssBaseline): the flex basis sizes the
+        // *content* box, with the `ch` padding on top, which is what keeps every row's chart the
+        // same width in both regimes (cap-limited when wide, leftover-limited when narrow). A
+        // global `box-sizing: border-box` would silently break the list's all-or-none behavior.
+        flex: `0 1 ${maxRowChartWidth}`,
+        minWidth: 0,
+        ml: "auto",
+        mr: 2,
+        pl: gap,
+        height: rowChartHeight,
+      }}
+    >
+      {showChart && (
+        <Box sx={{ position: "relative", height: "100%" }}>
+          {candleChartSelected() ? (
+            <Candlesticks
+              data={window}
+              capacity={collapsedPointCount}
+              interval={Settings.StockChartTicksPerCandle}
+              offset={offset}
+              fadeIn={rowFadeIn}
+            />
+          ) : (
+            <Sparkline
+              data={window}
+              capacity={collapsedPointCount}
+              color={forecastColor(stock)}
+              strokeWidth={1.5}
+              fadeIn={rowFadeIn}
+            />
+          )}
+          <Tooltip title={summary}>
+            <Box sx={{ position: "absolute", top: 0, bottom: 0, right: 0, width: hoverWidth }} />
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+interface IDetailProps extends IProps {
+  /**
+   * Rendered above the chart rather than over it. The trade controls are the one part of the panel
+   * with enough visual weight to fight with a line behind them.
+   */
+  controls: React.ReactNode;
+}
+
+/**
+ * Full price history behind an expanded ticker, with a hover readout.
+ *
+ * Takes the panel's content as children rather than rendering above it: the chart has to sit behind
+ * that content, and hover has to be tracked across the whole panel, since the content covers the
+ * chart even where it looks empty.
+ */
+export function StockPriceDetail({
+  stock,
+  controls,
+  children,
+}: React.PropsWithChildren<IDetailProps>): React.ReactElement {
+  const [ref, width] = useElementWidth<HTMLDivElement>();
+  const history = getStockPriceHistory(stock.symbol);
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  const [labelInFlow, setLabelInFlow] = useState(false);
+
+  useEffect(() => {
+    if (width === null) return;
+    // Hysteresis. Giving the label its own line changes the panel's height, which can add or remove
+    // the page's scrollbar, which changes this width again - a loop that would otherwise flicker
+    // between the two layouts. Switching at different widths in each direction settles it.
+    setLabelInFlow((inFlow) => {
+      if (width < narrowPanelWidth) return true;
+      if (width > narrowPanelWidth + narrowPanelHysteresis) return false;
+      return inFlow;
+    });
+  }, [width]);
+
+  // Room kept for the label at the bottom of the panel. One line of it, whichever layout it is in:
+  // in flow it is a row of its own down there, and absolute it is pinned to the same edge. Read at
+  // render rather than at module load, since line height is a player setting.
+  const labelClearance = `${Settings.styles.lineHeight + labelClearanceGap}em`;
+
+  const candles = candleChartSelected();
+  const capacity = getMaxPriceHistoryLength();
+  const geometry = sparklineGeometry(history, capacity);
+  const color = forecastColor(stock);
+  const lastIndex = history.length - 1;
+  const hasChart = history.length >= 2;
+  const hovered = hoverIndex !== null && hoverIndex <= lastIndex ? hoverIndex : null;
+
+  // The candle chart drops its fade once its capped box is clear of the panel's text (see
+  // candleTextClearance); the line always fades, since it always runs behind the text.
+  const chartFadeIn =
+    candles && width !== null && width - maxCandleChartWidth >= candleTextClearance ? 0 : expandedFadeIn;
+  // Where the hover readout starts responding, as a fraction of the chart's box: at the series
+  // itself (the empty left of a still-filling axis reads out nothing), plus the mostly-faded start
+  // of the ramp (see fadeHoverTrim) — which is also what keeps hovers over the foreground text from
+  // popping the readout.
+  const seriesStart = hasChart ? geometry.xOf(0) / geometry.viewWidth : 0;
+  const hoverStart = seriesStart + fadeHoverTrim * chartFadeIn * (1 - seriesStart);
+
+  function handleMouseMove(event: React.MouseEvent<HTMLDivElement>): void {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    // The candle chart's box may be narrower than the panel and right-anchored; the fraction has to
+    // be taken over the box the chart actually draws in — a pointer left of that box, or left of
+    // where the hover zone starts inside it, reads out nothing.
+    const chartWidth = candles ? Math.min(bounds.width, maxCandleChartWidth) : bounds.width;
+    const fraction = (event.clientX - (bounds.right - chartWidth)) / chartWidth;
+    setHoverIndex(fraction < hoverStart ? null : geometry.indexAtFraction(fraction));
+  }
+
+  // The hover readout replaces the range rather than sitting beside it, so the line never reflows
+  // and neither value is reachable only by hovering.
+  const label =
+    hovered === null
+      ? `Low ${formatMoney(geometry.min)} - High ${formatMoney(geometry.max)}`
+      : `${formatMoney(history[hovered])} - ${
+          hovered === lastIndex
+            ? "now"
+            : `${formatElapsedShort((lastIndex - hovered) * StockMarketConstants.msPerStockUpdate)} ago`
+        }`;
+
+  return (
+    <>
+      {controls}
+      <Box
+        ref={ref}
+        sx={{ position: "relative" }}
+        onMouseMove={hasChart ? handleMouseMove : undefined}
+        onMouseLeave={() => setHoverIndex(null)}
+      >
+        {hasChart && (
+          <Box
+            sx={{
+              position: "absolute",
+              top: 0,
+              right: 0,
+              bottom: labelClearance,
+              zIndex: 0,
+              pointerEvents: "none",
+              opacity: expandedOpacity,
+              // See maxCandleChartWidth. Until the panel has been measured, assume it is narrow.
+              ...(candles ? { width: "100%", maxWidth: `${maxCandleChartWidth}px` } : { left: 0 }),
+            }}
+          >
+            {candles ? (
+              <Candlesticks
+                data={history}
+                capacity={capacity}
+                interval={Settings.StockChartTicksPerCandle}
+                offset={getStockPriceHistoryOffset(stock.symbol)}
+                fadeIn={chartFadeIn}
+                highlightIndex={hovered ?? undefined}
+              />
+            ) : (
+              <Sparkline
+                data={history}
+                capacity={capacity}
+                color={color}
+                fadeIn={chartFadeIn}
+                highlightIndex={hovered ?? undefined}
+              />
+            )}
+          </Box>
+        )}
+        <Box sx={{ position: "relative", zIndex: 1 }}>{children}</Box>
+        {hasChart && (
+          <Typography
+            sx={
+              labelInFlow
+                ? { textAlign: "right", position: "relative", zIndex: 1 }
+                : { position: "absolute", right: 0, bottom: 0, zIndex: 1, pointerEvents: "none" }
+            }
+            // Fixed, not the line's color: the label is a readout, and having it change color on
+            // hover reads as the value itself having changed meaning.
+            color={Settings.theme.secondary}
+          >
+            {label}
+          </Typography>
+        )}
+      </Box>
+    </>
+  );
+}

--- a/src/StockMarket/ui/StockTicker.tsx
+++ b/src/StockMarket/ui/StockTicker.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 
 import { StockTickerHeaderText } from "./StockTickerHeaderText";
+import { StockPriceDetail, StockPriceRowChart } from "./StockPriceChart";
 import { StockTickerOrderList } from "./StockTickerOrderList";
 import { StockTickerPositionText } from "./StockTickerPositionText";
 import { StockTickerTxButton } from "./StockTickerTxButton";
@@ -278,45 +279,69 @@ export function StockTicker(props: IProps): React.ReactElement {
     return Player.bitNodeN === 8 || Player.activeSourceFileLvl(8) >= 2;
   }
 
+  const tickerControls = (
+    <Box display="flex" alignItems="center">
+      <TextField onChange={handleQuantityChange} placeholder="Quantity (Shares)" value={qty} />
+      <Select onChange={handlePositionTypeChange} value={position}>
+        <MenuItem value={PositionType.Long}>Long</MenuItem>
+        {hasShortAccess() && <MenuItem value={PositionType.Short}>Short</MenuItem>}
+      </Select>
+      <Select onChange={handleOrderTypeChange} value={orderType}>
+        <MenuItem value={SelectorOrderType.Market}>{SelectorOrderType.Market}</MenuItem>
+        {hasOrderAccess() && <MenuItem value={SelectorOrderType.Limit}>{SelectorOrderType.Limit}</MenuItem>}
+        {hasOrderAccess() && <MenuItem value={SelectorOrderType.Stop}>{SelectorOrderType.Stop}</MenuItem>}
+      </Select>
+
+      <StockTickerTxButton onClick={handleBuyButtonClick} text={"Buy"} tooltip={getBuyTransactionCostContent()} />
+      <StockTickerTxButton onClick={handleSellButtonClick} text={"Sell"} tooltip={getSellTransactionCostContent()} />
+      <StockTickerTxButton onClick={handleBuyMaxButtonClick} text={"Buy MAX"} />
+      <StockTickerTxButton onClick={handleSellAllButtonClick} text={"Sell ALL"} />
+    </Box>
+  );
+
+  const tickerBody = (
+    <>
+      <StockTickerPositionText stock={props.stock} />
+      <StockTickerOrderList orders={props.orders} stock={props.stock} />
+
+      <PlaceOrderModal
+        text={modalProps.text}
+        placeText={modalProps.placeText}
+        place={modalProps.place}
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+
   return (
     <Box component={Paper}>
       <ListItemButton onClick={() => setTicketOpen((old) => !old)}>
-        <ListItemText primary={<StockTickerHeaderText stock={props.stock} />} />
-        {tickerOpen ? <ExpandLess color="primary" /> : <ExpandMore color="primary" />}
+        {/* The header text keeps its natural width so the chart beside it can claim exactly what is
+            left over, and gives that up first when the window is too narrow for both. */}
+        <ListItemText sx={{ flex: "0 0 auto" }} primary={<StockTickerHeaderText stock={props.stock} />} />
+        {/* Redundant with the expanded panel's chart, so it yields to it - but keeps its space, so
+            expanding a ticker does not shift the row it was expanded from. */}
+        {Player.has4SData && <StockPriceRowChart stock={props.stock} hidden={tickerOpen} />}
+        {/* The chart is the only item allowed to shrink, so it absorbs every narrowing on its own. */}
+        {tickerOpen ? (
+          <ExpandLess color="primary" sx={{ flexShrink: 0 }} />
+        ) : (
+          <ExpandMore color="primary" sx={{ flexShrink: 0 }} />
+        )}
       </ListItemButton>
       <Collapse in={tickerOpen} unmountOnExit>
         <Box sx={{ mx: 4 }}>
-          <Box display="flex" alignItems="center">
-            <TextField onChange={handleQuantityChange} placeholder="Quantity (Shares)" value={qty} />
-            <Select onChange={handlePositionTypeChange} value={position}>
-              <MenuItem value={PositionType.Long}>Long</MenuItem>
-              {hasShortAccess() && <MenuItem value={PositionType.Short}>Short</MenuItem>}
-            </Select>
-            <Select onChange={handleOrderTypeChange} value={orderType}>
-              <MenuItem value={SelectorOrderType.Market}>{SelectorOrderType.Market}</MenuItem>
-              {hasOrderAccess() && <MenuItem value={SelectorOrderType.Limit}>{SelectorOrderType.Limit}</MenuItem>}
-              {hasOrderAccess() && <MenuItem value={SelectorOrderType.Stop}>{SelectorOrderType.Stop}</MenuItem>}
-            </Select>
-
-            <StockTickerTxButton onClick={handleBuyButtonClick} text={"Buy"} tooltip={getBuyTransactionCostContent()} />
-            <StockTickerTxButton
-              onClick={handleSellButtonClick}
-              text={"Sell"}
-              tooltip={getSellTransactionCostContent()}
-            />
-            <StockTickerTxButton onClick={handleBuyMaxButtonClick} text={"Buy MAX"} />
-            <StockTickerTxButton onClick={handleSellAllButtonClick} text={"Sell ALL"} />
-          </Box>
-          <StockTickerPositionText stock={props.stock} />
-          <StockTickerOrderList orders={props.orders} stock={props.stock} />
-
-          <PlaceOrderModal
-            text={modalProps.text}
-            placeText={modalProps.placeText}
-            place={modalProps.place}
-            open={open}
-            onClose={() => setOpen(false)}
-          />
+          {Player.has4SData ? (
+            <StockPriceDetail stock={props.stock} controls={tickerControls}>
+              {tickerBody}
+            </StockPriceDetail>
+          ) : (
+            <>
+              {tickerControls}
+              {tickerBody}
+            </>
+          )}
         </Box>
       </Collapse>
     </Box>

--- a/src/StockMarket/ui/StockTickerHeaderText.tsx
+++ b/src/StockMarket/ui/StockTickerHeaderText.tsx
@@ -21,6 +21,17 @@ interface IProps {
 
 const localesWithLongPriceFormat = ["cs", "lv", "pl", "ru"];
 
+/**
+ * Characters of `+`/`-` this stock's forecast is printed with. The only field of the header whose
+ * width varies from row to row - everything before it is padded to a fixed column.
+ */
+export function forecastLength(stock: Stock): number {
+  return Math.floor(Math.abs(stock.otlkMag) / 10) + 1;
+}
+
+/** Widest that field can get: `Stock.cycleForecast` clamps `otlkMag` to 50. */
+export const maxForecastLength = 6;
+
 export function StockTickerHeaderText(props: IProps): React.ReactElement {
   const stock = props.stock;
 
@@ -42,7 +53,7 @@ export function StockTickerHeaderText(props: IProps): React.ReactElement {
     if (stock.otlkMag < 0) {
       plusOrMinus = !plusOrMinus;
     }
-    hdrText += (plusOrMinus ? "+" : "-").repeat(Math.floor(Math.abs(stock.otlkMag) / 10) + 1);
+    hdrText += (plusOrMinus ? "+" : "-").repeat(forecastLength(stock));
   }
 
   let color = Settings.theme.success;

--- a/src/ui/React/Candlesticks.tsx
+++ b/src/ui/React/Candlesticks.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { Settings } from "../../Settings/Settings";
+import { sparklineGeometry } from "./Sparkline";
+
+/**
+ * Fraction of a candle's slot left empty on each side, so neighboring bodies do not touch. A share
+ * of the slot rather than a fixed distance: slots stretch with the container, and a fixed gap would
+ * disappear on wide panels and eat narrow candles whole.
+ */
+const candleGapFraction = 0.15;
+/** A doji's body would be zero-tall; give it a hairline so the open/close level still shows. */
+const minBodyHeight = 1;
+/** Thin against the body, per convention, but thick enough to survive the panel's own opacity. */
+const wickStrokeWidth = 1.5;
+
+interface Candle {
+  /** Array indices of the first and last tick this candle covers. */
+  firstIndex: number;
+  lastIndex: number;
+  open: number;
+  close: number;
+  high: number;
+  low: number;
+}
+
+/**
+ * Groups raw ticks into open/high/low/close candles of `interval` ticks each. Buckets are keyed by
+ * absolute tick index (`offset` + array position), not array position, so a candle's window is fixed
+ * in time: candles march left rigidly as ticks age out and a new one forms at the right edge,
+ * instead of every window shifting by one tick per update. The newest candle is usually partial
+ * (still forming) and the oldest may be too (its early ticks already dropped).
+ */
+function aggregate(data: readonly number[], interval: number, offset: number): Candle[] {
+  const candles: Candle[] = [];
+  for (let i = 0; i < data.length; i++) {
+    const price = data[i];
+    const last = candles[candles.length - 1];
+    if (
+      last !== undefined &&
+      Math.floor((offset + i) / interval) === Math.floor((offset + last.firstIndex) / interval)
+    ) {
+      last.lastIndex = i;
+      last.close = price;
+      last.high = Math.max(last.high, price);
+      last.low = Math.min(last.low, price);
+    } else {
+      candles.push({ firstIndex: i, lastIndex: i, open: price, close: price, high: price, low: price });
+    }
+  }
+  return candles;
+}
+
+interface CandlesticksProps {
+  /** Raw per-tick series to aggregate and plot, oldest first. */
+  data: readonly number[];
+  /** Ticks per candle. */
+  interval: number;
+  /** Number of ticks the full width represents, exactly as {@link Sparkline}'s capacity. */
+  capacity?: number;
+  /** Absolute index of `data[0]` - how many older ticks have been dropped. Anchors candle windows. */
+  offset?: number;
+  /** For candles that closed at or above their open. Defaults to the theme's success color. */
+  upColor?: string;
+  /** For candles that closed below their open. Defaults to the theme's error color. */
+  downColor?: string;
+  /**
+   * As {@link Sparkline}'s fadeIn: fraction of the width over which the oldest end ramps in. Unlike
+   * the line's gradient, the ramp is sampled once per candle, at its center - a gradient across a
+   * filled body shows up as a smear inside the mark, where on a thin line it reads as a fade.
+   */
+  fadeIn?: number;
+  /** Tick index (not candle index) to mark with a vertical rule, for a hover readout. */
+  highlightIndex?: number;
+}
+
+/**
+ * Candlestick chart over the same coordinate space as {@link Sparkline}: fills its container,
+ * fixed right-anchored time axis, memoized with `data` compared by reference. It takes the raw
+ * per-tick series and aggregates internally, so call sites swap renderers without reshaping data -
+ * and so the aggregation reruns only when `data` is actually replaced, not on every render the memo
+ * absorbs.
+ *
+ * Candles are colored individually by their own close-vs-open direction. That is the mark's meaning
+ * - unlike the line, whose single color had to come from somewhere and comes from the forecast.
+ */
+function CandlesticksInner({
+  data,
+  interval,
+  capacity,
+  offset = 0,
+  upColor,
+  downColor,
+  fadeIn = 0,
+  highlightIndex,
+}: CandlesticksProps): React.ReactElement | null {
+  // Same bail-out as Sparkline: nothing meaningful to draw.
+  if (data.length < 2 || !data.every((value) => Number.isFinite(value))) return null;
+
+  const up = upColor ?? Settings.theme.success;
+  const down = downColor ?? Settings.theme.error;
+  const { xOf, yOf, step, viewWidth, viewHeight } = sparklineGeometry(data, capacity);
+  const ticksPerCandle = Math.max(1, Math.floor(interval));
+  const candles = aggregate(data, ticksPerCandle, offset);
+  const colorOf = (candle: Candle): string => (candle.close >= candle.open ? up : down);
+
+  // The same ramp Sparkline's gradient describes - 0 at the series' start, 1 at fadeIn of the way
+  // to the right edge - evaluated at a single x.
+  const fadeSpan = fadeIn > 0 ? Math.min(fadeIn, 1) * (viewWidth - xOf(0)) : 0;
+  const opacityAt = (x: number): number => (fadeSpan <= 0 ? 1 : Math.min(1, Math.max(0, (x - xOf(0)) / fadeSpan)));
+
+  const highlighted = highlightIndex !== undefined && highlightIndex >= 0 && highlightIndex < data.length;
+  const highlightedCandle = highlighted
+    ? candles.find((candle) => highlightIndex >= candle.firstIndex && highlightIndex <= candle.lastIndex)
+    : undefined;
+
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${viewWidth} ${viewHeight}`}
+      preserveAspectRatio="none"
+      style={{ display: "block" }}
+    >
+      {highlightedCandle !== undefined && highlightIndex !== undefined && (
+        // The cursor rule, dimmed like the candle it crosses, so it fades out along with the marks
+        // it points at - the candle equivalent of the line's gradient-painted cursor.
+        <line
+          x1={xOf(highlightIndex)}
+          y1={0}
+          x2={xOf(highlightIndex)}
+          y2={viewHeight}
+          stroke={colorOf(highlightedCandle)}
+          strokeOpacity={0.5 * opacityAt(xOf(highlightIndex))}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+      {candles.map((candle) => {
+        // A candle's slot spans its ticks plus the half-step each end tick owns, clamped to the
+        // chart. Partial candles (forming at the right, aging out at the left) simply have fewer
+        // ticks and draw narrower - the forming candle visibly grows into its slot.
+        const slotLeft = Math.max(0, xOf(candle.firstIndex) - step / 2);
+        const slotRight = Math.min(viewWidth, xOf(candle.lastIndex) + step / 2);
+        const inset = (slotRight - slotLeft) * candleGapFraction;
+        const bodyTop = Math.min(yOf(candle.open), yOf(candle.close));
+        const bodyHeight = Math.max(minBodyHeight, Math.abs(yOf(candle.open) - yOf(candle.close)));
+        const color = colorOf(candle);
+        const centerX = (slotLeft + slotRight) / 2;
+        // The bucket number: stable for a candle's whole lifetime, unlike its first retained tick.
+        const key = Math.floor((offset + candle.firstIndex) / ticksPerCandle);
+        return (
+          <g key={key} opacity={opacityAt(centerX)}>
+            <line
+              x1={centerX}
+              y1={yOf(candle.high)}
+              x2={centerX}
+              y2={yOf(candle.low)}
+              stroke={color}
+              strokeWidth={wickStrokeWidth}
+              vectorEffect="non-scaling-stroke"
+            />
+            <rect
+              x={slotLeft + inset}
+              y={bodyTop}
+              width={slotRight - slotLeft - 2 * inset}
+              height={bodyHeight}
+              fill={color}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export const Candlesticks = React.memo(CandlesticksInner);

--- a/src/ui/React/Sparkline.tsx
+++ b/src/ui/React/Sparkline.tsx
@@ -1,0 +1,164 @@
+import React, { useRef } from "react";
+import { Settings } from "../../Settings/Settings";
+
+/**
+ * Nominal viewBox. The SVG stretches to fill its container on both axes, so these are arbitrary
+ * units rather than pixels - only their ratios to each other matter.
+ */
+const viewWidth = 1000;
+const viewHeight = 100;
+/** Keeps a stroke of any width from being clipped against the top and bottom edges. */
+const verticalInset = 4;
+
+interface SparklineProps {
+  /** Series to plot, oldest first. Auto-normalized to fill the vertical space. */
+  data: readonly number[];
+  /**
+   * Number of points the full width represents. The series is drawn against the right edge and
+   * occupies only as much of the width as it has points for, so the horizontal scale stays fixed
+   * while a series is still filling up rather than stretching a handful of points across the chart.
+   * Defaults to the series' own length, which fills the width.
+   */
+  capacity?: number;
+  /** Defaults to the active theme's primary color. */
+  color?: string;
+  /** In CSS pixels - unaffected by how far the container stretches the chart. */
+  strokeWidth?: number;
+  /**
+   * Fraction of the width (0-1) over which the oldest end ramps from transparent to opaque. Use it
+   * where the start of the series is only where recording began, not a real boundary in the data,
+   * or to keep the line clear of content it is drawn behind.
+   */
+  fadeIn?: number;
+  /** Index to mark with a vertical rule, for a hover readout. */
+  highlightIndex?: number;
+}
+
+/**
+ * Maps series indices and values onto the coordinates {@link Sparkline} draws at, so a caller
+ * overlaying its own marks stays aligned with the line.
+ */
+export function sparklineGeometry(data: readonly number[], capacity = data.length) {
+  const lastIndex = data.length - 1;
+  const min = data.reduce((acc, value) => Math.min(acc, value), Infinity);
+  const max = data.reduce((acc, value) => Math.max(acc, value), -Infinity);
+  const span = max - min;
+  // Never squeeze the series: a capacity smaller than the data just falls back to filling the width.
+  const slots = Math.max(capacity, data.length);
+  /** Horizontal distance between adjacent points. Fixed by capacity, not by how much data exists. */
+  const step = slots <= 1 ? 0 : viewWidth / (slots - 1);
+
+  // Anchored to the right edge, so the newest point is always in the same place and older points
+  // march leftwards as they age.
+  const xOf = (index: number): number => viewWidth - (lastIndex - index) * step;
+  // A flat series has no span to normalize against, so center it instead of dividing by zero.
+  const yOf = (value: number): number =>
+    span === 0
+      ? viewHeight / 2
+      : viewHeight - verticalInset - ((value - min) / span) * (viewHeight - 2 * verticalInset);
+  /**
+   * Series index nearest a horizontal position given as a 0-1 fraction of the rendered width.
+   * Taking a fraction rather than a pixel offset keeps callers independent of how wide the
+   * container happens to be. Positions left of the series clamp to its oldest point.
+   */
+  const indexAtFraction = (fraction: number): number =>
+    step === 0
+      ? 0
+      : Math.min(lastIndex, Math.max(0, Math.round(lastIndex - (viewWidth - fraction * viewWidth) / step)));
+
+  // viewWidth/viewHeight/step are exposed so a caller drawing marks of its own (in its own svg with
+  // the same viewBox) knows the coordinate space the mapping functions return positions in.
+  return { xOf, yOf, indexAtFraction, min, max, step, viewWidth, viewHeight };
+}
+
+// SVG gradients are referenced by document-wide id, and the Stock Market renders one sparkline per
+// stock, so each instance needs an id of its own. React 17 has no useId.
+let nextGradientId = 0;
+
+/**
+ * Minimal single-series line chart with no axes, grid or legend. Renders as inline SVG so it
+ * inherits the active theme and needs no charting dependency.
+ *
+ * Fills its container on both axes, which lets it be laid out as a background behind other content;
+ * give the container a size. The line is deliberately the only mark - end dots would be distorted
+ * by the non-uniform stretch, and read as noise behind text anyway.
+ *
+ * Memoized: callers re-render far more often than their data changes, and `data` is compared by
+ * reference, so pass a series that is replaced rather than mutated.
+ */
+function SparklineInner({
+  data,
+  capacity,
+  color,
+  strokeWidth = 2,
+  fadeIn = 0,
+  highlightIndex,
+}: SparklineProps): React.ReactElement | null {
+  const gradientId = useRef<string>();
+  if (gradientId.current === undefined) gradientId.current = `sparkline-fade-${nextGradientId++}`;
+
+  // Nothing meaningful to draw. Bail out rather than emit a polyline full of NaN.
+  if (data.length < 2 || !data.every((value) => Number.isFinite(value))) return null;
+
+  const stroke = color ?? Settings.theme.primary;
+  const { xOf, yOf } = sparklineGeometry(data, capacity);
+  const points = data.map((value, index) => `${xOf(index).toFixed(2)},${yOf(value).toFixed(2)}`).join(" ");
+  const highlighted = highlightIndex !== undefined && highlightIndex >= 0 && highlightIndex < data.length;
+  const strokePaint = fadeIn > 0 ? `url(#${gradientId.current})` : stroke;
+
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${viewWidth} ${viewHeight}`}
+      // The container decides both dimensions, so the drawing is stretched to match rather than
+      // letterboxed. `non-scaling-stroke` below keeps that stretch off the line weight.
+      preserveAspectRatio="none"
+      style={{ display: "block" }}
+    >
+      {fadeIn > 0 && (
+        <defs>
+          {/* Spans the series rather than the viewBox, so the ramp stays a fixed share of the line
+              even when a short series only occupies part of the width. */}
+          <linearGradient
+            id={gradientId.current}
+            gradientUnits="userSpaceOnUse"
+            x1={xOf(0)}
+            y1={0}
+            x2={viewWidth}
+            y2={0}
+          >
+            <stop offset={0} stopColor={stroke} stopOpacity={0} />
+            <stop offset={Math.min(fadeIn, 1)} stopColor={stroke} stopOpacity={1} />
+          </linearGradient>
+        </defs>
+      )}
+      {highlighted && (
+        // Painted with the same gradient as the line. It runs horizontally, so a vertical rule
+        // takes a single opacity from it - the one the line itself has at that x. The cursor then
+        // fades out along with the part of the series it is pointing at, instead of staying solid
+        // over a line that has faded to nothing.
+        <line
+          x1={xOf(highlightIndex)}
+          y1={0}
+          x2={xOf(highlightIndex)}
+          y2={viewHeight}
+          stroke={strokePaint}
+          strokeOpacity={0.5}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+      <polyline
+        points={points}
+        fill="none"
+        stroke={strokePaint}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+export const Sparkline = React.memo(SparklineInner);

--- a/src/ui/React/hooks.ts
+++ b/src/ui/React/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { GameCycleEvents } from "../../engine";
 
 /** Hook that returns a function for the component. Optionally set an interval to rerender the component.
@@ -29,6 +29,51 @@ export function useCycleRerender(): () => void {
     return unsubscribe;
   }, [rerender]);
   return rerender;
+}
+
+/**
+ * Tracks an element's rendered width in CSS pixels. Attach the returned ref to the element; the
+ * width is null until it has been measured, so callers can tell "not measured yet" from "zero wide".
+ *
+ * For layout decisions that CSS cannot express on its own - whether there is enough room left for a
+ * thing to be worth drawing at all.
+ */
+export function useElementWidth<T extends HTMLElement>(): [React.RefCallback<T>, number | null] {
+  const [width, setWidth] = useState<number | null>(null);
+  const observer = useRef<ResizeObserver | null>(null);
+  const frame = useRef<number | null>(null);
+  const measured = useRef<number | null>(null);
+
+  // A callback ref rather than useEffect + useRef: this fires on both attach and detach, so the
+  // observer follows the element even if it is swapped out.
+  const ref = useCallback((element: T | null) => {
+    observer.current?.disconnect();
+    if (frame.current !== null) cancelAnimationFrame(frame.current);
+    frame.current = null;
+    measured.current = null;
+    if (!element) {
+      observer.current = null;
+      setWidth(null);
+      return;
+    }
+    observer.current = new ResizeObserver((entries) => {
+      const next = entries[0].contentRect.width;
+      // A ResizeObserver reports any change to the box, height included, so an element whose height
+      // is being animated reports on every frame of that animation with the same width each time.
+      // Nothing downstream cares, so drop those here rather than scheduling a frame per report.
+      if (next === measured.current) return;
+      measured.current = next;
+      // Deferring to the next frame is what keeps a layout change made in response to this
+      // measurement from re-entering the observer before it has finished delivering - the browser
+      // reports that as "ResizeObserver loop completed with undelivered notifications". Callers
+      // whose layout can feed back into their own width still need hysteresis on top of this.
+      if (frame.current !== null) cancelAnimationFrame(frame.current);
+      frame.current = requestAnimationFrame(() => setWidth(next));
+    });
+    observer.current.observe(element);
+  }, []);
+
+  return [ref, width];
 }
 
 export function useBoolean(initialValue = false) {

--- a/test/jest/StockMarket/PriceHistory.test.ts
+++ b/test/jest/StockMarket/PriceHistory.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Proof that the in-memory stock price history (src/StockMarket/PriceHistory.ts) stays bounded
+ * over long sessions, is cleared and re-anchored by every reset path, never reaches a save file,
+ * and replaces its arrays rather than mutating them (the Sparkline memo compares by reference).
+ *
+ * The market is driven as a black box: through the same entry points the game loop and save
+ * system use (processStockPrices, init/load/deleteStockMarket), observing history only through
+ * getStockPriceHistory. recordStockPrice is deliberately never called directly.
+ *
+ * The default soak span is chosen for suite speed; set STOCK_SOAK=1 to simulate a full 14-day
+ * session (~200k market ticks). Every tick past the first fill exercises the same trim-and-append
+ * transition, so the short default loses no coverage, only endurance.
+ */
+import { CONSTANTS } from "../../../src/Constants";
+import { StockSymbol } from "../../../src/Enums";
+import {
+  getMaxPriceHistoryLength,
+  getPriceHistoryDurationMs,
+  getStockPriceHistory,
+} from "../../../src/StockMarket/PriceHistory";
+import { Settings } from "../../../src/Settings/Settings";
+import { Stock } from "../../../src/StockMarket/Stock";
+import {
+  deleteStockMarket,
+  initStockMarket,
+  initSymbolToStockMap,
+  loadStockMarket,
+  processStockPrices,
+  StockMarket,
+  SymbolToStockMap,
+} from "../../../src/StockMarket/StockMarket";
+import { StockMarketConstants } from "../../../src/StockMarket/data/Constants";
+
+const symbols: string[] = Object.values(StockSymbol);
+const cyclesPerTick = StockMarketConstants.msPerStockUpdate / CONSTANTS.MilliPerCycle;
+/**
+ * The retention bound is a live setting now; this captures it under the default settings, which is
+ * what every test except the duration-lowering one runs with.
+ */
+const maxPriceHistoryLength = getMaxPriceHistoryLength();
+
+/** Advance the mocked wall clock past the msPerStockUpdateMin gate and process exactly one market update. */
+function advanceOneTick(): void {
+  jest.setSystemTime(Date.now() + StockMarketConstants.msPerStockUpdate);
+  processStockPrices(cyclesPerTick);
+}
+
+function advanceTicks(count: number): void {
+  for (let i = 0; i < count; ++i) advanceOneTick();
+}
+
+function totalRetainedPoints(): number {
+  return symbols.reduce((sum, symbol) => sum + getStockPriceHistory(symbol).length, 0);
+}
+
+/** The stocks currently in the market. Reads StockMarket directly because loadStockMarket replaces the objects. */
+function marketStocks(): Stock[] {
+  return Object.values(StockMarket).filter((value): value is Stock => value instanceof Stock);
+}
+
+describe("stock price history", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    deleteStockMarket();
+    initStockMarket();
+    initSymbolToStockMap();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("records one point per symbol per market update", () => {
+    expect(symbols.length).toBeGreaterThan(0);
+    for (const symbol of symbols) {
+      expect(getStockPriceHistory(symbol)).toEqual([SymbolToStockMap[symbol].price]);
+    }
+    advanceTicks(3);
+    for (const symbol of symbols) {
+      const history = getStockPriceHistory(symbol);
+      expect(history).toHaveLength(4);
+      expect(history[history.length - 1]).toBe(SymbolToStockMap[symbol].price);
+    }
+  });
+
+  it("keeps every symbol bounded and the total flat over a long soak", () => {
+    const fourteenDaysTicks = Math.ceil((14 * 24 * 60 * 60 * 1000) / StockMarketConstants.msPerStockUpdate);
+    const defaultSoakTicks = 3 * maxPriceHistoryLength + 2 * StockMarketConstants.TicksPerCycle;
+    const soakTicks = process.env.STOCK_SOAK ? fourteenDaysTicks : defaultSoakTicks;
+    const fullTotal = symbols.length * maxPriceHistoryLength;
+
+    // Plain checks inside the loop: millions of expect() calls would dominate the runtime.
+    for (let tick = 1; tick <= soakTicks; ++tick) {
+      advanceOneTick();
+      for (const symbol of symbols) {
+        const length = getStockPriceHistory(symbol).length;
+        if (length > maxPriceHistoryLength) {
+          throw new Error(`history for ${symbol} reached ${length} points at tick ${tick}`);
+        }
+      }
+      // init anchored one point before the first tick, so buffers are full from tick maxPriceHistoryLength - 1.
+      if (tick >= maxPriceHistoryLength - 1) {
+        const total = totalRetainedPoints();
+        if (total !== fullTotal) {
+          throw new Error(`total retained points ${total} != ${fullTotal} at tick ${tick}`);
+        }
+      }
+    }
+    for (const symbol of symbols) {
+      expect(getStockPriceHistory(symbol)).toHaveLength(maxPriceHistoryLength);
+    }
+  }, 300_000);
+
+  it("retains at least the nominal duration", () => {
+    expect(maxPriceHistoryLength * StockMarketConstants.msPerStockUpdate).toBeGreaterThanOrEqual(
+      getPriceHistoryDurationMs(),
+    );
+  });
+
+  it("trims down within one tick per stock when the duration setting is lowered", () => {
+    advanceTicks(maxPriceHistoryLength + 5);
+    for (const symbol of symbols) {
+      expect(getStockPriceHistory(symbol)).toHaveLength(maxPriceHistoryLength);
+    }
+
+    const originalMinutes = Settings.StockChartHistoryMinutes;
+    try {
+      Settings.StockChartHistoryMinutes = Math.max(1, Math.floor(originalMinutes / 3));
+      const loweredLength = getMaxPriceHistoryLength();
+      expect(loweredLength).toBeLessThan(maxPriceHistoryLength);
+
+      advanceOneTick();
+      for (const symbol of symbols) {
+        expect(getStockPriceHistory(symbol)).toHaveLength(loweredLength);
+      }
+    } finally {
+      Settings.StockChartHistoryMinutes = originalMinutes;
+    }
+  });
+
+  it("does not record while the wall-clock gate holds, and records once when it opens", () => {
+    // Enough stored cycles, but no wall-clock time elapsed since init.
+    processStockPrices(cyclesPerTick);
+    for (const symbol of symbols) expect(getStockPriceHistory(symbol)).toHaveLength(1);
+
+    jest.setSystemTime(Date.now() + StockMarketConstants.msPerStockUpdateMin - 1);
+    processStockPrices(0);
+    for (const symbol of symbols) expect(getStockPriceHistory(symbol)).toHaveLength(1);
+
+    jest.setSystemTime(Date.now() + 1);
+    processStockPrices(0);
+    for (const symbol of symbols) expect(getStockPriceHistory(symbol)).toHaveLength(2);
+  });
+
+  it("records nothing while disabled, and resumes when re-enabled", () => {
+    advanceTicks(2);
+    for (const symbol of symbols) expect(getStockPriceHistory(symbol)).toHaveLength(3);
+
+    Settings.DisableStockPriceHistory = true;
+    try {
+      advanceTicks(3); // the market still moves; nothing may be recorded
+      for (const symbol of symbols) expect(getStockPriceHistory(symbol)).toHaveLength(3);
+    } finally {
+      Settings.DisableStockPriceHistory = false;
+    }
+
+    advanceOneTick();
+    for (const symbol of symbols) {
+      const history = getStockPriceHistory(symbol);
+      expect(history).toHaveLength(4);
+      expect(history[history.length - 1]).toBe(SymbolToStockMap[symbol].price);
+    }
+  });
+
+  describe("reset paths", () => {
+    it("initStockMarket discards history and re-anchors on current prices", () => {
+      advanceTicks(20);
+      initStockMarket();
+      initSymbolToStockMap();
+      for (const symbol of symbols) {
+        expect(getStockPriceHistory(symbol)).toEqual([SymbolToStockMap[symbol].price]);
+      }
+    });
+
+    it("deleteStockMarket clears all history", () => {
+      advanceTicks(20);
+      deleteStockMarket();
+      for (const symbol of symbols) {
+        expect(getStockPriceHistory(symbol)).toHaveLength(0);
+      }
+    });
+
+    it("loading a save discards history and re-anchors on the loaded prices", () => {
+      advanceTicks(20);
+      const save = JSON.stringify(StockMarket);
+      advanceTicks(5); // diverge so the assertion below can only pass via a real reset
+      loadStockMarket(save);
+      initSymbolToStockMap();
+      const stocks = marketStocks();
+      expect(stocks).toHaveLength(symbols.length); // guards against loadStockMarket's failure path
+      for (const stock of stocks) {
+        expect(getStockPriceHistory(stock.symbol)).toEqual([stock.price]);
+      }
+    });
+
+    it("does not accumulate points across repeated reset cycles", () => {
+      for (let cycle = 0; cycle < 25; ++cycle) {
+        advanceTicks(5);
+        const save = JSON.stringify(StockMarket);
+        loadStockMarket(save);
+        initSymbolToStockMap();
+        expect(totalRetainedPoints()).toBe(symbols.length);
+
+        advanceTicks(5);
+        initStockMarket();
+        initSymbolToStockMap();
+        expect(totalRetainedPoints()).toBe(symbols.length);
+
+        advanceTicks(5);
+        deleteStockMarket();
+        expect(totalRetainedPoints()).toBe(0);
+
+        initStockMarket();
+        initSymbolToStockMap();
+      }
+    });
+  });
+
+  describe("replace-not-mutate contract", () => {
+    // The Sparkline memo compares `data` by reference; a mutated array would silently freeze the chart.
+    function expectHistoriesReplacedNotMutated(): void {
+      const before = symbols.map((symbol) => {
+        const ref = getStockPriceHistory(symbol);
+        return { symbol, ref, copy: [...ref] };
+      });
+      advanceOneTick();
+      for (const { symbol, ref, copy } of before) {
+        expect(getStockPriceHistory(symbol)).not.toBe(ref);
+        expect(ref).toEqual(copy);
+      }
+    }
+
+    it("while the buffer is filling", () => {
+      advanceTicks(3);
+      expectHistoriesReplacedNotMutated();
+    });
+
+    it("once the buffer is full (trim path)", () => {
+      advanceTicks(maxPriceHistoryLength + 2);
+      expect(getStockPriceHistory(symbols[0])).toHaveLength(maxPriceHistoryLength);
+      expectHistoriesReplacedNotMutated();
+    });
+  });
+
+  it("never reaches the save file", () => {
+    advanceTicks(maxPriceHistoryLength + 5); // full buffers: the worst case for a leak
+    // The exact payload SaveObject.ts puts in StockMarketSave. History lives outside StockMarket,
+    // but a refactor hanging it off Stock would be serialized silently by Generic_toJSON - so
+    // instead of looking for a known key, reject any numeric series anywhere in the save.
+    const save: unknown = JSON.parse(JSON.stringify(StockMarket));
+    const offenders: string[] = [];
+    (function walk(node: unknown, path: string): void {
+      if (Array.isArray(node)) {
+        if (node.length >= 2 && node.every((entry) => typeof entry === "number")) offenders.push(path);
+        node.forEach((entry, index) => walk(entry, `${path}[${index}]`));
+      } else if (typeof node === "object" && node !== null) {
+        for (const [key, value] of Object.entries(node)) walk(value, `${path}.${key}`);
+      }
+    })(save, "StockMarketSave");
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/jest/StockMarket/StockTickerHeaderText.test.tsx
+++ b/test/jest/StockMarket/StockTickerHeaderText.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Drift guard for the collapsed row's chart sizing. The row chart pads itself by the forecast
+ * characters its row is missing, computed from forecastLength/maxForecastLength - so those two
+ * must agree exactly with the +/- run the header actually prints, across the whole otlkMag range
+ * the market can produce (Stock.cycleForecast clamps it to 50). If they ever disagree, the list's
+ * all-or-none chart behavior quietly goes ragged instead of failing anywhere visible.
+ */
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Player } from "@player";
+import { StockSymbol } from "../../../src/Enums";
+import { Stock } from "../../../src/StockMarket/Stock";
+import {
+  deleteStockMarket,
+  initStockMarket,
+  initSymbolToStockMap,
+  SymbolToStockMap,
+} from "../../../src/StockMarket/StockMarket";
+import {
+  forecastLength,
+  maxForecastLength,
+  StockTickerHeaderText,
+} from "../../../src/StockMarket/ui/StockTickerHeaderText";
+import { FormatsNeedToChange } from "../../../src/ui/formatNumber";
+
+function trailingForecastRun(stock: Stock): string {
+  const container = document.createElement("div");
+  container.innerHTML = renderToStaticMarkup(<StockTickerHeaderText stock={stock} />);
+  const text = container.textContent ?? "";
+  return /([+-]+)$/.exec(text)?.[1] ?? "";
+}
+
+describe("stock ticker header forecast run", () => {
+  let stock: Stock;
+
+  beforeAll(() => {
+    FormatsNeedToChange.emit();
+    initStockMarket();
+    initSymbolToStockMap();
+    Player.has4SData = true;
+    stock = SymbolToStockMap[Object.values(StockSymbol)[0]];
+  });
+
+  afterAll(() => {
+    Player.has4SData = false;
+    deleteStockMarket();
+  });
+
+  it("matches forecastLength and stays within maxForecastLength across the otlkMag range", () => {
+    // Whole and fractional magnitudes on both sides of every 10-boundary, both directions.
+    for (let otlkMag = 0; otlkMag <= 50; otlkMag += 0.5) {
+      for (const b of [true, false]) {
+        stock.otlkMag = otlkMag;
+        stock.b = b;
+        const run = trailingForecastRun(stock);
+        expect(run.length).toBe(forecastLength(stock));
+        expect(run.length).toBeLessThanOrEqual(maxForecastLength);
+        // The run is one repeated character; direction comes from b and the magnitude's sign.
+        expect(run).toBe(run[0].repeat(run.length));
+      }
+    }
+  });
+
+  it("can never outgrow the header column, because cycleForecast clamps otlkMag", () => {
+    stock.otlkMag = 49;
+    stock.b = true;
+    // cycleForecast branches on RNG internally, but the clamp at the end is unconditional - so
+    // hammer it with huge swings and require the invariant to hold every time.
+    for (let i = 0; i < 200; ++i) {
+      stock.cycleForecast(500);
+      expect(stock.otlkMag).toBeGreaterThanOrEqual(0);
+      expect(stock.otlkMag).toBeLessThanOrEqual(50);
+      expect(forecastLength(stock)).toBeLessThanOrEqual(maxForecastLength);
+      expect(trailingForecastRun(stock)).toHaveLength(forecastLength(stock));
+    }
+  });
+});

--- a/test/jest/ui/Candlesticks.test.tsx
+++ b/test/jest/ui/Candlesticks.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The candlestick renderer's aggregation and placement rules: OHLC per bucket, bucket boundaries
+ * keyed by absolute tick index (offset), per-candle up/down coloring, right-edge clamping, and the
+ * per-candle (not per-pixel) fade. Assertions parse the emitted SVG markup - the recipe this
+ * container allows in place of a browser.
+ */
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Candlesticks } from "../../../src/ui/React/Candlesticks";
+import { sparklineGeometry } from "../../../src/ui/React/Sparkline";
+
+/** Every `<tag ...>` occurrence in `markup`, as one attribute record per element. */
+function elements(markup: string, tag: string): Record<string, string>[] {
+  const out: Record<string, string>[] = [];
+  for (const match of markup.matchAll(new RegExp(`<${tag} ([^>]*?)/?>`, "g"))) {
+    const attrs: Record<string, string> = {};
+    for (const attr of match[1].matchAll(/([\w-]+)="([^"]*)"/g)) attrs[attr[1]] = attr[2];
+    out.push(attrs);
+  }
+  return out;
+}
+
+// 12 ticks at offset 3 with interval 5 span absolute indices 3..14, i.e. buckets [3,4] [5..9]
+// [10..14]: a 2-tick partial first candle, then two complete ones.
+const data = [10, 12, 11, 14, 13, 9, 8, 15, 16, 12, 11, 20];
+const interval = 5;
+const offset = 3;
+const capacity = 24;
+
+function render(extra?: Partial<React.ComponentProps<typeof Candlesticks>>): string {
+  return renderToStaticMarkup(
+    <Candlesticks
+      data={data}
+      interval={interval}
+      offset={offset}
+      capacity={capacity}
+      upColor="UP"
+      downColor="DOWN"
+      {...extra}
+    />,
+  );
+}
+
+describe("Candlesticks", () => {
+  it("renders nothing for series it cannot draw meaningfully", () => {
+    expect(renderToStaticMarkup(<Candlesticks data={[]} interval={5} />)).toBe("");
+    expect(renderToStaticMarkup(<Candlesticks data={[5]} interval={5} />)).toBe("");
+    expect(renderToStaticMarkup(<Candlesticks data={[1, NaN, 3]} interval={5} />)).toBe("");
+  });
+
+  it("buckets by absolute tick index, so the offset shifts the boundaries", () => {
+    // Offset 3: ticks 0,1 complete bucket [3,4]; the first candle covers 2 ticks.
+    // Offset 0: ticks 0..4 form bucket [0..4]; the first candle covers 5 ticks and is wider.
+    const withOffset = elements(render(), "rect");
+    const withoutOffset = elements(render({ offset: 0 }), "rect");
+    expect(withOffset).toHaveLength(3);
+    expect(withoutOffset).toHaveLength(3);
+    expect(Number(withOffset[0].width)).toBeLessThan(Number(withoutOffset[0].width));
+  });
+
+  it("computes OHLC per bucket and colors each candle by its own direction", () => {
+    // [10,12] rises; [11,14,13,9,8] opens 11 closes 8; [15,16,12,11,20] opens 15 closes 20.
+    const fills = elements(render(), "rect").map((rect) => rect.fill);
+    expect(fills).toEqual(["UP", "DOWN", "UP"]);
+
+    // Wick ends sit at the bucket's high and low on the shared vertical scale.
+    const { yOf } = sparklineGeometry(data, capacity);
+    const wicks = elements(render(), "line");
+    expect(Number(wicks[1].y1)).toBeCloseTo(yOf(14));
+    expect(Number(wicks[1].y2)).toBeCloseTo(yOf(8));
+    // Body spans open to close, top edge first.
+    const bodies = elements(render(), "rect");
+    expect(Number(bodies[1].y)).toBeCloseTo(yOf(11));
+    expect(Number(bodies[1].y) + Number(bodies[1].height)).toBeCloseTo(yOf(8));
+  });
+
+  it("keeps the newest candle inside the right edge", () => {
+    for (const rect of elements(render(), "rect")) {
+      expect(Number(rect.x) + Number(rect.width)).toBeLessThanOrEqual(1000 + 1e-6);
+    }
+  });
+
+  it("fades per candle - uniform within each body, no gradients, newest at full strength", () => {
+    const html = render({ fadeIn: 0.5 });
+    expect(html).not.toContain("linearGradient");
+    const opacities = elements(html, "g").map((group) => Number(group.opacity));
+    expect(opacities).toHaveLength(3);
+    // Monotonically stronger toward the newest candle, which is fully opaque.
+    expect(opacities[0]).toBeLessThan(opacities[1]);
+    expect(opacities[1]).toBeLessThanOrEqual(opacities[2]);
+    expect(opacities[2]).toBe(1);
+  });
+
+  it("treats a nonsense interval as one tick per candle", () => {
+    const rects = elements(render({ interval: 0, offset: 0 }), "rect");
+    expect(rects).toHaveLength(data.length);
+  });
+
+  it("marks the hovered tick with a rule dimmed like its candle", () => {
+    const { xOf } = sparklineGeometry(data, capacity);
+    // Tick 4 falls in the middle (DOWN) bucket.
+    const wicksAndRule = elements(render({ highlightIndex: 4 }), "line");
+    const rule = wicksAndRule.find((line) => line["stroke-opacity"] !== undefined);
+    expect(rule).toBeDefined();
+    expect(Number(rule?.x1)).toBeCloseTo(xOf(4));
+    expect(rule?.stroke).toBe("DOWN");
+  });
+});

--- a/test/jest/ui/Sparkline.test.tsx
+++ b/test/jest/ui/Sparkline.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The geometry contract every stock chart renderer draws against, plus Sparkline's own bail-outs.
+ * Coordinates are asserted from the math, not from the component, so a regression in the geometry
+ * cannot hide behind a matching regression in the renderer.
+ */
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Sparkline, sparklineGeometry } from "../../../src/ui/React/Sparkline";
+
+// The nominal viewBox the geometry maps into. Restated here so a change to the coordinate space
+// fails loudly instead of silently rescaling every assertion below.
+const viewWidth = 1000;
+const viewHeight = 100;
+const verticalInset = 4;
+
+describe("sparklineGeometry", () => {
+  it("exposes the coordinate space it maps into", () => {
+    const geometry = sparklineGeometry([1, 2]);
+    expect(geometry.viewWidth).toBe(viewWidth);
+    expect(geometry.viewHeight).toBe(viewHeight);
+  });
+
+  it("anchors a short series to the right edge on a fixed time axis", () => {
+    // 3 points against a 10-point axis: the newest sits on the right edge, the others one fixed
+    // step apart, and the left ~three quarters of the width stays empty.
+    const { xOf, step } = sparklineGeometry([10, 20, 30], 10);
+    expect(step).toBeCloseTo(viewWidth / 9);
+    expect(xOf(2)).toBe(viewWidth);
+    expect(xOf(1)).toBeCloseTo(viewWidth - viewWidth / 9);
+    expect(xOf(0)).toBeCloseTo(viewWidth - 2 * (viewWidth / 9));
+  });
+
+  it("falls back to filling the width when the series outgrows its capacity", () => {
+    // 5 points on a 3-point axis must not be squeezed: the axis widens to fit them.
+    const { xOf, step } = sparklineGeometry([1, 2, 3, 4, 5], 3);
+    expect(step).toBeCloseTo(viewWidth / 4);
+    expect(xOf(0)).toBeCloseTo(0);
+    expect(xOf(4)).toBe(viewWidth);
+  });
+
+  it("normalizes values into the inset vertical range", () => {
+    const { yOf } = sparklineGeometry([10, 20, 30]);
+    expect(yOf(10)).toBeCloseTo(viewHeight - verticalInset); // min at the bottom
+    expect(yOf(30)).toBeCloseTo(verticalInset); // max at the top
+    expect(yOf(20)).toBeCloseTo(viewHeight / 2);
+  });
+
+  it("centers a flat series instead of dividing by zero", () => {
+    const { yOf, min, max } = sparklineGeometry([7, 7, 7]);
+    expect(min).toBe(7);
+    expect(max).toBe(7);
+    expect(yOf(7)).toBe(viewHeight / 2);
+  });
+
+  it("clamps indexAtFraction at both ends", () => {
+    const { indexAtFraction, xOf } = sparklineGeometry([10, 20, 30], 10);
+    // Left of where the series starts: clamps to the oldest point rather than going negative.
+    expect(indexAtFraction(0)).toBe(0);
+    // Right edge: the newest point, never past it.
+    expect(indexAtFraction(1)).toBe(2);
+    // On a point exactly: that point.
+    expect(indexAtFraction(xOf(1) / viewWidth)).toBe(1);
+  });
+
+  it("maps fractions to the nearest index when the series fills the width", () => {
+    const { indexAtFraction } = sparklineGeometry([1, 2, 3, 4, 5]);
+    expect(indexAtFraction(0)).toBe(0);
+    expect(indexAtFraction(0.5)).toBe(2);
+    expect(indexAtFraction(1)).toBe(4);
+  });
+
+  it("degrades to a single right-anchored point without NaN", () => {
+    const { xOf, yOf, indexAtFraction, step } = sparklineGeometry([5]);
+    expect(step).toBe(0);
+    expect(xOf(0)).toBe(viewWidth);
+    expect(yOf(5)).toBe(viewHeight / 2);
+    expect(indexAtFraction(0.37)).toBe(0);
+  });
+});
+
+describe("Sparkline", () => {
+  it("renders nothing for series it cannot draw meaningfully", () => {
+    expect(renderToStaticMarkup(<Sparkline data={[]} />)).toBe("");
+    expect(renderToStaticMarkup(<Sparkline data={[5]} />)).toBe("");
+    expect(renderToStaticMarkup(<Sparkline data={[1, NaN, 3]} />)).toBe("");
+    expect(renderToStaticMarkup(<Sparkline data={[1, Infinity]} />)).toBe("");
+  });
+
+  it("draws the series at the geometry's coordinates", () => {
+    const data = [10, 30];
+    const { xOf, yOf } = sparklineGeometry(data, 4);
+    const html = renderToStaticMarkup(<Sparkline data={data} capacity={4} color="LINE" />);
+    const expectedPoints = data.map((value, index) => `${xOf(index).toFixed(2)},${yOf(value).toFixed(2)}`).join(" ");
+    expect(html).toContain(`points="${expectedPoints}"`);
+    expect(html).toContain('stroke="LINE"');
+    expect(html).not.toContain("linearGradient");
+  });
+
+  it("paints through a gradient when fading in, including the hover cursor", () => {
+    const data = [10, 20, 30];
+    const { xOf } = sparklineGeometry(data);
+    const html = renderToStaticMarkup(<Sparkline data={data} color="LINE" fadeIn={0.4} highlightIndex={1} />);
+    expect(html).toContain("linearGradient");
+    // Both the polyline and the cursor rule take the gradient paint, so they fade together.
+    expect(html.match(/stroke="url\(#/g)).toHaveLength(2);
+    expect(html).toContain(`x1="${xOf(1)}"`);
+  });
+});


### PR DESCRIPTION
Adds visual price history to the 4S Data Market Access upgrade

Linked issues: none

Quick preview
<img width="970" height="365" alt="image" src="https://github.com/user-attachments/assets/4258740d-7030-44fb-9f02-e245a642ff2f" />

# Documentation

New feature: Stock price history visual charts
  * **Requires 4S Market Data Access upgrade**
  * Stock price history is now recorded (in-memory only)
    *  _All price history is erased on game reload/exit, or after a max duration_
  * Expanded stock rows render a full chart
    * Mouse hover on expanded chart to see time-specific price detail
  * Collapsed stock rows render a compressed chart
    * Mouse hover on collapsed chart to see recent price detail

New options: _Interface > Stock Market price charts_
* Toggle price history
* Select chart type: Line or Candlestick 
* Price history duration, in minutes (default 15)
* Market ticks per candle (default 5)
* Toggle price chart preview in collapsed ticker rows

New options
<img width="1239" height="750" alt="image" src="https://github.com/user-attachments/assets/b99d5127-4e5f-4284-ad49-b910afb81e93" />

### More screenshots

Candlestick charts (preview option enabled)
<img width="1588" height="318" alt="image" src="https://github.com/user-attachments/assets/444cbd59-74d8-4809-a259-27521765306d" />

Candlestick charts (preview option disabled)
<img width="1588" height="412" alt="image" src="https://github.com/user-attachments/assets/8fbd9092-c672-4cf8-a08e-4901f5038aa7" />

Line charts (preview option enabled)
<img width="1588" height="317" alt="image" src="https://github.com/user-attachments/assets/3e9e65c1-977c-4461-8759-3061f52eb335" />

Line charts (preview option disabled)
<img width="1588" height="364" alt="image" src="https://github.com/user-attachments/assets/c6ab3dc8-b4b2-4c37-910c-c02ef0863ab2" />

Before purchasing `4S Market Data Access` upgrade
<img width="2558" height="1280" alt="image" src="https://github.com/user-attachments/assets/5340b825-50f1-4af1-8729-0bdca72cd508" />

After purchasing `4S Market Data Access` upgrade
<img width="2559" height="1280" alt="image" src="https://github.com/user-attachments/assets/55b537e9-c09d-45ca-930c-d4db6aa4ee6c" />

Compressed chart tooltip
<img width="1055" height="78" alt="image" src="https://github.com/user-attachments/assets/ade4b2e3-6efe-4cae-9684-62d726c85f41" />

### Non-obvious things that have been accommodated
* Jest
* Window resizing
* Themes
* Currency symbol

#### The provably resolved "memory leak" concern
Since recording a price point per stock per tick sounded risky for long-running sessions, the default test suite now carries a test that asserts total retained points stay exactly flat at symbols x maxHistoryLength (once the price history buffer fills)

The same test scales to a full 14-day run (~201k ticks) via `STOCK_SOAK=1 npx jest test/jest/StockMarket/PriceHistory.test.ts` - which passes.


BTW: `npm run format` and `npm run lint` were both run before pushing