### PR TITLE
UI: Added bonus time to Sleeves UI

### DIFF
--- a/src/PersonObjects/Sleeve/ui/MoreStatsModal.tsx
+++ b/src/PersonObjects/Sleeve/ui/MoreStatsModal.tsx
@@ -1,8 +1,5 @@
 import { Sleeve } from "../Sleeve";
 import { formatExp, formatPercent } from "../../../ui/formatNumber";
-import { convertTimeMsToTimeElapsedString } from "../../../utils/StringHelperFunctions";
-import { CONSTANTS } from "../../../Constants";
-import { Typography } from "@mui/material";
 import { StatsTable } from "../../../ui/React/StatsTable";
 import { Modal } from "../../../ui/React/Modal";
 import React from "react";
@@ -65,13 +62,6 @@ export function MoreStatsModal(props: IProps): React.ReactElement {
         ]}
         title="Multipliers:"
       />
-
-      {/* Check for storedCycles to be a bit over 0 to prevent jittering */}
-      {props.sleeve.storedCycles > 10 && (
-        <Typography sx={{ py: 2 }}>
-          Bonus Time: {convertTimeMsToTimeElapsedString(props.sleeve.storedCycles * CONSTANTS.MilliPerCycle)}
-        </Typography>
-      )}
     </Modal>
   );
 }

--- a/src/PersonObjects/Sleeve/ui/StatsElement.tsx
+++ b/src/PersonObjects/Sleeve/ui/StatsElement.tsx
@@ -13,6 +13,7 @@ import {
   formatSleeveShock,
   formatSleeveSynchro,
 } from "../../../ui/formatNumber";
+import { convertTimeMsToTimeElapsedString } from "../../../utils/StringHelperFunctions";
 import { Settings } from "../../../Settings/Settings";
 import { StatsRow } from "../../../ui/React/StatsRow";
 import { useStyles } from "../../../ui/React/CharacterOverview";
@@ -103,6 +104,17 @@ export function StatsElement(props: IProps): React.ReactElement {
           name="Memory"
           color={Settings.theme.primary}
           data={{ content: formatSleeveMemory(props.sleeve.memory) }}
+        />
+        <StatsRow
+          name="Bonus time"
+          color={Settings.theme.primary}
+          data={{
+            content: convertTimeMsToTimeElapsedString(
+              props.sleeve.storedCycles < 10 ? 0 : props.sleeve.storedCycles * CONSTANTS.MilliPerCycle,
+              false,
+              true,
+            ),
+          }}
         />
       </TableBody>
     </Table>

--- a/src/utils/StringHelperFunctions.ts
+++ b/src/utils/StringHelperFunctions.ts
@@ -6,7 +6,7 @@ Converts a date representing time in milliseconds to a string with the format H 
 e.g.    10000 -> "10 seconds"
         120000 -> "2 minutes and 0 seconds"
 */
-export function convertTimeMsToTimeElapsedString(time: number, showMilli = false): string {
+export function convertTimeMsToTimeElapsedString(time: number, showMilli = false, compact = false): string {
   const negFlag = time < 0;
   time = Math.abs(Math.floor(time));
   const millisecondsPerSecond = 1000;
@@ -36,17 +36,22 @@ export function convertTimeMsToTimeElapsedString(time: number, showMilli = false
 
   const seconds: string = showMilli ? `${secTruncMinutes}.${milliTruncSec}` : `${secTruncMinutes}`;
 
+  const dayString = compact ? `${days}d` : pluralize(days, "day");
+  const hourString = compact ? `${hours}h` : pluralize(hours, "hour");
+  const minuteString = compact ? `${minutes}m` : pluralize(minutes, "minute");
+  const secondString = compact ? "s" : `second${!showMilli && secTruncMinutes === 1 ? "" : "s"}`;
+
   let res = "";
   if (days > 0) {
-    res += `${pluralize(days, "day")} `;
+    res += `${dayString} `;
   }
   if (hours > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
-    res += `${pluralize(hours, "hour")} `;
+    res += `${hourString} `;
   }
   if (minutes > 0 || (Settings.ShowMiddleNullTimeUnit && res != "")) {
-    res += `${pluralize(minutes, "minute")} `;
+    res += `${minuteString} `;
   }
-  res += `${seconds} second${!showMilli && secTruncMinutes === 1 ? "" : "s"}`;
+  res += `${seconds}${compact ? "" : " "}${secondString}`;
 
   return negFlag ? `-(${res})` : res;
 }


### PR DESCRIPTION
Making the bonus time more visible for improved player happiness. Personally I think that putting bonus time in More Stats is taking the 'the UI is deliberately clunky' thing a step too far. 

Here's what it looks like:

<img width="511" height="376" alt="image" src="https://github.com/user-attachments/assets/1b98e604-461f-4ee6-b15c-98678564959c" />

Bonus time shows on the table even if it's 0s. I figured this was preferable to the tables getting bumped up and down the page when sleeves regain / run out of bonus time.

<img width="531" height="270" alt="image" src="https://github.com/user-attachments/assets/8eb9d9d7-3782-48ed-87b9-1e225a0a8271" />

Similar to the current behaviour, if the bonus time is less than 2s, it shows 0s to prevent 0s/1s flickering. 

Extracted from #3051 - too much scope creep.