### PR TITLE
BUGFIX: Preserve generated logs during authentication

### DIFF
--- a/src/DarkNet/models/packetSniffing.ts
+++ b/src/DarkNet/models/packetSniffing.ts
@@ -89,8 +89,8 @@ const getExactCharactersHint = (lastPassword: string, realPassword: string) => {
 
 export const logPasswordAttempt = (server: DarknetServer, passwordResponse: PasswordResponse, pid: number) => {
   const serverState = getServerState(server.hostname);
-  const serverLogs = serverState.serverLogs;
   populateServerLogsWithNoise(server);
+  const serverLogs = serverState.serverLogs;
 
   let message = passwordResponse;
 

--- a/test/jest/Darknet/PacketSniffing.test.ts
+++ b/test/jest/Darknet/PacketSniffing.test.ts
@@ -1,6 +1,7 @@
-import { getDefaultPasswordConfig, serverFactory } from "../../../src/DarkNet/controllers/ServerGenerator";
 import { getAuthResult } from "../../../src/DarkNet/effects/authentication";
 import { getServerState } from "../../../src/DarkNet/models/DarknetState";
+import { SpecialServers } from "../../../src/Server/data/SpecialServers";
+import { GetServerOrThrow } from "../../../src/Server/AllServers";
 import { initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
 
 beforeAll(() => {
@@ -18,7 +19,7 @@ afterEach(() => {
 test("authentication preserves generated server logs", () => {
   jest.spyOn(Math, "random").mockReturnValue(0.99);
 
-  const server = serverFactory(getDefaultPasswordConfig, 1, 0, 0);
+  const server = GetServerOrThrow(SpecialServers.DarkWeb);
   server.logTrafficInterval = 1;
 
   const serverState = getServerState(server.hostname);

--- a/test/jest/Darknet/PacketSniffing.test.ts
+++ b/test/jest/Darknet/PacketSniffing.test.ts
@@ -1,0 +1,31 @@
+import { getDefaultPasswordConfig, serverFactory } from "../../../src/DarkNet/controllers/ServerGenerator";
+import { getAuthResult } from "../../../src/DarkNet/effects/authentication";
+import { getServerState } from "../../../src/DarkNet/models/DarknetState";
+import { initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
+
+beforeAll(() => {
+  initGameEnvironment();
+});
+
+beforeEach(() => {
+  setupBasicTestingEnvironment();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test("authentication preserves generated server logs", () => {
+  jest.spyOn(Math, "random").mockReturnValue(0.99);
+
+  const server = serverFactory(getDefaultPasswordConfig, 1, 0, 0);
+  server.logTrafficInterval = 1;
+
+  const serverState = getServerState(server.hostname);
+  serverState.serverLogs = [{ message: "existing", pid: -1 }];
+  serverState.lastLogTime = new Date(Date.now() - 2500);
+
+  getAuthResult(server, "wrongPassword", 1);
+
+  expect(serverState.serverLogs.length).toBeGreaterThanOrEqual(4);
+});


### PR DESCRIPTION
Fixes #3030.

Authentication logs no longer discard noise logs generated immediately before them.