### PR TITLE
CODEBASE: Change Object.freeze usages and update comments

### DIFF
--- a/src/Augmentation/Augmentation.ts
+++ b/src/Augmentation/Augmentation.ts
@@ -211,9 +211,7 @@ export class Augmentation {
     this.prereqs = params.prereqs ? params.prereqs : [];
 
     this.baseRepRequirement = params.repCost;
-    Object.freeze(this.baseRepRequirement);
     this.baseCost = params.moneyCost;
-    Object.freeze(this.baseCost);
     this.factions = params.factions;
 
     if (params.isSpecial) {

--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -558,8 +558,7 @@ export function initBitNodes() {
   );
 }
 
-export const defaultMultipliers = new BitNodeMultipliers();
-Object.freeze(defaultMultipliers);
+export const defaultMultipliers = Object.freeze(new BitNodeMultipliers());
 
 export function getBitNodeMultipliers(n: number, lvl: number): BitNodeMultipliers {
   switch (n) {

--- a/src/CotMG/Fragment.ts
+++ b/src/CotMG/Fragment.ts
@@ -101,7 +101,6 @@ export function FragmentById(id: number): Fragment | null {
       1,
       1, // limit
       Effect(FragmentTypeEnum.Hacking),
-      //Effect(FragmentType.Hacking],
     ),
   );
   Fragments.push(

--- a/src/Netscript/ScriptDeath.ts
+++ b/src/Netscript/ScriptDeath.ts
@@ -11,7 +11,7 @@ import type { WorkerScript } from "./WorkerScript";
  * more easily detect this error type and ignore it (if desired) or get a stack
  * trace to help them identify the root cause (if the behaviour is unexpected).
  *
- * IMPORTANT: the game engine should not base any of it's decisions on the data
+ * IMPORTANT: the game engine should not base any of its decisions on the data
  * carried in a ScriptDeath instance.
  *
  * This is because ScriptDeath instances are thrown through player code when a

--- a/src/NetscriptFunctions/Darknet.ts
+++ b/src/NetscriptFunctions/Darknet.ts
@@ -364,7 +364,6 @@ export function NetscriptDarknet(): InternalAPI<DarknetAPI> {
         ctx,
         () => `Beginning stasis ${shouldLink ? "" : "removal "}procedure on ${server.hostname}... (Est: 30s)`,
       );
-      // setStasisLink's delay is hardcoded at 30s. We should skip this delay in Jest tests.
       return helpers.netscriptDelay(ctx, getSetStasisLinkDuration()).then(() => setStasisLink(ctx, server, shouldLink));
     },
     getStasisLinkLimit: (ctx: NetscriptContext): number => {

--- a/src/PersonObjects/Grafting/GraftableAugmentation.ts
+++ b/src/PersonObjects/Grafting/GraftableAugmentation.ts
@@ -10,7 +10,7 @@ export interface IConstructorParams {
 }
 
 export class GraftableAugmentation {
-  // The augmentation that this craftable corresponds to
+  // The augmentation that this graftable corresponds to
   augmentation: Augmentation;
 
   constructor(augmentation: Augmentation) {

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -82,7 +82,8 @@ export class Server extends BaseServer {
     this.hackDifficulty = Math.min(realDifficulty, 100);
     this.baseDifficulty = this.hackDifficulty;
     this.minDifficulty = Math.min(Math.max(1, Math.round(realDifficulty / 3)), 100);
-    this.serverGrowth = params.serverGrowth != null ? params.serverGrowth : 1; //Integer from 0 to 100. Affects money increase from grow()
+    // Integer from 0 to 100, or 3000 for n00dles. Affects money increase from grow()
+    this.serverGrowth = params.serverGrowth != null ? params.serverGrowth : 1;
 
     //Port information, required for porthacking servers to get admin rights
     this.numOpenPortsRequired = params.numOpenPortsRequired != null ? params.numOpenPortsRequired : 5;


### PR DESCRIPTION
This PR made these changes:
- `Object.freeze` usages:
  - `src/Augmentation/Augmentation.ts`: Remove `Object.freeze(this.fooNumber)`. It does not do anything.
  - `src/BitNode/BitNode.tsx`: Change the type of `defaultMultipliers` from `BitNodeMultipliers` to `Readonly<BitNodeMultipliers>`.
- Update comments in many files.