### PR TITLE
BUGFIX: Invalidate cached RAM when imported scripts change

### DIFF
--- a/src/NetscriptJSEvaluator.ts
+++ b/src/NetscriptJSEvaluator.ts
@@ -47,6 +47,7 @@ export function compile(script: Script, scripts: Map<ScriptFilePath, Script>): P
   try {
     script.mod = generateLoadedModule(script, scripts, []);
   } catch (error) {
+    script.clearModuleDependencies();
     throw new Error(`Cannot generate module ${script.filename}`, { cause: error });
   }
   return script.mod.module;
@@ -60,7 +61,7 @@ export function compile(script: Script, scripts: Map<ScriptFilePath, Script>): P
 function addDependencyInfo(script: Script, seenStack: Script[]) {
   if (!script.mod) throw new Error(`addDependencyInfo called without a LoadedModule (${script.filename})`);
   if (seenStack.length) {
-    script.dependents.add(seenStack[seenStack.length - 1]);
+    seenStack[seenStack.length - 1].registerModuleDependency(script);
     for (const dependent of seenStack) dependent.dependencies.set(script.mod.url, script);
   }
   // Add self to dependencies (it's not part of the stack, since we don't want

--- a/src/Script/RamCalculations.ts
+++ b/src/Script/RamCalculations.ts
@@ -31,9 +31,13 @@ export interface RamUsageEntry {
   cost: number;
 }
 
+export type RamDependencyEdge = [dependent: ScriptFilePath, dependency: ScriptFilePath];
+
 export type RamCalculationSuccess = {
   cost: number;
   entries: RamUsageEntry[];
+  dependencyEdges: RamDependencyEdge[];
+  parsedModules: ScriptFilePath[];
   errorCode?: never;
   errorMessage?: never;
 };
@@ -101,10 +105,11 @@ function parseOnlyRamCalculate(
   let dependencyMap: Record<string, Set<string>> = {};
 
   // Scripts we've parsed.
-  const completedParses = new Set();
+  const completedParses = new Set<ScriptFilePath>();
 
   // Scripts we've discovered that need to be parsed.
   const parseQueue: ScriptFilePath[] = [];
+  const dependencyEdges: RamDependencyEdge[] = [];
   // Parses a chunk of code with a given module name, and updates parseQueue and dependencyMap.
   function parseCode(ast: AST, moduleName: ScriptFilePath, fileTypeFeatureOfModule: FileTypeFeature): void {
     const result = parseOnlyCalculateDeps(ast, moduleName, fileTypeFeatureOfModule, otherScripts);
@@ -112,6 +117,7 @@ function parseOnlyRamCalculate(
 
     // Add any additional modules to the parse queue;
     for (const additionalModule of result.additionalModules) {
+      dependencyEdges.push([moduleName, additionalModule]);
       if (!completedParses.has(additionalModule) && !parseQueue.includes(additionalModule)) {
         parseQueue.push(additionalModule);
       }
@@ -179,7 +185,12 @@ function parseOnlyRamCalculate(
       // This is a RAM override for the main module. We can end ram calculation immediately.
       const [first] = dependencyMap[ref];
       const override = Number(first);
-      return { cost: override, entries: [{ type: "misc", name: "override", cost: override }] };
+      return {
+        cost: override,
+        entries: [{ type: "misc", name: "override", cost: override }],
+        dependencyEdges,
+        parsedModules: [...completedParses],
+      };
     }
     // Check if this is one of the special keys, and add the appropriate ram cost if so.
     if (ref === "document" && !resolvedRefs.has("document")) {
@@ -256,7 +267,12 @@ function parseOnlyRamCalculate(
     ram = RamCostConstants.Max;
     detailedCosts.push({ type: "misc", name: "Max Ram Cap", cost: RamCostConstants.Max });
   }
-  return { cost: ram, entries: detailedCosts.filter((e) => e.cost > 0) };
+  return {
+    cost: ram,
+    entries: detailedCosts.filter((e) => e.cost > 0),
+    dependencyEdges,
+    parsedModules: [...completedParses],
+  };
 }
 
 export function checkInfiniteLoop(ast: AST, code: string): number[] {

--- a/src/Script/Script.ts
+++ b/src/Script/Script.ts
@@ -23,6 +23,10 @@ export class Script extends ContentFile {
   mod: LoadedModule | null = null;
   /** Scripts that directly import this one. Stored so we can invalidate these dependent scripts when this one is invalidated. */
   dependents = new Set<Script>();
+  /** Scripts directly imported by the RAM calculation graph. */
+  private readonly ramDependencies = new Set<Script>();
+  /** Scripts directly imported by the compiled module graph. */
+  private readonly moduleDependencies = new Set<Script>();
   /**
    * Scripts that we directly or indirectly import, including ourselves.
    * Stored only so RunningScript can use it, to translate urls in error messages.
@@ -50,18 +54,59 @@ export class Script extends ContentFile {
 
   /** Invalidates the current script module and related data, e.g. when modifying the file. */
   invalidateModule(): void {
-    // Always clear ram usage
     this.ramUsage = null;
     this.ramUsageEntries.length = 0;
     this.ramCalculationError = null;
-    // Early return if there's already no URL
-    if (!this.mod) return;
     this.mod = null;
-    for (const dependent of this.dependents) dependent.invalidateModule();
-    this.dependents.clear();
     // This will be mutated in compile(), but is immutable after that.
     // (No RunningScripts can access this copy before that point).
     this.dependencies = new Map();
+
+    // Clear before recursing so circular dependency graphs terminate.
+    const dependents = [...this.dependents];
+    this.dependents.clear();
+    this.detachFromDependencies();
+
+    for (const dependent of dependents) dependent.invalidateModule();
+  }
+
+  /** Register one direct dependency discovered while compiling this script. */
+  registerModuleDependency(dependency: Script): void {
+    if (dependency === this) return;
+    this.moduleDependencies.add(dependency);
+    dependency.dependents.add(this);
+  }
+
+  /** Remove partially registered compile edges without disturbing a still-valid RAM graph. */
+  clearModuleDependencies(): void {
+    for (const dependency of this.moduleDependencies) {
+      if (!this.ramDependencies.has(dependency)) dependency.dependents.delete(this);
+    }
+    this.moduleDependencies.clear();
+  }
+
+  /** Replace RAM dependency edges only after a complete calculation succeeds. */
+  private replaceRamDependencies(dependencies: Set<Script>): void {
+    dependencies.delete(this);
+    for (const dependency of this.ramDependencies) {
+      if (!dependencies.has(dependency) && !this.moduleDependencies.has(dependency)) {
+        dependency.dependents.delete(this);
+      }
+    }
+    this.ramDependencies.clear();
+    for (const dependency of dependencies) {
+      this.ramDependencies.add(dependency);
+      dependency.dependents.add(this);
+    }
+  }
+
+  /** Detach all outgoing graph edges when this Script object is invalidated or removed. */
+  private detachFromDependencies(): void {
+    for (const dependency of new Set([...this.ramDependencies, ...this.moduleDependencies])) {
+      dependency.dependents.delete(this);
+    }
+    this.ramDependencies.clear();
+    this.moduleDependencies.clear();
   }
 
   /** Gets the ram usage, while also attempting to update it if it's currently null */
@@ -78,6 +123,21 @@ export class Script extends ContentFile {
   updateRamUsage(otherScripts: Map<ScriptFilePath, Script>): void {
     const ramCalc = calculateRamUsage(this.code, this.filename, this.server, otherScripts);
     if (ramCalc.cost && ramCalc.cost >= RamCostConstants.Base) {
+      const dependencyGraph = new Map<Script, Set<Script>>();
+      for (const path of ramCalc.parsedModules) {
+        const dependent = path === this.filename ? this : otherScripts.get(path);
+        if (dependent) dependencyGraph.set(dependent, new Set());
+      }
+      for (const [dependentPath, dependencyPath] of ramCalc.dependencyEdges) {
+        const dependent = dependentPath === this.filename ? this : otherScripts.get(dependentPath);
+        const dependency = dependencyPath === this.filename ? this : otherScripts.get(dependencyPath);
+        if (dependent && dependency && dependent !== dependency) {
+          const dependencies = dependencyGraph.get(dependent) ?? new Set<Script>();
+          dependencies.add(dependency);
+          dependencyGraph.set(dependent, dependencies);
+        }
+      }
+      for (const [dependent, dependencies] of dependencyGraph) dependent.replaceRamDependencies(dependencies);
       this.ramUsage = roundToTwo(ramCalc.cost);
       this.ramUsageEntries = ramCalc.entries;
       this.ramCalculationError = null;

--- a/test/jest/Script/Script.test.ts
+++ b/test/jest/Script/Script.test.ts
@@ -1,4 +1,5 @@
-import { resolveScriptFilePath } from "../../../src/Paths/ScriptFilePath";
+import { resolveScriptFilePath, type ScriptFilePath } from "../../../src/Paths/ScriptFilePath";
+import { Script } from "../../../src/Script/Script";
 import { Server } from "../../../src/Server/Server";
 
 const code = `/** @param {NS} ns */
@@ -20,5 +21,324 @@ describe("Validate Save Script Works", function () {
     expect(script.filename).toEqual(filename);
     expect(script.code).toEqual(code);
     expect(script.server).toEqual(hostname);
+  });
+});
+
+describe("RAM usage cache invalidation", () => {
+  const asPath = (path: string) => path as ScriptFilePath;
+  const noRamCode = `export function func(ns) { return ns.args.length; }`;
+  const hackRamCode = `export function func(ns) { return ns.hack("n00dles"); }`;
+  const growRamCode = `export function func(ns) { return ns.grow("n00dles"); }`;
+
+  function makeScripts(entries: [string, string][]): Map<ScriptFilePath, Script> {
+    return new Map(
+      entries.map(([filename, scriptCode]) => [asPath(filename), new Script(asPath(filename), scriptCode)]),
+    );
+  }
+
+  it("invalidates a cached importer when an uncompiled dependency changes", () => {
+    const scripts = makeScripts([
+      ["main.js", `import { func } from "b.js"; export function main(ns) { return func(ns); }`],
+      ["b.js", noRamCode],
+      ["independent.js", `export function main(ns) { return ns.args.length; }`],
+    ]);
+    const main = scripts.get(asPath("main.js"));
+    const dependency = scripts.get(asPath("b.js"));
+    const independent = scripts.get(asPath("independent.js"));
+    if (!main || !dependency || !independent) throw new Error("Missing test script");
+
+    const initialRam = main.getRamUsage(scripts);
+    const independentRam = independent.getRamUsage(scripts);
+    expect(initialRam).not.toBeNull();
+    expect(independentRam).not.toBeNull();
+    expect(main.mod).toBeNull();
+    expect(dependency.mod).toBeNull();
+
+    dependency.content = hackRamCode;
+
+    expect(main.ramUsage).toBeNull();
+    expect(independent.ramUsage).toBe(independentRam);
+    expect(main.getRamUsage(scripts)).toBeGreaterThan(initialRam ?? 0);
+  });
+
+  it("tracks transitive imports", () => {
+    const scripts = makeScripts([
+      ["main.js", `import { func } from "b.js"; export function main(ns) { return func(ns); }`],
+      ["b.js", `import { func as inner } from "c.js"; export function func(ns) { return inner(ns); }`],
+      ["c.js", noRamCode],
+    ]);
+    const main = scripts.get(asPath("main.js"));
+    const dependency = scripts.get(asPath("c.js"));
+    if (!main || !dependency) throw new Error("Missing test script");
+
+    const initialRam = main.getRamUsage(scripts);
+    expect(initialRam).not.toBeNull();
+
+    dependency.content = hackRamCode;
+    expect(main.ramUsage).toBeNull();
+    expect(main.getRamUsage(scripts)).toBeGreaterThan(initialRam ?? 0);
+  });
+
+  it("tracks multiple imports and supports repeated invalidation", () => {
+    const scripts = makeScripts([
+      [
+        "main.js",
+        `import { func as b } from "b.js"; import { func as c } from "c.js"; export function main(ns) { b(ns); return c(ns); }`,
+      ],
+      ["b.js", noRamCode],
+      ["c.js", noRamCode],
+    ]);
+    const main = scripts.get(asPath("main.js"));
+    const b = scripts.get(asPath("b.js"));
+    const c = scripts.get(asPath("c.js"));
+    if (!main || !b || !c) throw new Error("Missing test script");
+
+    const initialRam = main.getRamUsage(scripts);
+    expect(initialRam).not.toBeNull();
+
+    b.content = hackRamCode;
+    expect(main.ramUsage).toBeNull();
+    const afterFirstEdit = main.getRamUsage(scripts);
+    expect(afterFirstEdit).toBeGreaterThan(initialRam ?? 0);
+
+    c.content = growRamCode;
+    expect(main.ramUsage).toBeNull();
+    expect(main.getRamUsage(scripts)).toBeGreaterThan(afterFirstEdit ?? 0);
+
+    c.invalidateModule();
+    c.invalidateModule();
+    expect(main.ramUsage).toBeNull();
+  });
+
+  it("removes stale dependency edges when an importer changes imports", () => {
+    const scripts = makeScripts([
+      ["main.js", `import { func } from "b.js"; export function main(ns) { return func(ns); }`],
+      ["b.js", noRamCode],
+      ["c.js", hackRamCode],
+    ]);
+    const main = scripts.get(asPath("main.js"));
+    const b = scripts.get(asPath("b.js"));
+    const c = scripts.get(asPath("c.js"));
+    if (!main || !b || !c) throw new Error("Missing test script");
+
+    expect(main.getRamUsage(scripts)).not.toBeNull();
+    expect(b.dependents).toEqual(new Set([main]));
+
+    main.content = `import { func } from "c.js"; export function main(ns) { return func(ns); }`;
+    const currentRam = main.getRamUsage(scripts);
+    expect(currentRam).not.toBeNull();
+    expect(b.dependents).not.toContain(main);
+    expect(c.dependents).toContain(main);
+
+    b.content = growRamCode;
+    expect(main.ramUsage).toBe(currentRam);
+  });
+
+  it("does not retain deleted importers across same-name recreation", () => {
+    const server = new Server({ hostname: "home" });
+    const mainPath = asPath("main.js");
+    const dependencyPath = asPath("b.js");
+    server.writeToScriptFile(dependencyPath, noRamCode);
+    const dependency = server.scripts.get(dependencyPath);
+    if (!dependency) throw new Error("Missing dependency script");
+
+    const deletedImporters: Script[] = [];
+    for (let i = 0; i < 5; i++) {
+      server.writeToScriptFile(
+        mainPath,
+        `import { func } from "b.js"; export function main(ns) { return func(ns) + ${i}; }`,
+      );
+      const importer = server.scripts.get(mainPath);
+      if (!importer) throw new Error("Missing importer script");
+      expect(importer.getRamUsage(server.scripts)).not.toBeNull();
+      expect(dependency.dependents).toEqual(new Set([importer]));
+
+      deletedImporters.push(importer);
+      expect(server.removeFile(mainPath)).toEqual({ res: true });
+      expect(dependency.dependents.size).toBe(0);
+      expect(dependency.dependents).not.toContain(importer);
+    }
+
+    server.writeToScriptFile(mainPath, `import { func } from "b.js"; export function main(ns) { return func(ns); }`);
+    const replacement = server.scripts.get(mainPath);
+    if (!replacement) throw new Error("Missing replacement script");
+    expect(replacement.getRamUsage(server.scripts)).not.toBeNull();
+    expect(dependency.dependents).toEqual(new Set([replacement]));
+    for (const deletedImporter of deletedImporters) expect(dependency.dependents).not.toContain(deletedImporter);
+  });
+
+  it("invalidates an importer when a dependency is deleted and binds to the recreated object", () => {
+    const server = new Server({ hostname: "home" });
+    const mainPath = asPath("main.js");
+    const dependencyPath = asPath("b.js");
+    server.writeToScriptFile(mainPath, `import { func } from "b.js"; export function main(ns) { return func(ns); }`);
+    server.writeToScriptFile(dependencyPath, noRamCode);
+    const main = server.scripts.get(mainPath);
+    const oldDependency = server.scripts.get(dependencyPath);
+    if (!main || !oldDependency) throw new Error("Missing test script");
+
+    const initialRam = main.getRamUsage(server.scripts);
+    expect(initialRam).not.toBeNull();
+    expect(server.removeFile(dependencyPath)).toEqual({ res: true });
+    expect(main.ramUsage).toBeNull();
+    expect(oldDependency.dependents.size).toBe(0);
+
+    server.writeToScriptFile(dependencyPath, hackRamCode);
+    const newDependency = server.scripts.get(dependencyPath);
+    if (!newDependency) throw new Error("Missing recreated dependency");
+    expect(newDependency).not.toBe(oldDependency);
+    expect(main.getRamUsage(server.scripts)).toBeGreaterThan(initialRam ?? 0);
+    expect(oldDependency.dependents.size).toBe(0);
+    expect(newDependency.dependents).toEqual(new Set([main]));
+  });
+
+  it("tracks diamond imports without retaining duplicate edges", () => {
+    const scripts = makeScripts([
+      [
+        "a.js",
+        `import { funcB } from "b.js"; import { funcC } from "c.js"; export function main(ns) { funcB(ns); return funcC(ns); }`,
+      ],
+      ["b.js", `import { func } from "d.js"; export function funcB(ns) { return func(ns); }`],
+      ["c.js", `import { func } from "d.js"; export function funcC(ns) { return func(ns); }`],
+      ["d.js", noRamCode],
+    ]);
+    const a = scripts.get(asPath("a.js"));
+    const b = scripts.get(asPath("b.js"));
+    const c = scripts.get(asPath("c.js"));
+    const d = scripts.get(asPath("d.js"));
+    if (!a || !b || !c || !d) throw new Error("Missing test script");
+
+    const initialRam = a.getRamUsage(scripts);
+    expect(initialRam).not.toBeNull();
+    expect(d.dependents).toEqual(new Set([b, c]));
+
+    d.content = hackRamCode;
+    expect(a.ramUsage).toBeNull();
+    expect(a.getRamUsage(scripts)).toBeGreaterThan(initialRam ?? 0);
+    expect(d.dependents).toEqual(new Set([b, c]));
+  });
+
+  it("ignores self dependencies and keeps repeated RAM queries bounded", () => {
+    const scripts = makeScripts([["a.js", `import "a.js"; export function main(ns) { return ns.args.length; }`]]);
+    const a = scripts.get(asPath("a.js"));
+    if (!a) throw new Error("Missing test script");
+
+    expect(a.getRamUsage(scripts)).not.toBeNull();
+    expect(a.getRamUsage(scripts)).not.toBeNull();
+    a.updateRamUsage(scripts);
+    expect(a.dependents.size).toBe(0);
+  });
+
+  it("commits no partial graph on failure and preserves an old graph during a direct failed recalculation", () => {
+    const scripts = makeScripts([
+      ["main.js", `import { func } from "b.js"; export function main(ns) { return func(ns); }`],
+      ["b.js", noRamCode],
+    ]);
+    const main = scripts.get(asPath("main.js"));
+    const b = scripts.get(asPath("b.js"));
+    if (!main || !b) throw new Error("Missing test script");
+
+    expect(main.getRamUsage(scripts)).not.toBeNull();
+    expect(b.dependents).toEqual(new Set([main]));
+
+    main.code = `import { func } from "b.js"; import { missing } from "missing.js"; export function main(ns) { return func(ns) + missing(ns); }`;
+    main.updateRamUsage(scripts);
+    expect(main.ramUsage).toBeNull();
+    expect(b.dependents).toEqual(new Set([main]));
+
+    main.code = `import { func } from "b.js"; export function main(ns) { return func(ns); }`;
+    main.updateRamUsage(scripts);
+    expect(main.ramUsage).not.toBeNull();
+    expect(b.dependents).toEqual(new Set([main]));
+  });
+
+  it("keeps RAM and compile edge ownership independent", () => {
+    const scripts = makeScripts([
+      ["main.js", `import { func } from "b.js"; export function main(ns) { return func(ns); }`],
+      ["b.js", noRamCode],
+      ["c.js", hackRamCode],
+    ]);
+    const main = scripts.get(asPath("main.js"));
+    const b = scripts.get(asPath("b.js"));
+    const c = scripts.get(asPath("c.js"));
+    if (!main || !b || !c) throw new Error("Missing test script");
+
+    expect(main.getRamUsage(scripts)).not.toBeNull();
+    main.registerModuleDependency(b);
+
+    main.code = `import { func } from "c.js"; export function main(ns) { return func(ns); }`;
+    main.updateRamUsage(scripts);
+    expect(b.dependents).toContain(main);
+    expect(c.dependents).toContain(main);
+
+    main.clearModuleDependencies();
+    expect(b.dependents).not.toContain(main);
+    expect(c.dependents).toContain(main);
+
+    main.invalidateModule();
+    expect(c.dependents).not.toContain(main);
+  });
+
+  it("detaches the old object when a script is renamed through its real lifecycle", () => {
+    const server = new Server({ hostname: "home" });
+    const sourcePath = asPath("main.js");
+    const destinationPath = asPath("renamed.js");
+    const dependencyPath = asPath("b.js");
+    server.writeToScriptFile(dependencyPath, noRamCode);
+    server.writeToScriptFile(sourcePath, `import { func } from "b.js"; export function main(ns) { return func(ns); }`);
+    const dependency = server.scripts.get(dependencyPath);
+    const oldImporter = server.scripts.get(sourcePath);
+    if (!dependency || !oldImporter) throw new Error("Missing test script");
+
+    expect(oldImporter.getRamUsage(server.scripts)).not.toBeNull();
+    const content = oldImporter.content;
+    expect(oldImporter.deleteFromServer(server)).toBe(true);
+    server.writeToScriptFile(destinationPath, content);
+    const renamedImporter = server.scripts.get(destinationPath);
+    if (!renamedImporter) throw new Error("Missing renamed script");
+    expect(renamedImporter).not.toBe(oldImporter);
+    expect(renamedImporter.getRamUsage(server.scripts)).not.toBeNull();
+    expect(dependency.dependents).toEqual(new Set([renamedImporter]));
+    expect(dependency.dependents).not.toContain(oldImporter);
+  });
+
+  it("drops an invalidated old graph before a failed calculation", () => {
+    const scripts = makeScripts([
+      ["main.js", `import { func } from "b.js"; export function main(ns) { return func(ns); }`],
+      ["b.js", noRamCode],
+    ]);
+    const main = scripts.get(asPath("main.js"));
+    const b = scripts.get(asPath("b.js"));
+    if (!main || !b) throw new Error("Missing test script");
+
+    expect(main.getRamUsage(scripts)).not.toBeNull();
+    expect(b.dependents).toContain(main);
+
+    main.content = `import { func } from "b.js"; export function main(ns) {`;
+    expect(b.dependents).not.toContain(main);
+    expect(main.getRamUsage(scripts)).toBeNull();
+    expect(b.dependents).not.toContain(main);
+  });
+
+  it("terminates invalidation for a circular import graph", () => {
+    const scripts = makeScripts([
+      [
+        "a.js",
+        `import { funcB } from "b.js"; export function funcA(ns) { return ns.args.length; } export function main(ns) { return funcB(ns); }`,
+      ],
+      ["b.js", `import { funcA } from "a.js"; export function funcB(ns) { funcA(ns); return ns.args.length; }`],
+    ]);
+    const a = scripts.get(asPath("a.js"));
+    const b = scripts.get(asPath("b.js"));
+    if (!a || !b) throw new Error("Missing test script");
+
+    expect(a.getRamUsage(scripts)).not.toBeNull();
+    expect(a.mod).toBeNull();
+    expect(b.mod).toBeNull();
+
+    expect(() => {
+      b.content = hackRamCode;
+    }).not.toThrow();
+    expect(a.ramUsage).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #2907.

A RAM lookup can be the first operation that traverses a script's import graph. For example:

```js
// main.js
import { func } from "b.js";
export function main(ns) { return func(ns); }

// b.js
export function func(ns) { return ns.args.length; }
```

Running `mem main.js` before either script has been executed caches `main.js` at 1.6 GB without compiling a `LoadedModule`. If `b.js` is then changed to call a higher-cost API such as `ns.hack()`, another `mem main.js` still returns 1.6 GB instead of recalculating the importer.

`calculateRamUsage` already parses every imported module, but its module-level import edges were discarded with the calculation. The reverse `Script.dependents` edges used for invalidation were only registered by `NetscriptJSEvaluator` during module compilation. In this RAM-only path both scripts still have `mod === null`, so editing `b.js` clears its own RAM data but has no edge through which to invalidate `main.js`. The early return in `invalidateModule` for scripts without a compiled module made the same assumption.

Successful RAM calculations now return the direct import edges and the modules they parsed. `Script` installs those edges as a RAM-owned dependency graph alongside the existing compile-owned graph. The two owners are tracked separately so a RAM recalculation cannot remove an edge still needed by a compiled module, and compile cleanup cannot remove an edge still needed by a valid RAM cache. A failed calculation does not commit a partial replacement graph.

Invalidation clears the current node and detaches its outgoing edges before recursing through importers. That ordering makes circular imports terminate and prevents deleted, recreated, or renamed scripts from leaving old `Script` objects in another script's `dependents` set. Recalculation also removes edges for imports that are no longer present, so later edits to the old dependency do not invalidate an unrelated cache.

The automated regression calls `Script.getRamUsage` directly, which is the same cache path used by both `mem` and `ns.getScriptRam`; it does not drive the browser terminal UI. On the unpatched tree, changing an uncompiled dependency leaves the importer cached at the stale 1.6 GB value, and the same failure appears through transitive and circular import graphs. The permanent tests cover that RAM-only path, dependency replacement and script lifecycles, and shared RAM/compile ownership. The targeted file reports 14 passed, the related script and RAM suites report 167 passed and 2 skipped, and the full Jest suite reports 4,560 passed and 4 skipped.
