### PR TITLE
MISC: Sleeves stats table fix

### DIFF
--- a/src/PersonObjects/Sleeve/ui/StatsElement.tsx
+++ b/src/PersonObjects/Sleeve/ui/StatsElement.tsx
@@ -169,26 +169,22 @@ export function EarningsElement(props: IProps): React.ReactElement {
   }
 
   return (
-    <Table sx={{ display: "table", mb: 1, width: "100%", lineHeight: 0 }}>
-      <TableBody>
-        <TableRow>
-          <TableCell classes={{ root: classes.cellNone }}>
-            <Typography variant="h6">
-              Earnings {props.sleeve.storedCycles > 50 ? "(Boosted by bonus time)" : ""}
-            </Typography>
-          </TableCell>
-        </TableRow>
-        {data.map(([a, b]) => (
-          <TableRow key={getKeyFromReactElements(a, b)}>
-            <TableCell classes={{ root: classes.cellNone }}>
-              <Typography>{a}</Typography>
-            </TableCell>
-            <TableCell align="right" classes={{ root: classes.cellNone }}>
-              <Typography>{b}</Typography>
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+    <>
+      <Typography variant="h6">Earnings {props.sleeve.storedCycles > 50 ? "(boosted by bonus time)" : ""}</Typography>
+      <Table sx={{ display: "table", mb: 1, width: "100%", lineHeight: 0 }}>
+        <TableBody>
+          {data.map(([a, b]) => (
+            <TableRow key={getKeyFromReactElements(a, b)}>
+              <TableCell sx={{ width: "50%" }} classes={{ root: classes.cellNone }}>
+                <Typography>{a}</Typography>
+              </TableCell>
+              <TableCell sx={{ width: "50%" }} align="right" classes={{ root: classes.cellNone }}>
+                <Typography>{b}</Typography>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
   );
 }

--- a/src/PersonObjects/Sleeve/ui/StatsElement.tsx
+++ b/src/PersonObjects/Sleeve/ui/StatsElement.tsx
@@ -175,10 +175,10 @@ export function EarningsElement(props: IProps): React.ReactElement {
         <TableBody>
           {data.map(([a, b]) => (
             <TableRow key={getKeyFromReactElements(a, b)}>
-              <TableCell sx={{ width: "50%" }} classes={{ root: classes.cellNone }}>
+              <TableCell classes={{ root: classes.cellNone }}>
                 <Typography>{a}</Typography>
               </TableCell>
-              <TableCell sx={{ width: "50%" }} align="right" classes={{ root: classes.cellNone }}>
+              <TableCell align="right" classes={{ root: classes.cellNone }}>
                 <Typography>{b}</Typography>
               </TableCell>
             </TableRow>


### PR DESCRIPTION
The Earnings heading is currently inside the table as a row. That means it often gets squashed and runs onto 2 lines. It also squashes the right-hand column, forcing **that** to run onto 2 lines as well:

<img width="528" height="376" alt="image" src="https://github.com/user-attachments/assets/44cb532e-ac10-457f-8b17-e0cdca605f7d" />

I've moved the heading outside of the table. 

So now we go from this ...

<img width="529" height="298" alt="image" src="https://github.com/user-attachments/assets/9dda322a-6e04-49e0-b293-becf35ee3dff" />

to this!

<img width="529" height="273" alt="image" src="https://github.com/user-attachments/assets/4fb821b2-a06e-43ef-9dd6-88231816d412" />

Extracted from #3051 - too much scope creep.