### PR TITLE
RFA: Pressing enter key on textfields attempts to connect

### DIFF
--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -81,6 +81,11 @@ export const RemoteAPIPage = (): React.ReactElement => {
     setReconnectionDelayError("");
   }
 
+  function handleOnSubmitEvent(event: React.KeyboardEvent<HTMLDivElement>): void {
+    event.preventDefault();
+    if (canCreateNewRemoteFileApiConnection() && !isRemoteFileApiConnectionLive()) newRemoteFileApiConnection();
+  }
+
   return (
     <GameOptionsPage title="Remote API">
       <Typography>
@@ -111,6 +116,7 @@ export const RemoteAPIPage = (): React.ReactElement => {
             }}
             value={remoteFileApiHostname}
             onChange={handleRemoteFileApiHostnameChange}
+            onKeyDown={(e) => e.key == "Enter" && handleOnSubmitEvent(e)}
             placeholder="localhost"
             size={"medium"}
           />
@@ -139,6 +145,7 @@ export const RemoteAPIPage = (): React.ReactElement => {
             }}
             value={remoteFileApiPort}
             onChange={handleRemoteFileApiPortChange}
+            onKeyDown={(e) => e.key == "Enter" && handleOnSubmitEvent(e)}
             placeholder="12525"
             size={"medium"}
           />


### PR DESCRIPTION
While CatLover made it easier to connect within the Overview in #3050 , it has still to be done manually in the RFA settings page. This PR makes pressing enter on the "hostname"/"port" textfields attempt to connect. I didn't add this for the reconnection field because it seemed irrelevant to me, but I can add it if you want.