### PR TITLE
DOCUMENTATION: Clarify grafting prerequisite and entropy rules

### DIFF
--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -7,7 +7,7 @@ From there, you can spend a sum of money to begin grafting [Augmentations](../ba
 This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned: some who have tested grafting have reported unidentified malware.
+Be warned: some who have tested grafting have reported some unidentified malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
 
 Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though only at an exorbitant price.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -8,7 +8,7 @@ This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
 Be warned: some who have tested grafting have reported an unidentified form of malware.
-Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
+Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, impairing the capability of its victim.
 
 Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though at an exorbitant price.
 

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -7,7 +7,8 @@ From there, you can spend a sum of money to begin grafting [Augmentations](../ba
 This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned, some who have tested grafting have reported an unidentified malware.
-Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, causing unpredictable affects to the victim.
+Be warned: some who have tested grafting have reported an unidentified malware.
+Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, causing unpredictable effects to the victim.
+Perhaps there is a way to reverse its effects ...
 
 Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress, and the money spent will **not** be returned.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -7,7 +7,7 @@ From there, you can spend a sum of money to begin grafting [Augmentations](../ba
 This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned: some who have tested grafting have reported an unidentified malware.
+Be warned: some who have tested grafting have reported an insidious form of malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
 
 Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in Grafting research. The lab has begun making it available to customers – though only for an exorbitant price.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -7,7 +7,7 @@ From there, you can spend a sum of money to begin grafting [Augmentations](../ba
 This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned: some who have tested grafting have reported some unidentified malware.
+Be warned: some who have tested grafting have reported unidentified malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
 
 Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though at an exorbitant price.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -7,7 +7,7 @@ From there, you can spend a sum of money to begin grafting [Augmentations](../ba
 This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned: some who have tested grafting have reported unidentified malware.
+Be warned: some who have tested grafting have reported unidentified form of malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
 
 Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though at an exorbitant price.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -10,6 +10,6 @@ When done, the [Augmentation](../basic/augmentations.md) will be applied to your
 Be warned: some who have tested grafting have reported some unidentified malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
 
-Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though only at an exorbitant price.
+Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though at an exorbitant price.
 
 Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress, and the money spent will **not** be returned.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -8,7 +8,8 @@ This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
 Be warned: some who have tested grafting have reported an unidentified malware.
-Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, causing unpredictable effects to the victim.
-Perhaps there is a way to reverse its effects ...
+Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
+
+Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in Grafting research. The lab has begun making it available to customers – though only for an exorbitant price.
 
 Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress, and the money spent will **not** be returned.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -7,9 +7,9 @@ From there, you can spend a sum of money to begin grafting [Augmentations](../ba
 This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned: some who have tested grafting have reported an insidious form of malware.
+Be warned: some who have tested grafting have reported unidentified malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
 
-Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in Grafting research. The lab has begun making it available to customers – though only for an exorbitant price.
+Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though only at an exorbitant price.
 
 Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress, and the money spent will **not** be returned.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -8,7 +8,7 @@ This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
 Be warned: some who have tested grafting have reported an unidentified form of malware.
-Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, impairing the capabilities of its victims.
+Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, impairing the capability of its victim.
 
 Recently however, an implant has been developed that counteracts the effect of virus. The lab has begun making it available to customers, though at an exorbitant price.
 

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -10,6 +10,6 @@ When done, the [Augmentation](../basic/augmentations.md) will be applied to your
 Be warned: some who have tested grafting have reported an unidentified form of malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, impairing the capability of its victim.
 
-Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though at an exorbitant price.
+Recently however, an implant has been developed that counteracts the effect of virus. The lab has begun making it available to customers, though at an exorbitant price.
 
 Note that when grafting an [Augmentation](../basic/augmentations.md), cancelling will **not** save your progress, and the money spent will **not** be returned.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -7,7 +7,7 @@ From there, you can spend a sum of money to begin grafting [Augmentations](../ba
 This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
-Be warned: some who have tested grafting have reported unidentified form of malware.
+Be warned: some who have tested grafting have reported an unidentified form of malware.
 Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, with a debilitating effect on its victim.
 
 Recently, an implant has been developed that counteracts the virus, engineered by a pioneer in grafting research. The lab has begun making it available to customers – though at an exorbitant price.

--- a/src/Documentation/doc/en/advanced/grafting.md
+++ b/src/Documentation/doc/en/advanced/grafting.md
@@ -8,7 +8,7 @@ This will take some time.
 When done, the [Augmentation](../basic/augmentations.md) will be applied to your character without needing to install.
 
 Be warned: some who have tested grafting have reported an unidentified form of malware.
-Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, impairing the capability of its victim.
+Dubbed `Entropy`, this virus seems to grow in potency as more [Augmentations](../basic/augmentations.md) are grafted, impairing the capabilities of its victims.
 
 Recently however, an implant has been developed that counteracts the effect of virus. The lab has begun making it available to customers, though at an exorbitant price.
 

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -269,7 +269,7 @@ export const GraftingRoot = (): React.ReactElement => {
           hidden malware. However, grafted augmentations do not provide this security measure.
           <br />
           <br />
-          Individuals who tested augmentation grafting have reported symptoms of an unknown virus which persists even
+          Individuals who tested augmentation grafting have reported symptoms of an unknown virus, which persists even
           after a later body reset. They've dubbed it "Entropy". This virus seems to grow more potent with each grafted
           augmentation ...
         </Typography>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -110,6 +110,7 @@ export const GraftingRoot = (): React.ReactElement => {
       <Typography>
         You find yourself in a secret laboratory, owned by a mysterious researcher.
         <br />
+        <br />
         The scientist explains that they've been studying augmentation grafting, the process of applying augmentations
         without requiring a body reset.
         <br />

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -115,13 +115,12 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
-        even private designs. They offer to build and graft the augmentations to you, in exchange for both a hefty sum
-        of money, and being a lab rat.
+        even private designs. They offer to build and graft the augmentations onto you, in exchange for both a hefty 
+        sum of money, and your agreement to act as a lab rat.
         <br />
         <br />
-        Some augmentations have prerequisites. You normally must install the prerequisites before being able to buy and
-        install those augmentations. With grafting, you only need to buy ("queue") those prerequisites. You can also
-        graft the prerequisites.
+        When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequsities, 
+        you must buy, install or graft those prerequisites before you can graft the augmentation.
       </Typography>
 
       <Box sx={{ my: 3 }}>
@@ -269,8 +268,9 @@ export const GraftingRoot = (): React.ReactElement => {
           hidden malware. However, grafted augmentations do not provide this security measure.
           <br />
           <br />
-          Individuals who tested augmentation grafting have reported symptoms of an unknown virus, which they've dubbed
-          "Entropy". This virus seems to grow more potent with each grafted augmentation ...
+          Individuals who tested augmentation grafting have reported symptoms of an unknown virus, which persists even 
+          after a later body reset. They've dubbed it "Entropy". This virus seems to grow more potent with each grafted 
+          augmentation ...
         </Typography>
       </Box>
     </Container>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -270,7 +270,7 @@ export const GraftingRoot = (): React.ReactElement => {
           <br />
           <br />
           Individuals who tested augmentation grafting have reported symptoms of an unknown virus, which persists even
-          after a later body reset. They've dubbed it "Entropy". This virus seems to grow more potent with each grafted
+          after a body reset. They've dubbed it "Entropy". This virus seems to grow more potent with each grafted
           augmentation ...
         </Typography>
       </Box>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -116,8 +116,8 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
-        even private designs. They offer to build and graft the augmentations onto you, in exchange for both a hefty sum
-        of money, and being a lab rat.
+        even private designs. They offer to build and graft the augmentations to you, in exchange for both a hefty sum of
+        money, and being a lab rat.
         <br />
         <br />
         When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequisites, you

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -116,8 +116,8 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
-        even private designs. They offer to build and graft the augmentations to you, in exchange for both a hefty sum of
-        money, and being a lab rat.
+        even private designs. They offer to build and graft the augmentations to you, in exchange for both a hefty sum
+        of money, and being a lab rat.
         <br />
         <br />
         When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequisites, you

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -115,7 +115,7 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
-        even private designs. They offer to build and graft the augmentations onto you, in exchange for a hefty sum
+        even private designs. They offer to build and graft the augmentations onto you, in exchange both for a hefty sum
         of money, and for being a lab rat.
         <br />
         <br />

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -116,11 +116,11 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
-        even private designs. They offer to build and graft the augmentations onto you, in exchange both for a hefty sum
-        of money, and for being a lab rat.
+        even private designs. They offer to build and graft the augmentations onto you, in exchange for both a hefty sum
+        of money, and being a lab rat.
         <br />
         <br />
-        When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequsities, you
+        When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequisites, you
         must buy, install or graft those prerequisites before you can graft the augmentation.
       </Typography>
 

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -115,12 +115,12 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
-        even private designs. They offer to build and graft the augmentations onto you, in exchange for both a hefty 
-        sum of money, and your agreement to act as a lab rat.
+        even private designs. They offer to build and graft the augmentations onto you, in exchange for both a hefty sum
+        of money, and your agreement to act as a lab rat.
         <br />
         <br />
-        When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequsities, 
-        you must buy, install or graft those prerequisites before you can graft the augmentation.
+        When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequsities, you
+        must buy, install or graft those prerequisites before you can graft the augmentation.
       </Typography>
 
       <Box sx={{ my: 3 }}>
@@ -268,8 +268,8 @@ export const GraftingRoot = (): React.ReactElement => {
           hidden malware. However, grafted augmentations do not provide this security measure.
           <br />
           <br />
-          Individuals who tested augmentation grafting have reported symptoms of an unknown virus, which persists even 
-          after a later body reset. They've dubbed it "Entropy". This virus seems to grow more potent with each grafted 
+          Individuals who tested augmentation grafting have reported symptoms of an unknown virus, which persists even
+          after a later body reset. They've dubbed it "Entropy". This virus seems to grow more potent with each grafted
           augmentation ...
         </Typography>
       </Box>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -116,7 +116,7 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
         even private designs. They offer to build and graft the augmentations onto you, in exchange for both a hefty sum
-        of money, and your agreement to act as a lab rat.
+        of money, and for being a lab rat.
         <br />
         <br />
         When grafting augmentations, prerequisites work the same way as usual. If an augmentation has prerequsities, you
@@ -268,7 +268,7 @@ export const GraftingRoot = (): React.ReactElement => {
           hidden malware. However, grafted augmentations do not provide this security measure.
           <br />
           <br />
-          Individuals who tested augmentation grafting have reported symptoms of an unknown virus, which persists even
+          Individuals who tested augmentation grafting have reported symptoms of an unknown virus which persists even
           after a later body reset. They've dubbed it "Entropy". This virus seems to grow more potent with each grafted
           augmentation ...
         </Typography>

--- a/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
+++ b/src/PersonObjects/Grafting/ui/GraftingRoot.tsx
@@ -115,7 +115,7 @@ export const GraftingRoot = (): React.ReactElement => {
         <br />
         <br />
         Through legally questionable connections, the scientist has access to a vast array of augmentation blueprints,
-        even private designs. They offer to build and graft the augmentations onto you, in exchange for both a hefty sum
+        even private designs. They offer to build and graft the augmentations onto you, in exchange for a hefty sum
         of money, and for being a lab rat.
         <br />
         <br />


### PR DESCRIPTION
The main change is that grafting currently says:

> Some augmentations have prerequisites. You normally must **install** the prerequisites before being able to buy and install those augmentations. With grafting, you only need to buy ("queue") those prerequisites. You can also graft the prerequisites.

... which isn't true. You don't usually have to install prerequisites. You just have to buy them, same as grafting. So it works the same way as augmentations usually do.

The other changes are just mild fluff / flavour, streamlining things to be more idiomatic. Plus one one change to clarify that entropy is not reset when you later reset / install. Someone in Discord got that confused, and I think it's not wholly clear currently.