### PR TITLE
CODEBASE: Use population helper functions in random Bladeburner events

### DIFF
--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -579,8 +579,8 @@ export class Bladeburner implements OperationTeam {
       ++destCity.comms;
     }
     const count = Math.round(sourceCity.pop * percentage);
-    sourceCity.pop -= count;
-    destCity.pop += count;
+    sourceCity.changePopulationByCount(-count);
+    destCity.changePopulationByCount(count);
     if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
       destCity.pop += BladeburnerConstants.BasePopGrowth;
     }
@@ -615,7 +615,7 @@ export class Bladeburner implements OperationTeam {
       ++sourceCity.comms;
       const percentage = getRandomIntInclusive(10, 20) / 100;
       const count = Math.round(sourceCity.pop * percentage);
-      sourceCity.pop += count;
+      sourceCity.changePopulationByCount(count);
       if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
         sourceCity.pop += BladeburnerConstants.BasePopGrowth;
       }
@@ -629,7 +629,7 @@ export class Bladeburner implements OperationTeam {
         ++sourceCity.comms;
         const percentage = getRandomIntInclusive(10, 20) / 100;
         const count = Math.round(sourceCity.pop * percentage);
-        sourceCity.pop += count;
+        sourceCity.changePopulationByCount(count);
         if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
           sourceCity.pop += BladeburnerConstants.BasePopGrowth;
         }
@@ -643,8 +643,8 @@ export class Bladeburner implements OperationTeam {
         // Change pop
         const percentage = getRandomIntInclusive(10, 20) / 100;
         const count = Math.round(sourceCity.pop * percentage);
-        sourceCity.pop -= count;
-        destCity.pop += count;
+        sourceCity.changePopulationByCount(-count);
+        destCity.changePopulationByCount(count);
         if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
           destCity.pop += BladeburnerConstants.BasePopGrowth;
         }
@@ -658,7 +658,7 @@ export class Bladeburner implements OperationTeam {
       // New Synthoids (non community), 20%
       const percentage = getRandomIntInclusive(8, 24) / 100;
       const count = Math.round(sourceCity.pop * percentage);
-      sourceCity.pop += count;
+      sourceCity.changePopulationByCount(count);
       if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
         sourceCity.pop += BladeburnerConstants.BasePopGrowth;
       }
@@ -688,7 +688,7 @@ export class Bladeburner implements OperationTeam {
       // Less Synthoids, 20%
       const percentage = getRandomIntInclusive(8, 20) / 100;
       const count = Math.round(sourceCity.pop * percentage);
-      sourceCity.pop -= count;
+      sourceCity.changePopulationByCount(-count);
       if (this.logging.events) {
         this.log(
           "Intelligence indicates that the Synthoid population of " + sourceCityName + " just changed significantly",

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -578,9 +578,15 @@ export class Bladeburner implements OperationTeam {
       --sourceCity.comms;
       ++destCity.comms;
     }
-    const count = Math.round(sourceCity.pop * percentage);
-    sourceCity.pop -= count;
-    destCity.pop += count;
+    // community based population changes logically require a non-zero population change
+    sourceCity.changePopulationByPercentage(-percentage, {
+      nonZero: true,
+      changeEstEqually: false,
+    });
+    destCity.changePopulationByPercentage(percentage, {
+      nonZero: true,
+      changeEstEqually: false,
+    });
     if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
       destCity.pop += BladeburnerConstants.BasePopGrowth;
     }
@@ -614,8 +620,10 @@ export class Bladeburner implements OperationTeam {
       // New Synthoid Community, 5%
       ++sourceCity.comms;
       const percentage = getRandomIntInclusive(10, 20) / 100;
-      const count = Math.round(sourceCity.pop * percentage);
-      sourceCity.pop += count;
+      sourceCity.changePopulationByPercentage(percentage, {
+        nonZero: true,
+        changeEstEqually: false,
+      });
       if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
         sourceCity.pop += BladeburnerConstants.BasePopGrowth;
       }
@@ -628,8 +636,10 @@ export class Bladeburner implements OperationTeam {
         // If no comms in source city, then instead trigger a new Synthoid community event
         ++sourceCity.comms;
         const percentage = getRandomIntInclusive(10, 20) / 100;
-        const count = Math.round(sourceCity.pop * percentage);
-        sourceCity.pop += count;
+        sourceCity.changePopulationByPercentage(percentage, {
+          nonZero: true,
+          changeEstEqually: false,
+        });
         if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
           sourceCity.pop += BladeburnerConstants.BasePopGrowth;
         }
@@ -642,9 +652,14 @@ export class Bladeburner implements OperationTeam {
 
         // Change pop
         const percentage = getRandomIntInclusive(10, 20) / 100;
-        const count = Math.round(sourceCity.pop * percentage);
-        sourceCity.pop -= count;
-        destCity.pop += count;
+        sourceCity.changePopulationByPercentage(-percentage, {
+          nonZero: true,
+          changeEstEqually: false,
+        });
+        destCity.changePopulationByPercentage(percentage, {
+          nonZero: true,
+          changeEstEqually: false,
+        });
         if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
           destCity.pop += BladeburnerConstants.BasePopGrowth;
         }
@@ -657,8 +672,8 @@ export class Bladeburner implements OperationTeam {
     } else if (chance <= 0.3) {
       // New Synthoids (non community), 20%
       const percentage = getRandomIntInclusive(8, 24) / 100;
-      const count = Math.round(sourceCity.pop * percentage);
-      sourceCity.pop += count;
+      // Non-community based population changes may be zero
+      sourceCity.changePopulationByPercentage(percentage);
       if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
         sourceCity.pop += BladeburnerConstants.BasePopGrowth;
       }
@@ -687,8 +702,7 @@ export class Bladeburner implements OperationTeam {
     } else if (chance <= 0.9) {
       // Less Synthoids, 20%
       const percentage = getRandomIntInclusive(8, 20) / 100;
-      const count = Math.round(sourceCity.pop * percentage);
-      sourceCity.pop -= count;
+      sourceCity.changePopulationByPercentage(-percentage);
       if (this.logging.events) {
         this.log(
           "Intelligence indicates that the Synthoid population of " + sourceCityName + " just changed significantly",

--- a/src/Bladeburner/Bladeburner.ts
+++ b/src/Bladeburner/Bladeburner.ts
@@ -578,15 +578,9 @@ export class Bladeburner implements OperationTeam {
       --sourceCity.comms;
       ++destCity.comms;
     }
-    // community based population changes logically require a non-zero population change
-    sourceCity.changePopulationByPercentage(-percentage, {
-      nonZero: true,
-      changeEstEqually: false,
-    });
-    destCity.changePopulationByPercentage(percentage, {
-      nonZero: true,
-      changeEstEqually: false,
-    });
+    const count = Math.round(sourceCity.pop * percentage);
+    sourceCity.pop -= count;
+    destCity.pop += count;
     if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
       destCity.pop += BladeburnerConstants.BasePopGrowth;
     }
@@ -620,10 +614,8 @@ export class Bladeburner implements OperationTeam {
       // New Synthoid Community, 5%
       ++sourceCity.comms;
       const percentage = getRandomIntInclusive(10, 20) / 100;
-      sourceCity.changePopulationByPercentage(percentage, {
-        nonZero: true,
-        changeEstEqually: false,
-      });
+      const count = Math.round(sourceCity.pop * percentage);
+      sourceCity.pop += count;
       if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
         sourceCity.pop += BladeburnerConstants.BasePopGrowth;
       }
@@ -636,10 +628,8 @@ export class Bladeburner implements OperationTeam {
         // If no comms in source city, then instead trigger a new Synthoid community event
         ++sourceCity.comms;
         const percentage = getRandomIntInclusive(10, 20) / 100;
-        sourceCity.changePopulationByPercentage(percentage, {
-          nonZero: true,
-          changeEstEqually: false,
-        });
+        const count = Math.round(sourceCity.pop * percentage);
+        sourceCity.pop += count;
         if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
           sourceCity.pop += BladeburnerConstants.BasePopGrowth;
         }
@@ -652,14 +642,9 @@ export class Bladeburner implements OperationTeam {
 
         // Change pop
         const percentage = getRandomIntInclusive(10, 20) / 100;
-        sourceCity.changePopulationByPercentage(-percentage, {
-          nonZero: true,
-          changeEstEqually: false,
-        });
-        destCity.changePopulationByPercentage(percentage, {
-          nonZero: true,
-          changeEstEqually: false,
-        });
+        const count = Math.round(sourceCity.pop * percentage);
+        sourceCity.pop -= count;
+        destCity.pop += count;
         if (destCity.pop < BladeburnerConstants.PopGrowthCeiling) {
           destCity.pop += BladeburnerConstants.BasePopGrowth;
         }
@@ -672,8 +657,8 @@ export class Bladeburner implements OperationTeam {
     } else if (chance <= 0.3) {
       // New Synthoids (non community), 20%
       const percentage = getRandomIntInclusive(8, 24) / 100;
-      // Non-community based population changes may be zero
-      sourceCity.changePopulationByPercentage(percentage);
+      const count = Math.round(sourceCity.pop * percentage);
+      sourceCity.pop += count;
       if (sourceCity.pop < BladeburnerConstants.PopGrowthCeiling) {
         sourceCity.pop += BladeburnerConstants.BasePopGrowth;
       }
@@ -702,7 +687,8 @@ export class Bladeburner implements OperationTeam {
     } else if (chance <= 0.9) {
       // Less Synthoids, 20%
       const percentage = getRandomIntInclusive(8, 20) / 100;
-      sourceCity.changePopulationByPercentage(-percentage);
+      const count = Math.round(sourceCity.pop * percentage);
+      sourceCity.pop -= count;
       if (this.logging.events) {
         this.log(
           "Intelligence indicates that the Synthoid population of " + sourceCityName + " just changed significantly",


### PR DESCRIPTION
closes #2994 
Potentially avoids exceeding MAX_SAFE_INTEGER in niche situations, also looks cleaner and is more consistent.

Tested by sitting and watching numbers go up and down for a while of bonus time; I've never seen the MAX_SAFE_INTEGER issue come up in dev or normal play, but this appears to behave as before for the typical ranges of population.

If there's a better way to test this I'm down!