### PR TITLE
DNET: Removed darknet stock volatility influence from stock forecast

### DIFF
--- a/src/StockMarket/StockMarket.ts
+++ b/src/StockMarket/StockMarket.ts
@@ -265,8 +265,8 @@ export function processStockPrices(numCycles = 1): void {
   for (const name of Object.keys(StockMarket)) {
     const stock = StockMarket[name];
     if (!(stock instanceof Stock)) continue;
-    const volatility = stock.mv * getDarknetVolatilityMult(stock.symbol);
-    let av = (v * volatility) / 100;
+    const maxVolatility = stock.mv * getDarknetVolatilityMult(stock.symbol);
+    let av = (v * maxVolatility) / 100;
     if (isNaN(av)) {
       av = 0.02;
     }
@@ -304,7 +304,9 @@ export function processStockPrices(numCycles = 1): void {
       processOrders(stock, OrderType.StopSell, PositionType.Long, processOrderRefs);
     }
 
-    let otlkMagChange = stock.otlkMag * av;
+    // Remove darknet influence from stock volatility, so darknet only affects current price, and not the forecast
+    const normalizedVolatility = av / getDarknetVolatilityMult(stock.symbol);
+    let otlkMagChange = stock.otlkMag * normalizedVolatility;
     if (stock.otlkMag < 5) {
       if (stock.otlkMag <= 1) {
         otlkMagChange = 1;


### PR DESCRIPTION
Currently, the rolled volatility of a stock is influenced by darknet promoteStock, which was intended. However, that rolled volatility influences the stocks' forecast afterwards (including the influence from promoteStock) which is not intended. This PR removes the influence of darknet from the forecast updates.

I am opening this PR primarily as a conversation starter; @catloversg originally identified there was an issue and planned to think on it, but AFAIK has not yet made any changes to it.

Some more context: https://discord.com/channels/415207508303544321/415207923506216971/1526139835478179870