### PR TITLE
FIX: Preserve script editor state when switching tabs

### DIFF
--- a/src/ScriptEditor/ui/Editor.tsx
+++ b/src/ScriptEditor/ui/Editor.tsx
@@ -44,13 +44,16 @@ export function Editor({ onMount, onChange, onUnmount }: EditorProps) {
      * monaco editor has a bug that makes function definitions appear as duplicate ones. For more information, please
      * check: https://github.com/microsoft/monaco-editor/issues/3580 and https://github.com/microsoft/monaco-editor/pull/4544.
      */
-    monaco.editor.createModel(
-      netscriptDefinitions.replace(/^export /gm, ""),
-      "typescript",
-      monaco.Uri.file("netscript.d.ts"),
-    );
-    monaco.editor.createModel(reactTypes, "typescript", monaco.Uri.file("react.d.ts"));
-    monaco.editor.createModel(reactDomTypes, "typescript", monaco.Uri.file("react-dom.d.ts"));
+    const createLibModel = (content: string, fileName: string) => {
+      const uri = monaco.Uri.file(fileName);
+      // These models are kept alive across unmounts, so only create them once.
+      const existingModel = monaco.editor.getModel(uri);
+      if (existingModel && !existingModel.isDisposed()) return;
+      monaco.editor.createModel(content, "typescript", uri);
+    };
+    createLibModel(netscriptDefinitions.replace(/^export /gm, ""), "netscript.d.ts");
+    createLibModel(reactTypes, "react.d.ts");
+    createLibModel(reactDomTypes, "react-dom.d.ts");
 
     // Initialize monaco editor
     editorRef.current = monaco.editor.create(containerDiv.current, {
@@ -82,7 +85,11 @@ export function Editor({ onMount, onChange, onUnmount }: EditorProps) {
     return () => {
       onUnmount();
       subscription.current?.dispose();
-      monaco.editor.getModels().forEach((model) => model.dispose());
+      /**
+       * Models are intentionally not disposed here. They hold the undo/redo stack of each open script and the extra
+       * libraries synced to the TypeScript worker; disposing them on every page switch would wipe that state and force
+       * a full re-typecheck. Models of closed scripts are disposed in onTabClose instead.
+       */
       editorRef.current?.dispose();
     };
     // this eslint ignore instruction can potentially cause unobvious bugs

--- a/src/ScriptEditor/ui/OpenScript.ts
+++ b/src/ScriptEditor/ui/OpenScript.ts
@@ -11,6 +11,8 @@ export class OpenScript {
   code: string;
   hostname: string;
   lastPosition: Position;
+  /** Editor view state (folded regions, scroll position, cursor). Restored when the editor shows this script again. */
+  lastViewState: editor.ICodeEditorViewState | null = null;
   model: ITextModel;
   vimMode: boolean;
   isTxt: boolean;

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -355,7 +355,10 @@ function Root(props: IProps): React.ReactElement {
     if (!currentScript || !editorRef.current) return;
     const currentPosition = editorRef.current.getPosition();
     if (currentPosition) currentScript.lastPosition = currentPosition;
-    currentScript.lastViewState = editorRef.current.saveViewState();
+    const viewState = editorRef.current.saveViewState();
+    // Restoring the word highlighter rejects a promise monaco never handles, and its highlights are recomputed anyway.
+    if (viewState) delete viewState.contributionsState["editor.contrib.wordHighlighter"];
+    currentScript.lastViewState = viewState;
   }
 
   /** Restore what saveViewState stored. Must be called after the editor's model was set to openScript's model. */

--- a/src/ScriptEditor/ui/ScriptEditorRoot.tsx
+++ b/src/ScriptEditor/ui/ScriptEditorRoot.tsx
@@ -66,6 +66,12 @@ let currentScript: OpenScript | null = null;
 function Root(props: IProps): React.ReactElement {
   const rerender = useRerender();
   const editorRef = useRef<IStandaloneCodeEditor | null>(null);
+  /**
+   * The editor's container is hidden (display: none) while currentScript is null, and focusing an element inside a
+   * hidden container does nothing. currentScript is not React state, so onMount can set it without the container
+   * becoming visible in the same render, which is why onMount requests focus instead of taking it directly.
+   */
+  const focusRequested = useRef(false);
 
   // This is the workaround for a bug in monaco-editor: https://github.com/microsoft/monaco-editor/issues/4455
   const removeOutlineOfEditor = useCallback(() => {
@@ -152,9 +158,8 @@ function Root(props: IProps): React.ReactElement {
           );
           /**
            * We use openScripts to store all opened files when the player opens them in the editor. When they edit code,
-           * the changed code is in openScripts, regardless of whether they save it. When the player switches from the
-           * editor tab to another tab, all models are disposed, so the next time they open the editor, this function
-           * will load imported scripts. However, if the player did not save their code, loaded scripts would not
+           * the changed code is in openScripts, regardless of whether they save it. This function loads imported
+           * scripts from the server. However, if the player did not save their code, loaded scripts would not
            * contain changed code. Therefore, for each loaded script, we need to check if it is in openScripts. If it
            * is, we use the script content in openScripts.
            */
@@ -345,6 +350,26 @@ function Root(props: IProps): React.ReactElement {
     debouncedCodeParsing(newCode);
   };
 
+  /** Save the cursor position and the view state (folded regions, scroll position) of the current script. */
+  function saveViewState(): void {
+    if (!currentScript || !editorRef.current) return;
+    const currentPosition = editorRef.current.getPosition();
+    if (currentPosition) currentScript.lastPosition = currentPosition;
+    currentScript.lastViewState = editorRef.current.saveViewState();
+  }
+
+  /** Restore what saveViewState stored. Must be called after the editor's model was set to openScript's model. */
+  function restoreViewState(openScript: OpenScript): void {
+    if (!editorRef.current) return;
+    if (openScript.lastViewState) {
+      // The view state contains the cursor position, so there is no need to restore it separately.
+      editorRef.current.restoreViewState(openScript.lastViewState);
+      return;
+    }
+    editorRef.current.setPosition(openScript.lastPosition);
+    editorRef.current.revealLineInCenter(openScript.lastPosition.lineNumber);
+  }
+
   // When the editor is mounted
   function onMount(editor: IStandaloneCodeEditor): void {
     // Required when switching between site navigation (e.g. from Script Editor -> Terminal and back)
@@ -355,10 +380,9 @@ function Root(props: IProps): React.ReactElement {
     if (props.files.size === 0 && currentScript !== null) {
       currentScript.regenerateModel();
       editorRef.current.setModel(currentScript.model);
-      editorRef.current.setPosition(currentScript.lastPosition);
-      editorRef.current.revealLineInCenter(currentScript.lastPosition.lineNumber);
+      restoreViewState(currentScript);
       parseCode(currentScript.code);
-      editorRef.current.focus();
+      focusRequested.current = true;
       return;
     }
 
@@ -374,8 +398,7 @@ function Root(props: IProps): React.ReactElement {
 
         currentScript = openScript;
         editorRef.current.setModel(openScript.model);
-        editorRef.current.setPosition(openScript.lastPosition);
-        editorRef.current.revealLineInCenter(openScript.lastPosition.lineNumber);
+        restoreViewState(openScript);
         parseCode(openScript.code);
       } else {
         // Open script
@@ -394,7 +417,7 @@ function Root(props: IProps): React.ReactElement {
       }
     }
 
-    editorRef.current.focus();
+    focusRequested.current = true;
   }
 
   // When the code is updated within the editor
@@ -418,11 +441,7 @@ function Root(props: IProps): React.ReactElement {
 
   function onTabClick(index: number): void {
     if (currentScript !== null) {
-      // Save the current position of the cursor.
-      const currentPosition = editorRef.current?.getPosition();
-      if (currentPosition) {
-        currentScript.lastPosition = currentPosition;
-      }
+      saveViewState();
       // Save currentScript to openScripts
       const curIndex = currentTabIndex();
       if (curIndex !== undefined) {
@@ -437,8 +456,7 @@ function Root(props: IProps): React.ReactElement {
         currentScript.regenerateModel();
       }
       editorRef.current.setModel(currentScript.model);
-      editorRef.current.setPosition(currentScript.lastPosition);
-      editorRef.current.revealLineInCenter(currentScript.lastPosition.lineNumber);
+      restoreViewState(currentScript);
       parseCode(currentScript.code);
       editorRef.current.focus();
     }
@@ -463,7 +481,7 @@ function Root(props: IProps): React.ReactElement {
         },
       });
     }
-    //unmounting the editor will dispose all, doesnt hurt to dispose on close aswell
+    // Models outlive the editor, so closing a tab is what releases the model of that script.
     closingScript.model.dispose();
     openScripts.splice(index, 1);
     if (openScripts.length === 0) {
@@ -482,8 +500,7 @@ function Root(props: IProps): React.ReactElement {
           currentScript.regenerateModel();
         }
         editorRef.current.setModel(currentScript.model);
-        editorRef.current.setPosition(currentScript.lastPosition);
-        editorRef.current.revealLineInCenter(currentScript.lastPosition.lineNumber);
+        restoreViewState(currentScript);
         parseCode(currentScript.code);
         editorRef.current.focus();
       }
@@ -549,14 +566,7 @@ function Root(props: IProps): React.ReactElement {
   }
 
   function onUnmountEditor() {
-    if (!currentScript) {
-      return;
-    }
-    // Save the current position of the cursor.
-    const currentPosition = editorRef.current?.getPosition();
-    if (currentPosition) {
-      currentScript.lastPosition = currentPosition;
-    }
+    saveViewState();
   }
 
   const { statusBarRef } = useVimEditor({
@@ -576,6 +586,14 @@ function Root(props: IProps): React.ReactElement {
     // disable eslint because we want to run this only once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Take the focus requested by onMount. This runs after every render on purpose: the render that mounts the editor
+  // may still have the container hidden, in which case focusing does nothing and we retry once it becomes visible.
+  useEffect(() => {
+    if (!focusRequested.current || !editorRef.current) return;
+    editorRef.current.focus();
+    if (editorRef.current.hasTextFocus()) focusRequested.current = false;
+  });
 
   return (
     <>


### PR DESCRIPTION
Leaving the Script Editor for another tab and coming back used to reset the editor. This PR fixes several symptoms that come from the same bug, plus a semi-related focus issue.

### What was wrong

Undo/redo history in Script Editor was wiped after switching tabs in-game.
Collapsed (folded) code sections sprang back open.

### Why

Switching tabs fully unmounts the editor, and its cleanup disposed every Monaco model - both the open scripts and the ~380 KB of type definitions for the ns API and React. All that state lives in the models, so the next visit started from scratch and the type definitions had to be re-parsed from nothing.

The models were being disposed because the type definitions were re-created unconditionally on mount, and Monaco refuses to create a model for a file it already knows about. Clearing everything on the way out kept that from erroring.

### The fix

The type definitions are now created once and reused, so there's no longer a reason to throw the models away. Cleanup disposes only the editor itself; the models for open scripts stay alive until their tab is closed, which already disposed them.

Folding needed one more piece: it lives in the editor's view state, and only the cursor position was being saved. Each open script now remembers its full view state, so folds survive switching pages and switching between script tabs - the latter was broken too.

#### Bonus fixes

The first script opened in a session didn't get the text cursor; you had to click into the editor before typing. The editor is created inside a hidden container on that first open, and focusing something hidden does nothing. Focus is now applied once the editor is actually visible.

Using Script Editor to open files with JSDoc comments causes JSDoc-related errors to appear _briefly_ before they're resolved within ~1-2 seconds. This behavior remains, but now it's reduced because JSDoc is not being loaded every time the Script Editor is opened.

### Testing

Manually: fold a region and type in a script, switch to Terminal and back - folds, undo history, and cursor position are intact. nano a script on a fresh page load - the cursor is live immediately.

"BEFORE" - Script Editor behavior in Dev

<img alt="before" src="https://github.com/user-attachments/assets/98693656-c132-4d65-b0b0-00b9e6313eee" />

"AFTER" - Script Editor behavior in this PR

<img alt="after" src="https://github.com/user-attachments/assets/f32b792c-c5bf-4b48-b707-85e54f0a1a77" />