### PR TITLE
UI: Consistently show relevant material data in warehouse's storage space tooltip

### DIFF
--- a/src/Corporation/ui/DivisionWarehouse.tsx
+++ b/src/Corporation/ui/DivisionWarehouse.tsx
@@ -23,6 +23,7 @@ import { useCorporation, useDivision } from "./Context";
 import { gameCyclesPerCorpStateCycle } from "../data/Constants";
 import { ButtonWithTooltip } from "../../ui/Components/ButtonWithTooltip";
 import { StatsTable } from "../../ui/React/StatsTable";
+import { getRecordKeys } from "../../Types/Record";
 
 interface WarehouseProps {
   corp: Corporation;
@@ -97,9 +98,13 @@ function WarehouseRoot(props: WarehouseProps): React.ReactElement {
   }
 
   const breakdownItems: string[][] = [];
-  for (const matName of corpConstants.materialNames) {
+  const relevantMaterials = new Set([
+    ...getRecordKeys(props.division.requiredMaterials),
+    ...props.division.producedMaterials,
+    ...corpConstants.boostMaterials,
+  ]);
+  for (const matName of relevantMaterials) {
     const mat = props.warehouse.materials[matName];
-    if (mat.stored === 0) continue;
     breakdownItems.push([
       `${matName}:`,
       `${formatMaterialSize(MaterialInfo[matName].size)}`,


### PR DESCRIPTION
Currently, we only show materials with stored units greater than 0. This makes the tooltip hard to read during bonus time. Instead of this approach, we should show a list of relevant materials in a consistent order.

In theory, warehouses could contain irrelevant materials because players were able to purchase them. However, this could only have happened a long time ago (before we merged #660), so it's not really a concern now.

Closes #3033.

Video:

https://github.com/user-attachments/assets/c057b73b-3a79-498e-a0f5-e5ae002a0e95
