### PR TITLE
RFA: Add file size to metadata API responses

### DIFF
--- a/src/Documentation/doc/en/programming/remote_api.md
+++ b/src/Documentation/doc/en/programming/remote_api.md
@@ -43,6 +43,8 @@ All APIs use a request/response format similar to the JSON RPC 2.0 protocol.
 
 Unknown parameters in requests are ignored.
 
+Pagination is not supported.
+
 Request:
 
         {

--- a/src/Documentation/doc/en/programming/remote_api.md
+++ b/src/Documentation/doc/en/programming/remote_api.md
@@ -68,36 +68,6 @@ Error Response:
             "error": string
         }
 
-### Pagination
-
-Some APIs support pagination. These APIs accept the following optional parameters in `params`:
-
-- `limit`: The maximum number of items to return. If omitted, there is no limit.
-- `offset`: The number of items to skip before returning items. If omitted, defaults to 0.
-
-If specified, `limit` and `offset` must be a non-negative integer. `null` is not a valid value.
-
-        {
-            "jsonrpc": "2.0",
-            "id": number,
-            "method": string,
-            "params": {
-                "limit": number;
-                "offset": number;
-            }
-        }
-
-Paginated responses include a `total` field containing the total number of items before applying `limit` and `offset`:
-
-        {
-            "jsonrpc": "2.0",
-            "id": number,
-            "result": any,
-            "total": number
-        }
-
-In the next section, APIs that support pagination will say "This API supports pagination". For brevity, their request and response schemas do not include the optional `limit` and `offset` parameters or the `total` field. The pagination rules described above still apply.
-
 ### API list
 
 #### pushFile
@@ -172,9 +142,10 @@ Response:
             "id": number,
             "result": {
                 "filename": string,
-                "atime": string,
-                "btime": string,
-                "mtime": string
+                "size": number,
+                "atime": number,
+                "btime": number,
+                "mtime": number
             }
         }
 
@@ -206,8 +177,6 @@ Response:
 
 List all file names on a server.
 
-This API supports pagination.
-
 Request:
 
         {
@@ -230,8 +199,6 @@ Response:
 #### getAllFiles
 
 Get the content of all files on a server.
-
-This API supports pagination.
 
 Request:
 
@@ -259,8 +226,6 @@ Response:
 
 Get the content of all files on a server.
 
-This API supports pagination.
-
 Request:
 
         {
@@ -279,9 +244,10 @@ Response:
             "id": number,
             "result": {
                 "filename": string,
-                "atime": string
-                "btime": string,
-                "mtime": string,
+                "size": number,
+                "atime": number,
+                "btime": number,
+                "mtime": number
             }[]
         }
 

--- a/src/Documentation/doc/en/programming/remote_api.md
+++ b/src/Documentation/doc/en/programming/remote_api.md
@@ -37,7 +37,11 @@ Links:
 
 ## API specification
 
+### Overview
+
 All APIs use a request/response format similar to the JSON RPC 2.0 protocol.
+
+Unknown parameters in requests are ignored.
 
 Request:
 
@@ -64,7 +68,39 @@ Error Response:
             "error": string
         }
 
-### pushFile
+### Pagination
+
+Some APIs support pagination. These APIs accept the following optional parameters in `params`:
+
+- `limit`: The maximum number of items to return. If omitted, there is no limit.
+- `offset`: The number of items to skip before returning items. If omitted, defaults to 0.
+
+If specified, `limit` and `offset` must be a non-negative integer. `null` is not a valid value.
+
+        {
+            "jsonrpc": "2.0",
+            "id": number,
+            "method": string,
+            "params": {
+                "limit": number;
+                "offset": number;
+            }
+        }
+
+Paginated responses include a `total` field containing the total number of items before applying `limit` and `offset`:
+
+        {
+            "jsonrpc": "2.0",
+            "id": number,
+            "result": any,
+            "total": number
+        }
+
+In the next section, APIs that support pagination will say "This API supports pagination". For brevity, their request and response schemas do not include the optional `limit` and `offset` parameters or the `total` field. The pagination rules described above still apply.
+
+### API list
+
+#### pushFile
 
 Create or update a file.
 
@@ -89,7 +125,7 @@ Response:
             "result": "OK"
         }
 
-### getFile
+#### getFile
 
 Read a file and its content.
 
@@ -113,7 +149,7 @@ Response:
             "result": string
         }
 
-### getFileMetadata
+#### getFileMetadata
 
 Read metadata of a file.
 
@@ -142,7 +178,7 @@ Response:
             }
         }
 
-### deleteFile
+#### deleteFile
 
 Delete a file.
 
@@ -166,9 +202,11 @@ Response:
             "result": "OK"
         }
 
-### getFileNames
+#### getFileNames
 
 List all file names on a server.
+
+This API supports pagination.
 
 Request:
 
@@ -189,9 +227,11 @@ Response:
             "result": string[]
         }
 
-### getAllFiles
+#### getAllFiles
 
 Get the content of all files on a server.
+
+This API supports pagination.
 
 Request:
 
@@ -215,11 +255,13 @@ Response:
             }[]
         }
 
-### getAllFileMetadata
-
-Request:
+#### getAllFileMetadata
 
 Get the content of all files on a server.
+
+This API supports pagination.
+
+Request:
 
         {
             "jsonrpc": "2.0",
@@ -243,7 +285,7 @@ Response:
             }[]
         }
 
-### calculateRam
+#### calculateRam
 
 Calculate the in-game ram cost of a script.
 
@@ -267,7 +309,7 @@ Response:
             "result": number
         }
 
-### getDefinitionFile
+#### getDefinitionFile
 
 Get the definition file of NS APIs.
 
@@ -287,7 +329,7 @@ Response:
             "result": string
         }
 
-### getSaveFile
+#### getSaveFile
 
 Get save data.
 
@@ -311,7 +353,7 @@ Response:
             }
         }
 
-### getAllServers
+#### getAllServers
 
 Get all servers.
 

--- a/src/Paths/ContentFile.ts
+++ b/src/Paths/ContentFile.ts
@@ -3,6 +3,10 @@ import type { ScriptFilePath } from "./ScriptFilePath";
 import type { TextFilePath } from "./TextFilePath";
 import { FileMetadata } from "./FileMetadata";
 
+// Share a TextEncoder to avoid creating a new instance for each size calculation.
+// TextEncoder is stateless, so sharing it is safe.
+const textEncoder = new TextEncoder();
+
 /** Provide a common interface for accessing script and text files */
 export type ContentFilePath = ScriptFilePath | TextFilePath;
 export abstract class ContentFile {
@@ -16,6 +20,12 @@ export abstract class ContentFile {
     this.metadata = new FileMetadata();
   }
   abstract deleteFromServer(server: BaseServer): boolean;
+  /**
+   * Returns the UTF-8 byte size of the file content.
+   */
+  getSize(): number {
+    return textEncoder.encode(this.content).length;
+  }
 }
 export type ContentFileMap = Map<ContentFilePath, ContentFile>;
 

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -12,9 +12,9 @@ abstract class RFAMessage {
 
 export class RFARequest extends RFAMessage {
   public method: string;
-  public params: FileDescription & PaginationParams;
+  public params: FileDescription;
 
-  constructor(obj: { id: number; method: string; params: FileDescription & PaginationParams }) {
+  constructor(obj: { id: number; method: string; params: FileDescription }) {
     super(obj.id);
     this.method = obj.method;
     this.params = obj.params;
@@ -25,14 +25,10 @@ export abstract class RFAResponse extends RFAMessage {}
 
 export class RFASuccessResponse extends RFAResponse {
   public result: ResultType;
-  public total?: number;
 
-  constructor(obj: { id: number; result: ResultType; total?: number }) {
+  constructor(obj: { id: number; result: ResultType }) {
     super(obj.id);
     this.result = obj.result;
-    if (obj.total !== undefined) {
-      this.total = obj.total;
-    }
   }
 }
 
@@ -58,7 +54,6 @@ type ResultType =
     }
   | FileMetadata
   | FileMetadata[];
-
 type FileDescription = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {
@@ -86,11 +81,6 @@ export interface FileMetadata {
   atime: number;
   mtime: number;
   btime: number;
-}
-
-export interface PaginationParams {
-  limit?: number;
-  offset?: number;
 }
 
 export type RFAServerData = Pick<BaseServer, "hostname" | "hasAdminRights" | "purchasedByPlayer">;

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -12,9 +12,9 @@ abstract class RFAMessage {
 
 export class RFARequest extends RFAMessage {
   public method: string;
-  public params: FileDescription;
+  public params: FileDescription & PaginationParams;
 
-  constructor(obj: { id: number; method: string; params: FileDescription }) {
+  constructor(obj: { id: number; method: string; params: FileDescription & PaginationParams }) {
     super(obj.id);
     this.method = obj.method;
     this.params = obj.params;
@@ -25,10 +25,14 @@ export abstract class RFAResponse extends RFAMessage {}
 
 export class RFASuccessResponse extends RFAResponse {
   public result: ResultType;
+  public total?: number;
 
-  constructor(obj: { id: number; result: ResultType }) {
+  constructor(obj: { id: number; result: ResultType; total?: number }) {
     super(obj.id);
     this.result = obj.result;
+    if (obj.total !== undefined) {
+      this.total = obj.total;
+    }
   }
 }
 
@@ -54,6 +58,7 @@ type ResultType =
     }
   | FileMetadata
   | FileMetadata[];
+
 type FileDescription = FileData | FileContent | FileLocation | FileServer;
 
 export interface FileData {
@@ -81,6 +86,11 @@ export interface FileMetadata {
   atime: number;
   mtime: number;
   btime: number;
+}
+
+export interface PaginationParams {
+  limit?: number;
+  offset?: number;
 }
 
 export type RFAServerData = Pick<BaseServer, "hostname" | "hasAdminRights" | "purchasedByPlayer">;

--- a/src/RemoteFileAPI/MessageDefinitions.ts
+++ b/src/RemoteFileAPI/MessageDefinitions.ts
@@ -78,6 +78,7 @@ export interface FileServer {
 
 export interface FileMetadata {
   filename: string;
+  size: number;
   atime: number;
   mtime: number;
   btime: number;

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -130,6 +130,7 @@ export const RFARequestHandler: Record<string, (message: RFARequest) => RFARespo
     return new RFASuccessResponse({
       result: {
         filename: file.filename,
+        size: file.getSize(),
         ...file.metadata.plain(),
       },
       id: msg.id,
@@ -186,6 +187,7 @@ export const RFARequestHandler: Record<string, (message: RFARequest) => RFARespo
 
     const fileList = [...validationData.server.scripts, ...validationData.server.textFiles].map(([filename, file]) => ({
       filename: filename,
+      size: file.getSize(),
       ...file.metadata.plain(),
     }));
     return new RFASuccessResponse({ result: fileList, id: msg.id });

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -158,7 +158,7 @@ export const RFARequestHandler: Record<string, (message: RFARequest) => RFARespo
     }
     const validationData = validationResult.data;
 
-    const fileNameList = [...validationData.server.textFiles.keys(), ...validationData.server.scripts.keys()];
+    const fileNameList = [...validationData.server.scripts.keys(), ...validationData.server.textFiles.keys()];
 
     return new RFASuccessResponse({ result: fileNameList, id: msg.id });
   },

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -8,11 +8,11 @@ import {
   isFileData,
   type FileData,
   type FileLocation,
+  type FileServer,
   RFAErrorResponse,
   type RFARequest,
   type RFAResponse,
   RFASuccessResponse,
-  type PaginationParams,
 } from "./MessageDefinitions";
 
 import libSource from "../ScriptEditor/NetscriptDefinitions.d.ts?raw";
@@ -71,7 +71,9 @@ function validateFilePathAndServerParams<T extends FileData | FileLocation>(
   return { success: true, data: { filePath, server, params } };
 }
 
-function validateServerParams(request: RFARequest): { success: true; data: { server: BaseServer } } | FailureResult {
+function validateServerParams(
+  request: RFARequest,
+): { success: true; data: { server: BaseServer; params: FileServer } } | FailureResult {
   const validationResult = validateParams(isFileServer, request);
   if (!validationResult.success) {
     return validationResult;
@@ -83,33 +85,7 @@ function validateServerParams(request: RFARequest): { success: true; data: { ser
     return { success: false, errorResponse: getErrorResponse(`Invalid hostname: ${fileServer.server}`, request) };
   }
 
-  return { success: true, data: { server } };
-}
-
-function validatePaginationParams(request: RFARequest): { success: true; data: PaginationParams } | FailureResult {
-  if (request.params.limit !== undefined && (!Number.isInteger(request.params.limit) || request.params.limit < 0)) {
-    return {
-      success: false,
-      errorResponse: getErrorResponse(`Invalid limit: ${request.params.limit}`, request),
-    };
-  }
-
-  if (request.params.offset !== undefined && (!Number.isInteger(request.params.offset) || request.params.offset < 0)) {
-    return {
-      success: false,
-      errorResponse: getErrorResponse(`Invalid offset: ${request.params.offset}`, request),
-    };
-  }
-  return { success: true, data: { limit: request.params.limit, offset: request.params.offset } };
-}
-
-function paginate<T>(items: T[], paginationParams: PaginationParams): { items: T[]; total: number } {
-  const { limit = items.length, offset = 0 } = paginationParams;
-
-  return {
-    items: items.slice(offset, offset + limit),
-    total: items.length,
-  };
+  return { success: true, data: { server, params: fileServer } };
 }
 
 export const RFARequestHandler: Record<string, (message: RFARequest) => RFAResponse | Promise<RFAResponse>> = {
@@ -176,75 +152,43 @@ export const RFARequestHandler: Record<string, (message: RFARequest) => RFARespo
   },
 
   getFileNames: function (msg: RFARequest): RFAResponse {
-    const serverValidationResult = validateServerParams(msg);
-    if (!serverValidationResult.success) {
-      return serverValidationResult.errorResponse;
+    const validationResult = validateServerParams(msg);
+    if (!validationResult.success) {
+      return validationResult.errorResponse;
     }
+    const validationData = validationResult.data;
 
-    const paginationValidationResult = validatePaginationParams(msg);
-    if (!paginationValidationResult.success) {
-      return paginationValidationResult.errorResponse;
-    }
+    const fileNameList = [...validationData.server.textFiles.keys(), ...validationData.server.scripts.keys()];
 
-    const { server } = serverValidationResult.data;
-    const fileNameList = [...server.scripts.keys(), ...server.textFiles.keys()];
-    const { items, total } = paginate(fileNameList, paginationValidationResult.data);
-
-    return new RFASuccessResponse({
-      result: items,
-      total,
-      id: msg.id,
-    });
+    return new RFASuccessResponse({ result: fileNameList, id: msg.id });
   },
 
   getAllFiles: function (msg: RFARequest): RFAResponse {
-    const serverValidationResult = validateServerParams(msg);
-    if (!serverValidationResult.success) {
-      return serverValidationResult.errorResponse;
+    const validationResult = validateServerParams(msg);
+    if (!validationResult.success) {
+      return validationResult.errorResponse;
     }
+    const validationData = validationResult.data;
 
-    const paginationValidationResult = validatePaginationParams(msg);
-    if (!paginationValidationResult.success) {
-      return paginationValidationResult.errorResponse;
-    }
-
-    const { server } = serverValidationResult.data;
-    const fileList = [...server.scripts, ...server.textFiles].map(([filename, file]) => ({
+    const fileList = [...validationData.server.scripts, ...validationData.server.textFiles].map(([filename, file]) => ({
       filename,
       content: file.content,
     }));
-    const { items, total } = paginate(fileList, paginationValidationResult.data);
-
-    return new RFASuccessResponse({
-      result: items,
-      total,
-      id: msg.id,
-    });
+    return new RFASuccessResponse({ result: fileList, id: msg.id });
   },
 
   getAllFileMetadata: function (msg: RFARequest): RFAResponse {
-    const serverValidationResult = validateServerParams(msg);
-    if (!serverValidationResult.success) {
-      return serverValidationResult.errorResponse;
+    const validationResult = validateServerParams(msg);
+    if (!validationResult.success) {
+      return validationResult.errorResponse;
     }
+    const validationData = validationResult.data;
 
-    const paginationValidationResult = validatePaginationParams(msg);
-    if (!paginationValidationResult.success) {
-      return paginationValidationResult.errorResponse;
-    }
-
-    const { server } = serverValidationResult.data;
-    const fileList = [...server.scripts, ...server.textFiles].map(([filename, file]) => ({
-      filename,
+    const fileList = [...validationData.server.scripts, ...validationData.server.textFiles].map(([filename, file]) => ({
+      filename: filename,
       ...file.metadata.plain(),
     }));
-    const { items, total } = paginate(fileList, paginationValidationResult.data);
-
-    return new RFASuccessResponse({
-      result: items,
-      total,
-      id: msg.id,
-    });
+    return new RFASuccessResponse({ result: fileList, id: msg.id });
   },
 
   calculateRam: function (msg: RFARequest): RFAResponse {

--- a/src/RemoteFileAPI/MessageHandlers.ts
+++ b/src/RemoteFileAPI/MessageHandlers.ts
@@ -8,11 +8,11 @@ import {
   isFileData,
   type FileData,
   type FileLocation,
-  type FileServer,
   RFAErrorResponse,
   type RFARequest,
   type RFAResponse,
   RFASuccessResponse,
+  type PaginationParams,
 } from "./MessageDefinitions";
 
 import libSource from "../ScriptEditor/NetscriptDefinitions.d.ts?raw";
@@ -71,9 +71,7 @@ function validateFilePathAndServerParams<T extends FileData | FileLocation>(
   return { success: true, data: { filePath, server, params } };
 }
 
-function validateServerParams(
-  request: RFARequest,
-): { success: true; data: { server: BaseServer; params: FileServer } } | FailureResult {
+function validateServerParams(request: RFARequest): { success: true; data: { server: BaseServer } } | FailureResult {
   const validationResult = validateParams(isFileServer, request);
   if (!validationResult.success) {
     return validationResult;
@@ -85,7 +83,33 @@ function validateServerParams(
     return { success: false, errorResponse: getErrorResponse(`Invalid hostname: ${fileServer.server}`, request) };
   }
 
-  return { success: true, data: { server, params: fileServer } };
+  return { success: true, data: { server } };
+}
+
+function validatePaginationParams(request: RFARequest): { success: true; data: PaginationParams } | FailureResult {
+  if (request.params.limit !== undefined && (!Number.isInteger(request.params.limit) || request.params.limit < 0)) {
+    return {
+      success: false,
+      errorResponse: getErrorResponse(`Invalid limit: ${request.params.limit}`, request),
+    };
+  }
+
+  if (request.params.offset !== undefined && (!Number.isInteger(request.params.offset) || request.params.offset < 0)) {
+    return {
+      success: false,
+      errorResponse: getErrorResponse(`Invalid offset: ${request.params.offset}`, request),
+    };
+  }
+  return { success: true, data: { limit: request.params.limit, offset: request.params.offset } };
+}
+
+function paginate<T>(items: T[], paginationParams: PaginationParams): { items: T[]; total: number } {
+  const { limit = items.length, offset = 0 } = paginationParams;
+
+  return {
+    items: items.slice(offset, offset + limit),
+    total: items.length,
+  };
 }
 
 export const RFARequestHandler: Record<string, (message: RFARequest) => RFAResponse | Promise<RFAResponse>> = {
@@ -152,43 +176,75 @@ export const RFARequestHandler: Record<string, (message: RFARequest) => RFARespo
   },
 
   getFileNames: function (msg: RFARequest): RFAResponse {
-    const validationResult = validateServerParams(msg);
-    if (!validationResult.success) {
-      return validationResult.errorResponse;
+    const serverValidationResult = validateServerParams(msg);
+    if (!serverValidationResult.success) {
+      return serverValidationResult.errorResponse;
     }
-    const validationData = validationResult.data;
 
-    const fileNameList = [...validationData.server.textFiles.keys(), ...validationData.server.scripts.keys()];
+    const paginationValidationResult = validatePaginationParams(msg);
+    if (!paginationValidationResult.success) {
+      return paginationValidationResult.errorResponse;
+    }
 
-    return new RFASuccessResponse({ result: fileNameList, id: msg.id });
+    const { server } = serverValidationResult.data;
+    const fileNameList = [...server.scripts.keys(), ...server.textFiles.keys()];
+    const { items, total } = paginate(fileNameList, paginationValidationResult.data);
+
+    return new RFASuccessResponse({
+      result: items,
+      total,
+      id: msg.id,
+    });
   },
 
   getAllFiles: function (msg: RFARequest): RFAResponse {
-    const validationResult = validateServerParams(msg);
-    if (!validationResult.success) {
-      return validationResult.errorResponse;
+    const serverValidationResult = validateServerParams(msg);
+    if (!serverValidationResult.success) {
+      return serverValidationResult.errorResponse;
     }
-    const validationData = validationResult.data;
 
-    const fileList = [...validationData.server.scripts, ...validationData.server.textFiles].map(([filename, file]) => ({
+    const paginationValidationResult = validatePaginationParams(msg);
+    if (!paginationValidationResult.success) {
+      return paginationValidationResult.errorResponse;
+    }
+
+    const { server } = serverValidationResult.data;
+    const fileList = [...server.scripts, ...server.textFiles].map(([filename, file]) => ({
       filename,
       content: file.content,
     }));
-    return new RFASuccessResponse({ result: fileList, id: msg.id });
+    const { items, total } = paginate(fileList, paginationValidationResult.data);
+
+    return new RFASuccessResponse({
+      result: items,
+      total,
+      id: msg.id,
+    });
   },
 
   getAllFileMetadata: function (msg: RFARequest): RFAResponse {
-    const validationResult = validateServerParams(msg);
-    if (!validationResult.success) {
-      return validationResult.errorResponse;
+    const serverValidationResult = validateServerParams(msg);
+    if (!serverValidationResult.success) {
+      return serverValidationResult.errorResponse;
     }
-    const validationData = validationResult.data;
 
-    const fileList = [...validationData.server.scripts, ...validationData.server.textFiles].map(([filename, file]) => ({
-      filename: filename,
+    const paginationValidationResult = validatePaginationParams(msg);
+    if (!paginationValidationResult.success) {
+      return paginationValidationResult.errorResponse;
+    }
+
+    const { server } = serverValidationResult.data;
+    const fileList = [...server.scripts, ...server.textFiles].map(([filename, file]) => ({
+      filename,
       ...file.metadata.plain(),
     }));
-    return new RFASuccessResponse({ result: fileList, id: msg.id });
+    const { items, total } = paginate(fileList, paginationValidationResult.data);
+
+    return new RFASuccessResponse({
+      result: items,
+      total,
+      id: msg.id,
+    });
   },
 
   calculateRam: function (msg: RFARequest): RFAResponse {

--- a/src/Terminal/commands/ls.tsx
+++ b/src/Terminal/commands/ls.tsx
@@ -183,15 +183,13 @@ export function ls(args: (string | number | boolean)[], server: BaseServer): und
         : combinePath(baseDirectory, relativePath as FilePath);
 
     // Determine file size
-    let contentBytes = 0;
+    let file;
     if (fileType === FileType.TextFile) {
-      const file = server.textFiles.get(fullPath as TextFilePath);
-      contentBytes = file?.content ? new TextEncoder().encode(file.content).length : 0;
+      file = server.textFiles.get(fullPath as TextFilePath);
     } else {
-      // Script
-      const file = server.scripts.get(fullPath as ScriptFilePath);
-      contentBytes = file?.content ? new TextEncoder().encode(file.content).length : 0;
+      file = server.scripts.get(fullPath as ScriptFilePath);
     }
+    const contentBytes = file?.getSize() ?? 0;
     if (flags["-l"] && flags["-h"]) {
       sizeDisplay = formatBytes(contentBytes);
     } else {


### PR DESCRIPTION
Context: #3061.

I'm fine with adding pagination support, but I don't think we need to reject unsupported parameters. We would need to define schemas specifying which parameters are allowed for each API, then validate the input parameters against those schemas. Doing that is not hard, but it's also not trivial. IMO, it's not worth the effort, especially since being permissive as we are currently is not really an issue.

If a tool wants to know whether pagination is supported, it needs to read the documentation rather than guess based on the response. I updated the RFA documentation to explicitly mention this.

Note:
- The types defined in `src/RemoteFileAPI/MessageDefinitions.ts` are not exactly correct. For example, `RFARequest.params` was `FileDescription` (`FileDescription & PaginationParams` now). `FileDescription` is `FileData | FileContent | FileLocation | FileServer`, but `FileContent` is not a param type for any API's request. I think we can improve other things in `MessageDefinitions.ts` as well, but let's do that later. I want to keep the changes minimal.
- `getFileNames` returns `textFiles` before `scripts`, while the other two APIs return `scripts` before `textFiles`. Their behavior is now consistent.

Closes #3061.

Test code:
```js
/** @param {NS} ns */
export async function main(ns) {
  for (const filename of ns.ls("home")) {
    if (!filename.startsWith("script-")) {
      continue;
    }
    ns.rm(filename, "home");
  }
  for (let i = 0; i < 10; ++i) {
    ns.write(`script-${i}.js`, `/** @param {NS} ns */
export async function main(ns) {
}`, "w");
  }
}
```
RFA client:
```js
import EventEmitter from "node:events";
import { WebSocketServer } from "ws";

export const EventType = {
  MessageSent: "MessageSent",
};

const eventEmitter = new EventEmitter();
let messageCounter = 0;

const wss = new WebSocketServer({ port: 12525 });
wss.on("connection", function connection(ws) {
  ws.on("error", console.error);
  ws.on("message", (msg) => {
    const response = JSON.parse(msg.toString());
    if (response.error) {
      console.error(response);
      return;
    }
    if (response.total == null) {
      throw new Error("missing total");
    }
    console.log(
      response.result.map((v) => {
        if (v.filename != null) {
          return v.filename;
        }
        if (v.hostname != null) {
          return v.hostname;
        }
        return v;
      }),
    );
  });
  eventEmitter.on(EventType.MessageSent, (msg) => {
    ws.send(JSON.stringify(msg));
  });
  eventEmitter.emit(EventType.MessageSent, {
    jsonrpc: "2.0",
    method: "getFileNames",
    params: {
      server: "home",
      limit: null,
    },
    id: messageCounter++,
  });
  eventEmitter.emit(EventType.MessageSent, {
    jsonrpc: "2.0",
    method: "getFileNames",
    params: {
      server: "home",
      offset: null,
    },
    id: messageCounter++,
  });
  eventEmitter.emit(EventType.MessageSent, {
    jsonrpc: "2.0",
    method: "getFileNames",
    params: {
      server: "home",
      limit: -1,
    },
    id: messageCounter++,
  });
  eventEmitter.emit(EventType.MessageSent, {
    jsonrpc: "2.0",
    method: "getFileNames",
    params: {
      server: "home",
      limit: "foo",
    },
    id: messageCounter++,
  });
  eventEmitter.emit(EventType.MessageSent, {
    jsonrpc: "2.0",
    method: "getFileNames",
    params: {
      server: "home",
    },
    id: messageCounter++,
  });
  for (let i = 0; i < 5; ++i) {
    eventEmitter.emit(EventType.MessageSent, {
      jsonrpc: "2.0",
      method: "getFileNames",
      params: {
        server: "home",
        limit: 3,
        offset: i,
      },
      id: messageCounter++,
    });
  }
  for (let i = 0; i < 5; ++i) {
    eventEmitter.emit(EventType.MessageSent, {
      jsonrpc: "2.0",
      method: "getAllFiles",
      params: {
        server: "home",
        limit: 3,
        offset: i,
      },
      id: messageCounter++,
    });
  }
  for (let i = 0; i < 5; ++i) {
    eventEmitter.emit(EventType.MessageSent, {
      jsonrpc: "2.0",
      method: "getAllFileMetadata",
      params: {
        server: "home",
        limit: 3,
        offset: i,
      },
      id: messageCounter++,
    });
  }
});
```
