### PR TITLE
REFACTOR: Consistency in the RFA codebase

### DIFF
--- a/src/GameOptions/ui/RemoteAPIPage.tsx
+++ b/src/GameOptions/ui/RemoteAPIPage.tsx
@@ -2,36 +2,32 @@ import React, { useEffect, useState } from "react";
 import { Button, TextField, Tooltip, Typography } from "@mui/material";
 import { GameOptionsPage } from "./GameOptionsPage";
 import { Settings } from "../../Settings/Settings";
-import { isValidConnectionHostname, isValidRFAConnectionPortSetting } from "../../Settings/SettingsUtils";
-import { RemoteFileApiConnectionStatus } from "./RemoteFileApiConnectionStatus";
+import { isValidRFAHostname, isValidRFAPort } from "../../Settings/SettingsUtils";
+import { RFAConnectionStatus } from "./RemoteFileApiConnectionStatus";
 import {
-  canCreateNewRemoteFileApiConnection,
-  closeRemoteFileApiConnection,
-  isRemoteFileApiConnectionLive,
-  newRemoteFileApiConnection,
+  canCreateNewRFAConnection,
+  closeRFAConnection,
+  isRFAConnectionLive,
+  newRFAConnection,
 } from "../../RemoteFileAPI/RemoteFileAPI";
 import { OptionSwitch } from "../../ui/React/OptionSwitch";
 import { DocumentationLink } from "../../ui/React/DocumentationLink";
-import { RemoteFileApiConnectionEvents, RemoteFileApiConnectionSettingEvents } from "../../RemoteFileAPI/Remote";
+import { RFAConnectionEvents, RFAConnectionSettingEvents } from "../../RemoteFileAPI/Remote";
 import { useRerender } from "../../ui/React/hooks";
 
 export const RemoteAPIPage = (): React.ReactElement => {
-  const [remoteFileApiHostname, setRemoteFileApiHostname] = useState(Settings.RemoteFileApiAddress);
-  const [hostnameError, setHostnameError] = useState(
-    isValidConnectionHostname(Settings.RemoteFileApiAddress).message ?? "",
-  );
-  const [remoteFileApiPort, setRemoteFileApiPort] = useState(Settings.RemoteFileApiPort.toString());
-  const [portError, setPortError] = useState(isValidRFAConnectionPortSetting(Settings.RemoteFileApiPort).message ?? "");
-  const [remoteFileApiReconnectionDelay, setRemoteFileApiReconnectionDelay] = useState(
-    Settings.RemoteFileApiReconnectionDelay.toString(),
-  );
+  const [rfaHostname, setRFAHostname] = useState(Settings.RFAAddress);
+  const [hostnameError, setHostnameError] = useState(isValidRFAHostname(Settings.RFAAddress).message ?? "");
+  const [rfaPort, setRFAPort] = useState(Settings.RFAPort.toString());
+  const [portError, setPortError] = useState(isValidRFAPort(Settings.RFAPort).message ?? "");
+  const [rfaReconnectionDelay, setRFAReconnectionDelay] = useState(Settings.RFAReconnectionDelay.toString());
   const [reconnectionDelayError, setReconnectionDelayError] = useState("");
 
   const rerender = useRerender();
 
   useEffect(
     () =>
-      RemoteFileApiConnectionEvents.subscribe(() => {
+      RFAConnectionEvents.subscribe(() => {
         rerender();
       }),
     [rerender],
@@ -41,43 +37,43 @@ export const RemoteAPIPage = (): React.ReactElement => {
   const isValidPort = portError === "";
   const isValidReconnectionDelay = reconnectionDelayError === "";
 
-  function handleRemoteFileApiHostnameChange(event: React.ChangeEvent<HTMLInputElement>): void {
+  function handleRFAHostnameChange(event: React.ChangeEvent<HTMLInputElement>): void {
     const newValue = event.target.value.trim();
-    setRemoteFileApiHostname(newValue);
-    const result = isValidConnectionHostname(newValue);
+    setRFAHostname(newValue);
+    const result = isValidRFAHostname(newValue);
     if (!result.success) {
       setHostnameError(result.message);
       return;
     }
-    Settings.RemoteFileApiAddress = newValue;
-    RemoteFileApiConnectionSettingEvents.emit();
+    Settings.RFAAddress = newValue;
+    RFAConnectionSettingEvents.emit();
     setHostnameError("");
   }
 
-  function handleRemoteFileApiPortChange(event: React.ChangeEvent<HTMLInputElement>): void {
+  function handleRFAPortChange(event: React.ChangeEvent<HTMLInputElement>): void {
     const newValue = event.target.value.trim();
-    setRemoteFileApiPort(newValue);
+    setRFAPort(newValue);
     const port = Number(newValue);
-    const result = isValidRFAConnectionPortSetting(port);
+    const result = isValidRFAPort(port);
     if (!result.success) {
       setPortError(result.message);
       return;
     }
-    Settings.RemoteFileApiPort = port;
-    RemoteFileApiConnectionSettingEvents.emit();
+    Settings.RFAPort = port;
+    RFAConnectionSettingEvents.emit();
     setPortError("");
   }
 
-  function handleRemoteFileApiReconnectionDelayChange(event: React.ChangeEvent<HTMLInputElement>): void {
+  function handleRFAReconnectionDelayChange(event: React.ChangeEvent<HTMLInputElement>): void {
     const newValue = event.target.value.trim();
-    setRemoteFileApiReconnectionDelay(newValue);
+    setRFAReconnectionDelay(newValue);
     const reconnectionDelay = Number(newValue);
     if (!Number.isFinite(reconnectionDelay) || reconnectionDelay < 0) {
       setReconnectionDelayError("Invalid reconnection delay");
       return;
     }
-    Settings.RemoteFileApiReconnectionDelay = reconnectionDelay;
-    RemoteFileApiConnectionSettingEvents.emit();
+    Settings.RFAReconnectionDelay = reconnectionDelay;
+    RFAConnectionSettingEvents.emit();
     setReconnectionDelayError("");
   }
 
@@ -90,7 +86,7 @@ export const RemoteAPIPage = (): React.ReactElement => {
       <Typography>
         <DocumentationLink page="programming/remote_api.md">Documentation</DocumentationLink>
       </Typography>
-      <RemoteFileApiConnectionStatus showIcon={false} />
+      <RFAConnectionStatus showIcon={false} />
       <Tooltip
         title={
           <Typography>
@@ -109,8 +105,8 @@ export const RemoteAPIPage = (): React.ReactElement => {
             InputProps={{
               startAdornment: <Typography style={{ minWidth: "200px" }}>Hostname:&nbsp;</Typography>,
             }}
-            value={remoteFileApiHostname}
-            onChange={handleRemoteFileApiHostnameChange}
+            value={rfaHostname}
+            onChange={handleRFAHostnameChange}
             placeholder="localhost"
             size={"medium"}
           />
@@ -137,8 +133,8 @@ export const RemoteAPIPage = (): React.ReactElement => {
                 </Typography>
               ),
             }}
-            value={remoteFileApiPort}
-            onChange={handleRemoteFileApiPortChange}
+            value={rfaPort}
+            onChange={handleRFAPortChange}
             placeholder="12525"
             size={"medium"}
           />
@@ -167,8 +163,8 @@ export const RemoteAPIPage = (): React.ReactElement => {
                 </Typography>
               ),
             }}
-            value={remoteFileApiReconnectionDelay}
-            onChange={handleRemoteFileApiReconnectionDelayChange}
+            value={rfaReconnectionDelay}
+            onChange={handleRFAReconnectionDelayChange}
             placeholder="0"
             size={"medium"}
           />
@@ -176,25 +172,25 @@ export const RemoteAPIPage = (): React.ReactElement => {
         </div>
       </Tooltip>
       <OptionSwitch
-        checked={Settings.UseWssForRemoteFileApi}
+        checked={Settings.UseWssForRFA}
         onChange={(newValue) => {
-          Settings.UseWssForRemoteFileApi = newValue;
-          RemoteFileApiConnectionSettingEvents.emit();
+          Settings.UseWssForRFA = newValue;
+          RFAConnectionSettingEvents.emit();
         }}
         text="Use wss"
         tooltip={<>Use wss instead of ws when connecting to RFA clients.</>}
       />
       <Button
-        disabled={!isRemoteFileApiConnectionLive() && !canCreateNewRemoteFileApiConnection()}
+        disabled={!isRFAConnectionLive() && !canCreateNewRFAConnection()}
         onClick={() => {
-          if (!isRemoteFileApiConnectionLive()) {
-            newRemoteFileApiConnection();
+          if (!isRFAConnectionLive()) {
+            newRFAConnection();
           } else {
-            closeRemoteFileApiConnection();
+            closeRFAConnection();
           }
         }}
       >
-        {!isRemoteFileApiConnectionLive() ? "Connect" : "Disconnect"}
+        {!isRFAConnectionLive() ? "Connect" : "Disconnect"}
       </Button>
     </GameOptionsPage>
   );

--- a/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
+++ b/src/GameOptions/ui/RemoteFileApiConnectionStatus.tsx
@@ -1,27 +1,27 @@
 import React, { useState, useEffect } from "react";
 import { Box, IconButton, Tooltip, Typography } from "@mui/material";
 import {
-  canCreateNewRemoteFileApiConnection,
-  closeRemoteFileApiConnection,
-  getRemoteFileApiConnectionStatus,
-  newRemoteFileApiConnection,
+  canCreateNewRFAConnection,
+  closeRFAConnection,
+  getRFAConnectionStatus,
+  newRFAConnection,
 } from "../../RemoteFileAPI/RemoteFileAPI";
 import OnlinePredictionIcon from "@mui/icons-material/OnlinePrediction";
 import { Settings } from "../../Settings/Settings";
 import { Router } from "../../ui/GameRoot";
 import { Page } from "../../ui/Router";
-import { RemoteFileApiConnectionEvents, RemoteFileApiConnectionSettingEvents } from "../../RemoteFileAPI/Remote";
+import { RFAConnectionEvents, RFAConnectionSettingEvents } from "../../RemoteFileAPI/Remote";
 import { useRerender } from "../../ui/React/hooks";
 
-export const RemoteFileApiConnectionStatus = ({ showIcon }: { showIcon: boolean }): React.ReactElement => {
-  const [rfaConnectionStatus, setRfaConnectionStatus] = useState(getRemoteFileApiConnectionStatus());
+export const RFAConnectionStatus = ({ showIcon }: { showIcon: boolean }): React.ReactElement => {
+  const [rfaConnectionStatus, setRfaConnectionStatus] = useState(getRFAConnectionStatus());
   const rerender = useRerender();
 
   useEffect(() => {
-    const unsubscriberForRFAEvents = RemoteFileApiConnectionEvents.subscribe((status) => {
+    const unsubscriberForRFAEvents = RFAConnectionEvents.subscribe((status) => {
       setRfaConnectionStatus(status);
     });
-    const unsubscriberForRFASettingEvents = RemoteFileApiConnectionSettingEvents.subscribe(() => {
+    const unsubscriberForRFASettingEvents = RFAConnectionSettingEvents.subscribe(() => {
       rerender();
     });
     return () => {
@@ -34,11 +34,11 @@ export const RemoteFileApiConnectionStatus = ({ showIcon }: { showIcon: boolean 
     Online: { color: Settings.theme.success, instruction: "Click to disconnect" },
     Offline: {
       color: Settings.theme.error,
-      instruction: canCreateNewRemoteFileApiConnection() ? "Click to connect" : "Click to go to the option page",
+      instruction: canCreateNewRFAConnection() ? "Click to connect" : "Click to go to the option page",
     },
     Reconnecting: {
       color: Settings.theme.warning,
-      instruction: canCreateNewRemoteFileApiConnection()
+      instruction: canCreateNewRFAConnection()
         ? "Click to try to connect immediately without waiting"
         : "Click to go to the option page",
     },
@@ -58,12 +58,12 @@ export const RemoteFileApiConnectionStatus = ({ showIcon }: { showIcon: boolean 
           onClick={() => {
             switch (rfaConnectionStatus) {
               case "Online":
-                closeRemoteFileApiConnection();
+                closeRFAConnection();
                 break;
               case "Offline":
               case "Reconnecting":
-                if (canCreateNewRemoteFileApiConnection()) {
-                  newRemoteFileApiConnection();
+                if (canCreateNewRFAConnection()) {
+                  newRFAConnection();
                 } else {
                   Router.toPage(Page.Options, { tab: "Remote API" });
                 }

--- a/src/RemoteFileAPI/Remote.ts
+++ b/src/RemoteFileAPI/Remote.ts
@@ -4,7 +4,7 @@ import { SnackbarEvents } from "../ui/React/Snackbar";
 import { ToastVariant } from "@enums";
 import { Settings } from "../Settings/Settings";
 import { EventEmitter } from "../utils/EventEmitter";
-import type { getRemoteFileApiConnectionStatus } from "./RemoteFileAPI";
+import type { getRFAConnectionStatus } from "./RemoteFileAPI";
 
 const timeOutIds = new Set<number>();
 
@@ -12,8 +12,8 @@ function showErrorMessage(address: string, detail: string) {
   SnackbarEvents.emit(`Error with websocket ${address}, details: ${detail}`, ToastVariant.ERROR, 5000);
 }
 
-export const RemoteFileApiConnectionEvents = new EventEmitter<[ReturnType<typeof getRemoteFileApiConnectionStatus>]>();
-export const RemoteFileApiConnectionSettingEvents = new EventEmitter();
+export const RFAConnectionEvents = new EventEmitter<[ReturnType<typeof getRFAConnectionStatus>]>();
+export const RFAConnectionSettingEvents = new EventEmitter();
 
 export class Remote {
   connection?: WebSocket;
@@ -37,11 +37,11 @@ export class Remote {
       this.connection.intentionallyClosed = true;
     }
     this.connection?.close();
-    RemoteFileApiConnectionEvents.emit("Offline");
+    RFAConnectionEvents.emit("Offline");
   }
 
   public startConnection(autoConnectAttempt = 1): void {
-    const address = (Settings.UseWssForRemoteFileApi ? "wss" : "ws") + "://" + this.ipaddr + ":" + this.port;
+    const address = (Settings.UseWssForRFA ? "wss" : "ws") + "://" + this.ipaddr + ":" + this.port;
 
     // This tracks if a connection was established to prevent redundant toasts
     let successfullyConnected = false;
@@ -54,7 +54,7 @@ export class Remote {
       return;
     }
 
-    RemoteFileApiConnectionEvents.emit("Connecting");
+    RFAConnectionEvents.emit("Connecting");
     // Log connection errors on manual and the first auto connect attempts
     this.connection.addEventListener("error", (e: Event) => {
       if (autoConnectAttempt <= 1 || successfullyConnected) {
@@ -71,7 +71,7 @@ export class Remote {
         ToastVariant.SUCCESS,
         2000,
       );
-      RemoteFileApiConnectionEvents.emit("Online");
+      RFAConnectionEvents.emit("Online");
     });
     this.connection.addEventListener("close", (event) => {
       /**
@@ -92,7 +92,7 @@ export class Remote {
         SnackbarEvents.emit(`Remote API connection closed. Code: ${event.code}.`, ToastVariant.WARNING, 2000);
       }
 
-      if (Settings.RemoteFileApiReconnectionDelay > 0) {
+      if (Settings.RFAReconnectionDelay > 0) {
         this.reconnecting = true;
         const timeOutId = window.setTimeout(() => {
           timeOutIds.delete(timeOutId);
@@ -104,12 +104,12 @@ export class Remote {
           const attempts = successfullyConnected ? 1 : autoConnectAttempt + 1;
 
           this.startConnection(attempts);
-        }, Settings.RemoteFileApiReconnectionDelay * 1000);
+        }, Settings.RFAReconnectionDelay * 1000);
         timeOutIds.add(timeOutId);
-        RemoteFileApiConnectionEvents.emit("Reconnecting");
+        RFAConnectionEvents.emit("Reconnecting");
       } else {
         this.reconnecting = false;
-        RemoteFileApiConnectionEvents.emit("Offline");
+        RFAConnectionEvents.emit("Offline");
       }
     });
   }

--- a/src/RemoteFileAPI/RemoteFileAPI.ts
+++ b/src/RemoteFileAPI/RemoteFileAPI.ts
@@ -1,38 +1,35 @@
 import { Settings } from "../Settings/Settings";
-import { isValidConnectionHostname, isValidConnectionPort } from "../Settings/SettingsUtils";
+import { isValidRFAHostname, isValidRFAPort } from "../Settings/SettingsUtils";
 import { Remote } from "./Remote";
 
 let server: Remote | undefined;
 
-export function canCreateNewRemoteFileApiConnection(): boolean {
-  return (
-    isValidConnectionHostname(Settings.RemoteFileApiAddress).success &&
-    isValidConnectionPort(Settings.RemoteFileApiPort)
-  );
+export function canCreateNewRFAConnection(): boolean {
+  return isValidRFAHostname(Settings.RFAAddress).success && isValidRFAPort(Settings.RFAPort).success;
 }
 
-export function newRemoteFileApiConnection(): void {
-  closeRemoteFileApiConnection();
-  if (!canCreateNewRemoteFileApiConnection()) {
+export function newRFAConnection(): void {
+  closeRFAConnection();
+  if (!canCreateNewRFAConnection()) {
     return;
   }
-  server = new Remote(Settings.RemoteFileApiAddress, Settings.RemoteFileApiPort);
+  server = new Remote(Settings.RFAAddress, Settings.RFAPort);
   server.startConnection();
 }
 
-export function closeRemoteFileApiConnection(): void {
+export function closeRFAConnection(): void {
   if (!server) {
     return;
   }
   server.stopConnection();
 }
 
-export function isRemoteFileApiConnectionLive(): boolean {
+export function isRFAConnectionLive(): boolean {
   return server !== undefined && server.connection !== undefined && server.connection.readyState === 1;
 }
 
-export function getRemoteFileApiConnectionStatus(): "Online" | "Offline" | "Reconnecting" | "Connecting" {
-  if (isRemoteFileApiConnectionLive()) {
+export function getRFAConnectionStatus(): "Online" | "Offline" | "Reconnecting" | "Connecting" {
+  if (isRFAConnectionLive()) {
     return "Online";
   }
   if (server?.reconnecting) {

--- a/src/Settings/Settings.ts
+++ b/src/Settings/Settings.ts
@@ -42,13 +42,13 @@ export const Settings = {
   /** Limit the number of entries in the terminal. */
   MaxTerminalCapacity: 500,
   /** IP address the Remote File API client will try to connect to. Default localhost . */
-  RemoteFileApiAddress: "localhost",
+  RFAAddress: "localhost",
   /** Port the Remote File API client will try to connect to. 0 to disable. */
-  RemoteFileApiPort: 0,
+  RFAPort: 0,
   /** Automatically reconnect to the Remote File API client after this delay. Set it 0 to disable. */
-  RemoteFileApiReconnectionDelay: 0,
+  RFAReconnectionDelay: 0,
   /** Use wss instead of ws when connecting to RFA clients */
-  UseWssForRemoteFileApi: false,
+  UseWssForRFA: false,
   /** Whether to save the game when the player saves any file. */
   SaveGameOnFileSave: true,
   /** Whether to hide the confirmation dialog for augmentation purchases. */

--- a/src/Settings/SettingsUtils.ts
+++ b/src/Settings/SettingsUtils.ts
@@ -21,7 +21,7 @@ import { Settings } from "./Settings";
  * - Use non-http schemes in the hostname: "ftp://a.com"
  * - etc.
  */
-export function isValidConnectionHostname(hostname: string): Result {
+export function isValidRFAHostname(hostname: string): Result {
   // Return a user-friendly error message.
   if (hostname === "") {
     return {
@@ -67,7 +67,7 @@ export function isValidConnectionHostname(hostname: string): Result {
  *
  * Port 0 is normally invalid, but it is used to disable RFA, so this function treats 0 as valid.
  */
-export function isValidRFAConnectionPortSetting(port: number): Result {
+export function isValidRFAPort(port: number): Result {
   // 0 is not a valid port, but it is a valid configuration value that disables RFA.
   if (!Number.isFinite(port) || port < 0 || port > 65535) {
     return { success: false, message: "Invalid port" };
@@ -79,7 +79,7 @@ export function isValidRFAConnectionPortSetting(port: number): Result {
  * Checks whether the input is a valid RFA port before starting a new connection.
  */
 export function isValidConnectionPort(port: number): boolean {
-  return isValidRFAConnectionPortSetting(port).success && port !== 0;
+  return isValidRFAPort(port).success && port !== 0;
 }
 
 export function loadSettings(saveString: string) {
@@ -133,11 +133,11 @@ export function loadSettings(saveString: string) {
    * The hostname and port of RFA have not been validated properly, so the save data may contain invalid data. In that
    * case, we set them to the default value.
    */
-  if (!isValidConnectionHostname(Settings.RemoteFileApiAddress).success) {
-    Settings.RemoteFileApiAddress = "localhost";
+  if (!isValidRFAHostname(Settings.RFAAddress).success) {
+    Settings.RFAAddress = "localhost";
   }
-  if (!isValidRFAConnectionPortSetting(Settings.RemoteFileApiPort).success) {
-    Settings.RemoteFileApiPort = 0;
+  if (!isValidRFAPort(Settings.RFAPort).success) {
+    Settings.RFAPort = 0;
   }
 
   // Merge Settings.KeyBindings with DefaultKeyBindings.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { TTheme as Theme, ThemeEvents, refreshTheme } from "./Themes/ui/Theme";
 import { LoadingScreen } from "./ui/LoadingScreen";
 import { initElectron } from "./Electron";
 
-import { newRemoteFileApiConnection } from "./RemoteFileAPI/RemoteFileAPI";
+import { newRFAConnection } from "./RemoteFileAPI/RemoteFileAPI";
 
 import "./css/font.css";
 
@@ -34,7 +34,7 @@ styleElement.textContent = `#color-popover {
 }`;
 document.head.appendChild(styleElement);
 
-setTimeout(newRemoteFileApiConnection, 2000);
+setTimeout(newRFAConnection, 2000);
 
 function rerender(): void {
   refreshTheme();

--- a/src/ui/React/CharacterOverview.tsx
+++ b/src/ui/React/CharacterOverview.tsx
@@ -29,7 +29,7 @@ import { isCompanyWork } from "../../Work/CompanyWork";
 import { isCrimeWork } from "../../Work/CrimeWork";
 import { EventEmitter } from "../../utils/EventEmitter";
 import { useRerender } from "./hooks";
-import { RemoteFileApiConnectionStatus } from "../../GameOptions/ui/RemoteFileApiConnectionStatus";
+import { RFAConnectionStatus } from "../../GameOptions/ui/RemoteFileApiConnectionStatus";
 
 export const OverviewEventEmitter = new EventEmitter();
 
@@ -184,7 +184,7 @@ export function CharacterOverview({ parentOpen, save, killScripts }: OverviewPro
             </Tooltip>
           </IconButton>
         </Box>
-        <RemoteFileApiConnectionStatus showIcon={true} />
+        <RFAConnectionStatus showIcon={true} />
         <Box sx={{ display: "flex", flex: 1, justifyContent: "flex-end", alignItems: "center" }}>
           <IconButton aria-label="kill all scripts" onClick={() => setKillOpen(true)}>
             <Tooltip title="Kill all running scripts">


### PR DESCRIPTION
Context in and closes #3071 
For now, I have used RFA consistently across the codebase. Note that filenames remain untouched (they all used `remoteFileApi` so I don't think a change is necessary).
I may be refactoring some other names, such as using `can` or `is`