### PR TITLE
SIDEBAR: Minor refactor

### DIFF
--- a/src/Sidebar/ui/SidebarAccordion.tsx
+++ b/src/Sidebar/ui/SidebarAccordion.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import Collapse from "@mui/material/Collapse";
+import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
@@ -63,15 +64,17 @@ export function SidebarAccordion({
     <>
       {useMemo(
         () => (
-          <ListItemButton onClick={() => setOpen((open) => !open)}>
-            <ListItemIcon>
-              <Tooltip title={!sidebarOpen ? key_ : ""}>
-                <Icon color="primary" />
-              </Tooltip>
-            </ListItemIcon>
-            <ListItemText primary={<Typography>{key_}</Typography>} />
-            {open ? <ExpandLessIcon color="primary" /> : <ExpandMoreIcon color="primary" />}
-          </ListItemButton>
+          <ListItem disablePadding>
+            <ListItemButton onClick={() => setOpen((open) => !open)}>
+              <ListItemIcon>
+                <Tooltip title={!sidebarOpen ? key_ : ""}>
+                  <Icon color="primary" />
+                </Tooltip>
+              </ListItemIcon>
+              <ListItemText primary={<Typography>{key_}</Typography>} />
+              {open ? <ExpandLessIcon color="primary" /> : <ExpandMoreIcon color="primary" />}
+            </ListItemButton>
+          </ListItem>
         ),
         [sidebarOpen, key_, open, Icon],
       )}

--- a/src/Sidebar/ui/SidebarAccordion.tsx
+++ b/src/Sidebar/ui/SidebarAccordion.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import Collapse from "@mui/material/Collapse";
-import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Tooltip from "@mui/material/Tooltip";
@@ -20,7 +20,6 @@ type SidebarAccordionProps = {
   items: (IItemProps | boolean)[];
   icon: React.ReactElement["type"];
   sidebarOpen: boolean;
-  classes: Record<"listitem" | "active", string>;
 };
 
 type ClickFnCacheKeyType = (page: Page) => void;
@@ -47,7 +46,6 @@ function getClickFn(toWrap: (page: Page) => void, page: Page) {
 
 // This can't be usefully memoized, because props.items is a new array every time.
 export function SidebarAccordion({
-  classes,
   icon: Icon,
   sidebarOpen,
   key_,
@@ -57,7 +55,6 @@ export function SidebarAccordion({
   flash,
 }: SidebarAccordionProps): React.ReactElement {
   const [open, setOpen] = useState(true);
-  const li_classes = useMemo(() => ({ root: classes.listitem }), [classes.listitem]);
 
   // Explicitly useMemo() to save rerendering deep chunks of this tree.
   // memo() can't be (easily) used on components like <List>, because the
@@ -66,17 +63,17 @@ export function SidebarAccordion({
     <>
       {useMemo(
         () => (
-          <ListItem classes={li_classes} button onClick={() => setOpen((open) => !open)}>
+          <ListItemButton onClick={() => setOpen((open) => !open)}>
             <ListItemIcon>
               <Tooltip title={!sidebarOpen ? key_ : ""}>
-                <Icon color={"primary"} />
+                <Icon color="primary" />
               </Tooltip>
             </ListItemIcon>
             <ListItemText primary={<Typography>{key_}</Typography>} />
             {open ? <ExpandLessIcon color="primary" /> : <ExpandMoreIcon color="primary" />}
-          </ListItem>
+          </ListItemButton>
         ),
-        [li_classes, sidebarOpen, key_, open, Icon],
+        [sidebarOpen, key_, open, Icon],
       )}
       <Collapse in={open} timeout="auto" unmountOnExit>
         {items.map((x) => {
@@ -91,7 +88,6 @@ export function SidebarAccordion({
               active={active ?? (page === key_ || x.alternateKeys?.includes(page))}
               clickFn={getClickFn(clickPage, key_)}
               flash={flash === key_}
-              classes={classes}
               sidebarOpen={sidebarOpen}
             />
           );

--- a/src/Sidebar/ui/SidebarItem.tsx
+++ b/src/Sidebar/ui/SidebarItem.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from "react";
 import Badge from "@mui/material/Badge";
+import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
@@ -26,27 +27,29 @@ export const SidebarItem = memo(function SidebarItem(props: SidebarItemProps): R
   const colorToken = props.flash ? "info.main" : props.active ? "primary.main" : "secondary.main";
 
   return (
-    <ListItemButton
-      key={props.key_}
-      onClick={props.clickFn}
-      sx={{
-        ...(props.active && {
-          borderLeftWidth: 3,
-          borderLeftStyle: "solid",
-          borderLeftColor: "primary.main",
-        }),
-      }}
-    >
-      <ListItemIcon>
-        <Badge badgeContent={(props.count ?? 0) > 0 ? props.count : undefined} color="error">
-          <Tooltip title={!props.sidebarOpen ? props.key_ : ""}>
-            <props.icon sx={{ color: colorToken }} />
-          </Tooltip>
-        </Badge>
-      </ListItemIcon>
-      <ListItemText>
-        <Typography sx={{ color: colorToken }}>{props.key_}</Typography>
-      </ListItemText>
-    </ListItemButton>
+    <ListItem disablePadding>
+      <ListItemButton
+        key={props.key_}
+        onClick={props.clickFn}
+        sx={{
+          ...(props.active && {
+            borderLeftWidth: 3,
+            borderLeftStyle: "solid",
+            borderLeftColor: "primary.main",
+          }),
+        }}
+      >
+        <ListItemIcon>
+          <Badge badgeContent={(props.count ?? 0) > 0 ? props.count : undefined} color="error">
+            <Tooltip title={!props.sidebarOpen ? props.key_ : ""}>
+              <props.icon sx={{ color: colorToken }} />
+            </Tooltip>
+          </Badge>
+        </ListItemIcon>
+        <ListItemText>
+          <Typography sx={{ color: colorToken }}>{props.key_}</Typography>
+        </ListItemText>
+      </ListItemButton>
+    </ListItem>
   );
 });

--- a/src/Sidebar/ui/SidebarItem.tsx
+++ b/src/Sidebar/ui/SidebarItem.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react";
 import Badge from "@mui/material/Badge";
-import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Tooltip from "@mui/material/Tooltip";
@@ -19,30 +19,34 @@ export interface ICreateProps {
 export interface SidebarItemProps extends ICreateProps {
   clickFn: () => void;
   flash: boolean;
-  classes: Record<"listitem" | "active", string>;
   sidebarOpen: boolean;
 }
 
 export const SidebarItem = memo(function SidebarItem(props: SidebarItemProps): React.ReactElement {
-  const color = props.flash ? "error" : props.active ? "primary" : "secondary";
+  const colorToken = props.flash ? "info.main" : props.active ? "primary.main" : "secondary.main";
+
   return (
-    <ListItem
-      classes={{ root: props.classes.listitem }}
-      button
+    <ListItemButton
       key={props.key_}
-      className={props.active ? props.classes.active : ""}
       onClick={props.clickFn}
+      sx={{
+        ...(props.active && {
+          borderLeftWidth: 3,
+          borderLeftStyle: "solid",
+          borderLeftColor: "primary.main",
+        }),
+      }}
     >
       <ListItemIcon>
         <Badge badgeContent={(props.count ?? 0) > 0 ? props.count : undefined} color="error">
           <Tooltip title={!props.sidebarOpen ? props.key_ : ""}>
-            <props.icon color={color} />
+            <props.icon sx={{ color: colorToken }} />
           </Tooltip>
         </Badge>
       </ListItemIcon>
       <ListItemText>
-        <Typography color={color}>{props.key_}</Typography>
+        <Typography sx={{ color: colorToken }}>{props.key_}</Typography>
       </ListItemText>
-    </ListItem>
+    </ListItemButton>
   );
 });

--- a/src/Sidebar/ui/SidebarItem.tsx
+++ b/src/Sidebar/ui/SidebarItem.tsx
@@ -24,7 +24,7 @@ export interface SidebarItemProps extends ICreateProps {
 }
 
 export const SidebarItem = memo(function SidebarItem(props: SidebarItemProps): React.ReactElement {
-  const colorToken = props.flash ? "info.main" : props.active ? "primary.main" : "secondary.main";
+  const color = props.flash ? "error" : props.active ? "primary" : "secondary";
 
   return (
     <ListItem disablePadding>
@@ -42,12 +42,12 @@ export const SidebarItem = memo(function SidebarItem(props: SidebarItemProps): R
         <ListItemIcon>
           <Badge badgeContent={(props.count ?? 0) > 0 ? props.count : undefined} color="error">
             <Tooltip title={!props.sidebarOpen ? props.key_ : ""}>
-              <props.icon sx={{ color: colorToken }} />
+              <props.icon color={color} />
             </Tooltip>
           </Badge>
         </ListItemIcon>
         <ListItemText>
-          <Typography sx={{ color: colorToken }}>{props.key_}</Typography>
+          <Typography color={color}>{props.key_}</Typography>
         </ListItemText>
       </ListItemButton>
     </ListItem>

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -1,13 +1,12 @@
 import React, { useMemo, useCallback, useState, useEffect, useRef } from "react";
 import { styled, Theme, CSSObject } from "@mui/material/styles";
-import { makeStyles } from "tss-react/mui";
 import MuiDrawer from "@mui/material/Drawer";
 import List from "@mui/material/List";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
@@ -113,13 +112,6 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== "open" 
     ...closedMixin(theme),
     "& .MuiDrawer-paper": closedMixin(theme),
   }),
-}));
-
-const useStyles = makeStyles()((theme: Theme) => ({
-  active: {
-    borderLeft: "3px solid " + theme.palette.primary.main,
-  },
-  listitem: {},
 }));
 
 export function SidebarRoot(props: { page: Page }): React.ReactElement {
@@ -309,14 +301,13 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
     return () => document.removeEventListener("keydown", handleShortcuts);
   }, [canGoToPage, clickPage, props.page]);
 
-  const { classes } = useStyles();
   const [open, setOpen] = useState(Settings.IsSidebarOpened);
   const toggleDrawer = (): void =>
     setOpen((old) => {
       Settings.IsSidebarOpened = !old;
       return !old;
     });
-  const li_classes = useMemo(() => ({ root: classes.listitem }), [classes.listitem]);
+
   const ChevronOpenClose = open ? ChevronLeftIcon : ChevronRightIcon;
 
   // Explicitly useMemo() to save rerendering deep chunks of this tree.
@@ -326,7 +317,7 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
     <Drawer open={open} anchor="left" variant="permanent">
       {useMemo(
         () => (
-          <ListItem classes={li_classes} button onClick={toggleDrawer}>
+          <ListItemButton onClick={toggleDrawer}>
             <ListItemIcon>
               <ChevronOpenClose color={"primary"} />
             </ListItemIcon>
@@ -337,9 +328,9 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
                 </Tooltip>
               }
             />
-          </ListItem>
+          </ListItemButton>
         ),
-        [ChevronOpenClose, li_classes],
+        [ChevronOpenClose],
       )}
       <Divider />
       <List>
@@ -350,7 +341,6 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
           flash={flash}
           icon={ComputerIcon}
           sidebarOpen={open}
-          classes={classes}
           items={[
             { key_: Page.Terminal, icon: LastPageIcon },
             { key_: Page.ScriptEditor, icon: CreateIcon },
@@ -373,7 +363,6 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
           flash={flash}
           icon={AccountBoxIcon}
           sidebarOpen={open}
-          classes={classes}
           items={[
             { key_: Page.Stats, icon: EqualizerIcon },
             canOpenFactions && {
@@ -401,7 +390,6 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
           flash={flash}
           icon={PublicIcon}
           sidebarOpen={open}
-          classes={classes}
           items={[
             {
               key_: Page.City,
@@ -427,7 +415,6 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
           flash={flash}
           icon={LiveHelpIcon}
           sidebarOpen={open}
-          classes={classes}
           items={[
             { key_: Page.Milestones, icon: CheckIcon },
             { key_: Page.Documentation, icon: HelpIcon },

--- a/src/Sidebar/ui/SidebarRoot.tsx
+++ b/src/Sidebar/ui/SidebarRoot.tsx
@@ -6,6 +6,7 @@ import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
@@ -317,18 +318,20 @@ export function SidebarRoot(props: { page: Page }): React.ReactElement {
     <Drawer open={open} anchor="left" variant="permanent">
       {useMemo(
         () => (
-          <ListItemButton onClick={toggleDrawer}>
-            <ListItemIcon>
-              <ChevronOpenClose color={"primary"} />
-            </ListItemIcon>
-            <ListItemText
-              primary={
-                <Tooltip title={commitHash()}>
-                  <Typography>Bitburner v{CONSTANTS.VersionString}</Typography>
-                </Tooltip>
-              }
-            />
-          </ListItemButton>
+          <ListItem disablePadding>
+            <ListItemButton onClick={toggleDrawer}>
+              <ListItemIcon>
+                <ChevronOpenClose color={"primary"} />
+              </ListItemIcon>
+              <ListItemText
+                primary={
+                  <Tooltip title={commitHash()}>
+                    <Typography>Bitburner v{CONSTANTS.VersionString}</Typography>
+                  </Tooltip>
+                }
+              />
+            </ListItemButton>
+          </ListItem>
         ),
         [ChevronOpenClose],
       )}


### PR DESCRIPTION
Minor refactor.

* `<ListItem button>` is deprecated. Changed to `<ListItemButton>`.
* Removed a redundant MakeStyles with an empty listitem property (??), which in turn was being used by a few redundant useMemos (?!), which I've also removed, along with all the redundant class references (?!!)
* Moved the only useful bit of the MakeStyles thing into an sx{{}} at the relevant element