### PR TITLE
DNET: add lab depth and migration progress

### DIFF
--- a/markdown/bitburner.darknet.induceservermigration.md
+++ b/markdown/bitburner.darknet.induceservermigration.md
@@ -11,7 +11,7 @@ Effect scales with threads and charisma level.
 **Signature:**
 
 ```typescript
-induceServerMigration(host: string): Promise<DarknetResult>;
+induceServerMigration(host: string): Promise<DarknetResult & { progress?: number }>;
 ```
 
 ## Parameters
@@ -52,9 +52,9 @@ Hostname/IP of the connected server to migrate.
 
 **Returns:**
 
-Promise&lt;[DarknetResult](./bitburner.darknetresult.md)<!-- -->&gt;
+Promise&lt;[DarknetResult](./bitburner.darknetresult.md) &amp; { progress?: number }&gt;
 
-A promise that resolves to a [DarknetResult](./bitburner.darknetresult.md) object.
+A promise that resolves to a [DarknetResult](./bitburner.darknetresult.md) object with an additional `progress` field indicating the migration progress between 0 and 1.
 
 ## Remarks
 

--- a/markdown/bitburner.darknet.induceservermigration.md
+++ b/markdown/bitburner.darknet.induceservermigration.md
@@ -11,7 +11,7 @@ Effect scales with threads and charisma level.
 **Signature:**
 
 ```typescript
-induceServerMigration(host: string): Promise<DarknetResult & { progress?: number }>;
+induceServerMigration(host: string): Promise<DarknetResult & { progress: number }>;
 ```
 
 ## Parameters
@@ -52,9 +52,9 @@ Hostname/IP of the connected server to migrate.
 
 **Returns:**
 
-Promise&lt;[DarknetResult](./bitburner.darknetresult.md) &amp; { progress?: number }&gt;
+Promise&lt;[DarknetResult](./bitburner.darknetresult.md) &amp; { progress: number }&gt;
 
-A promise that resolves to a [DarknetResult](./bitburner.darknetresult.md) object with an additional `progress` field indicating the migration progress between 0 and 1.
+A promise that resolves to a [DarknetResult](./bitburner.darknetresult.md) object with a `progress` field indicating the total migration progress in the range \[0, 1\].
 
 ## Remarks
 

--- a/src/DarkNet/controllers/NetworkGenerator.ts
+++ b/src/DarkNet/controllers/NetworkGenerator.ts
@@ -247,7 +247,8 @@ export const addLabyrinth = () => {
     isStationary: true,
   };
 
-  for (const hostname of getLabyrinthServerNames()) {
+  const hostname = getLabyrinthDetails().name;
+  if (hostname) {
     const passwordSalt = Math.floor(Math.random() * 10000);
     const server = new DarknetServer({
       ...commonData,

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -337,7 +337,7 @@ export const addGuaranteedConnection = (server: DarknetServer): void => {
 export const validateDarknetNetwork = (): void => {
   const servers = getAllDarknetServers();
   // The darknet should have at least darkweb and labyrinth servers.
-  if (servers.length < getLabyrinthServerNames().length + 1) {
+  if (servers.length < 2) {
     exceptionAlert(new Error(`There are too few darknet servers. servers.length: ${servers.length}`), true);
   }
   for (const server of servers) {

--- a/src/DarkNet/controllers/NetworkMovement.ts
+++ b/src/DarkNet/controllers/NetworkMovement.ts
@@ -10,7 +10,7 @@ import { createDarknetServer } from "./ServerGenerator";
 import { addServerToNetwork, movePlayerIfNeeded } from "./NetworkGenerator";
 import { killServerScripts } from "../../Netscript/killWorkerScript";
 import { SpecialServers } from "../../Server/data/SpecialServers";
-import { getLabyrinthServerNames, getNetDepth, isLabyrinthServer } from "../effects/labyrinth";
+import { getNetDepth, isLabyrinthServer } from "../effects/labyrinth";
 import { LOW_LEVEL_SERVER_DENSITY, MAX_NET_DEPTH, NET_WIDTH, SERVER_DENSITY } from "../Enums";
 import {
   getAllAdjacentNeighbors,

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -26,6 +26,7 @@ import {
   getLabyrinthLocationReport,
   getSurroundingsVisualized,
   isLabyrinthServer,
+  labData,
 } from "../DarkNet/effects/labyrinth";
 import { getPhishingAttackSpeed, handlePhishingAttack } from "../DarkNet/effects/phishing";
 import { handleRamBlockRemoved } from "../DarkNet/effects/ramblock";
@@ -401,7 +402,9 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
       const localServer = ctx.workerScript.getServer();
       const isConnected = isDirectConnected(localServer, targetServer);
       const hasSession = isAuthenticated(targetServer, ctx.workerScript.pid);
-      const depth = isLabyrinthServer(targetServer.hostname) ? getLabyrinthDetails().depth : targetServer.depth;
+      const depth = isLabyrinthServer(targetServer.hostname)
+        ? labData[targetServer.hostname].depth
+        : targetServer.depth;
       return {
         isOnline: true,
         isConnectedToCurrentServer: isConnected,
@@ -419,8 +422,9 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
         isStationary: targetServer.isStationary,
       } satisfies ReturnType<DarknetAPI["getServerDetails"]>;
     },
-    induceServerMigration: (ctx, _host): Promise<DarknetResult & { progress?: number }> => {
+    induceServerMigration: (ctx, _host): Promise<DarknetResult & { progress: number }> => {
       const targetHost = helpers.string(ctx, "host", _host);
+      const currentProgress = DarknetState.migrationInductionServers.get(targetHost) ?? 0;
       const serverCheck = checkDarknetServer(ctx, targetHost, {
         requireDirectConnection: true,
         preventUseOnStationaryServers: true,
@@ -430,6 +434,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
           success: false,
           code: serverCheck.code,
           message: serverCheck.message,
+          progress: currentProgress,
         }));
       }
       const hostOfCurrentServer = !isIPAddress(targetHost)
@@ -442,6 +447,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
           success: false,
           code: ResponseCodeEnum.DirectConnectionRequired,
           message: message,
+          progress: currentProgress,
         }));
       }
       const server = serverCheck.server;
@@ -458,6 +464,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
             success: false,
             code: serverCheck.code,
             message: serverCheck.message,
+            progress: DarknetState.migrationInductionServers.get(targetHost) ?? 0,
           }));
         }
         const server = serverCheck.server;
@@ -710,7 +717,7 @@ export const getDarknetPropertiesForDeprecationSupport = (dnetServer: DarknetSer
   depth: {
     identifier: "ns.getServer().depth",
     message: "Use ns.dnet.getServerDetails().depth instead.",
-    value: dnetServer.depth,
+    value: isLabyrinthServer(dnetServer.hostname) ? labData[dnetServer.hostname].depth : dnetServer.depth,
   },
   modelId: {
     identifier: "ns.getServer().modelId",

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -401,6 +401,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
       const localServer = ctx.workerScript.getServer();
       const isConnected = isDirectConnected(localServer, targetServer);
       const hasSession = isAuthenticated(targetServer, ctx.workerScript.pid);
+      const depth = isLabyrinthServer(targetServer.hostname) ? getLabyrinthDetails().depth : targetServer.depth;
       return {
         isOnline: true,
         isConnectedToCurrentServer: isConnected,
@@ -414,11 +415,11 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
         blockedRam: targetServer.blockedRam,
         difficulty: targetServer.difficulty,
         requiredCharismaSkill: targetServer.requiredCharismaSkill,
-        depth: targetServer.depth,
+        depth: depth,
         isStationary: targetServer.isStationary,
       } satisfies ReturnType<DarknetAPI["getServerDetails"]>;
     },
-    induceServerMigration: (ctx, _host): Promise<DarknetResult> => {
+    induceServerMigration: (ctx, _host): Promise<DarknetResult & { progress?: number }> => {
       const targetHost = helpers.string(ctx, "host", _host);
       const serverCheck = checkDarknetServer(ctx, targetHost, {
         requireDirectConnection: true,
@@ -475,6 +476,7 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
           success: true,
           code: ResponseCodeEnum.Success,
           message: GenericResponseMessage.Success,
+          progress: result.newCharge,
         };
       });
     },

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4745,9 +4745,9 @@ export interface Darknet {
    * RAM cost: 4 GB
    *
    * @param host - Hostname/IP of the connected server to migrate.
-   * @returns A promise that resolves to a {@link DarknetResult} object with an additional `progress` field indicating the migration progress between 0 and 1.
+   * @returns A promise that resolves to a {@link DarknetResult} object with a `progress` field indicating the total migration progress in the range [0, 1].
    */
-  induceServerMigration(host: string): Promise<DarknetResult & { progress?: number }>;
+  induceServerMigration(host: string): Promise<DarknetResult & { progress: number }>;
 
   /**
    * Executes STORM_SEED.exe, if it is present on the server the script is running on.

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -4745,9 +4745,9 @@ export interface Darknet {
    * RAM cost: 4 GB
    *
    * @param host - Hostname/IP of the connected server to migrate.
-   * @returns A promise that resolves to a {@link DarknetResult} object.
+   * @returns A promise that resolves to a {@link DarknetResult} object with an additional `progress` field indicating the migration progress between 0 and 1.
    */
-  induceServerMigration(host: string): Promise<DarknetResult>;
+  induceServerMigration(host: string): Promise<DarknetResult & { progress?: number }>;
 
   /**
    * Executes STORM_SEED.exe, if it is present on the server the script is running on.

--- a/src/utils/APIBreaks/3.0.2.ts
+++ b/src/utils/APIBreaks/3.0.2.ts
@@ -17,5 +17,14 @@ export const breakingChanges302: VersionBreakingChange = {
         "Use ns.singularity.hasExportGameBonus() instead.",
       showWarning: false,
     },
+    {
+      brokenAPIs: [
+        {
+          name: "ns.dnet.getServerDetails",
+        },
+      ],
+      info: "ns.dnet.getServerDetails() now returns the visible depth of the darknet lab server, instead of -1.",
+      showWarning: true,
+    },
   ],
 };

--- a/src/utils/APIBreaks/3.0.2.ts
+++ b/src/utils/APIBreaks/3.0.2.ts
@@ -20,7 +20,7 @@ export const breakingChanges302: VersionBreakingChange = {
     {
       brokenAPIs: [
         {
-          name: "ns.dnet.getServerDetails",
+          name: "getServerDetails",
         },
       ],
       info: "ns.dnet.getServerDetails() now returns the visible depth of the darknet lab server, instead of -1.",

--- a/test/jest/Darknet/Labyrinth.test.ts
+++ b/test/jest/Darknet/Labyrinth.test.ts
@@ -10,11 +10,8 @@ import {
 import { initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
 import { getDarkscapeNavigator } from "../../../src/DarkNet/effects/effects";
 import { Player } from "@player";
-import { DarknetState } from "../../../src/DarkNet/models/DarknetState";
-import { populateDarknet } from "../../../src/DarkNet/controllers/NetworkGenerator";
+import { clearDarknet, populateDarknet } from "../../../src/DarkNet/controllers/NetworkGenerator";
 import { SpecialServers } from "../../../src/Server/data/SpecialServers";
-import { MAX_NET_DEPTH, NET_WIDTH } from "../../../src/DarkNet/Enums";
-import type { DarknetServer } from "../../../src/Server/DarknetServer";
 import { PlayerOwnedAugmentation } from "../../../src/Augmentation/PlayerOwnedAugmentation";
 import { AugmentationName } from "@enums";
 import { getAuthResult } from "../../../src/DarkNet/effects/authentication";
@@ -42,9 +39,7 @@ const setupBN15Environment = (labAugCount: number) => {
 
   Player.augmentations = augs.slice(0, labAugCount).map((aug) => new PlayerOwnedAugmentation(aug));
 
-  DarknetState.Network = new Array(MAX_NET_DEPTH)
-    .fill(null)
-    .map(() => new Array<DarknetServer | null>(NET_WIDTH).fill(null));
+  clearDarknet();
   populateDarknet();
 };
 
@@ -66,9 +61,7 @@ const setupNonBN15Environment = (labAugCount: number, hasSf15 = false, allowTRPI
     Player.augmentations.push(new PlayerOwnedAugmentation(augs[i]));
   }
 
-  DarknetState.Network = new Array(MAX_NET_DEPTH)
-    .fill(null)
-    .map(() => new Array<DarknetServer | null>(NET_WIDTH).fill(null));
+  clearDarknet();
   populateDarknet();
 };
 

--- a/test/jest/Darknet/Labyrinth.test.ts
+++ b/test/jest/Darknet/Labyrinth.test.ts
@@ -7,7 +7,7 @@ import {
   handleLabyrinthPassword,
   labData,
 } from "../../../src/DarkNet/effects/labyrinth";
-import { initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
+import { fixDoImportIssue, getNS, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
 import { getDarkscapeNavigator } from "../../../src/DarkNet/effects/effects";
 import { Player } from "@player";
 import { clearDarknet, populateDarknet } from "../../../src/DarkNet/controllers/NetworkGenerator";
@@ -16,6 +16,9 @@ import { PlayerOwnedAugmentation } from "../../../src/Augmentation/PlayerOwnedAu
 import { AugmentationName } from "@enums";
 import { getAuthResult } from "../../../src/DarkNet/effects/authentication";
 import { getMostRecentAuthLog } from "../../../src/DarkNet/models/packetSniffing";
+import { applyAugmentation } from "../../../src/Augmentation/AugmentationHelpers";
+
+fixDoImportIssue();
 
 beforeAll(() => {
   initGameEnvironment();
@@ -316,6 +319,43 @@ describe("Labyrinth Tests", () => {
       expect(labDetails.lab?.hostname).toEqual(SpecialServers.BonusLab);
       expect(labDetails.lab?.requiredCharismaSkill).toEqual(labData[SpecialServers.BonusLab].cha);
       expect(getLabAugReward()).toEqual(AugmentationName.NeuroFluxGovernor);
+    });
+  });
+
+  describe("current lab progression", () => {
+    it("should return the current lab's info via ns.dnet.getServerDetails", () => {
+      setupBN15Environment(0);
+      const currentLabName = getLabyrinthDetails().name;
+      expect(currentLabName).toEqual(SpecialServers.NormalLab);
+
+      const ns = getNS(SpecialServers.Home);
+      const serverDetails = ns.dnet.getServerDetails(currentLabName);
+
+      expect(serverDetails.isOnline).toBe(true);
+      expect(serverDetails.requiredCharismaSkill).toEqual(labData[SpecialServers.NormalLab].cha);
+      expect(serverDetails.depth).toEqual(labData[SpecialServers.NormalLab].depth);
+    });
+
+    it("should not return other lab's info via ns.dnet.getServerDetails", () => {
+      setupBN15Environment(0);
+      const currentLabName = getLabyrinthDetails().name;
+      expect(currentLabName).toEqual(SpecialServers.NormalLab);
+
+      const ns = getNS(SpecialServers.Home);
+      expect(() => ns.dnet.getServerDetails(SpecialServers.CruelLab)).toThrow("Invalid host: 'cru3l_l4byr1nth'");
+    });
+
+    it("should not change the current lab when queueing a lab aug, only when installing it", () => {
+      setupBN15Environment(0);
+      expect(getLabyrinthDetails().name).toEqual(SpecialServers.NormalLab);
+
+      const queuedAug = new PlayerOwnedAugmentation(AugmentationName.TheBrokenWings);
+      Player.queuedAugmentations.push(queuedAug);
+      expect(getLabyrinthDetails().name).toEqual(SpecialServers.NormalLab);
+
+      applyAugmentation(queuedAug);
+      Player.queuedAugmentations = [];
+      expect(getLabyrinthDetails().name).toEqual(SpecialServers.CruelLab);
     });
   });
 });


### PR DESCRIPTION
Player feedback tweaks to the values returned by dnet api methods:

- For dnet.getServerDetails(), return lab server depth as it appears in the UI, rather than its internal value of -1
- for dnet.induceServerMigration(), include the progress fraction in the response object, not just the script logging