### PR TITLE
MISC: Hacknet text

### DIFF
--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -40,7 +40,7 @@ export function GeneralInfo(props: IProps): React.ReactElement {
           <br />
           <Typography>
             Hacknet Servers can be used to run scripts, just like regular servers. However, running scripts on a Hacknet
-            Server reduces its hash rate by the percentage of its RAM being used.
+            Server reduces its hash rate by the percentage of its RAM you use.
           </Typography>
         </>
       )}

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -14,36 +14,33 @@ export function GeneralInfo(props: IProps): React.ReactElement {
   return (
     <>
       <Typography>
-        The Hacknet is a global, decentralized network of machines. It is used by hackers all around the world to
-        anonymously share computing power and perform distributed cyberattacks without the fear of being traced.
+        The Hacknet is a global, decentralized network of machines. It is used by hackers around the world to perform
+        cyber attacks without the fear of being traced.
+        {!props.hasHacknetServers &&
+          " The machines that the Hacknet runs on are called Hacknet Nodes, specialised rigs that can share computing power anonymously. " +
+            "Hackers who use the network distribute a small percentage of their profits to the owners of Hacknet Nodes."}
       </Typography>
       <br />
       {!props.hasHacknetServers ? (
         <>
+          <Typography>You can purchase Hacknet Nodes to passively earn money.</Typography>
+          <br />
           <Typography>
-            {`Here, you can purchase a Hacknet Node, a specialized machine that can connect ` +
-              `and contribute its resources to the Hacknet network. This allows you to take ` +
-              `a small percentage of profits from hacks performed on the network. Essentially, ` +
-              `you are renting out your Node's computing power.`}
-          </Typography>
-          <Typography>
-            {`Each Hacknet Node you purchase will passively earn you money. Each Hacknet Node ` +
-              `can be upgraded in order to increase its computing power and thereby increase ` +
-              `the profit you earn from it.`}
+            Each Node can be upgraded to increase its computing power and the profit you make from it.
           </Typography>
         </>
       ) : (
         <>
           <Typography>
-            {`Here, you can purchase a Hacknet Server, an upgraded version of the Hacknet Node. ` +
-              `Hacknet Servers will perform computations and operations on the network, earning ` +
-              `you hashes. Hashes can be spent on a variety of different upgrades.`}
+            Here you can purchase a Hacknet Server, an upgraded version of the Hacknet Node. Hacknet Servers will
+            perform computations and operations on the network, earning you hashes. Hashes can be spent on a variety of
+            different upgrades.
           </Typography>
+          <br />
           <Typography>
-            {`Hacknet Servers can also be used as servers to run scripts. However, running scripts ` +
-              `on a server will reduce its hash rate (hashes generated per second). A Hacknet Server's hash ` +
-              `rate will be reduced by the percentage of RAM that is being used by that Server to run ` +
-              `scripts.`}
+            Hacknet Servers can also be used as servers to run scripts. However, running scripts on a server will reduce
+            its hash rate (hashes generated per second). A Hacknet Server's hash rate will be reduced by the percentage
+            of RAM that is being used by that Server to run scripts.
           </Typography>
         </>
       )}

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -39,6 +39,11 @@ export function GeneralInfo(props: IProps): React.ReactElement {
           </Typography>
           <br />
           <Typography>
+            The number of hashes you can store is limited by the size of your cache. If your cache gets full, surplus
+            hashes will be automatically sold for money.
+          </Typography>
+          <br />
+          <Typography>
             Hacknet Servers can be used to run scripts, just like regular servers. However, running scripts on a Hacknet
             Server reduces its hash rate by the percentage of its RAM you use.
           </Typography>

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -16,14 +16,15 @@ export function GeneralInfo(props: IProps): React.ReactElement {
       <Typography>
         The Hacknet is a global, decentralized network of machines. It is used by hackers around the world to perform
         cyber attacks without the fear of being traced.
-        {!props.hasHacknetServers &&
-          " The machines that the Hacknet runs on are called Hacknet Nodes, specialised rigs that can share computing power anonymously. " +
-            "Hackers who use the network distribute a small percentage of their profits to the owners of Hacknet Nodes."}
       </Typography>
       <br />
       {!props.hasHacknetServers ? (
         <>
-          <Typography>You can purchase Hacknet Nodes to passively earn money.</Typography>
+          <Typography>
+            Here you can purchase Hacknet Nodes to passively earn money. Hacknet Nodes are the the machines that the
+            Hacknet runs on, specialised rigs that can share computing power anonymously. Hackers who use the network
+            distribute a small percentage of their profits to the owners of Hacknet Nodes.
+          </Typography>
           <br />
           <Typography>
             Each Node can be upgraded to increase its computing power and the profit you make from it.

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -33,15 +33,14 @@ export function GeneralInfo(props: IProps): React.ReactElement {
       ) : (
         <>
           <Typography>
-            Here you can purchase a Hacknet Server, an upgraded version of the Hacknet Node. Hacknet Servers will
-            perform computations and operations on the network, earning you hashes. Hashes can be spent on a variety of
-            different upgrades.
+            Here you can purchase Hacknet Servers, the upgraded version of the Hacknet Node. Hacknet Servers earn you
+            hashes by performing computations and operations on the network. Hashes can be spent on a variety of
+            upgrades.
           </Typography>
           <br />
           <Typography>
-            Hacknet Servers can also be used as servers to run scripts. However, running scripts on a server will reduce
-            its hash rate (hashes generated per second). A Hacknet Server's hash rate will be reduced by the percentage
-            of RAM that is being used by that Server to run scripts.
+            Hacknet Servers can be used to run scripts, just like regular servers. However, running scripts on a Hacknet
+            Server reduces its hash rate by the percentage of its RAM being used.
           </Typography>
         </>
       )}

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -21,13 +21,11 @@ export function GeneralInfo(props: IProps): React.ReactElement {
       {!props.hasHacknetServers ? (
         <>
           <Typography>
-            Here you can purchase Hacknet Nodes to passively earn money. Hacknet Nodes are the the machines that the
-            Hacknet runs on, specialised rigs that can share computing power anonymously. Hackers who use the network
-            distribute a small percentage of their profits to the owners of Hacknet Nodes.
-          </Typography>
-          <br />
-          <Typography>
-            Each Node can be upgraded to increase its computing power and the profit you make from it.
+            Here you can purchase Hacknet Nodes, specialised machines that contribute resources and computing power to the Hacknet. This allows you to take
+            a small percentage of profits from hacks performed on the network.
+            <br />
+            <br />
+            Purchasing Hacknet Nodes will earn you money passively. You can upgrade Nodes to increase their earnings.
           </Typography>
         </>
       ) : (
@@ -36,14 +34,12 @@ export function GeneralInfo(props: IProps): React.ReactElement {
             Here you can purchase Hacknet Servers, the upgraded version of the Hacknet Node. Hacknet Servers earn you
             hashes by performing computations and operations on the network. Hashes can be spent on a variety of
             upgrades.
-          </Typography>
-          <br />
-          <Typography>
-            The number of hashes you can store is limited by the size of your cache. If your cache gets full, surplus
-            hashes will be automatically sold for money.
-          </Typography>
-          <br />
-          <Typography>
+            <br />
+            <br />
+            The number of hashes you can store is limited by the size of your cache pool. If you fill your caches, surplus
+            hashes will automatically be sold for money.
+            <br />
+            <br />
             Hacknet Servers can be used to run scripts, just like regular servers. However, running scripts on a Hacknet
             Server reduces its hash rate by the percentage of its RAM you use.
           </Typography>

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -16,29 +16,26 @@ export function GeneralInfo(props: IProps): React.ReactElement {
       <Typography>
         The Hacknet is a global, decentralized network of machines. It is used by hackers around the world to perform
         cyber attacks without the fear of being traced.
+        <br />
       </Typography>
-      <br />
       {!props.hasHacknetServers ? (
         <>
           <Typography>
-            Here you can purchase Hacknet Nodes, specialised machines that contribute resources and computing power to
-            the Hacknet. They allow you to take a small percentage of profits from hacks performed on the network.
+            Here you can purchase Hacknet Nodes, specialized machines that connect and contribute their resources to the
+            Hacknet network. They allow you to take a small percentage of profits from hacks performed on the network.
+            Essentially, you are renting out your Nodes' computing power.
             <br />
             <br />
-            Purchased Hacknet Nodes will passively earn you money. You can upgrade Hacknet Nodes to increase their
-            earnings.
+            Hacknet Nodes passively earn you money, even when you're offline. You can upgrade Hacknet Nodes to increase
+            their earnings.
           </Typography>
         </>
       ) : (
         <>
           <Typography>
-            Here you can purchase Hacknet Servers, an upgraded version of the Hacknet Node. Hacknet Servers earn you
-            hashes by performing computations and operations on the network. Hashes can be spent on a variety of
+            Here you can purchase Hacknet Servers, the upgraded version of Hacknet Nodes. Hacknet Servers perform
+            computations and operations on the network, earning you hashes. Hashes can be spent on a variety of
             upgrades.
-            <br />
-            <br />
-            The number of hashes you can store is limited by the size of your cache pool. If you run out of cache space,
-            surplus hashes will automatically be sold for money.
             <br />
             <br />
             Hacknet Servers can be used to run scripts, just like regular servers. However, running scripts on a Hacknet

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -16,9 +16,8 @@ export function GeneralInfo(props: IProps): React.ReactElement {
       <Typography>
         The Hacknet is a global, decentralized network of machines. It is used by hackers around the world to perform
         cyber attacks without the fear of being traced.
-        <br />
-        <br />
       </Typography>
+      <br />
       {!props.hasHacknetServers ? (
         <>
           <Typography>

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -21,23 +21,24 @@ export function GeneralInfo(props: IProps): React.ReactElement {
       {!props.hasHacknetServers ? (
         <>
           <Typography>
-            Here you can purchase Hacknet Nodes, specialised machines that contribute resources and computing power to the Hacknet. This allows you to take
-            a small percentage of profits from hacks performed on the network.
+            Here you can purchase Hacknet Nodes, specialised machines that contribute resources and computing power to
+            the Hacknet. They allow you to take a small percentage of profits from hacks performed on the network.
             <br />
             <br />
-            Purchasing Hacknet Nodes will earn you money passively. You can upgrade Nodes to increase their earnings.
+            Purchased Hacknet Nodes will passively earn you money. You can upgrade Hacknet Nodes to increase their
+            earnings.
           </Typography>
         </>
       ) : (
         <>
           <Typography>
-            Here you can purchase Hacknet Servers, the upgraded version of the Hacknet Node. Hacknet Servers earn you
+            Here you can purchase Hacknet Servers, an upgraded version of the Hacknet Node. Hacknet Servers earn you
             hashes by performing computations and operations on the network. Hashes can be spent on a variety of
             upgrades.
             <br />
             <br />
-            The number of hashes you can store is limited by the size of your cache pool. If you fill your caches, surplus
-            hashes will automatically be sold for money.
+            The number of hashes you can store is limited by the size of your cache pool. If you run out of cache space,
+            surplus hashes will automatically be sold for money.
             <br />
             <br />
             Hacknet Servers can be used to run scripts, just like regular servers. However, running scripts on a Hacknet

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -33,7 +33,7 @@ export function GeneralInfo(props: IProps): React.ReactElement {
       ) : (
         <>
           <Typography>
-            Here you can purchase Hacknet Servers, the upgraded version of Hacknet Nodes. Hacknet Servers perform
+            Here you can purchase Hacknet Servers, an upgraded version of Hacknet Nodes. Hacknet Servers perform
             computations and operations on the network, earning you hashes. Hashes can be spent on a variety of
             upgrades.
             <br />

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -15,7 +15,7 @@ export function GeneralInfo(props: IProps): React.ReactElement {
     <>
       <Typography>
         The Hacknet is a global, decentralized network of machines. It is used by hackers around the world to perform
-        cyber attacks without the fear of being traced.
+        cyberattacks without the fear of being traced.
       </Typography>
       <br />
       {!props.hasHacknetServers ? (

--- a/src/Hacknet/ui/GeneralInfo.tsx
+++ b/src/Hacknet/ui/GeneralInfo.tsx
@@ -17,6 +17,7 @@ export function GeneralInfo(props: IProps): React.ReactElement {
         The Hacknet is a global, decentralized network of machines. It is used by hackers around the world to perform
         cyber attacks without the fear of being traced.
         <br />
+        <br />
       </Typography>
       {!props.hasHacknetServers ? (
         <>


### PR DESCRIPTION
* Added a missing `<br>` (been annoying me for ages)
* Reduced wordiness. It could be much shorter still, but I've erred on the side of preserving what's there. 
* Changed most singulars to plurals ("Here you can purchase a Hacknet Node" > "Here you can purchase Hacknet Nodes") for more idiomatic English

# Visuals

## Nodes

### Before

<img width="1157" height="363" alt="image" src="https://github.com/user-attachments/assets/284264d2-2b8c-4f4e-8d73-a7db55f4dd51" />

### After

<img width="1157" height="320" alt="image" src="https://github.com/user-attachments/assets/7558d855-9e8f-4efc-97d4-be803c7c3f97" />

## Servers

### Before

<img width="1149" height="337" alt="image" src="https://github.com/user-attachments/assets/92bb179c-419e-49a1-9a00-cf1168b8bc81" />

### After

<img width="1159" height="312" alt="image" src="https://github.com/user-attachments/assets/94d10797-043c-4e29-9c7d-c5bb59e4f728" />
