### PR TITLE
MISC: grow and weaken terminal command text output

### DIFF
--- a/src/Terminal/commands/grow.ts
+++ b/src/Terminal/commands/grow.ts
@@ -4,7 +4,7 @@ import { BaseServer } from "../../Server/BaseServer";
 import { Server } from "../../Server/Server";
 import { HacknetServer } from "../../Hacknet/HacknetServer";
 import { Player } from "@player";
-import { formatExp, formatPercent, formatSecurity } from "../../ui/formatNumber";
+import { formatExp, formatPercent, formatSecurity, formatMoney } from "../../ui/formatNumber";
 import { calculateHackingExpGain, calculateGrowTime } from "../../Hacking";
 import { processSingleServerGrowth } from "../../Server/ServerHelpers";
 
@@ -26,12 +26,13 @@ export function grow(args: (string | number | boolean)[], server: BaseServer): u
     const oldSec = server.hackDifficulty;
     const growth = processSingleServerGrowth(server, 25, server.cpuCores);
     const newSec = server.hackDifficulty;
+    const newMoney = server.moneyAvailable;
 
     Player.gainHackingExp(expGain);
     Terminal.print(
-      `Available money on '${server.hostname}' grown by ${formatPercent(growth - 1, 6)}. Gained ${formatExp(
-        expGain,
-      )} hacking exp.`,
+       `Available money on '${server.hostname}' grown by ${formatPercent(growth - 1, 6)} to ${formatMoney(
+        newMoney,
+      )}. Gained ${formatExp(expGain)} hacking exp.`,
     );
     Terminal.print(
       `Security increased on '${server.hostname}' from ${formatSecurity(oldSec)} to ${formatSecurity(newSec)}`,

--- a/src/Terminal/commands/grow.ts
+++ b/src/Terminal/commands/grow.ts
@@ -30,7 +30,7 @@ export function grow(args: (string | number | boolean)[], server: BaseServer): u
 
     Player.gainHackingExp(expGain);
     Terminal.print(
-       `Available money on '${server.hostname}' grown by ${formatPercent(growth - 1, 6)} to ${formatMoney(
+      `Available money on '${server.hostname}' grown by ${formatPercent(growth - 1, 6)} to ${formatMoney(
         newMoney,
       )}. Gained ${formatExp(expGain)} hacking exp.`,
     );

--- a/src/Terminal/commands/weaken.ts
+++ b/src/Terminal/commands/weaken.ts
@@ -32,8 +32,9 @@ export function weaken(args: (string | number | boolean)[], server: BaseServer):
     Terminal.print(
       `Security decreased on '${server.hostname}' by ${formatSecurity(weakenAmt)} from ${formatSecurity(
         oldSec,
-      )} to ${formatSecurity(newSec)} (min: ${formatSecurity(server.minDifficulty)})` +
-        ` and Gained ${formatExp(expGain)} hacking exp.`,
+      )} to ${formatSecurity(newSec)} (min: ${formatSecurity(server.minDifficulty)}). Gained ${formatExp(
+        expGain,
+      )} hacking exp`,
     );
   });
 }


### PR DESCRIPTION
**Weaken** – Just fixing a typo.

**Grow** – The aim to give players richer feedback on what grow's accomplished. 

The grow command will mostly be used by people who are brand new, and helps them understand what grow accomplishes before they start scripting it. 

Seeing the server's money would be really helpful for that. It gives them a sense of how much money servers hold, and what grow's done.

It also creates a better emotional feedback loop. A % increase is nice. But seeing the actual money is more rewarding.

I don't think this overpowers grow – there are other faster and more informative terminal commands that show you a server's available money.