### PR TITLE
BUGFIX: Allow closeTail for stopped scripts

### DIFF
--- a/markdown/bitburner.userinterface.closetail.md
+++ b/markdown/bitburner.userinterface.closetail.md
@@ -60,5 +60,7 @@ Closes a script’s logs. This is functionally the same as pressing the "Close" 
 
 If the function is called with no arguments, it will close the current script’s logs.
 
-Otherwise, the pid argument can be used to close the logs from another script.
+Otherwise, the pid argument can be used to close the logs from another script. Tail windows can remain open after a script finishes, and can still be closed using that script's PID. If the script is rerun from its tail window, use the PID of the new process.
+
+If no tail window exists for the given PID, this function has no effect.
 

--- a/src/NetscriptFunctions/UserInterface.tsx
+++ b/src/NetscriptFunctions/UserInterface.tsx
@@ -86,11 +86,6 @@ export function NetscriptUserInterface(): InternalAPI<IUserInterface> {
 
     closeTail: (ctx, _pid = ctx.workerScript.scriptRef.pid) => {
       const pid = helpers.number(ctx, "pid", _pid);
-      const runningScriptObj = helpers.getRunningScript(ctx, pid);
-      if (runningScriptObj == null) {
-        helpers.log(ctx, () => helpers.getCannotFindRunningScriptErrorMessage(pid));
-        return;
-      }
       // Emit an event to tell the game to close the tail window if it exists.
       LogBoxCloserEvents.emit(pid);
     },

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -6948,7 +6948,11 @@ interface UserInterface {
    *
    * If the function is called with no arguments, it will close the current script’s logs.
    *
-   * Otherwise, the pid argument can be used to close the logs from another script.
+   * Otherwise, the pid argument can be used to close the logs from another script. Tail windows can remain open
+   * after a script finishes, and can still be closed using that script's PID. If the script is rerun from its tail
+   * window, use the PID of the new process.
+   *
+   * If no tail window exists for the given PID, this function has no effect.
    *
    * @param pid - Optional. PID of the script having its tail closed. If omitted, the current script is used.
    */

--- a/test/jest/Netscript/UserInterface.test.ts
+++ b/test/jest/Netscript/UserInterface.test.ts
@@ -2,7 +2,7 @@ import { IStyleSettings, UserInterfaceTheme } from "../../../src/ScriptEditor/Ne
 import { Settings } from "../../../src/Settings/Settings";
 import { defaultStyles } from "../../../src/Themes/Styles";
 import { defaultTheme } from "../../../src/Themes/Themes";
-import { getNS, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
+import { getNS, getWorkerScriptAndNS, initGameEnvironment, setupBasicTestingEnvironment } from "../Utilities";
 import { SpecialServers } from "../../../src/Server/data/SpecialServers";
 import { AddToAllServers, GetServerOrThrow, prestigeAllServers, connectServers } from "../../../src/Server/AllServers";
 import { Player } from "@player";
@@ -10,6 +10,7 @@ import { CompletedProgramName } from "@enums";
 import { validateConnections } from "../../../src/Server/ServerHelpers";
 import { Server } from "../../../src/Server/Server";
 import type { IPAddress } from "../../../src/Types/strings";
+import { LogBoxCloserEvents } from "../../../src/ui/React/LogBoxManager";
 
 const themeHexColor = "#abc";
 const fontFamily = "monospace";
@@ -20,6 +21,23 @@ beforeAll(() => {
 
 beforeEach(() => {
   setupBasicTestingEnvironment();
+});
+
+describe("closeTail", () => {
+  test("closes a tail after its script has stopped", () => {
+    const { ws, ns } = getWorkerScriptAndNS();
+    let closedPid: number | undefined;
+    const unsubscribe = LogBoxCloserEvents.subscribe((pid) => {
+      closedPid = pid;
+    });
+
+    try {
+      ns.ui.closeTail(ws.scriptRef.pid);
+      expect(closedPid).toBe(ws.scriptRef.pid);
+    } finally {
+      unsubscribe();
+    }
+  });
 });
 
 describe("setTheme", () => {


### PR DESCRIPTION
Fixes #3006.

Tail windows can outlive the script that opened them, but `closeTail` currently returns before emitting the close event once that script is no longer running. Allow the close event for stopped scripts and document the no-op behavior when no matching tail exists.

Adds a regression test for closing a stopped script's tail and regenerates the API docs.

Validated with format/lint checks and the full test suite (4,547 passed, 4 skipped).
