### PR TITLE
UI: Add price history chart to stock market

### DIFF
--- a/src/StockMarket/Stock.ts
+++ b/src/StockMarket/Stock.ts
@@ -123,6 +123,8 @@ export class Stock {
    */
   readonly totalShares: number;
 
+  readonly priceHistory: { time: number; price: number }[];
+
   constructor(p: IConstructorParams = defaultConstructorParams) {
     this.name = p.name;
     this.symbol = p.symbol;
@@ -148,6 +150,8 @@ export class Stock {
     // Max Shares (Outstanding shares) is a percentage of total shares
     const outstandingSharePercentage = 0.2;
     this.maxShares = Math.round((this.totalShares * outstandingSharePercentage) / 1e5) * 1e5;
+
+    this.priceHistory = [];
   }
 
   /** Safely set the stock's second-order forecast to a new value */
@@ -188,11 +192,11 @@ export class Stock {
       this.otlkMag += changeAmt;
     }
 
-    this.otlkMag = Math.min(this.otlkMag, 50);
     if (this.otlkMag < 0) {
       this.otlkMag *= -1;
       this.b = !this.b;
     }
+    this.otlkMag = Math.min(this.otlkMag, 50);
   }
 
   /**

--- a/src/StockMarket/Stock.ts
+++ b/src/StockMarket/Stock.ts
@@ -123,7 +123,7 @@ export class Stock {
    */
   readonly totalShares: number;
 
-  readonly priceHistory: { time: number; price: number }[];
+  readonly priceHistory: { timeMs: number; price: number }[];
 
   constructor(p: IConstructorParams = defaultConstructorParams) {
     this.name = p.name;

--- a/src/StockMarket/StockMarket.ts
+++ b/src/StockMarket/StockMarket.ts
@@ -318,7 +318,7 @@ export function processStockPrices(numCycles = 1): void {
     // Shares required for price movement gradually approaches max over time
     stock.shareTxUntilMovement = Math.min(stock.shareTxUntilMovement + 10, stock.shareTxForMovement);
 
-    stock.priceHistory.push({ time: Date.now(), price: stock.price });
+    stock.priceHistory.push({ timeMs: Date.now(), price: stock.price });
     if (stock.priceHistory.length > 10) {
       stock.priceHistory.splice(0, stock.priceHistory.length - 10);
     }

--- a/src/StockMarket/StockMarket.ts
+++ b/src/StockMarket/StockMarket.ts
@@ -317,6 +317,11 @@ export function processStockPrices(numCycles = 1): void {
 
     // Shares required for price movement gradually approaches max over time
     stock.shareTxUntilMovement = Math.min(stock.shareTxUntilMovement + 10, stock.shareTxForMovement);
+
+    stock.priceHistory.push({ time: Date.now(), price: stock.price });
+    if (stock.priceHistory.length > 10) {
+      stock.priceHistory.splice(0, stock.priceHistory.length - 10);
+    }
   }
   // Handle "nextUpdate" resolver after this update
   if (StockMarketPromise.resolve) {

--- a/src/StockMarket/ui/PriceHistoryChart.tsx
+++ b/src/StockMarket/ui/PriceHistoryChart.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import Typography from "@mui/material/Typography";
+import type { Stock } from "../Stock";
+import { useCycleRerender } from "../../ui/React/hooks";
+import { Settings } from "../../Settings/Settings";
+import { Money } from "../../ui/React/Money";
+
+export function PriceHistoryChart({ stock }: { stock: Stock }) {
+  const [hoveredDataPoint, setHoveredDataPoint] = React.useState<number | null>(null);
+
+  useCycleRerender();
+
+  const prices = stock.priceHistory.map((v) => v.price);
+  if (prices.length === 0) {
+    return null;
+  }
+
+  const width = 800;
+  const height = 500;
+  const padding = 20;
+
+  const minPrice = Math.min(...prices);
+  const maxPrice = Math.max(...prices);
+  const range = Math.max(maxPrice - minPrice, Number.EPSILON);
+
+  const points = stock.priceHistory.map((entry, index) => {
+    const x = padding + (index / Math.max(prices.length - 1, 1)) * (width - padding * 2);
+    const y = height - padding - ((entry.price - minPrice) / range) * (height - padding * 2);
+    return { x, y };
+  });
+
+  return (
+    <div style={{ padding: 10 }}>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        style={{
+          background: Settings.theme.backgroundprimary,
+          marginBottom: "10px",
+        }}
+      >
+        <polyline
+          points={points.map(({ x, y }) => `${x},${y}`).join(" ")}
+          fill="none"
+          stroke={Settings.theme.primary}
+          strokeWidth={2}
+        />
+
+        {/* Wide invisible hit area that snaps the cursor to the nearest data point. */}
+        <polyline
+          points={points.map(({ x, y }) => `${x},${y}`).join(" ")}
+          fill="none"
+          stroke="transparent"
+          strokeWidth={20}
+          onMouseMove={(event) => {
+            const svg = event.currentTarget.ownerSVGElement;
+            if (svg == null) {
+              return;
+            }
+
+            const rect = svg.getBoundingClientRect();
+            const mouseX = ((event.clientX - rect.left) / rect.width) * width;
+            const index = Math.round(((mouseX - padding) / (width - padding * 2)) * (prices.length - 1));
+            if (index >= 0 && index < prices.length) {
+              setHoveredDataPoint(index);
+            }
+          }}
+          onMouseLeave={() => setHoveredDataPoint(null)}
+        />
+
+        {points.map(({ x, y }, index) => (
+          <React.Fragment key={index}>
+            <circle
+              stroke={Settings.theme.primary}
+              cx={x}
+              cy={y}
+              r={10}
+              onMouseEnter={() => setHoveredDataPoint(index)}
+              onMouseLeave={() => setHoveredDataPoint(null)}
+            />
+          </React.Fragment>
+        ))}
+      </svg>
+      <Typography>
+        The price history contains at most 10 data points.
+        <br />
+        Hover over the chart to view details for the nearest data point.
+        <br />
+        Time: {hoveredDataPoint !== null && new Date(stock.priceHistory[hoveredDataPoint].time).toLocaleTimeString()}
+        <br />
+        Price: {hoveredDataPoint !== null && <Money money={stock.priceHistory[hoveredDataPoint].price} />}
+      </Typography>
+    </div>
+  );
+}

--- a/src/StockMarket/ui/PriceHistoryChart.tsx
+++ b/src/StockMarket/ui/PriceHistoryChart.tsx
@@ -1,26 +1,30 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
+import Tooltip from "@mui/material/Tooltip";
+import InfoIcon from "@mui/icons-material/Info";
 import type { Stock } from "../Stock";
 import { useCycleRerender } from "../../ui/React/hooks";
 import { Settings } from "../../Settings/Settings";
 import { Money } from "../../ui/React/Money";
 
-export function PriceHistoryChart({ stock }: { stock: Stock }) {
+export function PriceHistoryChart({
+  stock,
+  width = 720,
+  height = 280,
+}: {
+  stock: Stock;
+  width?: number;
+  height?: number;
+}) {
   const [hoveredDataPoint, setHoveredDataPoint] = React.useState<number | null>(null);
 
   useCycleRerender();
 
   const prices = stock.priceHistory.map((v) => v.price);
-  if (prices.length === 0) {
-    return null;
-  }
-
-  const width = 800;
-  const height = 500;
   const padding = 20;
 
-  const minPrice = Math.min(...prices);
-  const maxPrice = Math.max(...prices);
+  const minPrice = prices.length > 0 ? Math.min(...prices) : 0;
+  const maxPrice = prices.length > 0 ? Math.max(...prices) : 0;
   const range = Math.max(maxPrice - minPrice, Number.EPSILON);
 
   const points = stock.priceHistory.map((entry, index) => {
@@ -29,66 +33,106 @@ export function PriceHistoryChart({ stock }: { stock: Stock }) {
     return { x, y };
   });
 
+  const hoveredPoint = hoveredDataPoint !== null ? points[hoveredDataPoint] : null;
+
   return (
-    <div style={{ padding: 10 }}>
-      <svg
-        viewBox={`0 0 ${width} ${height}`}
+    <div>
+      <Tooltip
+        title={
+          <Typography>
+            The price history contains at most 10 data points.
+            <br />
+            Hover over the chart to view details for the nearest data point.
+          </Typography>
+        }
+      >
+        <Typography sx={{ display: "flex", alignItems: "center" }}>
+          Price history
+          <InfoIcon sx={{ fontSize: "1.2em", marginLeft: "10px" }} />
+        </Typography>
+      </Tooltip>
+      <div
         style={{
-          background: Settings.theme.backgroundprimary,
-          marginBottom: "10px",
+          position: "relative",
         }}
       >
-        <polyline
-          points={points.map(({ x, y }) => `${x},${y}`).join(" ")}
-          fill="none"
-          stroke={Settings.theme.primary}
-          strokeWidth={2}
-        />
-
-        {/* Wide invisible hit area that snaps the cursor to the nearest data point. */}
-        <polyline
-          points={points.map(({ x, y }) => `${x},${y}`).join(" ")}
-          fill="none"
-          stroke="transparent"
-          strokeWidth={20}
-          onMouseMove={(event) => {
-            const svg = event.currentTarget.ownerSVGElement;
-            if (svg == null) {
-              return;
-            }
-
-            const rect = svg.getBoundingClientRect();
-            const mouseX = ((event.clientX - rect.left) / rect.width) * width;
-            const index = Math.round(((mouseX - padding) / (width - padding * 2)) * (prices.length - 1));
-            if (index >= 0 && index < prices.length) {
-              setHoveredDataPoint(index);
-            }
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          style={{
+            background: Settings.theme.backgroundprimary,
           }}
-          onMouseLeave={() => setHoveredDataPoint(null)}
-        />
+        >
+          <polyline
+            points={points.map(({ x, y }) => `${x},${y}`).join(" ")}
+            fill="none"
+            stroke={Settings.theme.primary}
+            strokeWidth={2}
+          />
 
-        {points.map(({ x, y }, index) => (
-          <React.Fragment key={index}>
-            <circle
-              stroke={Settings.theme.primary}
-              cx={x}
-              cy={y}
-              r={10}
-              onMouseEnter={() => setHoveredDataPoint(index)}
-              onMouseLeave={() => setHoveredDataPoint(null)}
+          {/* Wide invisible hit area that snaps the cursor to the nearest data point. */}
+          <polyline
+            points={points.map(({ x, y }) => `${x},${y}`).join(" ")}
+            fill="none"
+            stroke="transparent"
+            strokeWidth={20}
+            onMouseMove={(event) => {
+              if (prices.length === 0) {
+                return;
+              }
+              const svg = event.currentTarget.ownerSVGElement;
+              if (svg == null) {
+                return;
+              }
+
+              const rect = svg.getBoundingClientRect();
+              const mouseX = ((event.clientX - rect.left) / rect.width) * width;
+              const index = Math.round(((mouseX - padding) / (width - padding * 2)) * (prices.length - 1));
+              if (index >= 0 && index < prices.length) {
+                setHoveredDataPoint(index);
+              }
+            }}
+            onMouseLeave={() => setHoveredDataPoint(null)}
+          />
+
+          {points.map(({ x, y }, index) => (
+            <React.Fragment key={index}>
+              <circle
+                stroke={Settings.theme.primary}
+                cx={x}
+                cy={y}
+                r={10}
+                onMouseEnter={() => setHoveredDataPoint(index)}
+                onMouseLeave={() => setHoveredDataPoint(null)}
+              />
+            </React.Fragment>
+          ))}
+        </svg>
+        {hoveredDataPoint !== null && hoveredPoint !== null && (
+          <Tooltip
+            open
+            title={
+              <>
+                <div>{new Date(stock.priceHistory[hoveredDataPoint].time).toLocaleTimeString()}</div>
+                <div>
+                  <Money money={stock.priceHistory[hoveredDataPoint].price} />
+                </div>
+              </>
+            }
+            placement="right"
+          >
+            <span
+              style={{
+                position: "absolute",
+                left: `${(hoveredPoint.x / width) * 100}%`,
+                top: `${(hoveredPoint.y / height) * 100}%`,
+                width: 1,
+                height: 1,
+                pointerEvents: "none",
+              }}
             />
-          </React.Fragment>
-        ))}
-      </svg>
-      <Typography>
-        The price history contains at most 10 data points.
-        <br />
-        Hover over the chart to view details for the nearest data point.
-        <br />
-        Time: {hoveredDataPoint !== null && new Date(stock.priceHistory[hoveredDataPoint].time).toLocaleTimeString()}
-        <br />
-        Price: {hoveredDataPoint !== null && <Money money={stock.priceHistory[hoveredDataPoint].price} />}
-      </Typography>
+          </Tooltip>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/StockMarket/ui/PriceHistoryChart.tsx
+++ b/src/StockMarket/ui/PriceHistoryChart.tsx
@@ -16,7 +16,7 @@ export function PriceHistoryChart({
   width?: number;
   height?: number;
 }) {
-  const [hoveredDataPoint, setHoveredDataPoint] = React.useState<number | null>(null);
+  const [hoveredDataPoint, setHoveredDataPoint] = React.useState<Stock["priceHistory"][number] | null>(null);
 
   useCycleRerender();
 
@@ -32,8 +32,6 @@ export function PriceHistoryChart({
     const y = height - padding - ((entry.price - minPrice) / range) * (height - padding * 2);
     return { x, y };
   });
-
-  const hoveredPoint = hoveredDataPoint !== null ? points[hoveredDataPoint] : null;
 
   return (
     <div>
@@ -61,6 +59,7 @@ export function PriceHistoryChart({
           style={{
             background: Settings.theme.backgroundprimary,
           }}
+          onMouseLeave={() => setHoveredDataPoint(null)}
         >
           <polyline
             points={points.map(({ x, y }) => `${x},${y}`).join(" ")}
@@ -88,50 +87,38 @@ export function PriceHistoryChart({
               const mouseX = ((event.clientX - rect.left) / rect.width) * width;
               const index = Math.round(((mouseX - padding) / (width - padding * 2)) * (prices.length - 1));
               if (index >= 0 && index < prices.length) {
-                setHoveredDataPoint(index);
+                setHoveredDataPoint(stock.priceHistory[index]);
               }
             }}
-            onMouseLeave={() => setHoveredDataPoint(null)}
           />
 
-          {points.map(({ x, y }, index) => (
-            <React.Fragment key={index}>
-              <circle
-                stroke={Settings.theme.primary}
-                cx={x}
-                cy={y}
-                r={10}
-                onMouseEnter={() => setHoveredDataPoint(index)}
-                onMouseLeave={() => setHoveredDataPoint(null)}
-              />
-            </React.Fragment>
-          ))}
+          {points.map(({ x, y }, index) => {
+            const entry = stock.priceHistory[index];
+            return (
+              <Tooltip
+                key={index}
+                open={hoveredDataPoint === entry}
+                title={
+                  <>
+                    <div>{new Date(stock.priceHistory[index].timeMs).toLocaleTimeString()}</div>
+                    <div>
+                      <Money money={stock.priceHistory[index].price} />
+                    </div>
+                  </>
+                }
+                placement="right"
+              >
+                <circle
+                  stroke={Settings.theme.primary}
+                  cx={x}
+                  cy={y}
+                  r={10}
+                  onMouseEnter={() => setHoveredDataPoint(entry)}
+                />
+              </Tooltip>
+            );
+          })}
         </svg>
-        {hoveredDataPoint !== null && hoveredPoint !== null && (
-          <Tooltip
-            open
-            title={
-              <>
-                <div>{new Date(stock.priceHistory[hoveredDataPoint].time).toLocaleTimeString()}</div>
-                <div>
-                  <Money money={stock.priceHistory[hoveredDataPoint].price} />
-                </div>
-              </>
-            }
-            placement="right"
-          >
-            <span
-              style={{
-                position: "absolute",
-                left: `${(hoveredPoint.x / width) * 100}%`,
-                top: `${(hoveredPoint.y / height) * 100}%`,
-                width: 1,
-                height: 1,
-                pointerEvents: "none",
-              }}
-            />
-          </Tooltip>
-        )}
       </div>
     </div>
   );

--- a/src/StockMarket/ui/StockMarketRoot.tsx
+++ b/src/StockMarket/ui/StockMarketRoot.tsx
@@ -7,6 +7,7 @@ import { IStockMarket } from "../IStockMarket";
 
 import { Player } from "@player";
 import { useCycleRerender } from "../../ui/React/hooks";
+import Container from "@mui/material/Container";
 
 interface IProps {
   stockMarket: IStockMarket;
@@ -16,9 +17,9 @@ interface IProps {
 export function StockMarketRoot(props: IProps): React.ReactElement {
   const rerender = useCycleRerender();
   return (
-    <>
+    <Container disableGutters maxWidth="lg" sx={{ mx: 0 }}>
       <InfoAndPurchases rerender={rerender} />
       {Player.hasWseAccount && <StockTickers stockMarket={props.stockMarket} />}
-    </>
+    </Container>
   );
 }

--- a/src/StockMarket/ui/StockTicker.tsx
+++ b/src/StockMarket/ui/StockTicker.tsx
@@ -29,7 +29,6 @@ import Paper from "@mui/material/Paper";
 import Collapse from "@mui/material/Collapse";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import ExpandLess from "@mui/icons-material/ExpandLess";
-import Button from "@mui/material/Button";
 import { PriceHistoryChart } from "./PriceHistoryChart";
 
 enum SelectorOrderType {
@@ -308,18 +307,17 @@ export function StockTicker(props: IProps): React.ReactElement {
             />
             <StockTickerTxButton onClick={handleBuyMaxButtonClick} text={"Buy MAX"} />
             <StockTickerTxButton onClick={handleSellAllButtonClick} text={"Sell ALL"} />
-            <Button
-              sx={{ marginLeft: "20px" }}
-              disabled={props.stock.priceHistory.length === 0}
-              onClick={() => {
-                dialogBoxCreate(<PriceHistoryChart stock={props.stock} />);
-              }}
-            >
-              Price history chart
-            </Button>
           </Box>
-          <StockTickerPositionText stock={props.stock} />
-          <StockTickerOrderList orders={props.orders} stock={props.stock} />
+
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            <Box>
+              <StockTickerPositionText stock={props.stock} />
+              <StockTickerOrderList orders={props.orders} stock={props.stock} />
+            </Box>
+            <Box sx={{ flex: "1 1 450px" }}>
+              <PriceHistoryChart stock={props.stock} />
+            </Box>
+          </Box>
 
           <PlaceOrderModal
             text={modalProps.text}

--- a/src/StockMarket/ui/StockTicker.tsx
+++ b/src/StockMarket/ui/StockTicker.tsx
@@ -29,6 +29,8 @@ import Paper from "@mui/material/Paper";
 import Collapse from "@mui/material/Collapse";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import ExpandLess from "@mui/icons-material/ExpandLess";
+import Button from "@mui/material/Button";
+import { PriceHistoryChart } from "./PriceHistoryChart";
 
 enum SelectorOrderType {
   Market = "Market Order",
@@ -306,6 +308,15 @@ export function StockTicker(props: IProps): React.ReactElement {
             />
             <StockTickerTxButton onClick={handleBuyMaxButtonClick} text={"Buy MAX"} />
             <StockTickerTxButton onClick={handleSellAllButtonClick} text={"Sell ALL"} />
+            <Button
+              sx={{ marginLeft: "20px" }}
+              disabled={props.stock.priceHistory.length === 0}
+              onClick={() => {
+                dialogBoxCreate(<PriceHistoryChart stock={props.stock} />);
+              }}
+            >
+              Price history chart
+            </Button>
           </Box>
           <StockTickerPositionText stock={props.stock} />
           <StockTickerOrderList orders={props.orders} stock={props.stock} />


### PR DESCRIPTION
#3028 adds price history to the stock market UI. This kind of QoL feature usually needs to be considered case by case. On one hand, as a game, it's good to improve UI/UX. On the other hand, Bitburner has a unique design philosophy, so we sometimes intentionally do *not* add more QoL features or only add barely usable features. After considering the trade-offs, I'm fine with adding this feature, but I want to do it with a different approach.

For context, I will quote my own message about Bitburner's UI design philosophy in #3051:

In general, Bitburner UI is intentionally simple. We give players tools (NS APIs) and encourage them to build anything they want. This is not an excuse to have bad UI/UX (except some special cases in which we intentionally make the features bad enough so most players have to build their own custom solution, such as the server scan tool), so we will still try to improve the UI/UX. This means sometimes it's hard to determine whether a UI change is necessary, and it needs to be discussed case by case.

With this in mind, we need to answer these questions when designing the UI/UX for this feature:
- Do players actually need this feature? I.e., is the price history a mandatory feature or a purely cosmetic one? [1]
- If it's a mandatory feature, how good should the built-in implementation be? What kind of intentional restrictions should we put in place? [2]

There are two phases: pre-4S and post-4S. In pre-4S, players need to find a way to predict stock price movements. In order to do that, they need to record the price history and analyse it to estimate the hidden `otlkMag`. In post-4S, the hidden `otlkMag` can be queried directly, so players can easily find the most profitable stocks and decide whether to buy/sell each cycle. In other words, the stock market is practically a "solved" challenge in post-4S.

Therefore, the answer to question [1] is that, in pre-4S, the price history is a mandatory feature, but in post-4S, it's mostly a cosmetic feature.

For question [2], we need to consider:
- Should we lock the history access behind something such as the 4S data access?
- How many data points can the history contain?
- Can the history be queried by NS APIs?
- How easily can players check the history of a stock via the UI?
- Can players easily check the history of many stocks at the same time via the UI?

As I pointed out above, in post-4S, with access to the hidden `otlkMag`, the history is mostly a cosmetic feature. It's only useful in pre-4S. This is why I think we should let players access it right at the start.

The price history is not just a visualization tool; it's an important source of information that players need before they can analyze anything. Collecting information is very easy, but analyzing it is not. Naturally, players may think that they should analyze as many data points as possible. However, in this *game feature*, analyzing too many data points is actually counterproductive.

For example, let's say we have this timeline:
- Cycle 1: bull
- Cycle 2: bull
...
- Cycle 74: bull
- Cycle 75: flip bull/bear (bull => bear) and `otlkMagForecast`
- Cycle 76: bear
...
- Cycle 86: bear
- Cycle 96: bear

At cycle 96, if they use the data from the last 10 cycles, they may realize that the market is bear. With 20 cycles, they have a better chance of doing so. Naturally, they may think it's best to use as many collected data points as possible, potentially including all 96 cycles. However, if they do that, it's very likely that they will conclude that the current market is bull, which is wrong. Ideally, the history should contain *enough* data points to correctly infer the market state, but not too many points; otherwise, they will just infer the old and irrelevant market state (due to the flip cycle).

How many data points are *enough*? In theory, we can collect as many as possible (with a hard cap to avoid performance issues) and let players decide how many data points they want to look at. However, should we do that? This is where I want to mention the Bitburner's design philosophy again. Collecting data points is something players can and should do; it's part of their toolset for the stock market feature. We only need to provide a very basic chart so that players can use it to manually infer the market state. They will realize this is a mandatory feature (in pre-4S) and the built-in tool is very limited, so naturally they need to build their own tool.

Another important thing to note is that by observing a long history of many stocks, players can detect when the flip cycle happens without too much trouble. This is actually an advanced pre-4S technique. As shown above, if players can detect the flip around cycle 75 (with a small margin of error), they can collect a relatively long history to accurately guess the market state without worrying about the flip cycle. This is also why we randomize the first flip cycle. If the UI lets players access the long history of all stocks, they can guess the flip cycle too easily.

All things considered, I decided:
- Do *not* lock the history chart behind 4S data access.
- Only collect 10 data points.
- No NS APIs.
- Intentionally inconvenient UI: Players need to click on a stock, then click another button to view the history chart of that stock.
- No convenient way to view the history of all stocks at the same time.
- Nothing can be configured.

Other things to consider:
- Save the history in the save data. We only collect 10 data points, so it would not increase the save data size significantly. I think it's okay to do that, but I can change it if d0sboots wants.
- #3028 also fixes an edge case in `cycleForecast`. Currently, given the values of `changeAmt` used by `processStockPrices`, `otlkMag` cannot become greater than 50 after the `this.otlkMag < 0` block, so the fix is unnecessary with the current range of `changeAmt`. However, it preserves the `otlkMag` <= 50 invariant if `changeAmt` is ever increased significantly, so I incorporated it into this PR as well.

Screenshots:

<img width="764" height="317" alt="1" src="https://github.com/user-attachments/assets/23e4c303-8685-45ee-8d97-53eaeda60bc1" />

<img width="1001" height="529" alt="2" src="https://github.com/user-attachments/assets/426cd61b-388f-4b0c-99a0-cdc988e510ec" />
