### PR TITLE
DNET: Apply the SF15.2 authentication speed bonus at level 2

### DIFF
--- a/src/DarkNet/effects/effects.ts
+++ b/src/DarkNet/effects/effects.ts
@@ -77,7 +77,7 @@ export const calculateAuthenticationTime = (
   const applyUnderleveledFactor = person.skills.charisma <= chaRequired && darknetServerData.depth > 1;
   const underleveledFactor = applyUnderleveledFactor ? 1.5 + (chaRequired + 50) / (person.skills.charisma + 50) : 1;
   const hasBootsFactor = Player.hasAugmentation(AugmentationName.TheBoots) ? 0.8 : 1;
-  const hasSf15_2Factor = Player.activeSourceFileLvl(15) > 2 ? 0.8 : 1;
+  const hasSf15_2Factor = Player.activeSourceFileLvl(15) >= 2 ? 0.8 : 1;
   const intelligenceFactor = 1 / calculateIntelligenceBonus(person.skills.intelligence, 0.25);
 
   const time =


### PR DESCRIPTION
SF15.2 is documented as granting 20% authentication speed (`BitNode.tsx:549`,
`bitnodes.md:280`, `bitnode_recommendation_comprehensive_guide.md:201`), but the
gate in `calculateAuthenticationTime` is off by one and only fires at level 3.
The variable is even named `hasSf15_2Factor`. Every other SF15 gate matches its
documented level (`Work/Formulas.ts:133` `> 1`, `reputation.ts:55` and
`cacheFiles.ts:111` `>= 3`).

Only level 2 changes; 0, 1 and 3 are unaffected.

Tested by setting the SF15 override in BitNode options to 2 and then 3 and
comparing `ns.formulas.dnet.getAuthenticateTime` — before, the two differ by
0.8x; after, they match.