### PR TITLE
MISC: Do not show backup reminder if total play time is less than 1 day

### DIFF
--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -212,7 +212,11 @@ const Engine = {
     }
 
     if (Engine.Counters.exportSaveData <= 0) {
-      if (LastExportBonus < Date.now() - 86400000 && Settings.EnableSaveDataBackupReminder) {
+      if (
+        LastExportBonus < Date.now() - 86400000 &&
+        Settings.EnableSaveDataBackupReminder &&
+        Player.totalPlaytime >= 86400000
+      ) {
         SnackbarEvents.emit("You have not backed up your save data for over 24 hours!", ToastVariant.WARNING, 30000);
       }
       Engine.Counters.exportSaveData = 18000;


### PR DESCRIPTION
This is an optional change. I don't think it's necessary, but some new players may ask why the game warns them that it has been more than 1 day since they exported data when they just installed the game a few hours ago. I'll let d0sboots decide if we need to do this.