### PR TITLE
BUGFIX: Cannot restore default augmentation order after sorting by cost or reputation

### DIFF
--- a/src/Faction/ui/AugmentationsPage.tsx
+++ b/src/Faction/ui/AugmentationsPage.tsx
@@ -38,7 +38,10 @@ export function AugmentationsPage({ faction }: { faction: Faction }): React.Reac
   );
 
   function getAugs(): AugmentationName[] {
-    return filteredFactionAugs;
+    // filteredFactionAugs contains augs in the default order. We need to return a copy here so callers cannot
+    // accidentally mutate it.
+    // Using slice is enough because the array contains only strings.
+    return filteredFactionAugs.slice();
   }
 
   function getAugsSorted(): AugmentationName[] {


### PR DESCRIPTION
MRE:
- Load a clean save file.
- Join Illuminati.
- Open the "Faction Augmentations" page.
- The default order: NFG => Synthetic Heart => Synfibril Muscle => NEMEAN Subdermal Weave
- Press "Sort by Purchasable": NFG => Synfibril Muscle => Embedded Netburner Module Analyze Engine
- Press "Sort by Default Order": NFG => Synthetic Heart => Synfibril Muscle => NEMEAN Subdermal Weave (correct)
- Press "Sort by Cost": NFG => Synfibril Muscle => Synthetic Heart => NEMEAN Subdermal Weave
- Press "Sort by Default Order": The augs are still displayed in the order produced by "Sort by Cost".

`getAugsSortedByCost` and `getAugsSortedByReputation` mutates the array returned by `getAugs`, and that array is the memoized `filteredFactionAugs`, which contains the augs in the default order. `getAugsSortedByPurchasable` does not have this issue because it sorts a copy (`augs.filter(canBuy).sort()`).