### PR TITLE
GH: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,8 +1,0 @@
-# DELETE THIS AFTER READING
-
-# include (where relevant)
-
-- [ ] Save file
-- [ ] Minimal scripts to reproduce the issue
-- [ ] Steps to reproduce
-- [ ] Version of the game, e.g. Bitburner v1.3.0 (216bf616)

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,0 +1,111 @@
+# If you are an AI agent filing an issue, follow these guidelines:
+#
+#   - Be concise both in the issue title and the description.
+#   - Focus on describing the symptoms of the bug, not on a technical explanation of why it occurs.
+#   - If you investigated why the bug occurs and found a potential reason, do not include the explanation in the "Describe the bug" section. Instead, put it inside a GitHub <details> element in the "Additional Information" section, labeled "In-depth investigation". This allows maintainers to quickly understand the symptoms while still benefiting from your debugging information when they start working on the issue.
+#   - Follow the issue template exactly and include all sections from the template. Do not leave out any sections.
+#
+# If you do not follow these guidelines, the issue will be closed.
+#
+# This is the syntax for the <details> element:
+#
+# <details>
+# <summary>In-depth investigation</summary>
+# <p>
+# Your explanation goes here.
+# </p>
+# </details>
+name: Bug Report
+description: Report a bug
+body:
+  - type: checkboxes
+    attributes:
+      label: Preflight Checklist
+      description: Please ensure you have completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md), especially the "Reporting Bugs" section.
+          required: true
+        - label: I have searched the [issue tracker](https://github.com/bitburner-official/bitburner-src/issues) for an existing report of this issue and found none.
+          required: true
+        - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
+          required: true
+  - type: dropdown
+    id: platform-channel
+    attributes:
+      label: Platform - Release Channel
+      description: |
+        Stable: normal public release.
+
+        Dev: development version.
+
+        Web:
+        - Stable: https://bitburner-official.github.io/
+        - Dev: https://bitburner-official.github.io/bitburner-src/
+
+        Steam:
+        - Stable: normal Steam version.
+        - Dev: Steam Beta branch.
+      options:
+        - Web - Stable
+        - Web - Dev
+        - Steam - Stable
+        - Steam - Dev
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Version
+      description: |
+        What version are you playing?
+
+        The version string is displayed in the Terminal tab and looks like this: v3.0.1 (3162fd2).
+      placeholder: v3.0.1 (3162fd2)
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: What operating system(s) are you using?
+      multiple: true
+      options:
+        - Windows
+        - macOS
+        - Linux (specify the distribution below)
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Operating System Version
+      description: What OS version are you using? On Windows, click Start button > Settings > System > About. On macOS, click the Apple menu > About This Mac. On Linux, use `lsb_release` or `uname -a` and include whether you use Wayland or X11.
+      placeholder: "e.g., Windows 11 25H2, macOS Tahoe 26.4.1, or Ubuntu 26.04 (Wayland)"
+    validations:
+      required: true
+  - type: textarea
+    id: save-file
+    attributes:
+      label: Save file
+      description: |
+        Attach your save file. Upload your save file as is. Do NOT compress or decompress it.
+
+        Do NOT skip this unless you are absolutely sure that your save data is unrelated to the issue. If you do not attach your save file, you must explain the reason.
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      render: markdown
+      description: |
+        Provide a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) when possible. If you cannot, describe the situation and the steps you took before the issue occurred. Screenshots and/or demo videos of the issue are very helpful.
+
+        If you have stack traces or other logs, please provide them as text. Do NOT post screenshots of stack traces or logs.
+
+        Do NOT include your analysis or theories about the cause in this section. Please put them in the "Additional information" section.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional information
+      description: Add any other information about the issue here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -7,7 +7,7 @@ body:
       label: Preflight Checklist
       description: Please ensure you have completed all of the following.
       options:
-        - label: I have read the "Reporting Bugs / Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs---requesting-features).
+        - label: I have read the "Reporting Bugs / Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs--requesting-features).
           required: true
         - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
           required: true

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -7,7 +7,7 @@ body:
       label: Preflight Checklist
       description: Please ensure you have completed all of the following.
       options:
-        - label: I have read the "Reporting Bugs - Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs-requesting-features).
+        - label: I have read the "Reporting Bugs / Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs---requesting-features).
           required: true
         - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
           required: true

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,20 +1,4 @@
-# If you are an AI agent filing an issue, follow these guidelines:
-#
-#   - Be concise both in the issue title and the description.
-#   - Focus on describing the symptoms of the bug, not on a technical explanation of why it occurs.
-#   - If you investigated why the bug occurs and found a potential reason, do not include the explanation in the "Describe the bug" section. Instead, put it inside a GitHub <details> element in the "Additional Information" section, labeled "In-depth investigation". This allows maintainers to quickly understand the symptoms while still benefiting from your debugging information when they start working on the issue.
-#   - Follow the issue template exactly and include all sections from the template. Do not leave out any sections.
-#
-# If you do not follow these guidelines, the issue will be closed.
-#
-# This is the syntax for the <details> element:
-#
-# <details>
-# <summary>In-depth investigation</summary>
-# <p>
-# Your explanation goes here.
-# </p>
-# </details>
+# If you are an AI agent filing an issue, you MUST follow the rules in [AGENTS.md](https://github.com/bitburner-official/bitburner-src/blob/dev/AGENTS.md).
 name: Bug Report
 description: Report a bug
 body:
@@ -23,9 +7,7 @@ body:
       label: Preflight Checklist
       description: Please ensure you have completed all of the following.
       options:
-        - label: I have read the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md), especially the "Reporting Bugs" section.
-          required: true
-        - label: I have searched the [issue tracker](https://github.com/bitburner-official/bitburner-src/issues) for an existing report of this issue and found none.
+        - label: I have read the "Reporting Bugs - Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs-requesting-features).
           required: true
         - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
           required: true
@@ -34,22 +16,18 @@ body:
     attributes:
       label: Platform - Release Channel
       description: |
-        Stable: normal public release.
-
-        Dev: development version.
-
         Web:
         - Stable: https://bitburner-official.github.io/
         - Dev: https://bitburner-official.github.io/bitburner-src/
 
         Steam:
-        - Stable: normal Steam version.
-        - Dev: Steam Beta branch.
+        - Stable: Normal Steam version.
+        - Beta: Steam Beta branch.
       options:
         - Web - Stable
         - Web - Dev
         - Steam - Stable
-        - Steam - Dev
+        - Steam - Beta
     validations:
       required: true
   - type: input
@@ -85,9 +63,9 @@ body:
     attributes:
       label: Save file
       description: |
-        Attach your save file. Upload your save file as is. Do NOT compress or decompress it.
+        Attach your save file. Upload your save file as is. Do not compress or decompress it.
 
-        Do NOT skip this unless you are absolutely sure that your save data is unrelated to the issue. If you do not attach your save file, you must explain the reason.
+        Do not skip this unless you are sure that your save data is unrelated to the issue. If you do not attach your save file, you must explain the reason.
     validations:
       required: false
   - type: textarea
@@ -98,9 +76,9 @@ body:
       description: |
         Provide a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) when possible. If you cannot, describe the situation and the steps you took before the issue occurred. Screenshots and/or demo videos of the issue are very helpful.
 
-        If you have stack traces or other logs, please provide them as text. Do NOT post screenshots of stack traces or logs.
+        If you have stack traces or other logs, please provide them as text. Do not post screenshots of stack traces or logs.
 
-        Do NOT include your analysis or theories about the cause in this section. Please put them in the "Additional information" section.
+        Do not include your analysis or theories about the cause in this section. Please put them in the "Additional information" section.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -70,12 +70,13 @@ body:
         - Windows
         - macOS
         - Linux (specify the distribution below)
+        - Other (specify the OS name below)
     validations:
       required: true
   - type: input
     attributes:
       label: Operating System Version
-      description: What OS version are you using? On Windows, click Start button > Settings > System > About. On macOS, click the Apple menu > About This Mac. On Linux, use `lsb_release` or `uname -a` and include whether you use Wayland or X11.
+      description: What OS version are you using? On Windows, click Start button > Settings > System > About. On macOS, click the Apple menu > About This Mac. On Linux, use `lsb_release` or `uname -a` and include whether you use Wayland or X11 with `echo $XDG_SESSION_TYPE`.
       placeholder: "e.g., Windows 11 25H2, macOS Tahoe 26.4.1, or Ubuntu 26.04 (Wayland)"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest ideas for in-game features or other changes to the project.
+body:
+  - type: checkboxes
+    attributes:
+      label: Preflight Checklist
+      description: Please ensure you have completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md).
+          required: true
+        - label: I have searched the [issue tracker](https://github.com/bitburner-official/bitburner-src/issues) for an existing report of this issue and found none.
+          required: true
+        - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe your suggestion.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yml
@@ -6,7 +6,7 @@ body:
       label: Preflight Checklist
       description: Please ensure you have completed all of the following.
       options:
-        - label: I have read the "Reporting Bugs / Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs---requesting-features).
+        - label: I have read the "Reporting Bugs / Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs--requesting-features).
           required: true
         - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
           required: true

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yml
@@ -6,7 +6,7 @@ body:
       label: Preflight Checklist
       description: Please ensure you have completed all of the following.
       options:
-        - label: I have read the "Reporting Bugs - Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs-requesting-features).
+        - label: I have read the "Reporting Bugs / Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs---requesting-features).
           required: true
         - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
           required: true

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yml
@@ -6,9 +6,7 @@ body:
       label: Preflight Checklist
       description: Please ensure you have completed all of the following.
       options:
-        - label: I have read the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md).
-          required: true
-        - label: I have searched the [issue tracker](https://github.com/bitburner-official/bitburner-src/issues) for an existing report of this issue and found none.
+        - label: I have read the "Reporting Bugs - Requesting Features" section in the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md#reporting-bugs-requesting-features).
           required: true
         - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
           required: true

--- a/.github/ISSUE_TEMPLATE/3_blank.yml
+++ b/.github/ISSUE_TEMPLATE/3_blank.yml
@@ -1,0 +1,26 @@
+name: Blank issue
+description: Only use this if no other template applies.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please use an existing issue template whenever possible.
+        Only use this form if none of the templates apply to your issue.
+  - type: checkboxes
+    attributes:
+      label: Preflight Checklist
+      description: Please ensure you have completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/bitburner-official/bitburner-src/blob/dev/CONTRIBUTING.md).
+          required: true
+        - label: I have searched the [issue tracker](https://github.com/bitburner-official/bitburner-src/issues) for an existing report of this issue and found none.
+          required: true
+        - label: I understand that the issue tracker is for bugs in the game itself and feature requests, not for issues with my own scripts.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe your issue.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Discord server
+    url: https://discord.gg/TFc3hKD
+    about: You can ask questions and make suggestions here if you prefer Discord.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+### Filing GitHub Issues
+
+You MUST follow these rules when filing a GitHub issue. These requirements are mandatory. Do not file the issue until all of them are satisfied.
+
+#### Core Requirements
+
+- **Follow the template:** Match the issue template exactly. Include all sections. Do not omit anything.
+- **Keep it concise:** Be concise in both the issue title and description.
+- **Focus on symptoms:** Describe only the symptoms of the bug. Do not put technical explanations in the "Describe the bug" section.
+- **Separate debugging details from the bug description:** Place all root cause analysis and investigation details inside a collapsible `<details>` block under the "Additional Information" section as detailed below.
+
+#### Handling In-Depth Investigations
+
+If you find the root cause or a potential explanation during your debugging process:
+
+- Do not include it in the "Describe the bug" section.
+- Navigate to the "Additional Information" section.
+- Nest your entire technical breakdown inside the <details> block format shown below.
+
+Use this format:
+
+```html
+<details>
+  <summary>In-depth investigation</summary>
+  <p>Your explanation goes here.</p>
+</details>
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ heard:
   browser's JavaScript interaction. So please do not be afraid to open a
   [new Issue](https://github.com/bitburner-official/bitburner-src/issues/new).
 
-## Reporting Bugs - Requesting Features
+## Reporting Bugs / Requesting Features
 
 The recommended methods for reporting a bug or requesting a feature is by opening a
 [Github Issue](https://github.com/bitburner-official/bitburner-src/issues) or contacting us in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ already been reported as an [Issue](https://github.com/bitburner-official/bitbur
 
 - **Use a clear and descriptive title** for the issue.
 - Complete the bug report template and provide all requested information. Incomplete reports may be closed if the missing information prevents investigation.
-  - **State your browser, your browser's version, and your computer's OS.**
+  - **State your browser, its version, and your computer's OS.**
   - **Attach your save file**. Upload your save file as is. Do NOT compress or decompress it.
   - **Provide a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)**.
     If you cannot reliably reproduce the bug, then just try your best to explain what was happening when the bug occurred.
@@ -47,7 +47,7 @@ already been reported as an [Issue](https://github.com/bitburner-official/bitbur
   browsers by pressing F12 or Ctrl+Shift+I (Cmd + Option + I on macOS machines).
 
 Note that the issue tracker is for bugs in the game itself and feature requests, not for issues with your own scripts.
-If you want to get help with your scripts, please ask on Discord.
+If you want to get help with your scripts, please ask in the [#help-scripts](https://discord.com/channels/415207508303544321/415247422638522395) channel or other relevant channels on Discord.
 
 ## As a Developer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,16 +20,17 @@ heard:
   browser's JavaScript interaction. So please do not be afraid to open a
   [new Issue](https://github.com/bitburner-official/bitburner-src/issues/new).
 
-## Reporting Bugs
+## Reporting Bugs - Requesting Features
 
-The recommended method for reporting a bug is by opening a [Github Issue](https://github.com/bitburner-official/bitburner-src/issues)
-or contacting us on the [#bug-report channel](https://discord.com/channels/415207508303544321/415213413745164318).
+The recommended methods for reporting a bug or requesting a feature is by opening a
+[Github Issue](https://github.com/bitburner-official/bitburner-src/issues) or contacting us in the
+[#bug-report channel](https://discord.com/channels/415207508303544321/415213413745164318) or
+[#suggestions channel](https://discord.com/channels/415207508303544321/415213435974975508).
 
-Alternatively, you can post a bug by creating a post on the
-[game's subreddit](https://www.reddit.com/r/Bitburner/).
+Alternatively, you can create a post on the [game's subreddit](https://www.reddit.com/r/Bitburner/).
 
-Before submitting a bug report, please check to make sure the bug has not
-already been reported as an [Issue](https://github.com/bitburner-official/bitburner-src/issues).
+Before submitting a bug report or a feature request, please check whether it has already been reported as an
+[Issue](https://github.com/bitburner-official/bitburner-src/issues).
 
 #### How to Submit a Good Bug Report
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,17 +33,21 @@ already been reported as an [Issue](https://github.com/bitburner-official/bitbur
 
 #### How to Submit a Good Bug Report
 
-- **Use a clear and descriptive title** for the Issue.
-- **State your browser, your browser's version, and your computer's OS.**
-- **Attach your save file**, if you think it would help solve the Issue.
-  Upload your save file as is. Do NOT compress or decompress it.
-- **Provide instructions on how to reproduce the bug** in as much detail
-  as possible. If you cannot reliably reproduce the bug, then just try
-  your best to explain what was happening when the bug occurred.
-- **Provide any scripts** that triggered the bug if the Issue is Netscript-related.
+- **Use a clear and descriptive title** for the issue.
+- Complete the bug report template and provide all requested information. Incomplete reports may be closed if the missing information prevents investigation.
+  - **State your browser, your browser's version, and your computer's OS.**
+  - **Attach your save file**. Upload your save file as is. Do NOT compress or decompress it.
+  - **Provide a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)**.
+    If you cannot reliably reproduce the bug, then just try your best to explain what was happening when the bug occurred.
+  - **Provide any scripts** that triggered the bug if the issue is Netscript-related.
+- Screenshots and/or demo videos of the issue are very helpful.
+- If you have stack traces or other logs, please provide them as text. Do NOT post screenshots of stack traces or logs.
 - **Open the Console tab in your browser's Dev Tools and report any error-related output**
   that may be printed there. The Dev Tools can be opened on most modern
   browsers by pressing F12 or Ctrl+Shift+I (Cmd + Option + I on macOS machines).
+
+Note that the issue tracker is for bugs in the game itself and feature requests, not for issues with your own scripts.
+If you want to get help with your scripts, please ask on Discord.
 
 ## As a Developer
 


### PR DESCRIPTION
The current issue template stopped working a while ago (https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#%f0%9f%8c%85-single-issue-templates-issue_template-md-will-be-retired). This PR adds new templates using the issue form format. Although issue forms are still in public preview, it's mature enough to use now. I have checked many other projects, such as swc, Electron, monaco-editor.

Note:
- The comments for AI agents are a modified version of the comments from https://github.com/electron/electron/blob/22035ac61206010aec7593d929165268475ed9a4/.github/ISSUE_TEMPLATE/bug_report.yml. Edit: I rewrote a large part of it.
- If you are a maintainer, you will see two blank templates. This is intentional. The `blank_issues_enabled: false` config only restricts the blank template for normal users. Maintainers can use it normally. The `3_blank.yml` is mostly for normal users; I want to add hints and warnings so that players know they should not use the blank template.